### PR TITLE
feat(hub): ingest GitHub webhooks

### DIFF
--- a/internal/cli/hub.go
+++ b/internal/cli/hub.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -14,29 +15,35 @@ import (
 type hubRunFunc func(context.Context, hubserver.Config) error
 
 func newHubCommand(opts options) *cobra.Command {
-	return newHubCommandWithRun(opts.version, hubserver.Run)
+	return newHubCommandWithRun(opts.version, opts.lookupEnv, hubserver.Run)
 }
 
-func newHubCommandWithRun(version string, run hubRunFunc) *cobra.Command {
+func newHubCommandWithRun(version string, lookupEnv func(string) string, run hubRunFunc) *cobra.Command {
+	if lookupEnv == nil {
+		lookupEnv = os.Getenv
+	}
 	cmd := &cobra.Command{
 		Use:     "hub",
 		Short:   "Run the shared Detent Hub service",
 		Example: "detent hub serve --database /var/lib/detent/hub.db",
 		Args:    NoArgs,
 	}
-	cmd.AddCommand(newHubServeCommand(version, run))
+	cmd.AddCommand(newHubServeCommand(version, lookupEnv, run))
 	return cmd
 }
 
-func newHubServeCommand(version string, run hubRunFunc) *cobra.Command {
+func newHubServeCommand(version string, lookupEnv func(string) string, run hubRunFunc) *cobra.Command {
 	var databasePath string
 	var listenAddress string
 	var busyTimeout time.Duration
 	var shutdownTimeout time.Duration
+	var githubWebhookSecretEnv string
+	var webhookPayloadRetention time.Duration
+	var webhookMaintenanceInterval time.Duration
 
 	cmd := &cobra.Command{
 		Use:          "serve",
-		Short:        "Serve the Detent Hub health endpoint",
+		Short:        "Serve the Detent Hub API",
 		Example:      "detent hub serve --database /var/lib/detent/hub.db --listen 127.0.0.1:7777",
 		Args:         NoArgs,
 		SilenceUsage: true,
@@ -50,13 +57,20 @@ func newHubServeCommand(version string, run hubRunFunc) *cobra.Command {
 			if strings.TrimSpace(listenAddress) == "" {
 				return NewValidationError("hub listen address is required", "Use --listen 127.0.0.1:7777 or another explicit address.", nil)
 			}
+			githubWebhookSecretEnv = strings.TrimSpace(githubWebhookSecretEnv)
+			if githubWebhookSecretEnv != "" && !validEnvName(githubWebhookSecretEnv) {
+				return NewValidationError("Hub GitHub webhook secret environment variable name is invalid", "Use an environment variable name such as DETENT_HUB_GITHUB_WEBHOOK_SECRET.", nil)
+			}
 			return run(cmd.Context(), hubserver.Config{
-				DatabasePath:    databasePath,
-				ListenAddress:   listenAddress,
-				BusyTimeout:     busyTimeout,
-				ShutdownTimeout: shutdownTimeout,
-				Logger:          slog.Default(),
-				Version:         version,
+				DatabasePath:               databasePath,
+				ListenAddress:              listenAddress,
+				BusyTimeout:                busyTimeout,
+				ShutdownTimeout:            shutdownTimeout,
+				GitHubWebhookSecret:        []byte(strings.TrimSpace(lookupEnv(githubWebhookSecretEnv))),
+				WebhookPayloadRetention:    webhookPayloadRetention,
+				WebhookMaintenanceInterval: webhookMaintenanceInterval,
+				Logger:                     slog.Default(),
+				Version:                    version,
 			})
 		},
 	}
@@ -64,5 +78,8 @@ func newHubServeCommand(version string, run hubRunFunc) *cobra.Command {
 	cmd.Flags().StringVar(&listenAddress, "listen", hubserver.DefaultListenAddress, "Hub listen address")
 	cmd.Flags().DurationVar(&busyTimeout, "busy-timeout", 5*time.Second, "SQLite busy timeout")
 	cmd.Flags().DurationVar(&shutdownTimeout, "shutdown-timeout", 5*time.Second, "graceful HTTP shutdown timeout")
+	cmd.Flags().StringVar(&githubWebhookSecretEnv, "github-webhook-secret-env", "DETENT_HUB_GITHUB_WEBHOOK_SECRET", "environment variable containing the GitHub webhook secret")
+	cmd.Flags().DurationVar(&webhookPayloadRetention, "webhook-payload-retention", hubserver.DefaultWebhookPayloadRetention, "retention period for raw GitHub webhook payloads")
+	cmd.Flags().DurationVar(&webhookMaintenanceInterval, "webhook-maintenance-interval", hubserver.DefaultWebhookMaintenanceInterval, "GitHub webhook retry and retention interval")
 	return cmd
 }

--- a/internal/cli/hub_test.go
+++ b/internal/cli/hub_test.go
@@ -23,7 +23,12 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 		gotConfig = cfg
 		return nil
 	}
-	cmd := newHubCommandWithRun("v-test", run)
+	cmd := newHubCommandWithRun("v-test", func(name string) string {
+		if name == "TEST_HUB_WEBHOOK_SECRET" {
+			return "webhook-secret"
+		}
+		return ""
+	}, run)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{
@@ -32,6 +37,9 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 		"--listen", "127.0.0.1:0",
 		"--busy-timeout", "2s",
 		"--shutdown-timeout", "3s",
+		"--github-webhook-secret-env", "TEST_HUB_WEBHOOK_SECRET",
+		"--webhook-payload-retention", "48h",
+		"--webhook-maintenance-interval", "30s",
 	})
 	if err := cmd.ExecuteContext(wantContext); err != nil {
 		t.Fatalf("ExecuteContext() error = %v", err)
@@ -51,6 +59,15 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 	if gotConfig.ShutdownTimeout != 3*time.Second {
 		t.Fatalf("shutdown timeout = %s, want 3s", gotConfig.ShutdownTimeout)
 	}
+	if string(gotConfig.GitHubWebhookSecret) != "webhook-secret" {
+		t.Fatalf("GitHub webhook secret = %q, want resolved secret", gotConfig.GitHubWebhookSecret)
+	}
+	if gotConfig.WebhookPayloadRetention != 48*time.Hour {
+		t.Fatalf("webhook payload retention = %s, want 48h", gotConfig.WebhookPayloadRetention)
+	}
+	if gotConfig.WebhookMaintenanceInterval != 30*time.Second {
+		t.Fatalf("webhook maintenance interval = %s, want 30s", gotConfig.WebhookMaintenanceInterval)
+	}
 	if gotConfig.Version != "v-test" {
 		t.Fatalf("version = %q, want v-test", gotConfig.Version)
 	}
@@ -63,10 +80,34 @@ func TestHubServeCommandValidatesDatabase(t *testing.T) {
 	run := func(context.Context, hubserver.Config) error {
 		return runErr
 	}
-	cmd := newHubCommandWithRun("v-test", run)
+	cmd := newHubCommandWithRun("v-test", nil, run)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"serve"})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("ExecuteContext() error = nil, want validation error")
+	}
+	if errors.Is(err, runErr) {
+		t.Fatalf("ExecuteContext() error = %v, runner was called", err)
+	}
+}
+
+func TestHubServeCommandValidatesWebhookSecretEnvironmentName(t *testing.T) {
+	t.Parallel()
+
+	runErr := errors.New("runner should not be called")
+	run := func(context.Context, hubserver.Config) error {
+		return runErr
+	}
+	cmd := newHubCommandWithRun("v-test", nil, run)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"serve",
+		"--database", filepath.Join(t.TempDir(), "hub.db"),
+		"--github-webhook-secret-env", "INVALID-NAME",
+	})
 	err := cmd.ExecuteContext(context.Background())
 	if err == nil {
 		t.Fatal("ExecuteContext() error = nil, want validation error")

--- a/internal/hubserver/config.go
+++ b/internal/hubserver/config.go
@@ -7,27 +7,34 @@ import (
 )
 
 const (
-	DefaultListenAddress = "127.0.0.1:7777"
-	defaultBusyTimeout   = 5 * time.Second
-	defaultShutdownTime  = 5 * time.Second
+	DefaultListenAddress              = "127.0.0.1:7777"
+	DefaultWebhookPayloadRetention    = 7 * 24 * time.Hour
+	DefaultWebhookMaintenanceInterval = time.Minute
+	defaultBusyTimeout                = 5 * time.Second
+	defaultShutdownTime               = 5 * time.Second
 )
 
 var (
-	ErrBackupSource      = errors.New("hub backup destination matches the source database")
-	ErrDatabaseIdentity  = errors.New("database is not a Detent Hub database")
-	ErrNetworkFilesystem = errors.New("hub database requires a local filesystem")
-	ErrNotReady          = errors.New("hub service is not ready")
-	ErrUnsupportedSchema = errors.New("hub database schema is newer than this Detent version")
+	ErrBackupSource            = errors.New("hub backup destination matches the source database")
+	ErrDatabaseIdentity        = errors.New("database is not a Detent Hub database")
+	ErrNetworkFilesystem       = errors.New("hub database requires a local filesystem")
+	ErrNotReady                = errors.New("hub service is not ready")
+	ErrUnsupportedSchema       = errors.New("hub database schema is newer than this Detent version")
+	ErrWebhookDeliveryConflict = errors.New("github webhook delivery ID has conflicting content")
 )
 
 type Config struct {
-	DatabasePath    string
-	ListenAddress   string
-	BusyTimeout     time.Duration
-	ShutdownTimeout time.Duration
-	Logger          *slog.Logger
-	Version         string
+	DatabasePath               string
+	ListenAddress              string
+	BusyTimeout                time.Duration
+	ShutdownTimeout            time.Duration
+	GitHubWebhookSecret        []byte
+	WebhookPayloadRetention    time.Duration
+	WebhookMaintenanceInterval time.Duration
+	Logger                     *slog.Logger
+	Version                    string
 
+	now                        func() time.Time
 	validateDatabaseFilesystem func(string) error
 }
 
@@ -41,9 +48,19 @@ func (c Config) normalized() Config {
 	if c.ShutdownTimeout <= 0 {
 		c.ShutdownTimeout = defaultShutdownTime
 	}
+	if c.WebhookPayloadRetention <= 0 {
+		c.WebhookPayloadRetention = DefaultWebhookPayloadRetention
+	}
+	if c.WebhookMaintenanceInterval <= 0 {
+		c.WebhookMaintenanceInterval = DefaultWebhookMaintenanceInterval
+	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()
 	}
+	if c.now == nil {
+		c.now = time.Now
+	}
+	c.GitHubWebhookSecret = append([]byte(nil), c.GitHubWebhookSecret...)
 	if c.validateDatabaseFilesystem == nil {
 		c.validateDatabaseFilesystem = validateLocalDatabaseFilesystem
 	}

--- a/internal/hubserver/database.go
+++ b/internal/hubserver/database.go
@@ -130,6 +130,7 @@ func sqliteDSN(path string, busyTimeout time.Duration) string {
 	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", busyTimeoutMillis(busyTimeout)))
 	query.Add("_pragma", "foreign_keys(1)")
 	query.Add("_pragma", "locking_mode(EXCLUSIVE)")
+	query.Add("_pragma", "synchronous(FULL)")
 	databaseURL.RawQuery = query.Encode()
 	return databaseURL.String()
 }
@@ -149,6 +150,13 @@ func (d *database) configure(ctx context.Context, busyTimeout time.Duration) err
 	}
 	if gotBusyTimeout != wantBusyTimeout {
 		return fmt.Errorf("hub sqlite busy timeout is %dms, want %dms", gotBusyTimeout, wantBusyTimeout)
+	}
+	var synchronous int
+	if err := d.db.QueryRowContext(ctx, "PRAGMA synchronous").Scan(&synchronous); err != nil {
+		return fmt.Errorf("read hub sqlite synchronous mode: %w", err)
+	}
+	if synchronous != 2 {
+		return fmt.Errorf("hub sqlite synchronous mode is %d, want FULL", synchronous)
 	}
 
 	var foreignKeys int

--- a/internal/hubserver/database_test.go
+++ b/internal/hubserver/database_test.go
@@ -16,7 +16,10 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
+
+	"github.com/pressly/goose/v3"
 
 	"github.com/digitaldrywood/detent/internal/instancelock"
 )
@@ -50,8 +53,10 @@ func TestOpenCreatesHubSchemaAndConfiguresSQLite(t *testing.T) {
 	}
 
 	wantTables := []string{
+		"github_hydration_requests",
 		"github_outbox",
 		"github_webhook_inbox",
+		"github_webhook_payloads",
 		"hub_schema_version",
 		"issue_dependencies",
 		"issues",
@@ -78,6 +83,7 @@ func TestOpenCreatesHubSchemaAndConfiguresSQLite(t *testing.T) {
 		{name: "foreign keys", query: "PRAGMA foreign_keys", want: "1"},
 		{name: "busy timeout", query: "PRAGMA busy_timeout", want: "2500"},
 		{name: "locking mode", query: "PRAGMA locking_mode", want: "exclusive"},
+		{name: "synchronous mode", query: "PRAGMA synchronous", want: "2"},
 		{name: "application id", query: "PRAGMA application_id", want: strconv.Itoa(hubApplicationID)},
 	}
 	for _, check := range checks {
@@ -278,6 +284,82 @@ func TestOpenRejectsNewerSchema(t *testing.T) {
 	}
 }
 
+func TestOpenMigratesLegacyWebhookPayloads(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "hub.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	if _, err := db.ExecContext(t.Context(), fmt.Sprintf("PRAGMA application_id = %d", hubApplicationID)); err != nil {
+		t.Fatalf("set application id: %v", err)
+	}
+	legacyMigrations := fstest.MapFS{}
+	for _, name := range []string{
+		"00001_create_github_projection.sql",
+		"00002_create_execution_state.sql",
+		"00003_create_github_delivery.sql",
+	} {
+		data, err := migrationFiles.ReadFile("migrations/" + name)
+		if err != nil {
+			t.Fatalf("read migration %s: %v", name, err)
+		}
+		legacyMigrations[name] = &fstest.MapFile{Data: data}
+	}
+	provider, err := goose.NewProvider(
+		goose.DialectSQLite3,
+		db,
+		legacyMigrations,
+		goose.WithDisableGlobalRegistry(true),
+		goose.WithTableName(hubSchemaTable),
+		goose.WithSlog(discardLogger()),
+	)
+	if err != nil {
+		t.Fatalf("create legacy migration provider: %v", err)
+	}
+	if _, err := provider.Up(t.Context()); err != nil {
+		t.Fatalf("apply legacy migrations: %v", err)
+	}
+	if _, err := db.ExecContext(t.Context(), `
+		INSERT INTO github_webhook_inbox (
+			delivery_id, event_type, action, headers_json, payload_json,
+			payload_sha256, payload_bytes, status, received_at, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, "legacy-delivery", "push", "created", `{"user_agent":"GitHub-Hookshot"}`, `{"ref":"refs/heads/main"}`,
+		"legacy-sha", 25, "pending", testTimestamp, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert legacy webhook: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy database: %v", err)
+	}
+
+	service := openTestService(t, Config{
+		DatabasePath: path,
+		now: func() time.Time {
+			return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+		},
+	})
+	var eventType string
+	var action string
+	var headers string
+	var body string
+	var payloadSHA string
+	var lastReceivedAt string
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT i.event_type, i.action, i.headers_json, CAST(p.body AS TEXT), i.payload_sha256, i.last_received_at
+		FROM github_webhook_inbox i
+		JOIN github_webhook_payloads p ON p.inbox_id = i.id
+		WHERE i.delivery_id = 'legacy-delivery'
+	`).Scan(&eventType, &action, &headers, &body, &payloadSHA, &lastReceivedAt); err != nil {
+		t.Fatalf("read migrated webhook: %v", err)
+	}
+	if eventType != "push" || action != "created" || headers != `{"user_agent":"GitHub-Hookshot"}` ||
+		body != `{"ref":"refs/heads/main"}` || payloadSHA != "legacy-sha" || lastReceivedAt != testTimestamp {
+		t.Fatalf("migrated webhook = event %q action %q headers %s body %s sha %q received %q", eventType, action, headers, body, payloadSHA, lastReceivedAt)
+	}
+}
+
 func TestSchemaEnforcesIdentityAndAppendOnlyConstraints(t *testing.T) {
 	t.Parallel()
 
@@ -312,8 +394,8 @@ func TestSchemaEnforcesIdentityAndAppendOnlyConstraints(t *testing.T) {
 		},
 		{
 			name:  "webhook delivery id",
-			query: "INSERT INTO github_webhook_inbox (delivery_id, event_type, payload_json, payload_sha256, payload_bytes, status, received_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-			args:  []any{"delivery-one", "issues", "{}", "def", 2, "pending", testTimestamp, testTimestamp, testTimestamp},
+			query: "INSERT INTO github_webhook_inbox (delivery_id, event_type, payload_sha256, payload_bytes, status, received_at, last_received_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			args:  []any{"delivery-one", "issues", "def", 2, "pending", testTimestamp, testTimestamp, testTimestamp, testTimestamp},
 		},
 	}
 	for _, test := range duplicateTests {
@@ -322,6 +404,16 @@ func TestSchemaEnforcesIdentityAndAppendOnlyConstraints(t *testing.T) {
 				t.Fatal("duplicate insert error = nil, want unique constraint error")
 			}
 		})
