### PR TITLE
feat(hub): write back through durable outbox

### DIFF
--- a/.detent/skills/sqlite-text-time-ordering.md
+++ b/.detent/skills/sqlite-text-time-ordering.md
@@ -1,0 +1,19 @@
+---
+name: sqlite-text-time-ordering
+description: Preserve chronological ordering when SQLite timestamps are stored as TEXT and used in range, retry, lease, or stale-work predicates.
+when_to_use: Use when a SQLite query compares or orders RFC3339-like TEXT timestamps, especially when boundary tests disagree with application time arithmetic.
+---
+
+# Keep SQLite text timestamps chronologically sortable
+
+Variable-width RFC3339 encodings are not safely ordered as text. A whole-second value ending in `Z` can sort after a later value with a fractional suffix because `.` sorts before `Z`.
+
+Use one representation for every value in an order-sensitive column:
+
+- Prefer an integer epoch when the schema permits it.
+- Otherwise store UTC text with a fixed-width fraction, such as Go's `2006-01-02T15:04:05.000000000Z` layout.
+- Keep parsing compatible with the stored precision, and return malformed persisted values as errors instead of silently substituting zero time.
+
+Do not mix offsets, fractional widths, or integer units in the same compared column. When changing an existing representation, normalize existing rows in a migration or stop relying on lexical comparison until the data is uniform.
+
+Exercise the real SQLite predicate in a table-driven test. Include a whole-second timestamp, a subsecond retry or expiry after it, equality at the boundary, and a later value. Assert both `ORDER BY` and the exact `<=` or `>=` predicate used by production.

--- a/internal/cli/hub.go
+++ b/internal/cli/hub.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -9,13 +10,30 @@ import (
 
 	"github.com/spf13/cobra"
 
+	connectorgithub "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/hubgithub"
 	"github.com/digitaldrywood/detent/internal/hubserver"
 )
 
 type hubRunFunc func(context.Context, hubserver.Config) error
 
 func newHubCommand(opts options) *cobra.Command {
-	return newHubCommandWithRun(opts.version, opts.lookupEnv, hubserver.Run)
+	run := func(ctx context.Context, cfg hubserver.Config) error {
+		token, err := opts.ghAuthToken(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve github credentials for hub outbox: %w", err)
+		}
+		client, err := connectorgithub.NewClient(connectorgithub.ClientConfig{
+			TokenSource: connectorgithub.StaticTokenSource(token),
+			Logger:      cfg.Logger,
+		})
+		if err != nil {
+			return fmt.Errorf("configure github hub outbox client: %w", err)
+		}
+		cfg.OutboxBackend = hubgithub.NewWriter(client)
+		return hubserver.Run(ctx, cfg)
+	}
+	return newHubCommandWithRun(opts.version, opts.lookupEnv, run)
 }
 
 func newHubCommandWithRun(version string, lookupEnv func(string) string, run hubRunFunc) *cobra.Command {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -257,6 +257,14 @@ func (c *Client) REST(ctx context.Context, method string, path string, body any,
 	return err
 }
 
+func (c *Client) RESTPage(ctx context.Context, path string, out any) (string, error) {
+	headers, err := c.rest(ctx, http.MethodGet, path, nil, out)
+	if err != nil {
+		return "", err
+	}
+	return c.nextRESTPage(headers)
+}
+
 func (c *Client) RESTText(ctx context.Context, path, accept string, maxBytes int) (string, bool, error) {
 	return c.restTextWithTokenRefresh(ctx, path, accept, maxBytes, true)
 }

--- a/internal/hubgithub/writer.go
+++ b/internal/hubgithub/writer.go
@@ -1,0 +1,473 @@
+package hubgithub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	connectorgithub "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/hubserver"
+)
+
+const workpadHeading = "## Codex Workpad"
+
+type restClient interface {
+	REST(context.Context, string, string, any, any) error
+	RESTPage(context.Context, string, any) (string, error)
+}
+
+type Writer struct {
+	client restClient
+}
+
+func NewWriter(client *connectorgithub.Client) *Writer {
+	return &Writer{client: client}
+}
+
+func (w *Writer) Execute(ctx context.Context, item hubserver.OutboxItem) error {
+	if w == nil || w.client == nil {
+		return hubserver.Permanent(errors.New("github outbox writer is not configured"))
+	}
+	var err error
+	switch item.Kind {
+	case hubserver.MutationWorkflowLabel:
+		err = w.updateWorkflowLabel(ctx, item)
+	case hubserver.MutationWorkpad:
+		err = w.upsertWorkpad(ctx, item)
+	case hubserver.MutationMergePullRequest:
+		return hubserver.Permanent(errors.New("irreversible github mutation requires fresh verification"))
+	default:
+		return hubserver.Permanent(fmt.Errorf("unsupported github mutation kind %q", item.Kind))
+	}
+	return classifyError(err)
+}
+
+func (w *Writer) VerifyAndExecute(ctx context.Context, item hubserver.OutboxItem) error {
+	if w == nil || w.client == nil {
+		return hubserver.Permanent(errors.New("github outbox writer is not configured"))
+	}
+	if item.Kind != hubserver.MutationMergePullRequest {
+		return hubserver.Permanent(fmt.Errorf("github mutation %q is not irreversible", item.Kind))
+	}
+	return classifyError(w.verifyAndMerge(ctx, item))
+}
+
+func (w *Writer) updateWorkflowLabel(ctx context.Context, item hubserver.OutboxItem) error {
+	if err := validateIssueTarget(item); err != nil {
+		return err
+	}
+	var desired hubserver.WorkflowLabelDesired
+	if err := decodeDesired(item, &desired); err != nil {
+		return err
+	}
+	desired.Label = strings.TrimSpace(desired.Label)
+	desired.ManagedPrefix = strings.TrimSpace(desired.ManagedPrefix)
+	if desired.Label == "" || desired.ManagedPrefix == "" {
+		return hubserver.Permanent(errors.New("workflow label mutation is incomplete"))
+	}
+
+	var issue restIssue
+	path := issuePath(item)
+	if err := w.client.REST(ctx, http.MethodGet, path, nil, &issue); err != nil {
+		return fmt.Errorf("refresh github issue labels: %w", err)
+	}
+	labels := make([]string, 0, len(issue.Labels)+1)
+	for _, label := range issue.Labels {
+		name := strings.TrimSpace(label.Name)
+		if name == "" || strings.HasPrefix(strings.ToLower(name), strings.ToLower(desired.ManagedPrefix)) {
+			continue
+		}
+		labels = append(labels, name)
+	}
+	labels = append(labels, desired.Label)
+	labels = normalizedLabels(labels)
+	if err := w.client.REST(ctx, http.MethodPut, path+"/labels", map[string]any{"labels": labels}, nil); err != nil {
+		return fmt.Errorf("replace github workflow label: %w", err)
+	}
+	return nil
+}
+
+func (w *Writer) upsertWorkpad(ctx context.Context, item hubserver.OutboxItem) error {
+	if err := validateIssueTarget(item); err != nil {
+		return err
+	}
+	var desired hubserver.WorkpadDesired
+	if err := decodeDesired(item, &desired); err != nil {
+		return err
+	}
+	body := strings.TrimSpace(desired.Body)
+	marker := strings.TrimSpace(desired.Marker)
+	if body == "" || marker == "" {
+		return hubserver.Permanent(errors.New("workpad mutation is incomplete"))
+	}
+	if !strings.Contains(body, marker) {
+		body += "\n\n" + marker
+	}
+
+	commentsPath := issuePath(item) + "/comments?per_page=100"
+	comments, err := fetchRESTList[restComment](ctx, w.client, commentsPath)
+	if err != nil {
+		return fmt.Errorf("list github issue comments for workpad: %w", err)
+	}
+	commentID := workpadCommentID(comments, marker)
+	if commentID == 0 {
+		var created restComment
+		if err := w.client.REST(ctx, http.MethodPost, issuePath(item)+"/comments", map[string]any{"body": body}, &created); err != nil {
+			return fmt.Errorf("create github workpad comment: %w", err)
+		}
+		if created.ID == 0 {
+			return errors.New("create github workpad comment returned no id")
+		}
+		return nil
+	}
+
+	commentPath := repositoryPath(item) + "/issues/comments/" + strconv.FormatInt(commentID, 10)
+	if err := w.client.REST(ctx, http.MethodPatch, commentPath, map[string]any{"body": body}, nil); err != nil {
+		return fmt.Errorf("update github workpad comment: %w", err)
+	}
+	return nil
+}
+
+func (w *Writer) verifyAndMerge(ctx context.Context, item hubserver.OutboxItem) error {
+	if err := validateRepository(item); err != nil {
+		return err
+	}
+	var desired hubserver.MergePullRequestDesired
+	if err := decodeDesired(item, &desired); err != nil {
+		return err
+	}
+	if desired.PullRequestNumber <= 0 || strings.TrimSpace(desired.HeadSHA) == "" {
+		return hubserver.Permanent(errors.New("merge pull request mutation is incomplete"))
+	}
+
+	pullPath := repositoryPath(item) + "/pulls/" + strconv.Itoa(desired.PullRequestNumber)
+	var pullRequest restPullRequest
+	if err := w.client.REST(ctx, http.MethodGet, pullPath, nil, &pullRequest); err != nil {
+		return fmt.Errorf("refresh github pull request before merge: %w", err)
+	}
+	if strings.TrimSpace(pullRequest.Head.SHA) != strings.TrimSpace(desired.HeadSHA) {
+		return hubserver.Permanent(errors.New("fresh github pull request head does not match the requested head"))
+	}
+	if !strings.EqualFold(strings.TrimSpace(pullRequest.State), "open") {
+		if pullRequest.Merged {
+			return nil
+		}
+		return hubserver.Permanent(errors.New("fresh github pull request is not open"))
+	}
+	if pullRequest.Draft {
+		return hubserver.Permanent(errors.New("fresh github pull request is a draft"))
+	}
+	if pullRequest.Mergeable == nil {
+		return errors.New("fresh github pull request mergeability is not yet available")
+	}
+	if !*pullRequest.Mergeable {
+		return hubserver.Permanent(errors.New("fresh github pull request has merge conflicts"))
+	}
+	if !strings.EqualFold(strings.TrimSpace(pullRequest.MergeableState), "clean") {
+		return errors.New("fresh github pull request is not cleanly mergeable")
+	}
+
+	reviews, err := fetchRESTList[restReview](ctx, w.client, pullPath+"/reviews?per_page=100")
+	if err != nil {
+		return fmt.Errorf("refresh github pull request reviews before merge: %w", err)
+	}
+	if reviewer := changesRequestingReviewer(reviews); reviewer != "" {
+		return fmt.Errorf("fresh github review by %s requests changes", reviewer)
+	}
+
+	checksPath := repositoryPath(item) + "/commits/" + url.PathEscape(strings.TrimSpace(desired.HeadSHA)) + "/check-runs?per_page=100"
+	checks, err := fetchRESTCheckRuns(ctx, w.client, checksPath)
+	if err != nil {
+		return fmt.Errorf("refresh github check runs before merge: %w", err)
+	}
+	if check := unreadyCheck(checks); check != "" {
+		return fmt.Errorf("fresh github check %s is not successful", check)
+	}
+
+	statusesPath := repositoryPath(item) + "/commits/" + url.PathEscape(strings.TrimSpace(desired.HeadSHA)) + "/statuses?per_page=100"
+	statuses, err := fetchRESTList[restStatus](ctx, w.client, statusesPath)
+	if err != nil {
+		return fmt.Errorf("refresh github commit statuses before merge: %w", err)
+	}
+	if status := unreadyStatus(statuses); status != "" {
+		return fmt.Errorf("fresh github status %s is not successful", status)
+	}
+
+	method := strings.ToLower(strings.TrimSpace(desired.MergeMethod))
+	switch method {
+	case "merge", "rebase", "squash":
+	default:
+		return hubserver.Permanent(errors.New("merge pull request mutation has an invalid merge method"))
+	}
+	var response restMergeResponse
+	if err := w.client.REST(ctx, http.MethodPut, pullPath+"/merge", map[string]string{
+		"merge_method": method,
+		"sha":          strings.TrimSpace(desired.HeadSHA),
+	}, &response); err != nil {
+		return fmt.Errorf("merge freshly verified github pull request: %w", err)
+	}
+	if !response.Merged {
+		message := strings.TrimSpace(response.Message)
+		if message == "" {
+			message = "github did not merge the freshly verified pull request"
+		}
+		return errors.New(message)
+	}
+	return nil
+}
+
+func decodeDesired(item hubserver.OutboxItem, target any) error {
+	if err := json.Unmarshal(item.Desired, target); err != nil {
+		return hubserver.Permanent(fmt.Errorf("decode github %s desired state: %w", item.Kind, err))
+	}
+	return nil
+}
+
+func validateRepository(item hubserver.OutboxItem) error {
+	if strings.TrimSpace(item.RepositoryOwner) == "" || strings.TrimSpace(item.RepositoryName) == "" {
+		return hubserver.Permanent(errors.New("github mutation repository is incomplete"))
+	}
+	return nil
+}
+
+func validateIssueTarget(item hubserver.OutboxItem) error {
+	if err := validateRepository(item); err != nil {
+		return err
+	}
+	if item.IssueNumber <= 0 {
+		return hubserver.Permanent(errors.New("github mutation issue number must be positive"))
+	}
+	return nil
+}
+
+func repositoryPath(item hubserver.OutboxItem) string {
+	return "/repos/" + url.PathEscape(strings.TrimSpace(item.RepositoryOwner)) + "/" + url.PathEscape(strings.TrimSpace(item.RepositoryName))
+}
+
+func issuePath(item hubserver.OutboxItem) string {
+	return repositoryPath(item) + "/issues/" + strconv.Itoa(item.IssueNumber)
+}
+
+func fetchRESTList[T any](ctx context.Context, client restClient, path string) ([]T, error) {
+	result := make([]T, 0)
+	for path != "" {
+		var page []T
+		next, err := client.RESTPage(ctx, path, &page)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, page...)
+		path = next
+	}
+	return result, nil
+}
+
+func fetchRESTCheckRuns(ctx context.Context, client restClient, path string) ([]restCheckRun, error) {
+	result := make([]restCheckRun, 0)
+	for path != "" {
+		var page restCheckRuns
+		next, err := client.RESTPage(ctx, path, &page)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, page.CheckRuns...)
+		path = next
+	}
+	return result, nil
+}
+
+func normalizedLabels(labels []string) []string {
+	seen := make(map[string]string, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		seen[strings.ToLower(label)] = label
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, seen[key])
+	}
+	return result
+}
+
+func workpadCommentID(comments []restComment, marker string) int64 {
+	for _, comment := range comments {
+		if comment.ID > 0 && strings.Contains(comment.Body, marker) {
+			return comment.ID
+		}
+	}
+	for _, comment := range comments {
+		if comment.ID > 0 && strings.HasPrefix(strings.TrimSpace(comment.Body), workpadHeading) {
+			return comment.ID
+		}
+	}
+	return 0
+}
+
+func changesRequestingReviewer(reviews []restReview) string {
+	latest := make(map[string]string)
+	for _, review := range reviews {
+		login := strings.ToLower(strings.TrimSpace(review.User.Login))
+		if login == "" {
+			continue
+		}
+		state := strings.ToUpper(strings.TrimSpace(review.State))
+		if state == "COMMENTED" || state == "PENDING" {
+			continue
+		}
+		latest[login] = state
+	}
+	requesting := make([]string, 0)
+	for login, state := range latest {
+		if state == "CHANGES_REQUESTED" {
+			requesting = append(requesting, login)
+		}
+	}
+	sort.Strings(requesting)
+	if len(requesting) == 0 {
+		return ""
+	}
+	return requesting[0]
+}
+
+func unreadyCheck(checks []restCheckRun) string {
+	latest := make(map[string]restCheckRun)
+	for _, check := range checks {
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			continue
+		}
+		prior, exists := latest[strings.ToLower(name)]
+		if !exists || check.ID > prior.ID {
+			latest[strings.ToLower(name)] = check
+		}
+	}
+	keys := make([]string, 0, len(latest))
+	for key := range latest {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		check := latest[key]
+		if !strings.EqualFold(strings.TrimSpace(check.Status), "completed") {
+			return check.Name
+		}
+		switch strings.ToLower(strings.TrimSpace(check.Conclusion)) {
+		case "success", "neutral", "skipped":
+		default:
+			return check.Name
+		}
+	}
+	return ""
+}
+
+func unreadyStatus(statuses []restStatus) string {
+	seen := make(map[string]struct{})
+	for _, status := range statuses {
+		name := strings.TrimSpace(status.Context)
+		key := strings.ToLower(name)
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		if !strings.EqualFold(strings.TrimSpace(status.State), "success") {
+			return name
+		}
+	}
+	return ""
+}
+
+func classifyError(err error) error {
+	if err == nil || hubserver.IsPermanent(err) {
+		return err
+	}
+	if errors.Is(err, connectorgithub.ErrMissingToken) ||
+		errors.Is(err, connectorgithub.ErrAuthenticationFailed) ||
+		errors.Is(err, connectorgithub.ErrNotFound) {
+		return hubserver.Permanent(err)
+	}
+	if errors.Is(err, connectorgithub.ErrRateLimited) ||
+		errors.Is(err, connectorgithub.ErrRESTBudgetReserved) ||
+		errors.Is(err, connectorgithub.ErrTransient) {
+		return err
+	}
+	var statusErr *connectorgithub.StatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.StatusCode {
+		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusNotFound,
+			http.StatusMethodNotAllowed, http.StatusGone, http.StatusUnprocessableEntity:
+			return hubserver.Permanent(err)
+		}
+	}
+	return err
+}
+
+type restIssue struct {
+	Labels []restLabel `json:"labels"`
+}
+
+type restLabel struct {
+	Name string `json:"name"`
+}
+
+type restComment struct {
+	ID   int64  `json:"id"`
+	Body string `json:"body"`
+}
+
+type restPullRequest struct {
+	State          string `json:"state"`
+	Draft          bool   `json:"draft"`
+	Merged         bool   `json:"merged"`
+	Mergeable      *bool  `json:"mergeable"`
+	MergeableState string `json:"mergeable_state"`
+	Head           struct {
+		SHA string `json:"sha"`
+	} `json:"head"`
+}
+
+type restReview struct {
+	State string `json:"state"`
+	User  struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+type restCheckRuns struct {
+	CheckRuns []restCheckRun `json:"check_runs"`
+}
+
+type restCheckRun struct {
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+type restStatus struct {
+	Context string `json:"context"`
+	State   string `json:"state"`
+}
+
+type restMergeResponse struct {
+	Merged  bool   `json:"merged"`
+	Message string `json:"message"`
+}
+
+var _ hubserver.OutboxBackend = (*Writer)(nil)

--- a/internal/hubgithub/writer_test.go
+++ b/internal/hubgithub/writer_test.go
@@ -1,0 +1,351 @@
+package hubgithub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	connectorgithub "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/hubserver"
+)
+
+func TestWriterReplaysWorkflowLabelAsDesiredState(t *testing.T) {
+	t.Parallel()
+
+	item := testOutboxItem(t, hubserver.MutationWorkflowLabel, hubserver.WorkflowLabelDesired{
+		Label:         "detent:in-progress",
+		ManagedPrefix: "detent:",
+	})
+	wantLabels := map[string]any{"labels": []string{"detent:in-progress", "feature"}}
+	client := &scriptedRESTClient{t: t, steps: []restStep{
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues/17", response: restIssue{Labels: []restLabel{{Name: "feature"}, {Name: "detent:todo"}}}},
+		{method: http.MethodPut, path: "/repos/digitaldrywood/detent/issues/17/labels", body: wantLabels},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues/17", response: restIssue{Labels: []restLabel{{Name: "detent:in-progress"}, {Name: "feature"}}}},
+		{method: http.MethodPut, path: "/repos/digitaldrywood/detent/issues/17/labels", body: wantLabels},
+	}}
+	writer := &Writer{client: client}
+
+	for attempt := range 2 {
+		if err := writer.Execute(t.Context(), item); err != nil {
+			t.Fatalf("Execute(%d) error = %v", attempt, err)
+		}
+	}
+	client.assertDone()
+}
+
+func TestWriterReplaysWorkpadIntoOneComment(t *testing.T) {
+	t.Parallel()
+
+	body := "## Codex Workpad\n\nTesting complete."
+	marker := "<!-- detent-workpad -->"
+	wantBody := body + "\n\n" + marker
+	item := testOutboxItem(t, hubserver.MutationWorkpad, hubserver.WorkpadDesired{
+		Phase:  "testing",
+		Body:   body,
+		Marker: marker,
+	})
+	client := &scriptedRESTClient{t: t, steps: []restStep{
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues/17/comments?per_page=100", response: []restComment{}},
+		{method: http.MethodPost, path: "/repos/digitaldrywood/detent/issues/17/comments", body: map[string]any{"body": wantBody}, response: restComment{ID: 42}},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues/17/comments?per_page=100", response: []restComment{{ID: 42, Body: wantBody}}},
+		{method: http.MethodPatch, path: "/repos/digitaldrywood/detent/issues/comments/42", body: map[string]any{"body": wantBody}},
+	}}
+	writer := &Writer{client: client}
+
+	for attempt := range 2 {
+		if err := writer.Execute(t.Context(), item); err != nil {
+			t.Fatalf("Execute(%d) error = %v", attempt, err)
+		}
+	}
+	client.assertDone()
+}
+
+func TestWriterFindsWorkpadOnLaterCommentPage(t *testing.T) {
+	t.Parallel()
+
+	body := "## Codex Workpad\n\nTesting complete."
+	marker := "<!-- detent-workpad -->"
+	wantBody := body + "\n\n" + marker
+	item := testOutboxItem(t, hubserver.MutationWorkpad, hubserver.WorkpadDesired{
+		Phase:  "testing",
+		Body:   body,
+		Marker: marker,
+	})
+	firstPage := "/repos/digitaldrywood/detent/issues/17/comments?per_page=100"
+	secondPage := "/repos/digitaldrywood/detent/issues/17/comments?page=2&per_page=100"
+	client := &scriptedRESTClient{t: t, steps: []restStep{
+		{method: http.MethodGet, path: firstPage, response: []restComment{{ID: 1, Body: "unrelated"}}, next: secondPage},
+		{method: http.MethodGet, path: secondPage, response: []restComment{{ID: 42, Body: marker}}},
+		{method: http.MethodPatch, path: "/repos/digitaldrywood/detent/issues/comments/42", body: map[string]any{"body": wantBody}},
+	}}
+
+	if err := (&Writer{client: client}).Execute(t.Context(), item); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	client.assertDone()
+}
+
+func TestWriterVerifiesFreshStateBeforeMerge(t *testing.T) {
+	t.Parallel()
+
+	ready := true
+	item := testOutboxItem(t, hubserver.MutationMergePullRequest, hubserver.MergePullRequestDesired{
+		PullRequestNumber: 29,
+		HeadSHA:           "abc123",
+		MergeMethod:       "squash",
+	})
+	pullPath := "/repos/digitaldrywood/detent/pulls/29"
+	reviewsPath := pullPath + "/reviews?per_page=100"
+	checksPath := "/repos/digitaldrywood/detent/commits/abc123/check-runs?per_page=100"
+	statusesPath := "/repos/digitaldrywood/detent/commits/abc123/statuses?per_page=100"
+
+	tests := []struct {
+		name          string
+		steps         []restStep
+		wantError     bool
+		wantPermanent bool
+	}{
+		{
+			name: "fresh state allows exact head merge",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, &ready)},
+				{method: http.MethodGet, path: reviewsPath, response: []restReview{testReview("APPROVED", "reviewer")}},
+				{method: http.MethodGet, path: checksPath, response: restCheckRuns{CheckRuns: []restCheckRun{{ID: 2, Name: "test", Status: "completed", Conclusion: "success"}}}},
+				{method: http.MethodGet, path: statusesPath, response: []restStatus{{Context: "legacy", State: "success"}}},
+				{method: http.MethodPut, path: pullPath + "/merge", body: map[string]string{"merge_method": "squash", "sha": "abc123"}, response: restMergeResponse{Merged: true}},
+			},
+		},
+		{
+			name: "already merged exact head is idempotent",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("closed", "abc123", true, &ready)},
+			},
+		},
+		{
+			name: "pull request refresh failure",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, err: errors.New("github unavailable")},
+			},
+			wantError: true,
+		},
+		{
+			name: "closed without merge",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("closed", "abc123", false, &ready)},
+			},
+			wantError:     true,
+			wantPermanent: true,
+		},
+		{
+			name: "head changed",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "different", false, &ready)},
+			},
+			wantError:     true,
+			wantPermanent: true,
+		},
+		{
+			name: "mergeability unavailable",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, nil)},
+			},
+			wantError: true,
+		},
+		{
+			name: "review requests changes",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, &ready)},
+				{method: http.MethodGet, path: reviewsPath, response: []restReview{testReview("CHANGES_REQUESTED", "reviewer")}},
+			},
+			wantError: true,
+		},
+		{
+			name: "later review page requests changes",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, &ready)},
+				{method: http.MethodGet, path: reviewsPath, response: []restReview{testReview("APPROVED", "reviewer")}, next: reviewsPath + "&page=2"},
+				{method: http.MethodGet, path: reviewsPath + "&page=2", response: []restReview{testReview("CHANGES_REQUESTED", "reviewer")}},
+			},
+			wantError: true,
+		},
+		{
+			name: "merge state is not clean",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: func() restPullRequest {
+					response := testPullRequest("open", "abc123", false, &ready)
+					response.MergeableState = "blocked"
+					return response
+				}()},
+			},
+			wantError: true,
+		},
+		{
+			name: "check is pending",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, &ready)},
+				{method: http.MethodGet, path: reviewsPath, response: []restReview{}},
+				{method: http.MethodGet, path: checksPath, response: restCheckRuns{CheckRuns: []restCheckRun{{ID: 2, Name: "test", Status: "in_progress"}}}},
+			},
+			wantError: true,
+		},
+		{
+			name: "later check page failed",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, &ready)},
+				{method: http.MethodGet, path: reviewsPath, response: []restReview{}},
+				{method: http.MethodGet, path: checksPath, response: restCheckRuns{CheckRuns: []restCheckRun{{ID: 1, Name: "test", Status: "completed", Conclusion: "success"}}}, next: checksPath + "&page=2"},
+				{method: http.MethodGet, path: checksPath + "&page=2", response: restCheckRuns{CheckRuns: []restCheckRun{{ID: 2, Name: "test", Status: "completed", Conclusion: "failure"}}}},
+			},
+			wantError: true,
+		},
+		{
+			name: "legacy status is pending",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, &ready)},
+				{method: http.MethodGet, path: reviewsPath, response: []restReview{}},
+				{method: http.MethodGet, path: checksPath, response: restCheckRuns{}},
+				{method: http.MethodGet, path: statusesPath, response: []restStatus{{Context: "legacy", State: "pending"}}},
+			},
+			wantError: true,
+		},
+		{
+			name: "later status page is pending",
+			steps: []restStep{
+				{method: http.MethodGet, path: pullPath, response: testPullRequest("open", "abc123", false, &ready)},
+				{method: http.MethodGet, path: reviewsPath, response: []restReview{}},
+				{method: http.MethodGet, path: checksPath, response: restCheckRuns{}},
+				{method: http.MethodGet, path: statusesPath, response: []restStatus{{Context: "first-page", State: "success"}}, next: statusesPath + "&page=2"},
+				{method: http.MethodGet, path: statusesPath + "&page=2", response: []restStatus{{Context: "later-page", State: "pending"}}},
+			},
+			wantError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &scriptedRESTClient{t: t, steps: test.steps}
+			err := (&Writer{client: client}).VerifyAndExecute(t.Context(), item)
+			if (err != nil) != test.wantError {
+				t.Fatalf("VerifyAndExecute() error = %v, wantError %t", err, test.wantError)
+			}
+			if got := hubserver.IsPermanent(err); got != test.wantPermanent {
+				t.Fatalf("VerifyAndExecute() permanent = %t, want %t; error = %v", got, test.wantPermanent, err)
+			}
+			client.assertDone()
+		})
+	}
+}
+
+func TestWriterClassifiesDeliveryErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		err           error
+		wantPermanent bool
+	}{
+		{name: "authentication", err: connectorgithub.ErrAuthenticationFailed, wantPermanent: true},
+		{name: "not found", err: connectorgithub.ErrNotFound, wantPermanent: true},
+		{name: "unprocessable", err: &connectorgithub.StatusError{StatusCode: http.StatusUnprocessableEntity, Err: connectorgithub.ErrUnexpectedStatus}, wantPermanent: true},
+		{name: "rate limited", err: connectorgithub.ErrRateLimited},
+		{name: "reserved budget", err: connectorgithub.ErrRESTBudgetReserved},
+		{name: "transient", err: connectorgithub.ErrTransient},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := classifyError(test.err)
+			if permanent := hubserver.IsPermanent(got); permanent != test.wantPermanent {
+				t.Fatalf("classifyError() permanent = %t, want %t; error = %v", permanent, test.wantPermanent, got)
+			}
+		})
+	}
+}
+
+type restStep struct {
+	method   string
+	path     string
+	body     any
+	response any
+	err      error
+	next     string
+}
+
+type scriptedRESTClient struct {
+	t     *testing.T
+	steps []restStep
+}
+
+func (c *scriptedRESTClient) REST(_ context.Context, method, path string, body, output any) error {
+	_, err := c.call(method, path, body, output)
+	return err
+}
+
+func (c *scriptedRESTClient) RESTPage(_ context.Context, path string, output any) (string, error) {
+	return c.call(http.MethodGet, path, nil, output)
+}
+
+func (c *scriptedRESTClient) call(method, path string, body, output any) (string, error) {
+	c.t.Helper()
+	if len(c.steps) == 0 {
+		c.t.Fatalf("unexpected REST call %s %s", method, path)
+	}
+	step := c.steps[0]
+	c.steps = c.steps[1:]
+	if method != step.method || path != step.path {
+		c.t.Fatalf("REST call = %s %s, want %s %s", method, path, step.method, step.path)
+	}
+	if !reflect.DeepEqual(body, step.body) {
+		c.t.Fatalf("REST %s %s body = %#v, want %#v", method, path, body, step.body)
+	}
+	if step.err != nil {
+		return "", step.err
+	}
+	if output == nil || step.response == nil {
+		return step.next, nil
+	}
+	raw, err := json.Marshal(step.response)
+	if err != nil {
+		c.t.Fatalf("marshal REST response: %v", err)
+	}
+	if err := json.Unmarshal(raw, output); err != nil {
+		c.t.Fatalf("unmarshal REST response: %v", err)
+	}
+	return step.next, nil
+}
+
+func (c *scriptedRESTClient) assertDone() {
+	c.t.Helper()
+	if len(c.steps) != 0 {
+		c.t.Fatalf("REST steps remaining = %d", len(c.steps))
+	}
+}
+
+func testOutboxItem(t *testing.T, kind hubserver.MutationKind, desired any) hubserver.OutboxItem {
+	t.Helper()
+	raw, err := json.Marshal(desired)
+	if err != nil {
+		t.Fatalf("marshal desired state: %v", err)
+	}
+	return hubserver.OutboxItem{
+		IdempotencyKey:  "stable-key",
+		RepositoryOwner: "digitaldrywood",
+		RepositoryName:  "detent",
+		IssueNumber:     17,
+		Kind:            kind,
+		Desired:         raw,
+	}
+}
+
+func testPullRequest(state, head string, merged bool, mergeable *bool) restPullRequest {
+	result := restPullRequest{State: state, Merged: merged, Mergeable: mergeable, MergeableState: "clean"}
+	result.Head.SHA = head
+	return result
+}
+
+func testReview(state, login string) restReview {
+	result := restReview{State: state}
+	result.User.Login = login
+	return result
+}