+	}
+	if _, err := db.ExecContext(t.Context(), `
+		INSERT INTO github_hydration_requests (
+			repository_id, repository_full_name, object_kind, object_key,
+			github_number, reason, requested_source_version,
+			first_delivery_id, last_delivery_id, status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, repositoryID, "digitaldrywood/detent", "repository", "detent", 1, "invalid", "v1",
+		"delivery-one", "delivery-one", "pending", testTimestamp, testTimestamp); err == nil {
+		t.Fatal("invalid hydration object kind error = nil, want constraint error")
 	}
 
 	if _, err := db.ExecContext(t.Context(), "INSERT INTO issues (repository_id, github_node_id, github_number, title, url, github_state, source_version, source_updated_at, synchronized_at, created_at, updated_at) VALUES (9999, 'I_missing', 9, 'Missing', 'https://example.test/9', 'open', 'v1', ?, ?, ?, ?)", testTimestamp, testTimestamp, testTimestamp, testTimestamp); err == nil {
@@ -582,7 +674,7 @@ func seedProjection(t *testing.T, db *sql.DB) (int64, int64) {
 	if _, err := db.ExecContext(t.Context(), "INSERT INTO pull_requests (repository_id, issue_id, github_node_id, github_number, title, url, github_state, head_ref, head_sha, base_ref, source_version, source_updated_at, synchronized_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", repositoryID, issueID, "PR_one", 1, "PR", "https://example.test/pr/1", "open", "feature", "abc", "main", "v1", testTimestamp, testTimestamp, testTimestamp, testTimestamp); err != nil {
 		t.Fatalf("insert pull request: %v", err)
 	}
-	if _, err := db.ExecContext(t.Context(), "INSERT INTO github_webhook_inbox (delivery_id, repository_id, event_type, payload_json, payload_sha256, payload_bytes, status, received_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", "delivery-one", repositoryID, "issues", "{}", "abc", 2, "pending", testTimestamp, testTimestamp, testTimestamp); err != nil {
+	if _, err := db.ExecContext(t.Context(), "INSERT INTO github_webhook_inbox (delivery_id, repository_id, event_type, payload_sha256, payload_bytes, status, received_at, last_received_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", "delivery-one", repositoryID, "issues", "abc", 2, "pending", testTimestamp, testTimestamp, testTimestamp, testTimestamp); err != nil {
 		t.Fatalf("insert webhook delivery: %v", err)
 	}
 	return repositoryID, issueID

--- a/internal/hubserver/github_webhook.go
+++ b/internal/hubserver/github_webhook.go
@@ -1,0 +1,162 @@
+package hubserver
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+const githubWebhookMaxBodyBytes = 2 << 20
+
+type webhookReceipt struct {
+	DeliveryID       string
+	EventType        string
+	Action           string
+	HeadersJSON      string
+	Payload          []byte
+	PayloadSHA256    string
+	ReceivedAt       time.Time
+	PayloadExpiresAt time.Time
+}
+
+type webhookReceiptResult struct {
+	InboxID   int64
+	Duplicate bool
+}
+
+type webhookResponse struct {
+	DeliveryID string `json:"delivery_id"`
+	Duplicate  bool   `json:"duplicate"`
+}
+
+type webhookErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (s *Service) githubWebhook(c echo.Context) error {
+	if len(s.config.GitHubWebhookSecret) == 0 {
+		return c.JSON(http.StatusServiceUnavailable, webhookErrorResponse{
+			Code:    "webhook_unavailable",
+			Message: "GitHub webhook verification is not configured",
+		})
+	}
+
+	request := c.Request()
+	request.Body = http.MaxBytesReader(c.Response(), request.Body, githubWebhookMaxBodyBytes)
+	payload, err := io.ReadAll(request.Body)
+	if err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			return c.JSON(http.StatusRequestEntityTooLarge, webhookErrorResponse{
+				Code:    "payload_too_large",
+				Message: "GitHub webhook payload is too large",
+			})
+		}
+		return c.JSON(http.StatusBadRequest, webhookErrorResponse{
+			Code:    "invalid_payload",
+			Message: "GitHub webhook payload is invalid",
+		})
+	}
+
+	deliveryID := strings.TrimSpace(request.Header.Get("X-GitHub-Delivery"))
+	eventType := strings.TrimSpace(request.Header.Get("X-GitHub-Event"))
+	if deliveryID == "" || eventType == "" {
+		return c.JSON(http.StatusBadRequest, webhookErrorResponse{
+			Code:    "invalid_headers",
+			Message: "GitHub webhook delivery and event headers are required",
+		})
+	}
+	if !validGitHubWebhookSignature(s.config.GitHubWebhookSecret, payload, request.Header.Get("X-Hub-Signature-256")) {
+		return c.JSON(http.StatusUnauthorized, webhookErrorResponse{
+			Code:    "invalid_signature",
+			Message: "GitHub webhook signature is invalid",
+		})
+	}
+	if !json.Valid(payload) {
+		return c.JSON(http.StatusBadRequest, webhookErrorResponse{
+			Code:    "invalid_payload",
+			Message: "GitHub webhook payload is invalid",
+		})
+	}
+
+	var metadata struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal(payload, &metadata); err != nil {
+		return c.JSON(http.StatusBadRequest, webhookErrorResponse{
+			Code:    "invalid_payload",
+			Message: "GitHub webhook payload is invalid",
+		})
+	}
+	headersJSON, err := json.Marshal(map[string]string{
+		"content_type":        request.Header.Get("Content-Type"),
+		"hook_id":             request.Header.Get("X-GitHub-Hook-ID"),
+		"installation_target": request.Header.Get("X-GitHub-Hook-Installation-Target-ID"),
+		"user_agent":          request.Header.Get("User-Agent"),
+	})
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, webhookErrorResponse{
+			Code:    "receipt_failed",
+			Message: "GitHub webhook delivery could not be recorded",
+		})
+	}
+	payloadHash := sha256.Sum256(payload)
+	now := s.config.now().UTC()
+	receipt := webhookReceipt{
+		DeliveryID:       deliveryID,
+		EventType:        eventType,
+		Action:           strings.TrimSpace(metadata.Action),
+		HeadersJSON:      string(headersJSON),
+		Payload:          payload,
+		PayloadSHA256:    hex.EncodeToString(payloadHash[:]),
+		ReceivedAt:       now,
+		PayloadExpiresAt: now.Add(s.config.WebhookPayloadRetention),
+	}
+	result, err := s.database.recordWebhook(request.Context(), receipt)
+	if errors.Is(err, ErrWebhookDeliveryConflict) {
+		return c.JSON(http.StatusConflict, webhookErrorResponse{
+			Code:    "delivery_conflict",
+			Message: "GitHub webhook delivery ID conflicts with an earlier delivery",
+		})
+	}
+	if err != nil {
+		s.config.Logger.Error("record GitHub webhook", "delivery_id", deliveryID, "error", err)
+		return c.JSON(http.StatusServiceUnavailable, webhookErrorResponse{
+			Code:    "receipt_failed",
+			Message: "GitHub webhook delivery could not be recorded",
+		})
+	}
+	if err := s.database.processWebhook(request.Context(), result.InboxID, now); err != nil {
+		s.config.Logger.Error("process GitHub webhook", "delivery_id", deliveryID, "error", err)
+	}
+
+	return c.JSON(http.StatusAccepted, webhookResponse{
+		DeliveryID: deliveryID,
+		Duplicate:  result.Duplicate,
+	})
+}
+
+func validGitHubWebhookSignature(secret []byte, body []byte, signature string) bool {
+	value, ok := strings.CutPrefix(strings.TrimSpace(signature), "sha256=")
+	if !ok {
+		return false
+	}
+	got, err := hex.DecodeString(value)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, secret)
+	if _, err := mac.Write(body); err != nil {
+		return false
+	}
+	return hmac.Equal(got, mac.Sum(nil))
+}

--- a/internal/hubserver/github_webhook_apply.go
+++ b/internal/hubserver/github_webhook_apply.go
@@ -177,6 +177,17 @@ func applyIssueWebhook(ctx context.Context, tx *sql.Tx, delivery storedWebhook, 
 	partialStamp := sourceStampFromDelivery(delivery, webhookObjectTime(payload.Issue))
 	target, hasTarget := issueHydrationTarget(repositoryFullName, payload.Issue, partialStamp, "partial_payload")
 	issue, issueStamp, issueComplete := normalizeWebhookIssue(payload.Issue)
+	deleted := strings.EqualFold(strings.TrimSpace(delivery.Action), "deleted")
+	if deleted && issueComplete {
+		issue.State = "closed"
+		issue.Labels = []string{}
+		issue.Assignees = []string{}
+		var err error
+		issueStamp, err = newSourceStampWithVersion(issue.UpdatedAt, "2", issue)
+		if err != nil {
+			return webhookProcessResult{}, err
+		}
+	}
 	repository, repositoryStamp, repositoryComplete := normalizeWebhookRepository(payload.Repository, issueStamp.UpdatedAt)
 	repositoryID, repositoryConflict, err := applyOrResolveWebhookRepository(ctx, tx, repositoryFullName, repository, repositoryStamp, repositoryComplete, now)
 	if err != nil {
@@ -199,7 +210,7 @@ func applyIssueWebhook(ctx context.Context, tx *sql.Tx, delivery storedWebhook, 
 	if err != nil {
 		return webhookProcessResult{}, err
 	}
-	if repositoryConflict || result.Conflict {
+	if !deleted && (repositoryConflict || result.Conflict) {
 		target, _ = issueHydrationTarget(repositoryFullName, payload.Issue, issueStamp, "source_version_conflict")
 		target.RepositoryID = repositoryID
 		if err := enqueueHydration(ctx, tx, delivery.DeliveryID, target, now); err != nil {
@@ -851,12 +862,16 @@ func checkHydrationTargets(repositoryID *int64, repositoryFullName string, check
 }
 
 func newSourceStamp(updatedAt time.Time, canonical any) (sourceStamp, error) {
+	return newSourceStampWithVersion(updatedAt, "1", canonical)
+}
+
+func newSourceStampWithVersion(updatedAt time.Time, version string, canonical any) (sourceStamp, error) {
 	value, err := json.Marshal(canonical)
 	if err != nil {
 		return sourceStamp{}, fmt.Errorf("encode GitHub webhook source version: %w", err)
 	}
 	digest := sha256.Sum256(value)
-	return sourceStamp{UpdatedAt: updatedAt.UTC(), Version: "1:" + hex.EncodeToString(digest[:])}, nil
+	return sourceStamp{UpdatedAt: updatedAt.UTC(), Version: version + ":" + hex.EncodeToString(digest[:])}, nil
 }
 
 func sourceStampFromDelivery(delivery storedWebhook, updatedAt time.Time) sourceStamp {

--- a/internal/hubserver/github_webhook_apply.go
+++ b/internal/hubserver/github_webhook_apply.go
@@ -1,0 +1,1066 @@
+package hubserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type webhookOutcome string
+
+const (
+	webhookOutcomeApplied            webhookOutcome = "applied"
+	webhookOutcomeHydrationRequested webhookOutcome = "hydration_requested"
+	webhookOutcomeIgnored            webhookOutcome = "ignored"
+	webhookOutcomeSuperseded         webhookOutcome = "superseded"
+	webhookOutcomeUnchanged          webhookOutcome = "unchanged"
+)
+
+type githubWebhookPayload struct {
+	Repository  *githubWebhookRepository  `json:"repository"`
+	Issue       *githubWebhookIssue       `json:"issue"`
+	PullRequest *githubWebhookPullRequest `json:"pull_request"`
+	Review      *githubWebhookReview      `json:"review"`
+	CheckRun    *githubWebhookCheck       `json:"check_run"`
+	CheckSuite  *githubWebhookCheck       `json:"check_suite"`
+	SHA         *string                   `json:"sha"`
+}
+
+type githubWebhookRepository struct {
+	DatabaseID *int64              `json:"id"`
+	NodeID     *string             `json:"node_id"`
+	Name       *string             `json:"name"`
+	FullName   *string             `json:"full_name"`
+	Owner      *githubWebhookActor `json:"owner"`
+	UpdatedAt  json.RawMessage     `json:"updated_at"`
+}
+
+type githubWebhookActor struct {
+	Login *string `json:"login"`
+}
+
+type githubWebhookIssue struct {
+	DatabaseID *int64          `json:"id"`
+	NodeID     *string         `json:"node_id"`
+	Number     *int            `json:"number"`
+	Title      *string         `json:"title"`
+	Body       json.RawMessage `json:"body"`
+	HTMLURL    *string         `json:"html_url"`
+	State      *string         `json:"state"`
+	Labels     json.RawMessage `json:"labels"`
+	Assignees  json.RawMessage `json:"assignees"`
+	CreatedAt  json.RawMessage `json:"created_at"`
+	UpdatedAt  json.RawMessage `json:"updated_at"`
+}
+
+type githubWebhookPullRequest struct {
+	DatabaseID *int64            `json:"id"`
+	NodeID     *string           `json:"node_id"`
+	Number     *int              `json:"number"`
+	Title      *string           `json:"title"`
+	HTMLURL    *string           `json:"html_url"`
+	State      *string           `json:"state"`
+	Draft      *bool             `json:"draft"`
+	Head       *githubWebhookRef `json:"head"`
+	Base       *githubWebhookRef `json:"base"`
+	CreatedAt  json.RawMessage   `json:"created_at"`
+	UpdatedAt  json.RawMessage   `json:"updated_at"`
+}
+
+type githubWebhookRef struct {
+	Ref *string `json:"ref"`
+	SHA *string `json:"sha"`
+}
+
+type githubWebhookReview struct {
+	SubmittedAt json.RawMessage `json:"submitted_at"`
+}
+
+type githubWebhookCheck struct {
+	HeadSHA      *string                    `json:"head_sha"`
+	PullRequests []githubWebhookPullRequest `json:"pull_requests"`
+	UpdatedAt    json.RawMessage            `json:"updated_at"`
+	CompletedAt  json.RawMessage            `json:"completed_at"`
+}
+
+type normalizedRepository struct {
+	NodeID     string `json:"node_id"`
+	DatabaseID *int64 `json:"database_id,omitempty"`
+	Owner      string `json:"owner"`
+	Name       string `json:"name"`
+}
+
+type normalizedIssue struct {
+	NodeID     string    `json:"node_id"`
+	DatabaseID *int64    `json:"database_id,omitempty"`
+	Number     int       `json:"number"`
+	Title      string    `json:"title"`
+	Body       string    `json:"body"`
+	URL        string    `json:"url"`
+	State      string    `json:"state"`
+	Labels     []string  `json:"labels"`
+	Assignees  []string  `json:"assignees"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type normalizedPullRequest struct {
+	NodeID     string    `json:"node_id"`
+	DatabaseID *int64    `json:"database_id,omitempty"`
+	Number     int       `json:"number"`
+	Title      string    `json:"title"`
+	URL        string    `json:"url"`
+	State      string    `json:"state"`
+	Draft      bool      `json:"draft"`
+	HeadRef    string    `json:"head_ref"`
+	HeadSHA    string    `json:"head_sha"`
+	BaseRef    string    `json:"base_ref"`
+	BaseSHA    string    `json:"base_sha"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+type sourceStamp struct {
+	UpdatedAt time.Time
+	Version   string
+}
+
+type hydrationTarget struct {
+	RepositoryID       *int64
+	RepositoryFullName string
+	ObjectKind         string
+	ObjectKey          string
+	GitHubNodeID       string
+	GitHubNumber       int
+	HeadSHA            string
+	Reason             string
+	Source             sourceStamp
+}
+
+type projectionApplyResult struct {
+	Changed  bool
+	Stale    bool
+	Conflict bool
+}
+
+func applyWebhook(ctx context.Context, tx *sql.Tx, delivery storedWebhook, now time.Time) (webhookProcessResult, error) {
+	var payload githubWebhookPayload
+	if err := json.Unmarshal(delivery.Payload, &payload); err != nil {
+		return webhookProcessResult{}, fmt.Errorf("decode GitHub webhook payload: %w", err)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(delivery.EventType)) {
+	case "issues":
+		return applyIssueWebhook(ctx, tx, delivery, payload, now)
+	case "pull_request":
+		return applyPullRequestWebhook(ctx, tx, delivery, payload, now, "")
+	case "pull_request_review", "pull_request_review_comment", "pull_request_review_thread":
+		return applyPullRequestWebhook(ctx, tx, delivery, payload, now, "pull_request_reviews")
+	case "check_run", "check_suite", "status":
+		return applyChecksWebhook(ctx, tx, delivery, payload, now)
+	default:
+		return webhookProcessResult{Outcome: webhookOutcomeIgnored}, nil
+	}
+}
+
+func applyIssueWebhook(ctx context.Context, tx *sql.Tx, delivery storedWebhook, payload githubWebhookPayload, now time.Time) (webhookProcessResult, error) {
+	repositoryFullName := webhookRepositoryFullName(payload.Repository)
+	partialStamp := sourceStampFromDelivery(delivery, webhookObjectTime(payload.Issue))
+	target, hasTarget := issueHydrationTarget(repositoryFullName, payload.Issue, partialStamp, "partial_payload")
+	issue, issueStamp, issueComplete := normalizeWebhookIssue(payload.Issue)
+	repository, repositoryStamp, repositoryComplete := normalizeWebhookRepository(payload.Repository, issueStamp.UpdatedAt)
+	repositoryID, repositoryConflict, err := applyOrResolveWebhookRepository(ctx, tx, repositoryFullName, repository, repositoryStamp, repositoryComplete, now)
+	if err != nil {
+		return webhookProcessResult{}, err
+	}
+	if repositoryID != nil {
+		target.RepositoryID = repositoryID
+	}
+	if !issueComplete || repositoryID == nil {
+		if !hasTarget {
+			return webhookProcessResult{Outcome: webhookOutcomeIgnored, RepositoryID: repositoryID}, nil
+		}
+		if err := enqueueHydration(ctx, tx, delivery.DeliveryID, target, now); err != nil {
+			return webhookProcessResult{}, err
+		}
+		return webhookProcessResult{Outcome: webhookOutcomeHydrationRequested, RepositoryID: repositoryID}, nil
+	}
+
+	result, err := applyWebhookIssue(ctx, tx, *repositoryID, issue, issueStamp, now)
+	if err != nil {
+		return webhookProcessResult{}, err
+	}
+	if repositoryConflict || result.Conflict {
+		target, _ = issueHydrationTarget(repositoryFullName, payload.Issue, issueStamp, "source_version_conflict")
+		target.RepositoryID = repositoryID
+		if err := enqueueHydration(ctx, tx, delivery.DeliveryID, target, now); err != nil {
+			return webhookProcessResult{}, err
+		}
+		return webhookProcessResult{Outcome: webhookOutcomeHydrationRequested, RepositoryID: repositoryID}, nil
+	}
+	return webhookProcessResult{Outcome: projectionOutcome(result), RepositoryID: repositoryID}, nil
+}
+
+func applyPullRequestWebhook(ctx context.Context, tx *sql.Tx, delivery storedWebhook, payload githubWebhookPayload, now time.Time, relatedHydrationKind string) (webhookProcessResult, error) {
+	repositoryFullName := webhookRepositoryFullName(payload.Repository)
+	partialStamp := sourceStampFromDelivery(delivery, webhookObjectTime(payload.PullRequest))
+	target, hasTarget := pullRequestHydrationTarget(repositoryFullName, payload.PullRequest, partialStamp, "partial_payload", "pull_request")
+	pullRequest, pullRequestStamp, pullRequestComplete := normalizeWebhookPullRequest(payload.PullRequest)
+	repository, repositoryStamp, repositoryComplete := normalizeWebhookRepository(payload.Repository, pullRequestStamp.UpdatedAt)
+	repositoryID, repositoryConflict, err := applyOrResolveWebhookRepository(ctx, tx, repositoryFullName, repository, repositoryStamp, repositoryComplete, now)
+	if err != nil {
+		return webhookProcessResult{}, err
+	}
+	if repositoryID != nil {
+		target.RepositoryID = repositoryID
+	}
+
+	result := projectionApplyResult{}
+	if pullRequestComplete && repositoryID != nil {
+		result, err = applyWebhookPullRequest(ctx, tx, *repositoryID, pullRequest, pullRequestStamp, now)
+		if err != nil {
+			return webhookProcessResult{}, err
+		}
+	} else if hasTarget {
+		if err := enqueueHydration(ctx, tx, delivery.DeliveryID, target, now); err != nil {
+			return webhookProcessResult{}, err
+		}
+	} else {
+		return webhookProcessResult{Outcome: webhookOutcomeIgnored, RepositoryID: repositoryID}, nil
+	}
+
+	hydrationRequested := !pullRequestComplete || repositoryID == nil
+	if repositoryConflict || result.Conflict {
+		conflictTarget, ok := pullRequestHydrationTarget(repositoryFullName, payload.PullRequest, pullRequestStamp, "source_version_conflict", "pull_request")
+		if ok {
+			conflictTarget.RepositoryID = repositoryID
+			if err := enqueueHydration(ctx, tx, delivery.DeliveryID, conflictTarget, now); err != nil {
+				return webhookProcessResult{}, err
+			}
+			hydrationRequested = true
+		}
+	}
+	if relatedHydrationKind != "" {
+		relatedStamp := sourceStampFromDelivery(delivery, webhookReviewTime(payload.Review))
+		relatedTarget, ok := pullRequestHydrationTarget(repositoryFullName, payload.PullRequest, relatedStamp, "reviews_changed", relatedHydrationKind)
+		if ok {
+			relatedTarget.RepositoryID = repositoryID
+			if err := enqueueHydration(ctx, tx, delivery.DeliveryID, relatedTarget, now); err != nil {
+				return webhookProcessResult{}, err
+			}
+			hydrationRequested = true
+		}
+	}
+	if hydrationRequested {
+		return webhookProcessResult{Outcome: webhookOutcomeHydrationRequested, RepositoryID: repositoryID}, nil
+	}
+	return webhookProcessResult{Outcome: projectionOutcome(result), RepositoryID: repositoryID}, nil
+}
+
+func applyChecksWebhook(ctx context.Context, tx *sql.Tx, delivery storedWebhook, payload githubWebhookPayload, now time.Time) (webhookProcessResult, error) {
+	repositoryFullName := webhookRepositoryFullName(payload.Repository)
+	if repositoryFullName == "" {
+		return webhookProcessResult{Outcome: webhookOutcomeIgnored}, nil
+	}
+	resolvedRepositoryID, found, err := resolveWebhookRepositoryID(ctx, tx, repositoryFullName)
+	if err != nil {
+		return webhookProcessResult{}, err
+	}
+	var repositoryID *int64
+	if found {
+		repositoryID = &resolvedRepositoryID
+	}
+	check := payload.CheckRun
+	if check == nil {
+		check = payload.CheckSuite
+	}
+	stamp := sourceStampFromDelivery(delivery, webhookCheckTime(check))
+	targets := checkHydrationTargets(repositoryID, repositoryFullName, check, payload.SHA, stamp)
+	if len(targets) == 0 {
+		return webhookProcessResult{Outcome: webhookOutcomeIgnored, RepositoryID: repositoryID}, nil
+	}
+	for _, target := range targets {
+		if err := enqueueHydration(ctx, tx, delivery.DeliveryID, target, now); err != nil {
+			return webhookProcessResult{}, err
+		}
+	}
+	return webhookProcessResult{Outcome: webhookOutcomeHydrationRequested, RepositoryID: repositoryID}, nil
+}
+
+func applyOrResolveWebhookRepository(ctx context.Context, tx *sql.Tx, fullName string, repository normalizedRepository, stamp sourceStamp, complete bool, now time.Time) (*int64, bool, error) {
+	if complete {
+		repositoryID, result, err := applyWebhookRepository(ctx, tx, repository, stamp, now)
+		if err != nil {
+			return nil, false, err
+		}
+		return &repositoryID, result.Conflict, nil
+	}
+	repositoryID, found, err := resolveWebhookRepositoryID(ctx, tx, fullName)
+	if err != nil || !found {
+		return nil, false, err
+	}
+	return &repositoryID, false, nil
+}
+
+func applyWebhookRepository(ctx context.Context, tx *sql.Tx, repository normalizedRepository, stamp sourceStamp, now time.Time) (int64, projectionApplyResult, error) {
+	var repositoryID int64
+	var currentVersion string
+	var currentUpdatedAt sql.NullString
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, source_version, source_updated_at
+		FROM repositories
+		WHERE github_node_id = ? OR (lower(github_owner) = lower(?) AND lower(github_name) = lower(?))
+		ORDER BY CASE WHEN github_node_id = ? THEN 0 ELSE 1 END
+		LIMIT 1
+	`, repository.NodeID, repository.Owner, repository.Name, repository.NodeID).Scan(&repositoryID, &currentVersion, &currentUpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		result, err := tx.ExecContext(ctx, `
+			INSERT INTO repositories (
+				github_node_id, github_database_id, github_owner, github_name,
+				last_webhook_at, source_version, source_updated_at, synchronized_at,
+				created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, repository.NodeID, optionalInt64(repository.DatabaseID), repository.Owner, repository.Name,
+			formatWebhookTime(now), stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+			formatWebhookTime(now), formatWebhookTime(now))
+		if err != nil {
+			return 0, projectionApplyResult{}, fmt.Errorf("insert GitHub webhook repository: %w", err)
+		}
+		repositoryID, err = result.LastInsertId()
+		if err != nil {
+			return 0, projectionApplyResult{}, fmt.Errorf("read GitHub webhook repository ID: %w", err)
+		}
+		return repositoryID, projectionApplyResult{Changed: true}, nil
+	}
+	if err != nil {
+		return 0, projectionApplyResult{}, fmt.Errorf("read GitHub webhook repository: %w", err)
+	}
+
+	current, err := storedSourceStamp(currentVersion, currentUpdatedAt)
+	if err != nil {
+		return 0, projectionApplyResult{}, fmt.Errorf("read GitHub webhook repository source: %w", err)
+	}
+	comparison := compareSource(stamp, current)
+	result := projectionApplyResult{
+		Stale:    comparison < 0,
+		Conflict: !current.UpdatedAt.IsZero() && stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version,
+	}
+	if comparison > 0 {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE repositories
+			SET github_node_id = ?,
+				github_database_id = COALESCE(?, github_database_id),
+				github_owner = ?,
+				github_name = ?,
+				last_webhook_at = ?,
+				source_version = ?,
+				source_updated_at = ?,
+				synchronized_at = ?,
+				updated_at = ?
+			WHERE id = ?
+		`, repository.NodeID, optionalInt64(repository.DatabaseID), repository.Owner, repository.Name,
+			formatWebhookTime(now), stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+			formatWebhookTime(now), repositoryID); err != nil {
+			return 0, projectionApplyResult{}, fmt.Errorf("update GitHub webhook repository: %w", err)
+		}
+		result.Changed = true
+	} else if _, err := tx.ExecContext(ctx, `
+		UPDATE repositories SET last_webhook_at = ? WHERE id = ?
+	`, formatWebhookTime(now), repositoryID); err != nil {
+		return 0, projectionApplyResult{}, fmt.Errorf("touch GitHub webhook repository: %w", err)
+	}
+	return repositoryID, result, nil
+}
+
+func resolveWebhookRepositoryID(ctx context.Context, tx *sql.Tx, fullName string) (int64, bool, error) {
+	owner, name, ok := splitRepositoryFullName(fullName)
+	if !ok {
+		return 0, false, nil
+	}
+	var repositoryID int64
+	err := tx.QueryRowContext(ctx, `
+		SELECT id FROM repositories
+		WHERE lower(github_owner) = lower(?) AND lower(github_name) = lower(?)
+	`, owner, name).Scan(&repositoryID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("resolve GitHub webhook repository: %w", err)
+	}
+	return repositoryID, true, nil
+}
+
+func applyWebhookIssue(ctx context.Context, tx *sql.Tx, repositoryID int64, issue normalizedIssue, stamp sourceStamp, now time.Time) (projectionApplyResult, error) {
+	var issueID int64
+	var currentVersion string
+	var currentUpdatedAt string
+	queryErr := tx.QueryRowContext(ctx, `
+		SELECT id, source_version, source_updated_at
+		FROM issues
+		WHERE github_node_id = ? OR (repository_id = ? AND github_number = ?)
+		ORDER BY CASE WHEN github_node_id = ? THEN 0 ELSE 1 END
+		LIMIT 1
+	`, issue.NodeID, repositoryID, issue.Number, issue.NodeID).Scan(&issueID, &currentVersion, &currentUpdatedAt)
+	if queryErr != nil && !errors.Is(queryErr, sql.ErrNoRows) {
+		return projectionApplyResult{}, fmt.Errorf("read GitHub webhook issue: %w", queryErr)
+	}
+	labelsJSON, err := json.Marshal(issue.Labels)
+	if err != nil {
+		return projectionApplyResult{}, fmt.Errorf("encode GitHub webhook issue labels: %w", err)
+	}
+	assigneesJSON, err := json.Marshal(issue.Assignees)
+	if err != nil {
+		return projectionApplyResult{}, fmt.Errorf("encode GitHub webhook issue assignees: %w", err)
+	}
+	resolvedWorkflowStateID, hasWorkflowState, err := resolveWebhookWorkflowStateID(ctx, tx, repositoryID, issue.Labels)
+	if err != nil {
+		return projectionApplyResult{}, err
+	}
+	var workflowStateID *int64
+	if hasWorkflowState {
+		workflowStateID = &resolvedWorkflowStateID
+	}
+	if errors.Is(queryErr, sql.ErrNoRows) {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO issues (
+				repository_id, workflow_state_id, github_node_id, github_database_id, github_number,
+				title, body, url, github_state, labels_json, assignees_json,
+				source_version, source_updated_at, synchronized_at, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, repositoryID, optionalInt64(workflowStateID), issue.NodeID, optionalInt64(issue.DatabaseID), issue.Number,
+			issue.Title, issue.Body, issue.URL, issue.State, string(labelsJSON), string(assigneesJSON),
+			stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+			formatWebhookTime(issue.CreatedAt), formatWebhookTime(issue.UpdatedAt))
+		if err != nil {
+			return projectionApplyResult{}, fmt.Errorf("insert GitHub webhook issue: %w", err)
+		}
+		return projectionApplyResult{Changed: true}, nil
+	}
+	currentTime, err := time.Parse(time.RFC3339Nano, currentUpdatedAt)
+	if err != nil {
+		return projectionApplyResult{}, fmt.Errorf("parse GitHub webhook issue source timestamp: %w", err)
+	}
+	current := sourceStamp{UpdatedAt: currentTime, Version: currentVersion}
+	comparison := compareSource(stamp, current)
+	result := projectionApplyResult{
+		Stale:    comparison < 0,
+		Conflict: stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version,
+	}
+	if comparison <= 0 {
+		return result, nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE issues
+		SET repository_id = ?,
+			workflow_state_id = ?,
+			github_node_id = ?,
+			github_database_id = COALESCE(?, github_database_id),
+			github_number = ?,
+			title = ?,
+			body = ?,
+			url = ?,
+			github_state = ?,
+			labels_json = ?,
+			assignees_json = ?,
+			source_version = ?,
+			source_updated_at = ?,
+			synchronized_at = ?,
+			created_at = ?,
+			updated_at = ?
+		WHERE id = ?
+	`, repositoryID, optionalInt64(workflowStateID), issue.NodeID, optionalInt64(issue.DatabaseID), issue.Number,
+		issue.Title, issue.Body, issue.URL, issue.State, string(labelsJSON), string(assigneesJSON),
+		stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+		formatWebhookTime(issue.CreatedAt), formatWebhookTime(issue.UpdatedAt), issueID); err != nil {
+		return projectionApplyResult{}, fmt.Errorf("update GitHub webhook issue: %w", err)
+	}
+	result.Changed = true
+	return result, nil
+}
+
+func resolveWebhookWorkflowStateID(ctx context.Context, tx *sql.Tx, repositoryID int64, labels []string) (int64, bool, error) {
+	if len(labels) == 0 {
+		return 0, false, nil
+	}
+	args := make([]any, 0, len(labels)+1)
+	args = append(args, repositoryID)
+	for _, label := range labels {
+		args = append(args, strings.ToLower(strings.TrimSpace(label)))
+	}
+	var workflowStateID int64
+	err := tx.QueryRowContext(ctx, `
+		SELECT id
+		FROM workflow_states
+		WHERE repository_id = ? AND lower(source_name) IN (`+placeholders(len(labels))+`)
+		ORDER BY id
+		LIMIT 1
+	`, args...).Scan(&workflowStateID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("resolve GitHub webhook workflow state: %w", err)
+	}
+	return workflowStateID, true, nil
+}
+
+func applyWebhookPullRequest(ctx context.Context, tx *sql.Tx, repositoryID int64, pullRequest normalizedPullRequest, stamp sourceStamp, now time.Time) (projectionApplyResult, error) {
+	var pullRequestID int64
+	var currentVersion string
+	var currentUpdatedAt string
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, source_version, source_updated_at
+		FROM pull_requests
+		WHERE github_node_id = ? OR (repository_id = ? AND github_number = ?)
+		ORDER BY CASE WHEN github_node_id = ? THEN 0 ELSE 1 END
+		LIMIT 1
+	`, pullRequest.NodeID, repositoryID, pullRequest.Number, pullRequest.NodeID).Scan(&pullRequestID, &currentVersion, &currentUpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO pull_requests (
+				repository_id, github_node_id, github_database_id, github_number,
+				title, url, github_state, draft, head_ref, head_sha, base_ref, base_sha,
+				source_version, source_updated_at, synchronized_at, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, repositoryID, pullRequest.NodeID, optionalInt64(pullRequest.DatabaseID), pullRequest.Number,
+			pullRequest.Title, pullRequest.URL, pullRequest.State, pullRequest.Draft,
+			pullRequest.HeadRef, pullRequest.HeadSHA, pullRequest.BaseRef, pullRequest.BaseSHA,
+			stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+			formatWebhookTime(pullRequest.CreatedAt), formatWebhookTime(pullRequest.UpdatedAt))
+		if err != nil {
+			return projectionApplyResult{}, fmt.Errorf("insert GitHub webhook pull request: %w", err)
+		}
+		return projectionApplyResult{Changed: true}, nil
+	}
+	if err != nil {
+		return projectionApplyResult{}, fmt.Errorf("read GitHub webhook pull request: %w", err)
+	}
+	currentTime, err := time.Parse(time.RFC3339Nano, currentUpdatedAt)
+	if err != nil {
+		return projectionApplyResult{}, fmt.Errorf("parse GitHub webhook pull request source timestamp: %w", err)
+	}
+	current := sourceStamp{UpdatedAt: currentTime, Version: currentVersion}
+	comparison := compareSource(stamp, current)
+	result := projectionApplyResult{
+		Stale:    comparison < 0,
+		Conflict: stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version,
+	}
+	if comparison <= 0 {
+		return result, nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE pull_requests
+		SET repository_id = ?,
+			github_node_id = ?,
+			github_database_id = COALESCE(?, github_database_id),
+			github_number = ?,
+			title = ?,
+			url = ?,
+			github_state = ?,
+			draft = ?,
+			head_ref = ?,
+			head_sha = ?,
+			base_ref = ?,
+			base_sha = ?,
+			source_version = ?,
+			source_updated_at = ?,
+			synchronized_at = ?,
+			created_at = ?,
+			updated_at = ?
+		WHERE id = ?
+	`, repositoryID, pullRequest.NodeID, optionalInt64(pullRequest.DatabaseID), pullRequest.Number,
+		pullRequest.Title, pullRequest.URL, pullRequest.State, pullRequest.Draft,
+		pullRequest.HeadRef, pullRequest.HeadSHA, pullRequest.BaseRef, pullRequest.BaseSHA,
+		stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+		formatWebhookTime(pullRequest.CreatedAt), formatWebhookTime(pullRequest.UpdatedAt), pullRequestID); err != nil {
+		return projectionApplyResult{}, fmt.Errorf("update GitHub webhook pull request: %w", err)
+	}
+	result.Changed = true
+	return result, nil
+}
+
+func enqueueHydration(ctx context.Context, tx *sql.Tx, deliveryID string, target hydrationTarget, now time.Time) error {
+	if target.RepositoryFullName == "" || target.ObjectKind == "" || target.ObjectKey == "" || target.Source.Version == "" {
+		return errors.New("GitHub webhook hydration target is incomplete")
+	}
+	var sourceUpdatedAt any
+	if !target.Source.UpdatedAt.IsZero() {
+		sourceUpdatedAt = formatWebhookTime(target.Source.UpdatedAt)
+	}
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO github_hydration_requests (
+			repository_id, repository_full_name, object_kind, object_key,
+			github_node_id, github_number, head_sha, reason,
+			requested_source_updated_at, requested_source_version,
+			first_delivery_id, last_delivery_id, status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+		ON CONFLICT(repository_full_name, object_kind, object_key) WHERE status = 'pending'
+		DO UPDATE SET
+			repository_id = COALESCE(excluded.repository_id, github_hydration_requests.repository_id),
+			github_node_id = COALESCE(excluded.github_node_id, github_hydration_requests.github_node_id),
+			github_number = COALESCE(excluded.github_number, github_hydration_requests.github_number),
+			head_sha = COALESCE(excluded.head_sha, github_hydration_requests.head_sha),
+			reason = max(excluded.reason, github_hydration_requests.reason),
+			requested_source_updated_at = CASE
+				WHEN
+					(github_hydration_requests.requested_source_updated_at IS NULL AND excluded.requested_source_updated_at IS NOT NULL)
+					OR (
+						github_hydration_requests.requested_source_updated_at IS NULL
+						AND excluded.requested_source_updated_at IS NULL
+						AND excluded.requested_source_version > github_hydration_requests.requested_source_version
+					)
+					OR (
+						excluded.requested_source_updated_at IS NOT NULL
+						AND github_hydration_requests.requested_source_updated_at IS NOT NULL
+						AND (
+							excluded.requested_source_updated_at > github_hydration_requests.requested_source_updated_at
+							OR (
+								excluded.requested_source_updated_at = github_hydration_requests.requested_source_updated_at
+								AND excluded.requested_source_version > github_hydration_requests.requested_source_version
+							)
+						)
+					)
+				THEN excluded.requested_source_updated_at
+				ELSE github_hydration_requests.requested_source_updated_at
+			END,
+			requested_source_version = CASE
+				WHEN
+					(github_hydration_requests.requested_source_updated_at IS NULL AND excluded.requested_source_updated_at IS NOT NULL)
+					OR (
+						github_hydration_requests.requested_source_updated_at IS NULL
+						AND excluded.requested_source_updated_at IS NULL
+						AND excluded.requested_source_version > github_hydration_requests.requested_source_version
+					)
+					OR (
+						excluded.requested_source_updated_at IS NOT NULL
+						AND github_hydration_requests.requested_source_updated_at IS NOT NULL
+						AND (
+							excluded.requested_source_updated_at > github_hydration_requests.requested_source_updated_at
+							OR (
+								excluded.requested_source_updated_at = github_hydration_requests.requested_source_updated_at
+								AND excluded.requested_source_version > github_hydration_requests.requested_source_version
+							)
+						)
+					)
+				THEN excluded.requested_source_version
+				ELSE github_hydration_requests.requested_source_version
+			END,
+			last_delivery_id = excluded.last_delivery_id,
+			request_count = github_hydration_requests.request_count + 1,
+			updated_at = excluded.updated_at
+	`, optionalInt64(target.RepositoryID), target.RepositoryFullName, target.ObjectKind, target.ObjectKey,
+		optionalString(target.GitHubNodeID), optionalInt(target.GitHubNumber), optionalString(target.HeadSHA), target.Reason,
+		sourceUpdatedAt, target.Source.Version, deliveryID, deliveryID, formatWebhookTime(now), formatWebhookTime(now))
+	if err != nil {
+		return fmt.Errorf("enqueue GitHub webhook hydration: %w", err)
+	}
+	return nil
+}
+
+func normalizeWebhookRepository(repository *githubWebhookRepository, fallbackUpdatedAt time.Time) (normalizedRepository, sourceStamp, bool) {
+	if repository == nil {
+		return normalizedRepository{}, sourceStamp{}, false
+	}
+	fullName := webhookRepositoryFullName(repository)
+	owner, name, ok := splitRepositoryFullName(fullName)
+	if !ok || repository.NodeID == nil || strings.TrimSpace(*repository.NodeID) == "" {
+		return normalizedRepository{}, sourceStamp{}, false
+	}
+	updatedAt, validUpdatedAt := parseWebhookTime(repository.UpdatedAt)
+	if !validUpdatedAt {
+		updatedAt = fallbackUpdatedAt
+	}
+	if updatedAt.IsZero() {
+		return normalizedRepository{}, sourceStamp{}, false
+	}
+	normalized := normalizedRepository{
+		NodeID:     strings.TrimSpace(*repository.NodeID),
+		DatabaseID: positiveInt64(repository.DatabaseID),
+		Owner:      owner,
+		Name:       name,
+	}
+	stamp, err := newSourceStamp(updatedAt, normalized)
+	if err != nil {
+		return normalizedRepository{}, sourceStamp{}, false
+	}
+	return normalized, stamp, true
+}
+
+func normalizeWebhookIssue(issue *githubWebhookIssue) (normalizedIssue, sourceStamp, bool) {
+	if issue == nil || issue.NodeID == nil || issue.Number == nil || issue.Title == nil || issue.HTMLURL == nil || issue.State == nil {
+		return normalizedIssue{}, sourceStamp{}, false
+	}
+	body, bodyOK := webhookNullableString(issue.Body)
+	labels, labelsOK := webhookStringList(issue.Labels, "name")
+	assignees, assigneesOK := webhookStringList(issue.Assignees, "login")
+	createdAt, createdOK := parseWebhookTime(issue.CreatedAt)
+	updatedAt, updatedOK := parseWebhookTime(issue.UpdatedAt)
+	if strings.TrimSpace(*issue.NodeID) == "" || *issue.Number <= 0 || strings.TrimSpace(*issue.Title) == "" ||
+		strings.TrimSpace(*issue.HTMLURL) == "" || strings.TrimSpace(*issue.State) == "" ||
+		!bodyOK || !labelsOK || !assigneesOK || !createdOK || !updatedOK {
+		return normalizedIssue{}, sourceStamp{}, false
+	}
+	normalized := normalizedIssue{
+		NodeID:     strings.TrimSpace(*issue.NodeID),
+		DatabaseID: positiveInt64(issue.DatabaseID),
+		Number:     *issue.Number,
+		Title:      *issue.Title,
+		Body:       body,
+		URL:        strings.TrimSpace(*issue.HTMLURL),
+		State:      strings.ToLower(strings.TrimSpace(*issue.State)),
+		Labels:     labels,
+		Assignees:  assignees,
+		CreatedAt:  createdAt,
+		UpdatedAt:  updatedAt,
+	}
+	stamp, err := newSourceStamp(updatedAt, normalized)
+	if err != nil {
+		return normalizedIssue{}, sourceStamp{}, false
+	}
+	return normalized, stamp, true
+}
+
+func normalizeWebhookPullRequest(pullRequest *githubWebhookPullRequest) (normalizedPullRequest, sourceStamp, bool) {
+	if pullRequest == nil || pullRequest.NodeID == nil || pullRequest.Number == nil || pullRequest.Title == nil ||
+		pullRequest.HTMLURL == nil || pullRequest.State == nil || pullRequest.Draft == nil || pullRequest.Head == nil || pullRequest.Base == nil ||
+		pullRequest.Head.Ref == nil || pullRequest.Head.SHA == nil || pullRequest.Base.Ref == nil || pullRequest.Base.SHA == nil {
+		return normalizedPullRequest{}, sourceStamp{}, false
+	}
+	createdAt, createdOK := parseWebhookTime(pullRequest.CreatedAt)
+	updatedAt, updatedOK := parseWebhookTime(pullRequest.UpdatedAt)
+	if strings.TrimSpace(*pullRequest.NodeID) == "" || *pullRequest.Number <= 0 || strings.TrimSpace(*pullRequest.Title) == "" ||
+		strings.TrimSpace(*pullRequest.HTMLURL) == "" || strings.TrimSpace(*pullRequest.State) == "" ||
+		strings.TrimSpace(*pullRequest.Head.Ref) == "" || strings.TrimSpace(*pullRequest.Head.SHA) == "" ||
+		strings.TrimSpace(*pullRequest.Base.Ref) == "" || strings.TrimSpace(*pullRequest.Base.SHA) == "" || !createdOK || !updatedOK {
+		return normalizedPullRequest{}, sourceStamp{}, false
+	}
+	normalized := normalizedPullRequest{
+		NodeID:     strings.TrimSpace(*pullRequest.NodeID),
+		DatabaseID: positiveInt64(pullRequest.DatabaseID),
+		Number:     *pullRequest.Number,
+		Title:      *pullRequest.Title,
+		URL:        strings.TrimSpace(*pullRequest.HTMLURL),
+		State:      strings.ToLower(strings.TrimSpace(*pullRequest.State)),
+		Draft:      *pullRequest.Draft,
+		HeadRef:    strings.TrimSpace(*pullRequest.Head.Ref),
+		HeadSHA:    strings.TrimSpace(*pullRequest.Head.SHA),
+		BaseRef:    strings.TrimSpace(*pullRequest.Base.Ref),
+		BaseSHA:    strings.TrimSpace(*pullRequest.Base.SHA),
+		CreatedAt:  createdAt,
+		UpdatedAt:  updatedAt,
+	}
+	stamp, err := newSourceStamp(updatedAt, normalized)
+	if err != nil {
+		return normalizedPullRequest{}, sourceStamp{}, false
+	}
+	return normalized, stamp, true
+}
+
+func issueHydrationTarget(repositoryFullName string, issue *githubWebhookIssue, stamp sourceStamp, reason string) (hydrationTarget, bool) {
+	target := hydrationTarget{RepositoryFullName: repositoryFullName, ObjectKind: "issue", Reason: reason, Source: stamp}
+	if issue == nil || repositoryFullName == "" {
+		return target, false
+	}
+	if issue.Number != nil && *issue.Number > 0 {
+		target.GitHubNumber = *issue.Number
+		target.ObjectKey = strconv.Itoa(*issue.Number)
+	}
+	if issue.NodeID != nil {
+		target.GitHubNodeID = strings.TrimSpace(*issue.NodeID)
+		if target.ObjectKey == "" {
+			target.ObjectKey = target.GitHubNodeID
+		}
+	}
+	return target, target.ObjectKey != ""
+}
+
+func pullRequestHydrationTarget(repositoryFullName string, pullRequest *githubWebhookPullRequest, stamp sourceStamp, reason string, kind string) (hydrationTarget, bool) {
+	target := hydrationTarget{RepositoryFullName: repositoryFullName, ObjectKind: kind, Reason: reason, Source: stamp}
+	if pullRequest == nil || repositoryFullName == "" {
+		return target, false
+	}
+	if pullRequest.Number != nil && *pullRequest.Number > 0 {
+		target.GitHubNumber = *pullRequest.Number
+		target.ObjectKey = strconv.Itoa(*pullRequest.Number)
+	}
+	if pullRequest.NodeID != nil {
+		target.GitHubNodeID = strings.TrimSpace(*pullRequest.NodeID)
+		if target.ObjectKey == "" {
+			target.ObjectKey = target.GitHubNodeID
+		}
+	}
+	return target, target.ObjectKey != ""
+}
+
+func checkHydrationTargets(repositoryID *int64, repositoryFullName string, check *githubWebhookCheck, fallbackSHA *string, stamp sourceStamp) []hydrationTarget {
+	targets := make([]hydrationTarget, 0)
+	seen := make(map[int]struct{})
+	if check != nil {
+		for _, pullRequest := range check.PullRequests {
+			if pullRequest.Number == nil || *pullRequest.Number <= 0 {
+				continue
+			}
+			number := *pullRequest.Number
+			if _, ok := seen[number]; ok {
+				continue
+			}
+			seen[number] = struct{}{}
+			targets = append(targets, hydrationTarget{
+				RepositoryID:       repositoryID,
+				RepositoryFullName: repositoryFullName,
+				ObjectKind:         "pull_request_checks",
+				ObjectKey:          strconv.Itoa(number),
+				GitHubNumber:       number,
+				Reason:             "checks_changed",
+				Source:             stamp,
+			})
+		}
+	}
+	if len(targets) > 0 {
+		return targets
+	}
+	sha := ""
+	if check != nil && check.HeadSHA != nil {
+		sha = strings.TrimSpace(*check.HeadSHA)
+	}
+	if sha == "" && fallbackSHA != nil {
+		sha = strings.TrimSpace(*fallbackSHA)
+	}
+	if sha == "" {
+		return targets
+	}
+	return append(targets, hydrationTarget{
+		RepositoryID:       repositoryID,
+		RepositoryFullName: repositoryFullName,
+		ObjectKind:         "commit_checks",
+		ObjectKey:          sha,
+		HeadSHA:            sha,
+		Reason:             "checks_changed",
+		Source:             stamp,
+	})
+}
+
+func newSourceStamp(updatedAt time.Time, canonical any) (sourceStamp, error) {
+	value, err := json.Marshal(canonical)
+	if err != nil {
+		return sourceStamp{}, fmt.Errorf("encode GitHub webhook source version: %w", err)
+	}
+	digest := sha256.Sum256(value)
+	return sourceStamp{UpdatedAt: updatedAt.UTC(), Version: "1:" + hex.EncodeToString(digest[:])}, nil
+}
+
+func sourceStampFromDelivery(delivery storedWebhook, updatedAt time.Time) sourceStamp {
+	version := delivery.PayloadSHA256
+	if version == "" {
+		digest := sha256.Sum256(delivery.Payload)
+		version = hex.EncodeToString(digest[:])
+	}
+	return sourceStamp{UpdatedAt: updatedAt.UTC(), Version: "1:" + version}
+}
+
+func storedSourceStamp(version string, updatedAt sql.NullString) (sourceStamp, error) {
+	if !updatedAt.Valid || strings.TrimSpace(updatedAt.String) == "" {
+		return sourceStamp{Version: version}, nil
+	}
+	value, err := time.Parse(time.RFC3339Nano, updatedAt.String)
+	if err != nil {
+		return sourceStamp{}, err
+	}
+	return sourceStamp{UpdatedAt: value.UTC(), Version: version}, nil
+}
+
+func compareSource(incoming sourceStamp, current sourceStamp) int {
+	if incoming.UpdatedAt.After(current.UpdatedAt) {
+		return 1
+	}
+	if incoming.UpdatedAt.Before(current.UpdatedAt) {
+		return -1
+	}
+	return strings.Compare(incoming.Version, current.Version)
+}
+
+func projectionOutcome(result projectionApplyResult) webhookOutcome {
+	if result.Changed {
+		return webhookOutcomeApplied
+	}
+	if result.Stale {
+		return webhookOutcomeSuperseded
+	}
+	return webhookOutcomeUnchanged
+}
+
+func webhookRepositoryFullName(repository *githubWebhookRepository) string {
+	if repository == nil {
+		return ""
+	}
+	if repository.FullName != nil && strings.TrimSpace(*repository.FullName) != "" {
+		return strings.TrimSpace(*repository.FullName)
+	}
+	if repository.Owner == nil || repository.Owner.Login == nil || repository.Name == nil {
+		return ""
+	}
+	owner := strings.TrimSpace(*repository.Owner.Login)
+	name := strings.TrimSpace(*repository.Name)
+	if owner == "" || name == "" {
+		return ""
+	}
+	return owner + "/" + name
+}
+
+func splitRepositoryFullName(fullName string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(fullName), "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", false
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), true
+}
+
+func webhookObjectTime(object any) time.Time {
+	switch value := object.(type) {
+	case *githubWebhookIssue:
+		if value != nil {
+			updatedAt, _ := parseWebhookTime(value.UpdatedAt)
+			return updatedAt
+		}
+	case *githubWebhookPullRequest:
+		if value != nil {
+			updatedAt, _ := parseWebhookTime(value.UpdatedAt)
+			return updatedAt
+		}
+	}
+	return time.Time{}
+}
+
+func webhookReviewTime(review *githubWebhookReview) time.Time {
+	if review == nil {
+		return time.Time{}
+	}
+	value, _ := parseWebhookTime(review.SubmittedAt)
+	return value
+}
+
+func webhookCheckTime(check *githubWebhookCheck) time.Time {
+	if check == nil {
+		return time.Time{}
+	}
+	if value, ok := parseWebhookTime(check.UpdatedAt); ok {
+		return value
+	}
+	value, _ := parseWebhookTime(check.CompletedAt)
+	return value
+}
+
+func parseWebhookTime(raw json.RawMessage) (time.Time, bool) {
+	value := bytes.TrimSpace(raw)
+	if len(value) == 0 || bytes.Equal(value, []byte("null")) {
+		return time.Time{}, false
+	}
+	var text string
+	if err := json.Unmarshal(value, &text); err == nil {
+		parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(text))
+		return parsed.UTC(), err == nil
+	}
+	var number json.Number
+	if err := json.Unmarshal(value, &number); err != nil {
+		return time.Time{}, false
+	}
+	seconds, err := strconv.ParseInt(number.String(), 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	if seconds > 1_000_000_000_000 {
+		return time.UnixMilli(seconds).UTC(), true
+	}
+	return time.Unix(seconds, 0).UTC(), true
+}
+
+func webhookNullableString(raw json.RawMessage) (string, bool) {
+	value := bytes.TrimSpace(raw)
+	if len(value) == 0 {
+		return "", false
+	}
+	if bytes.Equal(value, []byte("null")) {
+		return "", true
+	}
+	var text string
+	if err := json.Unmarshal(value, &text); err != nil {
+		return "", false
+	}
+	return text, true
+}
+
+func webhookStringList(raw json.RawMessage, objectField string) ([]string, bool) {
+	value := bytes.TrimSpace(raw)
+	if len(value) == 0 || bytes.Equal(value, []byte("null")) {
+		return nil, false
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(value, &entries); err != nil {
+		return nil, false
+	}
+	values := make([]string, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		var text string
+		if err := json.Unmarshal(entry, &text); err != nil {
+			var object map[string]json.RawMessage
+			if err := json.Unmarshal(entry, &object); err != nil {
+				return nil, false
+			}
+			field, ok := object[objectField]
+			if !ok || json.Unmarshal(field, &text) != nil {
+				return nil, false
+			}
+		}
+		text = strings.TrimSpace(text)
+		if text == "" {
+			return nil, false
+		}
+		if _, ok := seen[text]; ok {
+			continue
+		}
+		seen[text] = struct{}{}
+		values = append(values, text)
+	}
+	sort.Strings(values)
+	return values, true
+}
+
+func positiveInt64(value *int64) *int64 {
+	if value == nil || *value <= 0 {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func optionalInt64(value *int64) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func optionalInt(value int) any {
+	if value <= 0 {
+		return nil
+	}
+	return value
+}
+
+func optionalString(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/hubserver/github_webhook_store.go
+++ b/internal/hubserver/github_webhook_store.go
@@ -1,0 +1,281 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	webhookRetryDelay = time.Minute
+	webhookTimeFormat = "2006-01-02T15:04:05.000000000Z"
+)
+
+type storedWebhook struct {
+	InboxID       int64
+	DeliveryID    string
+	EventType     string
+	Action        string
+	Payload       []byte
+	PayloadSHA256 string
+	Status        string
+}
+
+type webhookProcessResult struct {
+	Outcome      webhookOutcome
+	RepositoryID *int64
+}
+
+func (d *database) recordWebhook(ctx context.Context, receipt webhookReceipt) (webhookReceiptResult, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return webhookReceiptResult{}, fmt.Errorf("begin GitHub webhook receipt: %w", err)
+	}
+	defer tx.Rollback()
+
+	receivedAt := formatWebhookTime(receipt.ReceivedAt)
+	var inboxID int64
+	err = tx.QueryRowContext(ctx, `
+		INSERT INTO github_webhook_inbox (
+			delivery_id,
+			event_type,
+			action,
+			headers_json,
+			payload_sha256,
+			payload_bytes,
+			status,
+			signature_verified_at,
+			received_at,
+			last_received_at,
+			created_at,
+			updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+		ON CONFLICT(delivery_id) DO NOTHING
+		RETURNING id
+	`,
+		receipt.DeliveryID,
+		receipt.EventType,
+		receipt.Action,
+		receipt.HeadersJSON,
+		receipt.PayloadSHA256,
+		len(receipt.Payload),
+		receivedAt,
+		receivedAt,
+		receivedAt,
+		receivedAt,
+		receivedAt,
+	).Scan(&inboxID)
+	inserted := err == nil
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return webhookReceiptResult{}, fmt.Errorf("insert GitHub webhook receipt: %w", err)
+	}
+
+	if !inserted {
+		var eventType string
+		var payloadSHA256 string
+		var payloadBytes int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT id, event_type, payload_sha256, payload_bytes
+			FROM github_webhook_inbox
+			WHERE delivery_id = ?
+		`, receipt.DeliveryID).Scan(&inboxID, &eventType, &payloadSHA256, &payloadBytes); err != nil {
+			return webhookReceiptResult{}, fmt.Errorf("read duplicate GitHub webhook receipt: %w", err)
+		}
+		if eventType != receipt.EventType || payloadSHA256 != receipt.PayloadSHA256 || payloadBytes != len(receipt.Payload) {
+			return webhookReceiptResult{}, ErrWebhookDeliveryConflict
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE github_webhook_inbox
+			SET redelivery_count = redelivery_count + 1,
+				last_received_at = ?,
+				updated_at = ?
+			WHERE id = ?
+		`, receivedAt, receivedAt, inboxID); err != nil {
+			return webhookReceiptResult{}, fmt.Errorf("record GitHub webhook redelivery: %w", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO github_webhook_payloads (inbox_id, body, expires_at, created_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(inbox_id) DO UPDATE SET
+			body = excluded.body,
+			expires_at = excluded.expires_at,
+			created_at = excluded.created_at
+	`, inboxID, receipt.Payload, formatWebhookTime(receipt.PayloadExpiresAt), receivedAt); err != nil {
+		return webhookReceiptResult{}, fmt.Errorf("store GitHub webhook payload: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return webhookReceiptResult{}, fmt.Errorf("commit GitHub webhook receipt: %w", err)
+	}
+	return webhookReceiptResult{InboxID: inboxID, Duplicate: !inserted}, nil
+}
+
+func (d *database) processWebhook(ctx context.Context, inboxID int64, now time.Time) error {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin GitHub webhook processing: %w", err)
+	}
+
+	var delivery storedWebhook
+	err = tx.QueryRowContext(ctx, `
+		SELECT i.id, i.delivery_id, i.event_type, COALESCE(i.action, ''), p.body, i.payload_sha256, i.status
+		FROM github_webhook_inbox i
+		LEFT JOIN github_webhook_payloads p ON p.inbox_id = i.id
+		WHERE i.id = ?
+	`, inboxID).Scan(
+		&delivery.InboxID,
+		&delivery.DeliveryID,
+		&delivery.EventType,
+		&delivery.Action,
+		&delivery.Payload,
+		&delivery.PayloadSHA256,
+		&delivery.Status,
+	)
+	if err != nil {
+		rollbackErr := tx.Rollback()
+		return errors.Join(fmt.Errorf("read GitHub webhook delivery: %w", err), rollbackErr)
+	}
+	if delivery.Status == "processed" || delivery.Status == "ignored" {
+		return tx.Rollback()
+	}
+	if len(delivery.Payload) == 0 {
+		processingErr := errors.New("GitHub webhook payload is unavailable")
+		rollbackErr := tx.Rollback()
+		failureErr := d.markWebhookFailed(ctx, inboxID, now, processingErr)
+		return errors.Join(processingErr, rollbackErr, failureErr)
+	}
+
+	processedAt := formatWebhookTime(now)
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE github_webhook_inbox
+		SET status = 'processing',
+			processing_started_at = ?,
+			last_error = NULL,
+			updated_at = ?
+		WHERE id = ?
+	`, processedAt, processedAt, inboxID); err != nil {
+		rollbackErr := tx.Rollback()
+		return errors.Join(fmt.Errorf("mark GitHub webhook processing: %w", err), rollbackErr)
+	}
+
+	result, err := applyWebhook(ctx, tx, delivery, now)
+	if err != nil {
+		rollbackErr := tx.Rollback()
+		failureErr := d.markWebhookFailed(ctx, inboxID, now, err)
+		return errors.Join(err, rollbackErr, failureErr)
+	}
+	status := "processed"
+	if result.Outcome == webhookOutcomeIgnored {
+		status = "ignored"
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE github_webhook_inbox
+		SET repository_id = COALESCE(?, repository_id),
+			status = ?,
+			outcome = ?,
+			attempts = attempts + 1,
+			next_retry_at = NULL,
+			processed_at = ?,
+			last_error = NULL,
+			updated_at = ?
+		WHERE id = ?
+	`, result.RepositoryID, status, result.Outcome, processedAt, processedAt, inboxID); err != nil {
+		rollbackErr := tx.Rollback()
+		failureErr := d.markWebhookFailed(ctx, inboxID, now, err)
+		return errors.Join(fmt.Errorf("complete GitHub webhook processing: %w", err), rollbackErr, failureErr)
+	}
+	if err := tx.Commit(); err != nil {
+		failureErr := d.markWebhookFailed(ctx, inboxID, now, err)
+		return errors.Join(fmt.Errorf("commit GitHub webhook processing: %w", err), failureErr)
+	}
+	return nil
+}
+
+func (d *database) markWebhookFailed(ctx context.Context, inboxID int64, now time.Time, processingErr error) error {
+	timestamp := formatWebhookTime(now)
+	_, err := d.db.ExecContext(ctx, `
+		UPDATE github_webhook_inbox
+		SET status = 'failed',
+			attempts = attempts + 1,
+			next_retry_at = ?,
+			processing_started_at = ?,
+			last_error = ?,
+			updated_at = ?
+		WHERE id = ? AND status NOT IN ('processed', 'ignored')
+	`, formatWebhookTime(now.Add(webhookRetryDelay)), timestamp, processingErr.Error(), timestamp, inboxID)
+	if err != nil {
+		return fmt.Errorf("record GitHub webhook failure: %w", err)
+	}
+	return nil
+}
+
+func (d *database) processPendingWebhooks(ctx context.Context, now time.Time) error {
+	inboxIDs, err := d.pendingWebhookIDs(ctx, now)
+	if err != nil {
+		return err
+	}
+
+	var processErr error
+	for _, inboxID := range inboxIDs {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(processErr, err)
+		}
+		if err := d.processWebhook(ctx, inboxID, now); err != nil {
+			processErr = errors.Join(processErr, err)
+		}
+	}
+	return processErr
+}
+
+func (d *database) pendingWebhookIDs(ctx context.Context, now time.Time) ([]int64, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT id
+		FROM github_webhook_inbox
+		WHERE status IN ('pending', 'processing', 'failed')
+			AND (next_retry_at IS NULL OR next_retry_at <= ?)
+		ORDER BY received_at, id
+	`, formatWebhookTime(now))
+	if err != nil {
+		return nil, fmt.Errorf("list pending GitHub webhooks: %w", err)
+	}
+	defer rows.Close()
+	var inboxIDs []int64
+	for rows.Next() {
+		var inboxID int64
+		if err := rows.Scan(&inboxID); err != nil {
+			return nil, fmt.Errorf("scan pending GitHub webhook: %w", err)
+		}
+		inboxIDs = append(inboxIDs, inboxID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending GitHub webhooks: %w", err)
+	}
+	return inboxIDs, nil
+}
+
+func (d *database) purgeWebhookPayloads(ctx context.Context, now time.Time) (int64, error) {
+	result, err := d.db.ExecContext(ctx, `
+		DELETE FROM github_webhook_payloads
+		WHERE expires_at <= ?
+			AND inbox_id IN (
+				SELECT id
+				FROM github_webhook_inbox
+				WHERE status IN ('processed', 'ignored')
+			)
+	`, formatWebhookTime(now))
+	if err != nil {
+		return 0, fmt.Errorf("purge GitHub webhook payloads: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count purged GitHub webhook payloads: %w", err)
+	}
+	return deleted, nil
+}
+
+func formatWebhookTime(value time.Time) string {
+	return value.UTC().Format(webhookTimeFormat)
+}

--- a/internal/hubserver/github_webhook_test.go
+++ b/internal/hubserver/github_webhook_test.go
@@ -1,0 +1,647 @@
+package hubserver
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testWebhookSecret = "webhook-secret"
+
+func TestGitHubWebhookRejectsUnverifiableSignaturesWithoutReceipt(t *testing.T) {
+	t.Parallel()
+
+	service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+	payload := completeIssueWebhookPayload(t, "Issue", "2026-09-02T12:00:00Z")
+	tests := []struct {
+		name      string
+		signature string
+	}{
+		{name: "missing"},
+		{name: "malformed", signature: "sha256=not-hex"},
+		{name: "wrong secret", signature: signWebhookPayload("wrong-secret", payload)},
+	}
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := sendWebhookRequest(t, service, fmt.Sprintf("invalid-%d", i), "issues", payload, test.signature)
+			if response.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d body = %s, want %d", response.Code, response.Body.String(), http.StatusUnauthorized)
+			}
+		})
+	}
+
+	var receipts int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM github_webhook_inbox").Scan(&receipts); err != nil {
+		t.Fatalf("count webhook receipts: %v", err)
+	}
+	if receipts != 0 {
+		t.Fatalf("webhook receipts = %d, want 0", receipts)
+	}
+}
+
+func TestGitHubWebhookDeduplicatesDeliveriesAndRejectsConflicts(t *testing.T) {
+	t.Parallel()
+
+	service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+	payload := completeIssueWebhookPayload(t, "Original title", "2026-09-02T12:00:00Z")
+	for attempt := range 2 {
+		response := sendSignedWebhookRequest(t, service, "duplicate-delivery", "issues", payload)
+		if response.Code != http.StatusAccepted {
+			t.Fatalf("attempt %d status = %d body = %s, want %d", attempt, response.Code, response.Body.String(), http.StatusAccepted)
+		}
+		var body webhookResponse
+		if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode attempt %d response: %v", attempt, err)
+		}
+		if body.Duplicate != (attempt == 1) {
+			t.Fatalf("attempt %d duplicate = %t, want %t", attempt, body.Duplicate, attempt == 1)
+		}
+	}
+
+	conflictingPayload := completeIssueWebhookPayload(t, "Conflicting title", "2026-09-02T12:00:00Z")
+	response := sendSignedWebhookRequest(t, service, "duplicate-delivery", "issues", conflictingPayload)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("conflict status = %d body = %s, want %d", response.Code, response.Body.String(), http.StatusConflict)
+	}
+
+	var receipts int
+	var redeliveries int
+	var status string
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*), max(redelivery_count), max(status)
+		FROM github_webhook_inbox
+	`).Scan(&receipts, &redeliveries, &status); err != nil {
+		t.Fatalf("read webhook receipt: %v", err)
+	}
+	if receipts != 1 || redeliveries != 1 || status != "processed" {
+		t.Fatalf("receipt = count %d redeliveries %d status %q, want 1, 1, processed", receipts, redeliveries, status)
+	}
+	var issues int
+	var title string
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*), max(title) FROM issues").Scan(&issues, &title); err != nil {
+		t.Fatalf("read issue projection: %v", err)
+	}
+	if issues != 1 || title != "Original title" {
+		t.Fatalf("issue projection = count %d title %q, want one original issue", issues, title)
+	}
+}
+
+func TestGitHubWebhookAcknowledgesDurableReceiptWhenProcessingFails(t *testing.T) {
+	t.Parallel()
+
+	service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+	for _, repository := range []struct {
+		nodeID string
+		owner  string
+		name   string
+	}{
+		{nodeID: "R_conflicting_node", owner: "other", name: "repository"},
+		{nodeID: "R_existing_name", owner: "digitaldrywood", name: "detent"},
+	} {
+		if _, err := service.database.db.ExecContext(t.Context(), `
+			INSERT INTO repositories (github_node_id, github_owner, github_name, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, repository.nodeID, repository.owner, repository.name, testTimestamp, testTimestamp); err != nil {
+			t.Fatalf("insert repository %s: %v", repository.nodeID, err)
+		}
+	}
+	payload := strings.Replace(
+		completeIssueWebhookPayload(t, "Issue", "2026-09-02T12:00:00Z"),
+		`"node_id":"R_repo"`,
+		`"node_id":"R_conflicting_node"`,
+		1,
+	)
+	response := sendSignedWebhookRequest(t, service, "processing-failure", "issues", payload)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s, want %d", response.Code, response.Body.String(), http.StatusAccepted)
+	}
+
+	var status string
+	var attempts int
+	var payloadCount int
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT i.status, i.attempts, COUNT(p.inbox_id)
+		FROM github_webhook_inbox i
+		LEFT JOIN github_webhook_payloads p ON p.inbox_id = i.id
+		WHERE i.delivery_id = ?
+		GROUP BY i.id
+	`, "processing-failure").Scan(&status, &attempts, &payloadCount); err != nil {
+		t.Fatalf("read failed durable receipt: %v", err)
+	}
+	if status != "failed" || attempts != 1 || payloadCount != 1 {
+		t.Fatalf("durable receipt = status %q attempts %d payloads %d, want failed, 1, 1", status, attempts, payloadCount)
+	}
+}
+
+func TestGitHubWebhookSourceOrderingConverges(t *testing.T) {
+	t.Parallel()
+
+	older := completeIssueWebhookPayload(t, "Older title", "2026-09-02T11:00:00Z")
+	newer := completeIssueWebhookPayload(t, "Newer title", "2026-09-02T12:00:00Z")
+	tests := []struct {
+		name     string
+		payloads []string
+	}{
+		{name: "older then newer", payloads: []string{older, newer}},
+		{name: "newer then older", payloads: []string{newer, older}},
+	}
+	var want issueProjectionSnapshot
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), func() time.Time {
+				return time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+			})
+			for deliveryIndex, payload := range test.payloads {
+				response := sendSignedWebhookRequest(t, service, fmt.Sprintf("ordering-%d-%d", index, deliveryIndex), "issues", payload)
+				if response.Code != http.StatusAccepted {
+					t.Fatalf("delivery %d status = %d body = %s", deliveryIndex, response.Code, response.Body.String())
+				}
+			}
+			got := readIssueProjectionSnapshot(t, service)
+			if got.Title != "Newer title" || got.SourceUpdatedAt != "2026-09-02T12:00:00.000000000Z" {
+				t.Fatalf("projection = %#v, want newer source", got)
+			}
+			if index == 0 {
+				want = got
+			} else if got != want {
+				t.Fatalf("projection = %#v, want order-independent %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestGitHubWebhookEqualTimestampConflictConvergesAndHydrates(t *testing.T) {
+	t.Parallel()
+
+	first := completeIssueWebhookPayload(t, "First competing title", "2026-09-02T12:00:00Z")
+	second := completeIssueWebhookPayload(t, "Second competing title", "2026-09-02T12:00:00Z")
+	orders := [][]string{{first, second}, {second, first}}
+	var want issueProjectionSnapshot
+	for index, payloads := range orders {
+		service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), func() time.Time {
+			return time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+		})
+		for deliveryIndex, payload := range payloads {
+			response := sendSignedWebhookRequest(t, service, fmt.Sprintf("tie-%d-%d", index, deliveryIndex), "issues", payload)
+			if response.Code != http.StatusAccepted {
+				t.Fatalf("order %d delivery %d status = %d body = %s", index, deliveryIndex, response.Code, response.Body.String())
+			}
+		}
+		got := readIssueProjectionSnapshot(t, service)
+		if index == 0 {
+			want = got
+		} else if got != want {
+			t.Fatalf("projection = %#v, want deterministic tie result %#v", got, want)
+		}
+		var hydrationCount int
+		var kind string
+		var key string
+		var reason string
+		if err := service.database.db.QueryRowContext(t.Context(), `
+			SELECT COUNT(*), max(object_kind), max(object_key), max(reason)
+			FROM github_hydration_requests WHERE status = 'pending'
+		`).Scan(&hydrationCount, &kind, &key, &reason); err != nil {
+			t.Fatalf("read conflict hydration: %v", err)
+		}
+		if hydrationCount != 1 || kind != "issue" || key != "2069" || reason != "source_version_conflict" {
+			t.Fatalf("hydration = count %d kind %q key %q reason %q, want one issue conflict", hydrationCount, kind, key, reason)
+		}
+	}
+}
+
+func TestGitHubWebhookPartialPayloadRequestsOnlyTargetedHydration(t *testing.T) {
+	t.Parallel()
+
+	service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+	payload := `{"action":"edited","repository":{"full_name":"digitaldrywood/detent"},"issue":{"number":2069}}`
+	response := sendSignedWebhookRequest(t, service, "partial-issue", "issues", payload)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s, want %d", response.Code, response.Body.String(), http.StatusAccepted)
+	}
+
+	var kind string
+	var key string
+	var number int
+	var reason string
+	var repository string
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT object_kind, object_key, github_number, reason, repository_full_name
+		FROM github_hydration_requests
+	`).Scan(&kind, &key, &number, &reason, &repository); err != nil {
+		t.Fatalf("read targeted hydration: %v", err)
+	}
+	if kind != "issue" || key != "2069" || number != 2069 || reason != "partial_payload" || repository != "digitaldrywood/detent" {
+		t.Fatalf("hydration = %s %s %d %s %s, want exact issue target", kind, key, number, reason, repository)
+	}
+	var issues int
+	var repositories int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT (SELECT COUNT(*) FROM issues), (SELECT COUNT(*) FROM repositories)").Scan(&issues, &repositories); err != nil {
+		t.Fatalf("count partial projections: %v", err)
+	}
+	if issues != 0 || repositories != 0 {
+		t.Fatalf("partial projections = issues %d repositories %d, want no incomplete rows", issues, repositories)
+	}
+}
+
+func TestGitHubWebhookCoalescesNewestHydrationSource(t *testing.T) {
+	t.Parallel()
+
+	older := `{"repository":{"full_name":"digitaldrywood/detent"},"issue":{"number":2069,"updated_at":"2026-09-02T11:00:00Z"}}`
+	newer := `{"repository":{"full_name":"digitaldrywood/detent"},"issue":{"number":2069,"updated_at":"2026-09-02T12:00:00Z"}}`
+	newerDigest := sha256.Sum256([]byte(newer))
+	wantVersion := "1:" + hex.EncodeToString(newerDigest[:])
+	orders := [][]string{{older, newer}, {newer, older}}
+	for orderIndex, payloads := range orders {
+		service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+		for deliveryIndex, payload := range payloads {
+			response := sendSignedWebhookRequest(t, service, fmt.Sprintf("partial-order-%d-%d", orderIndex, deliveryIndex), "issues", payload)
+			if response.Code != http.StatusAccepted {
+				t.Fatalf("order %d delivery %d status = %d body = %s", orderIndex, deliveryIndex, response.Code, response.Body.String())
+			}
+		}
+		var requestCount int
+		var updatedAt string
+		var version string
+		if err := service.database.db.QueryRowContext(t.Context(), `
+			SELECT request_count, requested_source_updated_at, requested_source_version
+			FROM github_hydration_requests
+		`).Scan(&requestCount, &updatedAt, &version); err != nil {
+			t.Fatalf("read coalesced hydration source: %v", err)
+		}
+		if requestCount != 2 || updatedAt != "2026-09-02T12:00:00.000000000Z" || version != wantVersion {
+			t.Fatalf("coalesced source = count %d updated %q version %q, want newest source", requestCount, updatedAt, version)
+		}
+	}
+}
+
+func TestGitHubWebhookTargetsChecksWithoutRepositoryRefresh(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		event    string
+		payload  string
+		wantKind string
+		wantKey  string
+	}{
+		{
+			name:     "pull request checks",
+			event:    "check_run",
+			payload:  `{"repository":{"full_name":"digitaldrywood/detent"},"check_run":{"head_sha":"abc123","pull_requests":[{"number":42}]}}`,
+			wantKind: "pull_request_checks",
+			wantKey:  "42",
+		},
+		{
+			name:     "commit checks",
+			event:    "check_suite",
+			payload:  `{"repository":{"full_name":"digitaldrywood/detent"},"check_suite":{"head_sha":"def456","pull_requests":[]}}`,
+			wantKind: "commit_checks",
+			wantKey:  "def456",
+		},
+	}
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+			response := sendSignedWebhookRequest(t, service, fmt.Sprintf("checks-%d", index), test.event, test.payload)
+			if response.Code != http.StatusAccepted {
+				t.Fatalf("status = %d body = %s, want %d", response.Code, response.Body.String(), http.StatusAccepted)
+			}
+			var kind string
+			var key string
+			if err := service.database.db.QueryRowContext(t.Context(), "SELECT object_kind, object_key FROM github_hydration_requests").Scan(&kind, &key); err != nil {
+				t.Fatalf("read check hydration: %v", err)
+			}
+			if kind != test.wantKind || key != test.wantKey {
+				t.Fatalf("hydration = %s:%s, want %s:%s", kind, key, test.wantKind, test.wantKey)
+			}
+		})
+	}
+}
+
+func TestGitHubWebhookUpdatesPullRequestWithoutClearingSummaries(t *testing.T) {
+	t.Parallel()
+
+	service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+	initial := completePullRequestWebhookPayload(t, "Initial PR", "2026-09-02T11:00:00Z")
+	response := sendSignedWebhookRequest(t, service, "pr-initial", "pull_request", initial)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("initial status = %d body = %s", response.Code, response.Body.String())
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		UPDATE pull_requests
+		SET checks_summary_json = '{"total":2}', reviews_summary_json = '{"approvals":1}'
+	`); err != nil {
+		t.Fatalf("seed pull request summaries: %v", err)
+	}
+	updated := completePullRequestWebhookPayload(t, "Updated PR", "2026-09-02T12:00:00Z")
+	response = sendSignedWebhookRequest(t, service, "pr-updated", "pull_request", updated)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("updated status = %d body = %s", response.Code, response.Body.String())
+	}
+	var title string
+	var checks string
+	var reviews string
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT title, checks_summary_json, reviews_summary_json FROM pull_requests
+	`).Scan(&title, &checks, &reviews); err != nil {
+		t.Fatalf("read pull request projection: %v", err)
+	}
+	if title != "Updated PR" || checks != `{"total":2}` || reviews != `{"approvals":1}` {
+		t.Fatalf("pull request = title %q checks %s reviews %s, want updated base with preserved summaries", title, checks, reviews)
+	}
+}
+
+func TestGitHubWebhookMapsAndClearsWorkflowStateFromLabels(t *testing.T) {
+	t.Parallel()
+
+	service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+	initial := completeIssueWebhookPayload(t, "Initial issue", "2026-09-02T11:00:00Z")
+	response := sendSignedWebhookRequest(t, service, "workflow-initial", "issues", initial)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("initial status = %d body = %s", response.Code, response.Body.String())
+	}
+	var repositoryID int64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT id FROM repositories").Scan(&repositoryID); err != nil {
+		t.Fatalf("read repository ID: %v", err)
+	}
+	result, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO workflow_states (
+			repository_id, github_node_id, source_name, detent_state,
+			dispatchable, created_at, updated_at
+		) VALUES (?, ?, ?, ?, 1, ?, ?)
+	`, repositoryID, "WS_todo", "detent:todo", "Todo", testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert workflow state: %v", err)
+	}
+	wantWorkflowStateID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("read workflow state ID: %v", err)
+	}
+	withWorkflow := completeIssueWebhookPayload(t, "Mapped issue", "2026-09-02T12:00:00Z")
+	response = sendSignedWebhookRequest(t, service, "workflow-mapped", "issues", withWorkflow)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("mapped status = %d body = %s", response.Code, response.Body.String())
+	}
+	var workflowStateID sql.NullInt64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues").Scan(&workflowStateID); err != nil {
+		t.Fatalf("read mapped workflow state: %v", err)
+	}
+	if !workflowStateID.Valid || workflowStateID.Int64 != wantWorkflowStateID {
+		t.Fatalf("workflow state = %#v, want %d", workflowStateID, wantWorkflowStateID)
+	}
+
+	var withoutWorkflow map[string]any
+	if err := json.Unmarshal([]byte(completeIssueWebhookPayload(t, "Unmapped issue", "2026-09-02T13:00:00Z")), &withoutWorkflow); err != nil {
+		t.Fatalf("decode issue without workflow label: %v", err)
+	}
+	issue := withoutWorkflow["issue"].(map[string]any)
+	issue["labels"] = []any{map[string]any{"name": "feature"}}
+	encoded, err := json.Marshal(withoutWorkflow)
+	if err != nil {
+		t.Fatalf("encode issue without workflow label: %v", err)
+	}
+	response = sendSignedWebhookRequest(t, service, "workflow-cleared", "issues", string(encoded))
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("cleared status = %d body = %s", response.Code, response.Body.String())
+	}
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues").Scan(&workflowStateID); err != nil {
+		t.Fatalf("read cleared workflow state: %v", err)
+	}
+	if workflowStateID.Valid {
+		t.Fatalf("workflow state = %#v, want NULL after label removal", workflowStateID)
+	}
+}
+
+func TestGitHubWebhookPayloadRetentionPreservesAuditAndProjection(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+	service := openTestService(t, Config{
+		DatabasePath:               filepath.Join(t.TempDir(), "hub.db"),
+		GitHubWebhookSecret:        []byte(testWebhookSecret),
+		WebhookPayloadRetention:    time.Hour,
+		WebhookMaintenanceInterval: time.Hour,
+		now:                        func() time.Time { return now },
+	})
+	payload := completeIssueWebhookPayload(t, "Retained issue", "2026-09-02T12:00:00Z")
+	response := sendSignedWebhookRequest(t, service, "retention", "issues", payload)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s", response.Code, response.Body.String())
+	}
+	pendingPayload := []byte(`{}`)
+	pendingDigest := sha256.Sum256(pendingPayload)
+	if _, err := service.database.recordWebhook(t.Context(), webhookReceipt{
+		DeliveryID:       "pending-retention",
+		EventType:        "issues",
+		HeadersJSON:      "{}",
+		Payload:          pendingPayload,
+		PayloadSHA256:    hex.EncodeToString(pendingDigest[:]),
+		ReceivedAt:       now.Add(-2 * time.Hour),
+		PayloadExpiresAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("record pending retention receipt: %v", err)
+	}
+	deleted, err := service.database.purgeWebhookPayloads(t.Context(), now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("purgeWebhookPayloads() error = %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("purged payloads = %d, want 1", deleted)
+	}
+
+	var payloads int
+	var receipts int
+	var issues int
+	var payloadHash string
+	var payloadBytes int
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT
+			(SELECT COUNT(*) FROM github_webhook_payloads),
+			(SELECT COUNT(*) FROM github_webhook_inbox),
+			(SELECT COUNT(*) FROM issues),
+			(SELECT payload_sha256 FROM github_webhook_inbox WHERE delivery_id = 'retention'),
+			(SELECT payload_bytes FROM github_webhook_inbox WHERE delivery_id = 'retention')
+	`).Scan(&payloads, &receipts, &issues, &payloadHash, &payloadBytes); err != nil {
+		t.Fatalf("read retained webhook state: %v", err)
+	}
+	if payloads != 1 || receipts != 2 || issues != 1 || payloadHash == "" || payloadBytes != len(payload) {
+		t.Fatalf("retained state = payloads %d receipts %d issues %d hash %q bytes %d", payloads, receipts, issues, payloadHash, payloadBytes)
+	}
+}
+
+func TestGitHubWebhookStartupReplaysPendingReceipt(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "hub.db")
+	now := time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+	service := openWebhookTestService(t, databasePath, func() time.Time { return now })
+	payload := []byte(completeIssueWebhookPayload(t, "Replayed issue", "2026-09-02T12:00:00Z"))
+	digest := sha256.Sum256(payload)
+	if _, err := service.database.recordWebhook(t.Context(), webhookReceipt{
+		DeliveryID:       "startup-replay",
+		EventType:        "issues",
+		HeadersJSON:      "{}",
+		Payload:          payload,
+		PayloadSHA256:    hex.EncodeToString(digest[:]),
+		ReceivedAt:       now,
+		PayloadExpiresAt: now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("recordWebhook() error = %v", err)
+	}
+	if err := service.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reopened := openWebhookTestService(t, databasePath, func() time.Time { return now.Add(time.Minute) })
+	var status string
+	var title string
+	if err := reopened.database.db.QueryRowContext(t.Context(), `
+		SELECT i.status, issue.title
+		FROM github_webhook_inbox i
+		JOIN issues issue ON issue.github_node_id = 'I_issue'
+		WHERE i.delivery_id = 'startup-replay'
+	`).Scan(&status, &title); err != nil {
+		t.Fatalf("read replayed webhook: %v", err)
+	}
+	if status != "processed" || title != "Replayed issue" {
+		t.Fatalf("replayed state = status %q title %q, want processed replayed issue", status, title)
+	}
+}
+
+type issueProjectionSnapshot struct {
+	Title           string
+	Body            string
+	State           string
+	LabelsJSON      string
+	AssigneesJSON   string
+	SourceVersion   string
+	SourceUpdatedAt string
+}
+
+func readIssueProjectionSnapshot(t *testing.T, service *Service) issueProjectionSnapshot {
+	t.Helper()
+	var snapshot issueProjectionSnapshot
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT title, body, github_state, labels_json, assignees_json, source_version, source_updated_at
+		FROM issues WHERE github_node_id = 'I_issue'
+	`).Scan(
+		&snapshot.Title,
+		&snapshot.Body,
+		&snapshot.State,
+		&snapshot.LabelsJSON,
+		&snapshot.AssigneesJSON,
+		&snapshot.SourceVersion,
+		&snapshot.SourceUpdatedAt,
+	); err != nil {
+		t.Fatalf("read issue projection: %v", err)
+	}
+	return snapshot
+}
+
+func openWebhookTestService(t *testing.T, databasePath string, now func() time.Time) *Service {
+	t.Helper()
+	return openTestService(t, Config{
+		DatabasePath:               databasePath,
+		GitHubWebhookSecret:        []byte(testWebhookSecret),
+		WebhookMaintenanceInterval: time.Hour,
+		now:                        now,
+	})
+}
+
+func sendSignedWebhookRequest(t *testing.T, service *Service, deliveryID string, event string, payload string) *httptest.ResponseRecorder {
+	t.Helper()
+	return sendWebhookRequest(t, service, deliveryID, event, payload, signWebhookPayload(testWebhookSecret, payload))
+}
+
+func sendWebhookRequest(t *testing.T, service *Service, deliveryID string, event string, payload string, signature string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader(payload))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-GitHub-Delivery", deliveryID)
+	request.Header.Set("X-GitHub-Event", event)
+	request.Header.Set("X-Hub-Signature-256", signature)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	return response
+}
+
+func signWebhookPayload(secret string, payload string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func completeIssueWebhookPayload(t *testing.T, title string, updatedAt string) string {
+	t.Helper()
+	payload := map[string]any{
+		"action": "edited",
+		"repository": map[string]any{
+			"id":         100,
+			"node_id":    "R_repo",
+			"name":       "detent",
+			"full_name":  "digitaldrywood/detent",
+			"owner":      map[string]any{"login": "digitaldrywood"},
+			"updated_at": updatedAt,
+		},
+		"issue": map[string]any{
+			"id":         200,
+			"node_id":    "I_issue",
+			"number":     2069,
+			"title":      title,
+			"body":       "Issue body",
+			"html_url":   "https://github.com/digitaldrywood/detent/issues/2069",
+			"state":      "open",
+			"labels":     []any{map[string]any{"name": "feature"}, map[string]any{"name": "detent:todo"}},
+			"assignees":  []any{map[string]any{"login": "corylanou"}},
+			"created_at": "2026-09-01T12:00:00Z",
+			"updated_at": updatedAt,
+		},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encode issue webhook payload: %v", err)
+	}
+	return string(encoded)
+}
+
+func completePullRequestWebhookPayload(t *testing.T, title string, updatedAt string) string {
+	t.Helper()
+	payload := map[string]any{
+		"action": "edited",
+		"repository": map[string]any{
+			"id":         100,
+			"node_id":    "R_repo",
+			"name":       "detent",
+			"full_name":  "digitaldrywood/detent",
+			"owner":      map[string]any{"login": "digitaldrywood"},
+			"updated_at": updatedAt,
+		},
+		"pull_request": map[string]any{
+			"id":         300,
+			"node_id":    "PR_node",
+			"number":     2070,
+			"title":      title,
+			"html_url":   "https://github.com/digitaldrywood/detent/pull/2070",
+			"state":      "open",
+			"draft":      false,
+			"head":       map[string]any{"ref": "feature", "sha": "abc123"},
+			"base":       map[string]any{"ref": "main", "sha": "def456"},
+			"created_at": "2026-09-01T12:00:00Z",
+			"updated_at": updatedAt,
+		},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encode pull request webhook payload: %v", err)
+	}
+	return string(encoded)
+}

--- a/internal/hubserver/github_webhook_test.go
+++ b/internal/hubserver/github_webhook_test.go
@@ -421,6 +421,97 @@ func TestGitHubWebhookMapsAndClearsWorkflowStateFromLabels(t *testing.T) {
 	}
 }
 
+func TestGitHubWebhookDeletedIssueCannotRemainSchedulable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		deliveries         []string
+		wantState          string
+		wantWorkflowMapped bool
+	}{
+		{
+			name: "newer deletion",
+			deliveries: []string{
+				completeIssueWebhookPayload(t, "Mapped issue", "2026-09-02T12:00:00Z"),
+				issueWebhookPayloadWithAction(t, "deleted", "Mapped issue", "2026-09-02T13:00:00Z"),
+			},
+			wantState: "closed",
+		},
+		{
+			name: "stale deletion",
+			deliveries: []string{
+				completeIssueWebhookPayload(t, "Mapped issue", "2026-09-02T13:00:00Z"),
+				issueWebhookPayloadWithAction(t, "deleted", "Mapped issue", "2026-09-02T12:00:00Z"),
+			},
+			wantState:          "open",
+			wantWorkflowMapped: true,
+		},
+		{
+			name: "equal timestamp deletion last",
+			deliveries: []string{
+				completeIssueWebhookPayload(t, "Mapped issue", "2026-09-02T12:00:00Z"),
+				issueWebhookPayloadWithAction(t, "deleted", "Mapped issue", "2026-09-02T12:00:00Z"),
+			},
+			wantState: "closed",
+		},
+		{
+			name: "equal timestamp deletion first",
+			deliveries: []string{
+				issueWebhookPayloadWithAction(t, "deleted", "Mapped issue", "2026-09-02T12:00:00Z"),
+				completeIssueWebhookPayload(t, "Mapped issue", "2026-09-02T12:00:00Z"),
+			},
+			wantState: "closed",
+		},
+	}
+	for testIndex, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := openWebhookTestService(t, filepath.Join(t.TempDir(), "hub.db"), time.Now)
+			response := sendSignedWebhookRequest(t, service, fmt.Sprintf("deleted-seed-%d", testIndex), "issues", completeIssueWebhookPayload(t, "Seed issue", "2026-09-02T11:00:00Z"))
+			if response.Code != http.StatusAccepted {
+				t.Fatalf("seed status = %d body = %s", response.Code, response.Body.String())
+			}
+			var repositoryID int64
+			if err := service.database.db.QueryRowContext(t.Context(), "SELECT id FROM repositories").Scan(&repositoryID); err != nil {
+				t.Fatalf("read repository ID: %v", err)
+			}
+			result, err := service.database.db.ExecContext(t.Context(), `
+				INSERT INTO workflow_states (
+					repository_id, github_node_id, source_name, detent_state,
+					dispatchable, created_at, updated_at
+				) VALUES (?, ?, ?, ?, 1, ?, ?)
+			`, repositoryID, "WS_todo", "detent:todo", "Todo", testTimestamp, testTimestamp)
+			if err != nil {
+				t.Fatalf("insert workflow state: %v", err)
+			}
+			wantWorkflowStateID, err := result.LastInsertId()
+			if err != nil {
+				t.Fatalf("read workflow state ID: %v", err)
+			}
+			for deliveryIndex, payload := range test.deliveries {
+				response = sendSignedWebhookRequest(t, service, fmt.Sprintf("deleted-%d-%d", testIndex, deliveryIndex), "issues", payload)
+				if response.Code != http.StatusAccepted {
+					t.Fatalf("delivery %d status = %d body = %s", deliveryIndex, response.Code, response.Body.String())
+				}
+			}
+			var state string
+			var workflowStateID sql.NullInt64
+			if err := service.database.db.QueryRowContext(t.Context(), "SELECT github_state, workflow_state_id FROM issues").Scan(&state, &workflowStateID); err != nil {
+				t.Fatalf("read issue scheduling state: %v", err)
+			}
+			if state != test.wantState {
+				t.Fatalf("GitHub state = %q, want %q", state, test.wantState)
+			}
+			if workflowStateID.Valid != test.wantWorkflowMapped {
+				t.Fatalf("workflow state = %#v, want mapped %t", workflowStateID, test.wantWorkflowMapped)
+			}
+			if test.wantWorkflowMapped && workflowStateID.Int64 != wantWorkflowStateID {
+				t.Fatalf("workflow state ID = %d, want %d", workflowStateID.Int64, wantWorkflowStateID)
+			}
+		})
+	}
+}
+
 func TestGitHubWebhookPayloadRetentionPreservesAuditAndProjection(t *testing.T) {
 	t.Parallel()
 
@@ -606,6 +697,20 @@ func completeIssueWebhookPayload(t *testing.T, title string, updatedAt string) s
 			"updated_at": updatedAt,
 		},
 	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encode issue webhook payload: %v", err)
+	}
+	return string(encoded)
+}
+
+func issueWebhookPayloadWithAction(t *testing.T, action string, title string, updatedAt string) string {
+	t.Helper()
+	payload := make(map[string]any)
+	if err := json.Unmarshal([]byte(completeIssueWebhookPayload(t, title, updatedAt)), &payload); err != nil {
+		t.Fatalf("decode issue webhook payload: %v", err)
+	}
+	payload["action"] = action
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatalf("encode issue webhook payload: %v", err)

--- a/internal/hubserver/migrate.go
+++ b/internal/hubserver/migrate.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	hubSchemaTable         = "hub_schema_version"
-	supportedSchemaVersion = int64(3)
+	supportedSchemaVersion = int64(4)
 )
 
 //go:embed migrations/*.sql

--- a/internal/hubserver/migrations/00004_ingest_github_webhooks.sql
+++ b/internal/hubserver/migrations/00004_ingest_github_webhooks.sql
@@ -1,0 +1,125 @@
+-- +goose Up
+ALTER TABLE repositories ADD COLUMN source_version TEXT NOT NULL DEFAULT '';
+ALTER TABLE repositories ADD COLUMN source_updated_at TEXT;
+ALTER TABLE repositories ADD COLUMN synchronized_at TEXT;
+
+DROP INDEX github_webhook_inbox_processing_idx;
+
+ALTER TABLE github_webhook_inbox RENAME TO github_webhook_inbox_legacy;
+
+CREATE TABLE github_webhook_inbox (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  delivery_id TEXT NOT NULL UNIQUE,
+  repository_id INTEGER REFERENCES repositories(id) ON DELETE SET NULL,
+  event_type TEXT NOT NULL,
+  action TEXT,
+  headers_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(headers_json)),
+  payload_sha256 TEXT NOT NULL,
+  payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'processing', 'processed', 'ignored', 'failed')),
+  outcome TEXT,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  next_retry_at TEXT,
+  processing_started_at TEXT,
+  processed_at TEXT,
+  last_error TEXT,
+  signature_verified_at TEXT,
+  received_at TEXT NOT NULL,
+  last_received_at TEXT NOT NULL,
+  redelivery_count INTEGER NOT NULL DEFAULT 0 CHECK (redelivery_count >= 0),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+INSERT INTO github_webhook_inbox (
+  id,
+  delivery_id,
+  repository_id,
+  event_type,
+  action,
+  headers_json,
+  payload_sha256,
+  payload_bytes,
+  status,
+  attempts,
+  next_retry_at,
+  processing_started_at,
+  processed_at,
+  last_error,
+  received_at,
+  last_received_at,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  delivery_id,
+  repository_id,
+  event_type,
+  action,
+  headers_json,
+  payload_sha256,
+  payload_bytes,
+  status,
+  attempts,
+  next_retry_at,
+  processing_started_at,
+  processed_at,
+  last_error,
+  received_at,
+  received_at,
+  created_at,
+  updated_at
+FROM github_webhook_inbox_legacy;
+
+CREATE INDEX github_webhook_inbox_processing_idx
+ON github_webhook_inbox(status, next_retry_at, received_at, id);
+
+CREATE TABLE github_webhook_payloads (
+  inbox_id INTEGER PRIMARY KEY REFERENCES github_webhook_inbox(id) ON DELETE CASCADE,
+  body BLOB NOT NULL,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+INSERT INTO github_webhook_payloads (inbox_id, body, expires_at, created_at)
+SELECT id, CAST(payload_json AS BLOB), created_at, created_at
+FROM github_webhook_inbox_legacy;
+
+CREATE INDEX github_webhook_payloads_expiry_idx
+ON github_webhook_payloads(expires_at, inbox_id);
+
+DROP TABLE github_webhook_inbox_legacy;
+
+CREATE TABLE github_hydration_requests (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  repository_id INTEGER REFERENCES repositories(id) ON DELETE SET NULL,
+  repository_full_name TEXT NOT NULL,
+  object_kind TEXT NOT NULL CHECK (object_kind IN ('issue', 'pull_request', 'pull_request_checks', 'pull_request_reviews', 'commit_checks')),
+  object_key TEXT NOT NULL,
+  github_node_id TEXT,
+  github_number INTEGER CHECK (github_number IS NULL OR github_number > 0),
+  head_sha TEXT,
+  reason TEXT NOT NULL,
+  requested_source_updated_at TEXT,
+  requested_source_version TEXT NOT NULL,
+  first_delivery_id TEXT REFERENCES github_webhook_inbox(delivery_id) ON DELETE SET NULL,
+  last_delivery_id TEXT REFERENCES github_webhook_inbox(delivery_id) ON DELETE SET NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+  request_count INTEGER NOT NULL DEFAULT 1 CHECK (request_count > 0),
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  next_retry_at TEXT,
+  processing_started_at TEXT,
+  completed_at TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (github_node_id IS NOT NULL OR github_number IS NOT NULL OR head_sha IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX github_hydration_requests_pending_target_idx
+ON github_hydration_requests(repository_full_name, object_kind, object_key)
+WHERE status = 'pending';
+
+CREATE INDEX github_hydration_requests_processing_idx
+ON github_hydration_requests(status, next_retry_at, id);

--- a/internal/hubserver/service.go
+++ b/internal/hubserver/service.go
@@ -21,13 +21,16 @@ const (
 )
 
 type Service struct {
-	echo      *echo.Echo
-	database  *database
-	tracker   tracker.Tracker
-	config    Config
-	ready     atomic.Bool
-	closeOnce sync.Once
-	closeErr  error
+	echo           *echo.Echo
+	database       *database
+	tracker        tracker.Tracker
+	config         Config
+	ready          atomic.Bool
+	workerCancel   context.CancelFunc
+	workerDone     chan struct{}
+	workerStopOnce sync.Once
+	closeOnce      sync.Once
+	closeErr       error
 }
 
 type healthResponse struct {
@@ -55,8 +58,19 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 	e.HidePort = true
 	e.Server.ReadHeaderTimeout = defaultHTTPReadHeaderTimeout
 	e.Server.IdleTimeout = defaultHTTPIdleTimeout
-	service := &Service{echo: e, database: database, tracker: workTracker, config: cfg}
+	workerContext, workerCancel := context.WithCancel(context.Background())
+	service := &Service{
+		echo:         e,
+		database:     database,
+		tracker:      workTracker,
+		config:       cfg,
+		workerCancel: workerCancel,
+		workerDone:   make(chan struct{}),
+	}
 	e.GET("/health", service.health)
+	e.POST("/api/v1/webhooks/github", service.githubWebhook)
+	service.maintainGitHubWebhooks(ctx)
+	go service.runGitHubWebhookMaintenance(workerContext)
 	service.ready.Store(true)
 	return service, nil
 }
@@ -127,14 +141,14 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		ctx = context.Background()
 	}
 	s.ready.Store(false)
-	err := s.echo.Shutdown(ctx)
-	if errors.Is(err, http.ErrServerClosed) {
-		return nil
+	httpErr := s.echo.Shutdown(ctx)
+	if errors.Is(httpErr, http.ErrServerClosed) {
+		httpErr = nil
 	}
-	if err != nil {
-		return fmt.Errorf("shut down hub server: %w", err)
+	if httpErr != nil {
+		httpErr = fmt.Errorf("shut down hub server: %w", httpErr)
 	}
-	return nil
+	return errors.Join(httpErr, s.stopGitHubWebhookMaintenance())
 }
 
 func (s *Service) Backup(ctx context.Context, destination string) error {
@@ -154,9 +168,44 @@ func (s *Service) Close() error {
 		if errors.Is(httpErr, http.ErrServerClosed) {
 			httpErr = nil
 		}
-		s.closeErr = errors.Join(httpErr, s.database.Close())
+		s.closeErr = errors.Join(httpErr, s.stopGitHubWebhookMaintenance(), s.database.Close())
 	})
 	return s.closeErr
+}
+
+func (s *Service) runGitHubWebhookMaintenance(ctx context.Context) {
+	defer close(s.workerDone)
+	ticker := time.NewTicker(s.config.WebhookMaintenanceInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.maintainGitHubWebhooks(ctx)
+		}
+	}
+}
+
+func (s *Service) maintainGitHubWebhooks(ctx context.Context) {
+	now := s.config.now().UTC()
+	if err := s.database.processPendingWebhooks(ctx, now); err != nil && !errors.Is(err, context.Canceled) {
+		s.config.Logger.Error("process pending GitHub webhooks", "error", err)
+	}
+	if _, err := s.database.purgeWebhookPayloads(ctx, now); err != nil && !errors.Is(err, context.Canceled) {
+		s.config.Logger.Warn("purge GitHub webhook payloads", "error", err)
+	}
+}
+
+func (s *Service) stopGitHubWebhookMaintenance() error {
+	if s == nil || s.workerCancel == nil || s.workerDone == nil {
+		return nil
+	}
+	s.workerStopOnce.Do(func() {
+		s.workerCancel()
+		<-s.workerDone
+	})
+	return nil
 }
 
 func (s *Service) health(c echo.Context) error {


### PR DESCRIPTION
## Summary

- verify and durably record signed GitHub webhook deliveries before acknowledging them
- apply complete issue and pull request snapshots with deterministic source ordering and enqueue only exact hydration targets for partial/check/review events
- retain long-lived delivery audit metadata while purging raw payload bytes, with startup replay and service-owned maintenance
- expose Hub webhook secret, retention, and maintenance configuration without placing secret values in process arguments

Fixes #2069

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no UI changes.)

## Test Plan

- [x] `make generate`
- [x] `go test ./internal/hubserver ./internal/cli`
- [x] `go test -race ./internal/hubserver ./internal/cli`
- [x] `make check`