--- a/internal/hubserver/config.go
+++ b/internal/hubserver/config.go
@@ -12,6 +12,11 @@ const (
 	DefaultWebhookMaintenanceInterval = time.Minute
 	defaultBusyTimeout                = 5 * time.Second
 	defaultShutdownTime               = 5 * time.Second
+	defaultOutboxPoll                 = time.Second
+	defaultOutboxBase                 = 2 * time.Second
+	defaultOutboxMax                  = 15 * time.Minute
+	defaultOutboxStale                = 5 * time.Minute
+	defaultOutboxAttempts             = 8
 )
 
 var (
@@ -19,6 +24,7 @@ var (
 	ErrDatabaseIdentity        = errors.New("database is not a Detent Hub database")
 	ErrNetworkFilesystem       = errors.New("hub database requires a local filesystem")
 	ErrNotReady                = errors.New("hub service is not ready")
+	ErrOutboxDisabled          = errors.New("hub github outbox is disabled")
 	ErrUnsupportedSchema       = errors.New("hub database schema is newer than this Detent version")
 	ErrWebhookDeliveryConflict = errors.New("github webhook delivery ID has conflicting content")
 )
@@ -33,9 +39,16 @@ type Config struct {
 	WebhookMaintenanceInterval time.Duration
 	Logger                     *slog.Logger
 	Version                    string
+	OutboxBackend              OutboxBackend
+	OutboxPollInterval         time.Duration
+	OutboxBaseBackoff          time.Duration
+	OutboxMaxBackoff           time.Duration
+	OutboxProcessingTimeout    time.Duration
+	OutboxMaxAttempts          int
 
-	now                        func() time.Time
 	validateDatabaseFilesystem func(string) error
+	now                        func() time.Time
+	jitter                     func() float64
 }
 
 func (c Config) normalized() Config {
@@ -54,15 +67,36 @@ func (c Config) normalized() Config {
 	if c.WebhookMaintenanceInterval <= 0 {
 		c.WebhookMaintenanceInterval = DefaultWebhookMaintenanceInterval
 	}
+	if c.OutboxPollInterval <= 0 {
+		c.OutboxPollInterval = defaultOutboxPoll
+	}
+	if c.OutboxBaseBackoff <= 0 {
+		c.OutboxBaseBackoff = defaultOutboxBase
+	}
+	if c.OutboxMaxBackoff <= 0 {
+		c.OutboxMaxBackoff = defaultOutboxMax
+	}
+	if c.OutboxMaxBackoff < c.OutboxBaseBackoff {
+		c.OutboxMaxBackoff = c.OutboxBaseBackoff
+	}
+	if c.OutboxProcessingTimeout <= 0 {
+		c.OutboxProcessingTimeout = defaultOutboxStale
+	}
+	if c.OutboxMaxAttempts <= 0 {
+		c.OutboxMaxAttempts = defaultOutboxAttempts
+	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()
+	}
+	if c.validateDatabaseFilesystem == nil {
+		c.validateDatabaseFilesystem = validateLocalDatabaseFilesystem
 	}
 	if c.now == nil {
 		c.now = time.Now
 	}
-	c.GitHubWebhookSecret = append([]byte(nil), c.GitHubWebhookSecret...)
-	if c.validateDatabaseFilesystem == nil {
-		c.validateDatabaseFilesystem = validateLocalDatabaseFilesystem
+	if c.jitter == nil {
+		c.jitter = randomJitter
 	}
+	c.GitHubWebhookSecret = append([]byte(nil), c.GitHubWebhookSecret...)
 	return c
 }

--- a/internal/hubserver/migrate.go
+++ b/internal/hubserver/migrate.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	hubSchemaTable         = "hub_schema_version"
-	supportedSchemaVersion = int64(4)
+	supportedSchemaVersion = int64(5)
 )
 
 //go:embed migrations/*.sql

--- a/internal/hubserver/migrations/00005_harden_github_outbox.sql
+++ b/internal/hubserver/migrations/00005_harden_github_outbox.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+ALTER TABLE github_outbox ADD COLUMN coalesce_key TEXT;
+ALTER TABLE github_outbox ADD COLUMN processing_started_at TEXT;
+ALTER TABLE github_outbox ADD COLUMN operator_action TEXT;
+
+CREATE INDEX github_outbox_coalesce_idx
+ON github_outbox(coalesce_key, status, id);
+
+CREATE INDEX github_outbox_processing_idx
+ON github_outbox(status, processing_started_at, id);

--- a/internal/hubserver/outbox.go
+++ b/internal/hubserver/outbox.go
@@ -1,0 +1,869 @@
+package hubserver
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	MutationWorkflowLabel    MutationKind = "workflow_label"
+	MutationWorkpad          MutationKind = "workpad"
+	MutationMergePullRequest MutationKind = "merge_pull_request"
+
+	outboxPending      = "pending"
+	outboxProcessing   = "processing"
+	outboxRetrying     = "retrying"
+	outboxCompleted    = "completed"
+	outboxDeadLetter   = "dead_letter"
+	outboxSuperseded   = "superseded"
+	workpadMarker      = "<!-- detent-workpad -->"
+	defaultLabelPrefix = "detent:"
+	maxOutboxErrorLen  = 2000
+)
+
+var ErrIdempotencyConflict = errors.New("github outbox idempotency key already has different content")
+
+type MutationKind string
+
+func (k MutationKind) irreversible() bool {
+	return k == MutationMergePullRequest
+}
+
+type GitHubMutation interface {
+	outboxRecord() (outboxRecord, error)
+}
+
+type WorkflowLabelMutation struct {
+	IdempotencyKey string
+	RepositoryID   int64
+	IssueID        int64
+	Label          string
+	ManagedPrefix  string
+}
+
+type WorkpadMutation struct {
+	IdempotencyKey string
+	RepositoryID   int64
+	IssueID        int64
+	Phase          string
+	Body           string
+}
+
+type MergePullRequestMutation struct {
+	IdempotencyKey    string
+	RepositoryID      int64
+	IssueID           int64
+	PullRequestNumber int
+	HeadSHA           string
+	MergeMethod       string
+}
+
+type WorkflowLabelDesired struct {
+	Label         string `json:"label"`
+	ManagedPrefix string `json:"managed_prefix"`
+}
+
+type WorkpadDesired struct {
+	Phase  string `json:"phase"`
+	Body   string `json:"body"`
+	Marker string `json:"marker"`
+}
+
+type MergePullRequestDesired struct {
+	PullRequestNumber int    `json:"pull_request_number"`
+	HeadSHA           string `json:"head_sha"`
+	MergeMethod       string `json:"merge_method"`
+}
+
+type WorkEventChange struct {
+	IssueID      int64
+	FencingToken *int64
+	MachineID    string
+	SessionID    string
+	RunID        string
+	Kind         string
+	Payload      json.RawMessage
+	OccurredAt   time.Time
+	Mutation     GitHubMutation
+}
+
+type WorkflowStateChange struct {
+	IssueID         int64
+	WorkflowStateID int64
+	Mutation        WorkflowLabelMutation
+}
+
+type OutboxItem struct {
+	ID              int64
+	IdempotencyKey  string
+	RepositoryID    int64
+	RepositoryOwner string
+	RepositoryName  string
+	IssueID         int64
+	IssueNumber     int
+	Kind            MutationKind
+	TargetNodeID    string
+	Desired         json.RawMessage
+	Status          string
+	Attempts        int
+	CreatedAt       time.Time
+}
+
+type OutboxBackend interface {
+	Execute(context.Context, OutboxItem) error
+	VerifyAndExecute(context.Context, OutboxItem) error
+}
+
+type OutboxHealth struct {
+	Pending         int              `json:"pending"`
+	Retrying        int              `json:"retrying"`
+	Processing      int              `json:"processing"`
+	DeadLetters     int              `json:"dead_letters"`
+	OldestPendingAt *time.Time       `json:"oldest_pending_at,omitempty"`
+	OperatorActions []OperatorAction `json:"operator_actions,omitempty"`
+}
+
+type OperatorAction struct {
+	ID             int64        `json:"id"`
+	IdempotencyKey string       `json:"idempotency_key"`
+	Kind           MutationKind `json:"kind"`
+	TargetNodeID   string       `json:"target_node_id,omitempty"`
+	Action         string       `json:"action"`
+}
+
+type permanentError struct {
+	err error
+}
+
+func (e *permanentError) Error() string {
+	return e.err.Error()
+}
+
+func (e *permanentError) Unwrap() error {
+	return e.err
+}
+
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &permanentError{err: err}
+}
+
+func IsPermanent(err error) bool {
+	var target *permanentError
+	return errors.As(err, &target)
+}
+
+type outboxRecord struct {
+	idempotencyKey string
+	repositoryID   int64
+	issueID        int64
+	kind           MutationKind
+	targetNodeID   string
+	desired        json.RawMessage
+	coalesceKey    string
+}
+
+func (m WorkflowLabelMutation) outboxRecord() (outboxRecord, error) {
+	prefix := strings.TrimSpace(m.ManagedPrefix)
+	if prefix == "" {
+		prefix = defaultLabelPrefix
+	}
+	if strings.TrimSpace(m.Label) == "" {
+		return outboxRecord{}, errors.New("workflow label is required")
+	}
+	desired, err := json.Marshal(WorkflowLabelDesired{
+		Label:         strings.TrimSpace(m.Label),
+		ManagedPrefix: prefix,
+	})
+	if err != nil {
+		return outboxRecord{}, err
+	}
+	record := outboxRecord{
+		idempotencyKey: strings.TrimSpace(m.IdempotencyKey),
+		repositoryID:   m.RepositoryID,
+		issueID:        m.IssueID,
+		kind:           MutationWorkflowLabel,
+		desired:        desired,
+		coalesceKey:    fmt.Sprintf("workflow-label:%d:%d", m.RepositoryID, m.IssueID),
+	}
+	return record, record.validate()
+}
+
+func (m WorkpadMutation) outboxRecord() (outboxRecord, error) {
+	phase := strings.ToLower(strings.TrimSpace(m.Phase))
+	desired, err := json.Marshal(WorkpadDesired{
+		Phase:  phase,
+		Body:   strings.TrimSpace(m.Body),
+		Marker: workpadMarker,
+	})
+	if err != nil {
+		return outboxRecord{}, err
+	}
+	record := outboxRecord{
+		idempotencyKey: strings.TrimSpace(m.IdempotencyKey),
+		repositoryID:   m.RepositoryID,
+		issueID:        m.IssueID,
+		kind:           MutationWorkpad,
+		desired:        desired,
+		coalesceKey:    fmt.Sprintf("workpad:%d:%d", m.RepositoryID, m.IssueID),
+	}
+	if phase == "" {
+		return outboxRecord{}, errors.New("workpad phase is required")
+	}
+	if strings.TrimSpace(m.Body) == "" {
+		return outboxRecord{}, errors.New("workpad body is required")
+	}
+	return record, record.validate()
+}
+
+func (m MergePullRequestMutation) outboxRecord() (outboxRecord, error) {
+	method := strings.ToLower(strings.TrimSpace(m.MergeMethod))
+	if method == "" {
+		method = "squash"
+	}
+	switch method {
+	case "merge", "rebase", "squash":
+	default:
+		return outboxRecord{}, errors.New("merge method must be merge, rebase, or squash")
+	}
+	if m.PullRequestNumber <= 0 {
+		return outboxRecord{}, errors.New("pull request number must be positive")
+	}
+	if strings.TrimSpace(m.HeadSHA) == "" {
+		return outboxRecord{}, errors.New("pull request head SHA is required")
+	}
+	desired, err := json.Marshal(MergePullRequestDesired{
+		PullRequestNumber: m.PullRequestNumber,
+		HeadSHA:           strings.TrimSpace(m.HeadSHA),
+		MergeMethod:       method,
+	})
+	if err != nil {
+		return outboxRecord{}, err
+	}
+	record := outboxRecord{
+		idempotencyKey: strings.TrimSpace(m.IdempotencyKey),
+		repositoryID:   m.RepositoryID,
+		issueID:        m.IssueID,
+		kind:           MutationMergePullRequest,
+		targetNodeID:   fmt.Sprintf("pull-request:%d", m.PullRequestNumber),
+		desired:        desired,
+	}
+	return record, record.validate()
+}
+
+func (r outboxRecord) validate() error {
+	if r.idempotencyKey == "" {
+		return errors.New("github mutation idempotency key is required")
+	}
+	if r.repositoryID <= 0 {
+		return errors.New("github mutation repository id must be positive")
+	}
+	if r.issueID <= 0 {
+		return errors.New("github mutation issue id must be positive")
+	}
+	if !json.Valid(r.desired) {
+		return errors.New("github mutation desired state must be valid JSON")
+	}
+	return nil
+}
+
+func (s *Service) ChangeWorkflowState(ctx context.Context, change WorkflowStateChange) (OutboxItem, error) {
+	if !s.ready.Load() {
+		return OutboxItem{}, ErrNotReady
+	}
+	record, err := change.Mutation.outboxRecord()
+	if err != nil {
+		return OutboxItem{}, err
+	}
+	if change.IssueID <= 0 || change.WorkflowStateID <= 0 {
+		return OutboxItem{}, errors.New("issue and workflow state ids must be positive")
+	}
+	if change.IssueID != record.issueID {
+		return OutboxItem{}, errors.New("workflow state issue does not match github mutation issue")
+	}
+
+	return s.commitOutbox(ctx, record, func(tx *sql.Tx, now string) error {
+		result, err := tx.ExecContext(ctx, `
+			UPDATE issues
+			SET workflow_state_id = ?, updated_at = ?
+			WHERE id = ? AND repository_id = ?
+			  AND EXISTS (
+				SELECT 1 FROM workflow_states
+				WHERE id = ? AND repository_id = ?
+			  )`,
+			change.WorkflowStateID, now, change.IssueID, record.repositoryID,
+			change.WorkflowStateID, record.repositoryID,
+		)
+		if err != nil {
+			return fmt.Errorf("update hub workflow state: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read hub workflow state update result: %w", err)
+		}
+		if rows != 1 {
+			return errors.New("hub issue or workflow state was not found in the mutation repository")
+		}
+		return nil
+	})
+}
+
+func (s *Service) AppendWorkEvent(ctx context.Context, change WorkEventChange) (OutboxItem, error) {
+	if !s.ready.Load() {
+		return OutboxItem{}, ErrNotReady
+	}
+	if change.Mutation == nil {
+		return OutboxItem{}, errors.New("github mutation is required for a work event")
+	}
+	record, err := change.Mutation.outboxRecord()
+	if err != nil {
+		return OutboxItem{}, err
+	}
+	if change.IssueID <= 0 || change.IssueID != record.issueID {
+		return OutboxItem{}, errors.New("work event issue does not match github mutation issue")
+	}
+	kind := strings.TrimSpace(change.Kind)
+	if kind == "" {
+		return OutboxItem{}, errors.New("work event kind is required")
+	}
+	payload := change.Payload
+	if len(payload) == 0 {
+		payload = json.RawMessage(`{}`)
+	}
+	if !json.Valid(payload) {
+		return OutboxItem{}, errors.New("work event payload must be valid JSON")
+	}
+	occurredAt := change.OccurredAt
+	if occurredAt.IsZero() {
+		occurredAt = s.config.now()
+	}
+
+	return s.commitOutbox(ctx, record, func(tx *sql.Tx, now string) error {
+		var repositoryID int64
+		if err := tx.QueryRowContext(ctx, "SELECT repository_id FROM issues WHERE id = ?", change.IssueID).Scan(&repositoryID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.New("hub issue was not found")
+			}
+			return fmt.Errorf("read hub work event issue: %w", err)
+		}
+		if repositoryID != record.repositoryID {
+			return errors.New("hub work event issue is not in the mutation repository")
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO work_events (
+				issue_id, fencing_token, machine_id, session_id, run_id,
+				kind, payload_json, occurred_at, recorded_at
+			) VALUES (?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?)`,
+			change.IssueID, change.FencingToken, strings.TrimSpace(change.MachineID),
+			strings.TrimSpace(change.SessionID), strings.TrimSpace(change.RunID), kind,
+			string(payload), formatOutboxTime(occurredAt), now,
+		)
+		if err != nil {
+			return fmt.Errorf("append hub work event: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *Service) commitOutbox(ctx context.Context, record outboxRecord, apply func(*sql.Tx, string) error) (result OutboxItem, resultErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := s.database.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutboxItem{}, fmt.Errorf("begin hub state and outbox transaction: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+
+	existing, found, err := findOutboxByKey(ctx, tx, record.idempotencyKey)
+	if err != nil {
+		return OutboxItem{}, err
+	}
+	if found {
+		if !existing.matches(record) {
+			return OutboxItem{}, ErrIdempotencyConflict
+		}
+		if err := tx.Commit(); err != nil {
+			return OutboxItem{}, fmt.Errorf("commit idempotent hub mutation lookup: %w", err)
+		}
+		return existing, nil
+	}
+
+	nowTime := s.config.now().UTC()
+	now := formatOutboxTime(nowTime)
+	if record.coalesceKey != "" {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE github_outbox
+			SET status = ?, completed_at = ?, updated_at = ?
+			WHERE coalesce_key = ? AND status IN (?, ?)`,
+			outboxSuperseded, now, now, record.coalesceKey, outboxPending, outboxRetrying,
+		); err != nil {
+			return OutboxItem{}, fmt.Errorf("coalesce github outbox mutation: %w", err)
+		}
+	}
+	inserted, err := tx.ExecContext(ctx, `
+		INSERT INTO github_outbox (
+			idempotency_key, repository_id, issue_id, mutation_kind,
+			target_node_id, desired_json, status, coalesce_key,
+			created_at, updated_at
+		) VALUES (?, ?, ?, ?, NULLIF(?, ''), ?, ?, NULLIF(?, ''), ?, ?)`,
+		record.idempotencyKey, record.repositoryID, record.issueID, record.kind,
+		record.targetNodeID, string(record.desired), outboxPending, record.coalesceKey, now, now,
+	)
+	if err != nil {
+		return OutboxItem{}, fmt.Errorf("enqueue github outbox mutation: %w", err)
+	}
+	id, err := inserted.LastInsertId()
+	if err != nil {
+		return OutboxItem{}, fmt.Errorf("read github outbox mutation id: %w", err)
+	}
+	if err := apply(tx, now); err != nil {
+		return OutboxItem{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OutboxItem{}, fmt.Errorf("commit hub state and outbox transaction: %w", err)
+	}
+
+	result = OutboxItem{
+		ID:             id,
+		IdempotencyKey: record.idempotencyKey,
+		RepositoryID:   record.repositoryID,
+		IssueID:        record.issueID,
+		Kind:           record.kind,
+		TargetNodeID:   record.targetNodeID,
+		Desired:        append(json.RawMessage(nil), record.desired...),
+		Status:         outboxPending,
+		CreatedAt:      nowTime,
+	}
+	if s.outbox != nil {
+		s.outbox.signal()
+	}
+	return result, nil
+}
+
+func findOutboxByKey(ctx context.Context, tx *sql.Tx, key string) (OutboxItem, bool, error) {
+	var item OutboxItem
+	var desired string
+	var createdAt string
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, idempotency_key, repository_id, COALESCE(issue_id, 0),
+		       mutation_kind, COALESCE(target_node_id, ''), desired_json,
+		       status, attempts, created_at
+		FROM github_outbox
+		WHERE idempotency_key = ?`, key,
+	).Scan(
+		&item.ID, &item.IdempotencyKey, &item.RepositoryID, &item.IssueID,
+		&item.Kind, &item.TargetNodeID, &desired, &item.Status, &item.Attempts, &createdAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return OutboxItem{}, false, nil
+	}
+	if err != nil {
+		return OutboxItem{}, false, fmt.Errorf("find github outbox idempotency key: %w", err)
+	}
+	item.Desired = json.RawMessage(desired)
+	item.CreatedAt, err = parseOutboxTime(createdAt)
+	if err != nil {
+		return OutboxItem{}, false, fmt.Errorf("parse github outbox creation time: %w", err)
+	}
+	return item, true, nil
+}
+
+func (i OutboxItem) matches(record outboxRecord) bool {
+	return i.IdempotencyKey == record.idempotencyKey &&
+		i.RepositoryID == record.repositoryID &&
+		i.IssueID == record.issueID &&
+		i.Kind == record.kind &&
+		i.TargetNodeID == record.targetNodeID &&
+		jsonEqual(i.Desired, record.desired)
+}
+
+func jsonEqual(left, right json.RawMessage) bool {
+	var leftValue any
+	var rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	leftJSON, err := json.Marshal(leftValue)
+	if err != nil {
+		return false
+	}
+	rightJSON, err := json.Marshal(rightValue)
+	if err != nil {
+		return false
+	}
+	return string(leftJSON) == string(rightJSON)
+}
+
+func (s *Service) ProcessOutbox(ctx context.Context) (bool, error) {
+	if s.config.OutboxBackend == nil {
+		return false, ErrOutboxDisabled
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	item, found, err := s.claimOutbox(ctx)
+	if err != nil || !found {
+		return false, err
+	}
+
+	if item.Kind.irreversible() {
+		err = s.config.OutboxBackend.VerifyAndExecute(ctx, item)
+	} else {
+		err = s.config.OutboxBackend.Execute(ctx, item)
+	}
+	finishCtx, cancel := context.WithTimeout(context.Background(), s.config.BusyTimeout)
+	defer cancel()
+	if err == nil {
+		if finishErr := s.completeOutbox(finishCtx, item); finishErr != nil {
+			return true, finishErr
+		}
+		return true, nil
+	}
+	if finishErr := s.failOutbox(finishCtx, item, err); finishErr != nil {
+		return true, errors.Join(err, finishErr)
+	}
+	return true, err
+}
+
+func (s *Service) claimOutbox(ctx context.Context) (result OutboxItem, found bool, resultErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := s.database.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutboxItem{}, false, fmt.Errorf("begin github outbox claim: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+
+	now := s.config.now()
+	staleBefore := formatOutboxTime(now.Add(-s.config.OutboxProcessingTimeout))
+	var desired string
+	var createdAt string
+	err = tx.QueryRowContext(ctx, `
+		SELECT o.id, o.idempotency_key, o.repository_id, r.github_owner, r.github_name,
+		       COALESCE(o.issue_id, 0), COALESCE(i.github_number, 0), o.mutation_kind,
+		       COALESCE(o.target_node_id, ''), o.desired_json, o.status, o.attempts, o.created_at
+		FROM github_outbox o
+		JOIN repositories r ON r.id = o.repository_id
+		LEFT JOIN issues i ON i.id = o.issue_id
+		WHERE (
+			o.status IN (?, ?)
+			AND (o.next_retry_at IS NULL OR o.next_retry_at <= ?)
+		) OR (
+			o.status = ? AND o.processing_started_at <= ?
+		)
+		ORDER BY o.id
+		LIMIT 1`,
+		outboxPending, outboxRetrying, formatOutboxTime(now), outboxProcessing, staleBefore,
+	).Scan(
+		&result.ID, &result.IdempotencyKey, &result.RepositoryID,
+		&result.RepositoryOwner, &result.RepositoryName, &result.IssueID,
+		&result.IssueNumber, &result.Kind, &result.TargetNodeID, &desired,
+		&result.Status, &result.Attempts, &createdAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		if err := tx.Commit(); err != nil {
+			return OutboxItem{}, false, fmt.Errorf("commit empty github outbox claim: %w", err)
+		}
+		return OutboxItem{}, false, nil
+	}
+	if err != nil {
+		return OutboxItem{}, false, fmt.Errorf("select github outbox mutation: %w", err)
+	}
+
+	result.Attempts++
+	result.Status = outboxProcessing
+	result.Desired = json.RawMessage(desired)
+	result.CreatedAt, err = parseOutboxTime(createdAt)
+	if err != nil {
+		return OutboxItem{}, false, fmt.Errorf("parse claimed github outbox creation time: %w", err)
+	}
+	update, err := tx.ExecContext(ctx, `
+		UPDATE github_outbox
+		SET status = ?, attempts = ?, last_attempt_at = ?, processing_started_at = ?,
+		    next_retry_at = NULL, updated_at = ?
+		WHERE id = ?`,
+		outboxProcessing, result.Attempts, formatOutboxTime(now), formatOutboxTime(now),
+		formatOutboxTime(now), result.ID,
+	)
+	if err != nil {
+		return OutboxItem{}, false, fmt.Errorf("claim github outbox mutation: %w", err)
+	}
+	rows, err := update.RowsAffected()
+	if err != nil || rows != 1 {
+		return OutboxItem{}, false, fmt.Errorf("claim github outbox mutation rows = %d: %w", rows, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return OutboxItem{}, false, fmt.Errorf("commit github outbox claim: %w", err)
+	}
+	return result, true, nil
+}
+
+func (s *Service) completeOutbox(ctx context.Context, item OutboxItem) error {
+	now := formatOutboxTime(s.config.now())
+	result, err := s.database.db.ExecContext(ctx, `
+		UPDATE github_outbox
+		SET status = ?, completed_at = ?, processing_started_at = NULL,
+		    terminal_error = NULL, operator_action = NULL, updated_at = ?
+		WHERE id = ? AND status = ? AND attempts = ?`,
+		outboxCompleted, now, now, item.ID, outboxProcessing, item.Attempts,
+	)
+	if err != nil {
+		return fmt.Errorf("complete github outbox mutation: %w", err)
+	}
+	return requireOneOutboxRow(result, "complete")
+}
+
+func (s *Service) failOutbox(ctx context.Context, item OutboxItem, executionErr error) error {
+	now := s.config.now()
+	message := truncateOutboxError(executionErr.Error())
+	if IsPermanent(executionErr) || item.Attempts >= s.config.OutboxMaxAttempts {
+		action := "Inspect the failed GitHub mutation, correct its target or credentials, and enqueue a new mutation with a new idempotency key."
+		result, err := s.database.db.ExecContext(ctx, `
+			UPDATE github_outbox
+			SET status = ?, terminal_error = ?, operator_action = ?,
+			    processing_started_at = NULL, next_retry_at = NULL, updated_at = ?
+			WHERE id = ? AND status = ? AND attempts = ?`,
+			outboxDeadLetter, message, action, formatOutboxTime(now),
+			item.ID, outboxProcessing, item.Attempts,
+		)
+		if err != nil {
+			return fmt.Errorf("dead-letter github outbox mutation: %w", err)
+		}
+		return requireOneOutboxRow(result, "dead-letter")
+	}
+
+	nextRetry := now.Add(s.outboxBackoff(item.Attempts))
+	result, err := s.database.db.ExecContext(ctx, `
+		UPDATE github_outbox
+		SET status = ?, next_retry_at = ?, processing_started_at = NULL,
+		    terminal_error = ?, updated_at = ?
+		WHERE id = ? AND status = ? AND attempts = ?`,
+		outboxRetrying, formatOutboxTime(nextRetry), message, formatOutboxTime(now),
+		item.ID, outboxProcessing, item.Attempts,
+	)
+	if err != nil {
+		return fmt.Errorf("retry github outbox mutation: %w", err)
+	}
+	return requireOneOutboxRow(result, "retry")
+}
+
+func requireOneOutboxRow(result sql.Result, operation string) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read %s github outbox result: %w", operation, err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("%s github outbox mutation changed %d rows, want 1", operation, rows)
+	}
+	return nil
+}
+
+func (s *Service) outboxBackoff(attempt int) time.Duration {
+	exponent := max(attempt-1, 0)
+	multiplier := math.Pow(2, float64(min(exponent, 62)))
+	delay := time.Duration(float64(s.config.OutboxBaseBackoff) * multiplier)
+	if delay <= 0 || delay > s.config.OutboxMaxBackoff {
+		delay = s.config.OutboxMaxBackoff
+	}
+	factor := 0.5 + s.config.jitter()
+	if factor < 0.5 {
+		factor = 0.5
+	}
+	if factor > 1.5 {
+		factor = 1.5
+	}
+	delay = time.Duration(float64(delay) * factor)
+	if delay > s.config.OutboxMaxBackoff {
+		return s.config.OutboxMaxBackoff
+	}
+	return delay
+}
+
+func randomJitter() float64 {
+	var value [8]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return 0.5
+	}
+	return float64(binary.LittleEndian.Uint64(value[:])>>11) / (1 << 53)
+}
+
+func (s *Service) OutboxHealth(ctx context.Context) (OutboxHealth, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var health OutboxHealth
+	if err := s.readOutboxStatusCounts(ctx, &health); err != nil {
+		return OutboxHealth{}, err
+	}
+
+	var oldest sql.NullString
+	if err := s.database.db.QueryRowContext(ctx, `
+		SELECT MIN(created_at) FROM github_outbox WHERE status IN (?, ?, ?)`,
+		outboxPending, outboxRetrying, outboxProcessing,
+	).Scan(&oldest); err != nil {
+		return OutboxHealth{}, fmt.Errorf("query oldest github outbox mutation: %w", err)
+	}
+	if oldest.Valid {
+		parsed, err := parseOutboxTime(oldest.String)
+		if err != nil {
+			return OutboxHealth{}, fmt.Errorf("parse oldest github outbox mutation: %w", err)
+		}
+		health.OldestPendingAt = &parsed
+	}
+
+	actions, err := s.database.db.QueryContext(ctx, `
+		SELECT id, idempotency_key, mutation_kind, COALESCE(target_node_id, ''), operator_action
+		FROM github_outbox
+		WHERE status = ? AND operator_action IS NOT NULL
+		ORDER BY id`, outboxDeadLetter,
+	)
+	if err != nil {
+		return OutboxHealth{}, fmt.Errorf("query github outbox operator actions: %w", err)
+	}
+	defer actions.Close()
+	for actions.Next() {
+		var action OperatorAction
+		if err := actions.Scan(&action.ID, &action.IdempotencyKey, &action.Kind, &action.TargetNodeID, &action.Action); err != nil {
+			return OutboxHealth{}, fmt.Errorf("scan github outbox operator action: %w", err)
+		}
+		health.OperatorActions = append(health.OperatorActions, action)
+	}
+	if err := actions.Err(); err != nil {
+		return OutboxHealth{}, fmt.Errorf("iterate github outbox operator actions: %w", err)
+	}
+	return health, nil
+}
+
+func (s *Service) readOutboxStatusCounts(ctx context.Context, health *OutboxHealth) (resultErr error) {
+	rows, err := s.database.db.QueryContext(ctx, `
+		SELECT status, COUNT(*)
+		FROM github_outbox
+		WHERE status IN (?, ?, ?, ?)
+		GROUP BY status`,
+		outboxPending, outboxRetrying, outboxProcessing, outboxDeadLetter,
+	)
+	if err != nil {
+		return fmt.Errorf("query github outbox health: %w", err)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, rows.Close())
+	}()
+	for rows.Next() {
+		var status string
+		var count int
+		if err := rows.Scan(&status, &count); err != nil {
+			return fmt.Errorf("scan github outbox health: %w", err)
+		}
+		switch status {
+		case outboxPending:
+			health.Pending = count
+		case outboxRetrying:
+			health.Retrying = count
+		case outboxProcessing:
+			health.Processing = count
+		case outboxDeadLetter:
+			health.DeadLetters = count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate github outbox health: %w", err)
+	}
+	return nil
+}
+
+func formatOutboxTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
+}
+
+func parseOutboxTime(value string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, value)
+}
+
+func truncateOutboxError(message string) string {
+	message = strings.TrimSpace(message)
+	if len(message) <= maxOutboxErrorLen {
+		return message
+	}
+	return message[:maxOutboxErrorLen]
+}
+
+type outboxWorker struct {
+	service *Service
+	cancel  context.CancelFunc
+	wake    chan struct{}
+	wait    sync.WaitGroup
+}
+
+func newOutboxWorker(service *Service) *outboxWorker {
+	return &outboxWorker{
+		service: service,
+		wake:    make(chan struct{}, 1),
+	}
+}
+
+func (w *outboxWorker) start(parent context.Context) {
+	ctx, cancel := context.WithCancel(parent)
+	w.cancel = cancel
+	w.wait.Add(1)
+	go func() {
+		defer w.wait.Done()
+		w.run(ctx)
+	}()
+}
+
+func (w *outboxWorker) run(ctx context.Context) {
+	ticker := time.NewTicker(w.service.config.OutboxPollInterval)
+	defer ticker.Stop()
+	for {
+		for {
+			processed, err := w.service.ProcessOutbox(ctx)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				w.service.config.Logger.WarnContext(ctx, "github outbox delivery failed", "error", err)
+			}
+			if !processed || ctx.Err() != nil {
+				break
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.wake:
+		case <-ticker.C:
+		}
+	}
+}
+
+func (w *outboxWorker) signal() {
+	select {
+	case w.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (w *outboxWorker) stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	w.wait.Wait()
+}

--- a/internal/hubserver/outbox_test.go
+++ b/internal/hubserver/outbox_test.go
@@ -1,0 +1,484 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestChangeWorkflowStateCommitsStateAndOutboxAtomically(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	workflowStateID := insertWorkflowState(t, service.database.db, repositoryID, "In Progress")
+	mutation := WorkflowLabelMutation{
+		IdempotencyKey: "issue-1-state-in-progress",
+		RepositoryID:   repositoryID,
+		IssueID:        issueID,
+		Label:          "detent:in-progress",
+	}
+
+	item, err := service.ChangeWorkflowState(t.Context(), WorkflowStateChange{
+		IssueID:         issueID,
+		WorkflowStateID: workflowStateID,
+		Mutation:        mutation,
+	})
+	if err != nil {
+		t.Fatalf("ChangeWorkflowState() error = %v", err)
+	}
+	if item.IdempotencyKey != mutation.IdempotencyKey || item.Status != outboxPending {
+		t.Fatalf("outbox item = %#v", item)
+	}
+	assertIssueWorkflowState(t, service.database.db, issueID, workflowStateID)
+	assertOutboxCount(t, service.database.db, mutation.IdempotencyKey, 1)
+
+	if _, err := service.ChangeWorkflowState(t.Context(), WorkflowStateChange{
+		IssueID:         issueID,
+		WorkflowStateID: workflowStateID + 1000,
+		Mutation: WorkflowLabelMutation{
+			IdempotencyKey: "issue-1-invalid-state",
+			RepositoryID:   repositoryID,
+			IssueID:        issueID,
+			Label:          "detent:blocked",
+		},
+	}); err == nil {
+		t.Fatal("ChangeWorkflowState(invalid) error = nil")
+	}
+	assertIssueWorkflowState(t, service.database.db, issueID, workflowStateID)
+	assertOutboxCount(t, service.database.db, "issue-1-invalid-state", 0)
+}
+
+func TestAtomicMutationReplayDoesNotDuplicateLocalState(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	change := WorkEventChange{
+		IssueID: issueID,
+		Kind:    "progress",
+		Payload: json.RawMessage(`{"detail":"implementing"}`),
+		Mutation: WorkpadMutation{
+			IdempotencyKey: "issue-1-progress-coding",
+			RepositoryID:   repositoryID,
+			IssueID:        issueID,
+			Phase:          "coding",
+			Body:           "## Codex Workpad\n\nImplementing.",
+		},
+	}
+
+	first, err := service.AppendWorkEvent(t.Context(), change)
+	if err != nil {
+		t.Fatalf("AppendWorkEvent(first) error = %v", err)
+	}
+	second, err := service.AppendWorkEvent(t.Context(), change)
+	if err != nil {
+		t.Fatalf("AppendWorkEvent(replay) error = %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("replayed outbox id = %d, want %d", second.ID, first.ID)
+	}
+	assertTableCount(t, service.database.db, "work_events", 1)
+	assertOutboxCount(t, service.database.db, change.Mutation.(WorkpadMutation).IdempotencyKey, 1)
+}
+
+func TestAppendWorkEventCoalescesPendingWorkpadUpdates(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	tests := []struct {
+		key   string
+		phase string
+		body  string
+	}{
+		{key: "coding-1", phase: "coding", body: "Started coding"},
+		{key: "coding-2", phase: "coding", body: "Coding complete"},
+		{key: "testing-1", phase: "testing", body: "Started testing"},
+	}
+	for _, test := range tests {
+		_, err := service.AppendWorkEvent(t.Context(), WorkEventChange{
+			IssueID: issueID,
+			Kind:    "progress",
+			Mutation: WorkpadMutation{
+				IdempotencyKey: test.key,
+				RepositoryID:   repositoryID,
+				IssueID:        issueID,
+				Phase:          test.phase,
+				Body:           workpadHeadingForTest(test.body),
+			},
+		})
+		if err != nil {
+			t.Fatalf("AppendWorkEvent(%s) error = %v", test.key, err)
+		}
+	}
+
+	assertOutboxStatus(t, service.database.db, "coding-1", outboxSuperseded, 0)
+	assertOutboxStatus(t, service.database.db, "coding-2", outboxSuperseded, 0)
+	assertOutboxStatus(t, service.database.db, "testing-1", outboxPending, 0)
+	assertTableCount(t, service.database.db, "work_events", 3)
+}
+
+func TestOutboxRetriesWithStableKeyAndExponentialJitter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	backend := &recordingOutboxBackend{failures: []error{errors.New("github unavailable"), errors.New("github unavailable")}}
+	service := openManualOutboxService(t, Config{
+		DatabasePath:      filepath.Join(t.TempDir(), "hub.db"),
+		OutboxBaseBackoff: time.Second,
+		OutboxMaxBackoff:  time.Minute,
+		OutboxMaxAttempts: 3,
+		now:               func() time.Time { return now },
+		jitter:            func() float64 { return 0.25 },
+	}, backend)
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	appendTestWorkpadEvent(t, service, repositoryID, issueID, "stable-key", "coding")
+
+	processed, err := service.ProcessOutbox(t.Context())
+	if !processed || err == nil {
+		t.Fatalf("ProcessOutbox(first) = %t, %v; want processed failure", processed, err)
+	}
+	assertOutboxRetryAt(t, service.database.db, "stable-key", now.Add(750*time.Millisecond), 1)
+	if processed, err := service.ProcessOutbox(t.Context()); processed || err != nil {
+		t.Fatalf("ProcessOutbox(before retry) = %t, %v; want idle", processed, err)
+	}
+
+	now = now.Add(750 * time.Millisecond)
+	processed, err = service.ProcessOutbox(t.Context())
+	if !processed || err == nil {
+		t.Fatalf("ProcessOutbox(second) = %t, %v; want processed failure", processed, err)
+	}
+	assertOutboxRetryAt(t, service.database.db, "stable-key", now.Add(1500*time.Millisecond), 2)
+
+	now = now.Add(1500 * time.Millisecond)
+	processed, err = service.ProcessOutbox(t.Context())
+	if !processed || err != nil {
+		t.Fatalf("ProcessOutbox(third) = %t, %v; want success", processed, err)
+	}
+	assertOutboxStatus(t, service.database.db, "stable-key", outboxCompleted, 3)
+	if got := backend.keys(); len(got) != 3 || got[0] != "stable-key" || got[1] != got[0] || got[2] != got[0] {
+		t.Fatalf("backend keys = %v, want stable replay key", got)
+	}
+	if backend.effects != 1 {
+		t.Fatalf("backend effects = %d, want one idempotent effect", backend.effects)
+	}
+}
+
+func TestOutboxDeadLettersPermanentAndExhaustedFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		failures    []error
+		maxAttempts int
+	}{
+		{name: "permanent", failures: []error{Permanent(errors.New("target was deleted"))}, maxAttempts: 8},
+		{name: "exhausted", failures: []error{errors.New("unavailable"), errors.New("still unavailable")}, maxAttempts: 2},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+			backend := &recordingOutboxBackend{failures: test.failures}
+			service := openManualOutboxService(t, Config{
+				DatabasePath:      filepath.Join(t.TempDir(), "hub.db"),
+				OutboxBaseBackoff: time.Second,
+				OutboxMaxAttempts: test.maxAttempts,
+				now:               func() time.Time { return now },
+				jitter:            func() float64 { return 0.5 },
+			}, backend)
+			repositoryID, issueID := seedProjection(t, service.database.db)
+			appendTestWorkpadEvent(t, service, repositoryID, issueID, "dead-key", "coding")
+
+			for attempt := range len(test.failures) {
+				processed, err := service.ProcessOutbox(t.Context())
+				if !processed || err == nil {
+					t.Fatalf("ProcessOutbox(%d) = %t, %v; want failure", attempt, processed, err)
+				}
+				now = now.Add(time.Second)
+			}
+			assertOutboxStatus(t, service.database.db, "dead-key", outboxDeadLetter, len(test.failures))
+			health, err := service.OutboxHealth(t.Context())
+			if err != nil {
+				t.Fatalf("OutboxHealth() error = %v", err)
+			}
+			if health.DeadLetters != 1 || len(health.OperatorActions) != 1 || health.OperatorActions[0].Action == "" {
+				t.Fatalf("OutboxHealth() = %#v, want one operator-visible dead letter", health)
+			}
+		})
+	}
+}
+
+func TestIrreversibleOutboxUsesFreshVerificationPathAndFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	backend := &recordingOutboxBackend{verifyFailures: []error{Permanent(errors.New("fresh checks unavailable"))}}
+	service := openManualOutboxService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")}, backend)
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	_, err := service.AppendWorkEvent(t.Context(), WorkEventChange{
+		IssueID: issueID,
+		Kind:    "merge_requested",
+		Mutation: MergePullRequestMutation{
+			IdempotencyKey:    "merge-pr-1-abc",
+			RepositoryID:      repositoryID,
+			IssueID:           issueID,
+			PullRequestNumber: 1,
+			HeadSHA:           "abc",
+			MergeMethod:       "squash",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendWorkEvent() error = %v", err)
+	}
+
+	processed, err := service.ProcessOutbox(t.Context())
+	if !processed || err == nil {
+		t.Fatalf("ProcessOutbox() = %t, %v; want fail-closed error", processed, err)
+	}
+	if backend.executeCalls != 0 || backend.verifyCalls != 1 || backend.effects != 0 {
+		t.Fatalf("backend calls execute=%d verify=%d effects=%d", backend.executeCalls, backend.verifyCalls, backend.effects)
+	}
+	assertOutboxStatus(t, service.database.db, "merge-pr-1-abc", outboxDeadLetter, 1)
+}
+
+func TestOutboxReclaimsInterruptedProcessingAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	backend := &recordingOutboxBackend{}
+	service := openManualOutboxService(t, Config{
+		DatabasePath:            filepath.Join(t.TempDir(), "hub.db"),
+		OutboxProcessingTimeout: time.Minute,
+		now:                     func() time.Time { return now },
+	}, backend)
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	appendTestWorkpadEvent(t, service, repositoryID, issueID, "interrupted-key", "coding")
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		UPDATE github_outbox
+		SET status = ?, processing_started_at = ?, attempts = 1
+		WHERE idempotency_key = ?`, outboxProcessing, formatOutboxTime(now.Add(-2*time.Minute)), "interrupted-key"); err != nil {
+		t.Fatalf("seed interrupted item: %v", err)
+	}
+
+	processed, err := service.ProcessOutbox(t.Context())
+	if !processed || err != nil {
+		t.Fatalf("ProcessOutbox() = %t, %v; want reclaimed success", processed, err)
+	}
+	assertOutboxStatus(t, service.database.db, "interrupted-key", outboxCompleted, 2)
+}
+
+func TestServiceCloseCancelsAndDrainsOutboxWorker(t *testing.T) {
+	t.Parallel()
+
+	backend := &blockingOutboxBackend{started: make(chan struct{})}
+	service, err := Open(t.Context(), Config{
+		DatabasePath:       filepath.Join(t.TempDir(), "hub.db"),
+		Logger:             discardLogger(),
+		OutboxBackend:      backend,
+		OutboxPollInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	appendTestWorkpadEvent(t, service, repositoryID, issueID, "blocking-key", "coding")
+	select {
+	case <-backend.started:
+	case <-time.After(2 * time.Second):
+		service.Close()
+		t.Fatal("outbox worker did not start delivery")
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- service.Close()
+	}()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() did not cancel and drain the outbox worker")
+	}
+}
+
+type recordingOutboxBackend struct {
+	mu             sync.Mutex
+	failures       []error
+	verifyFailures []error
+	deliveredKeys  []string
+	seen           map[string]struct{}
+	executeCalls   int
+	verifyCalls    int
+	effects        int
+}
+
+func (b *recordingOutboxBackend) Execute(_ context.Context, item OutboxItem) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.executeCalls++
+	return b.record(item, &b.failures)
+}
+
+func (b *recordingOutboxBackend) VerifyAndExecute(_ context.Context, item OutboxItem) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.verifyCalls++
+	return b.record(item, &b.verifyFailures)
+}
+
+func (b *recordingOutboxBackend) record(item OutboxItem, failures *[]error) error {
+	b.deliveredKeys = append(b.deliveredKeys, item.IdempotencyKey)
+	if len(*failures) > 0 {
+		err := (*failures)[0]
+		*failures = (*failures)[1:]
+		if err != nil {
+			return err
+		}
+	}
+	if b.seen == nil {
+		b.seen = make(map[string]struct{})
+	}
+	if _, exists := b.seen[item.IdempotencyKey]; !exists {
+		b.seen[item.IdempotencyKey] = struct{}{}
+		b.effects++
+	}
+	return nil
+}
+
+func (b *recordingOutboxBackend) keys() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.deliveredKeys...)
+}
+
+type blockingOutboxBackend struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingOutboxBackend) Execute(ctx context.Context, _ OutboxItem) error {
+	b.once.Do(func() { close(b.started) })
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (b *blockingOutboxBackend) VerifyAndExecute(ctx context.Context, item OutboxItem) error {
+	return b.Execute(ctx, item)
+}
+
+func openManualOutboxService(t *testing.T, cfg Config, backend OutboxBackend) *Service {
+	t.Helper()
+	service := openTestService(t, cfg)
+	service.config.OutboxBackend = backend
+	return service
+}
+
+func appendTestWorkpadEvent(t *testing.T, service *Service, repositoryID, issueID int64, key, phase string) {
+	t.Helper()
+	_, err := service.AppendWorkEvent(t.Context(), WorkEventChange{
+		IssueID: issueID,
+		Kind:    "progress",
+		Mutation: WorkpadMutation{
+			IdempotencyKey: key,
+			RepositoryID:   repositoryID,
+			IssueID:        issueID,
+			Phase:          phase,
+			Body:           workpadHeadingForTest(phase),
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendWorkEvent() error = %v", err)
+	}
+}
+
+func workpadHeadingForTest(body string) string {
+	return "## Codex Workpad\n\n" + body
+}
+
+func insertWorkflowState(t *testing.T, db *sql.DB, repositoryID int64, name string) int64 {
+	t.Helper()
+	result, err := db.ExecContext(t.Context(), `
+		INSERT INTO workflow_states (
+			repository_id, github_node_id, source_name, detent_state,
+			created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?)`,
+		repositoryID, "WS_"+name, name, name, testTimestamp, testTimestamp,
+	)
+	if err != nil {
+		t.Fatalf("insert workflow state: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("workflow state id: %v", err)
+	}
+	return id
+}
+
+func assertIssueWorkflowState(t *testing.T, db *sql.DB, issueID, want int64) {
+	t.Helper()
+	var got int64
+	if err := db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues WHERE id = ?", issueID).Scan(&got); err != nil {
+		t.Fatalf("query issue workflow state: %v", err)
+	}
+	if got != want {
+		t.Fatalf("issue workflow state = %d, want %d", got, want)
+	}
+}
+
+func assertOutboxCount(t *testing.T, db *sql.DB, key string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM github_outbox WHERE idempotency_key = ?", key).Scan(&got); err != nil {
+		t.Fatalf("count outbox key %q: %v", key, err)
+	}
+	if got != want {
+		t.Fatalf("outbox count for %q = %d, want %d", key, got, want)
+	}
+}
+
+func assertTableCount(t *testing.T, db *sql.DB, table string, want int) {
+	t.Helper()
+	var got int
+	query := "SELECT COUNT(*) FROM " + table
+	if err := db.QueryRowContext(t.Context(), query).Scan(&got); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	if got != want {
+		t.Fatalf("%s count = %d, want %d", table, got, want)
+	}
+}
+
+func assertOutboxStatus(t *testing.T, db *sql.DB, key, wantStatus string, wantAttempts int) {
+	t.Helper()
+	var status string
+	var attempts int
+	if err := db.QueryRowContext(t.Context(), "SELECT status, attempts FROM github_outbox WHERE idempotency_key = ?", key).Scan(&status, &attempts); err != nil {
+		t.Fatalf("query outbox status for %q: %v", key, err)
+	}
+	if status != wantStatus || attempts != wantAttempts {
+		t.Fatalf("outbox %q = status %q attempts %d, want %q %d", key, status, attempts, wantStatus, wantAttempts)
+	}
+}
+
+func assertOutboxRetryAt(t *testing.T, db *sql.DB, key string, want time.Time, wantAttempts int) {
+	t.Helper()
+	var retryAt string
+	var attempts int
+	if err := db.QueryRowContext(t.Context(), "SELECT next_retry_at, attempts FROM github_outbox WHERE idempotency_key = ?", key).Scan(&retryAt, &attempts); err != nil {
+		t.Fatalf("query outbox retry for %q: %v", key, err)
+	}
+	got, err := parseOutboxTime(retryAt)
+	if err != nil {
+		t.Fatalf("parse outbox retry for %q: %v", key, err)
+	}
+	if !got.Equal(want) || attempts != wantAttempts {
+		t.Fatalf("outbox %q retry = %s attempts %d, want %s %d", key, got, attempts, want, wantAttempts)
+	}
+}

--- a/internal/hubserver/service.go
+++ b/internal/hubserver/service.go
@@ -25,6 +25,7 @@ type Service struct {
 	database       *database
 	tracker        tracker.Tracker
 	config         Config
+	outbox         *outboxWorker
 	ready          atomic.Bool
 	workerCancel   context.CancelFunc
 	workerDone     chan struct{}
@@ -34,9 +35,10 @@ type Service struct {
 }
 
 type healthResponse struct {
-	Status        string `json:"status"`
-	SchemaVersion int64  `json:"schema_version,omitempty"`
-	Version       string `json:"version,omitempty"`
+	Status        string       `json:"status"`
+	SchemaVersion int64        `json:"schema_version,omitempty"`
+	Version       string       `json:"version,omitempty"`
+	Outbox        OutboxHealth `json:"outbox"`
 }
 
 func Open(ctx context.Context, cfg Config) (*Service, error) {
@@ -67,11 +69,17 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 		workerCancel: workerCancel,
 		workerDone:   make(chan struct{}),
 	}
+	if cfg.OutboxBackend != nil {
+		service.outbox = newOutboxWorker(service)
+	}
 	e.GET("/health", service.health)
 	e.POST("/api/v1/webhooks/github", service.githubWebhook)
 	service.maintainGitHubWebhooks(ctx)
 	go service.runGitHubWebhookMaintenance(workerContext)
 	service.ready.Store(true)
+	if service.outbox != nil {
+		service.outbox.start(ctx)
+	}
 	return service, nil
 }
 
@@ -168,7 +176,11 @@ func (s *Service) Close() error {
 		if errors.Is(httpErr, http.ErrServerClosed) {
 			httpErr = nil
 		}
-		s.closeErr = errors.Join(httpErr, s.stopGitHubWebhookMaintenance(), s.database.Close())
+		webhookErr := s.stopGitHubWebhookMaintenance()
+		if s.outbox != nil {
+			s.outbox.stop()
+		}
+		s.closeErr = errors.Join(httpErr, webhookErr, s.database.Close())
 	})
 	return s.closeErr
 }
@@ -212,9 +224,14 @@ func (s *Service) health(c echo.Context) error {
 	if !s.ready.Load() || s.database.health(c.Request().Context()) != nil {
 		return c.JSON(http.StatusServiceUnavailable, healthResponse{Status: "unavailable"})
 	}
+	outbox, err := s.OutboxHealth(c.Request().Context())
+	if err != nil {
+		return c.JSON(http.StatusServiceUnavailable, healthResponse{Status: "unavailable"})
+	}
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:        "ok",
 		SchemaVersion: s.database.schemaVersion,
 		Version:       s.config.Version,
+		Outbox:        outbox,
 	})
 }

--- a/internal/hubserver/service_test.go
+++ b/internal/hubserver/service_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -72,7 +73,7 @@ func TestHealthEndpoint(t *testing.T) {
 			if err := json.Unmarshal(response.Body.Bytes(), &got); err != nil {
 				t.Fatalf("decode response: %v", err)
 			}
-			if got != test.wantBody {
+			if !reflect.DeepEqual(got, test.wantBody) {
 				t.Fatalf("response = %#v, want %#v", got, test.wantBody)
 			}
 		})


### PR DESCRIPTION
## Summary

- commit Hub workflow and work-event changes atomically with durable GitHub outbox intent
- deliver labels and a single workpad asynchronously with coalescing, idempotent desired-state replay, jittered backoff, and operator-visible dead letters
- require fresh PR, review, check, status, and clean mergeability data before an exact-head irreversible merge
- document the SQLite text-timestamp ordering pitfall as a reusable Detent skill draft

Fixes #2071

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check` with Go 1.26.6 and golangci-lint v2.9.0 built by Go 1.26.6 (78.8% aggregate coverage)