### PR TITLE
feat(hub): add atomic fenced leases

### DIFF
--- a/.detent/skills/sqlite-fenced-leases.md
+++ b/.detent/skills/sqlite-fenced-leases.md
@@ -1,0 +1,16 @@
+---
+name: sqlite-fenced-leases
+description: Implement atomic SQLite lease ownership with monotonic fencing tokens, stale-writer rejection, and durable recovery metadata.
+when_to_use: Use when multiple clients contend for durable work through one SQLite-owning service and expired owners must never mutate reassigned work.
+---
+
+# SQLite fenced leases
+
+- Keep every ownership decision and its write in one transaction on the sole SQLite-owning service.
+- Generate fencing tokens with an `INTEGER PRIMARY KEY AUTOINCREMENT` lease row. Never derive tokens from wall time or reuse a previous row.
+- Read the unreleased lease first. Return an idempotent result only for the same machine and session; reject another unexpired owner; mark an expired row released before inserting its successor.
+- Preserve lease rows and append-only session events. Return the previous session identity and latest durable recovery event to the successor instead of deleting expired metadata.
+- Require the exact positive fencing token on renew, release, and event append. In the same transaction, verify the row is unreleased and unexpired before any mutation.
+- Parse persisted timestamps and compare them as time values. Do not order RFC3339Nano strings in SQL because optional fractional seconds are not lexically ordered at equal whole seconds.
+- Use the current lease row as the authority for machine and session identity when appending events; reject supplied identities that disagree.
+- Test contention with a start barrier and distinct sessions, deterministic expiry with an injected clock, every stale mutation path after reassignment, and restart recovery of prior session metadata.

--- a/internal/hubserver/config.go
+++ b/internal/hubserver/config.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"log/slog"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -22,6 +24,7 @@ const (
 var (
 	ErrBackupSource            = errors.New("hub backup destination matches the source database")
 	ErrDatabaseIdentity        = errors.New("database is not a Detent Hub database")
+	ErrInvalidClock            = errors.New("hub clock returned a zero time")
 	ErrNetworkFilesystem       = errors.New("hub database requires a local filesystem")
 	ErrNotReady                = errors.New("hub service is not ready")
 	ErrOutboxDisabled          = errors.New("hub github outbox is disabled")
@@ -49,6 +52,7 @@ type Config struct {
 	validateDatabaseFilesystem func(string) error
 	now                        func() time.Time
 	jitter                     func() float64
+	newLeaseID                 func() string
 }
 
 func (c Config) normalized() Config {
@@ -96,6 +100,9 @@ func (c Config) normalized() Config {
 	}
 	if c.jitter == nil {
 		c.jitter = randomJitter
+	}
+	if c.newLeaseID == nil {
+		c.newLeaseID = uuid.NewString
 	}
 	c.GitHubWebhookSecret = append([]byte(nil), c.GitHubWebhookSecret...)
 	return c

--- a/internal/hubserver/database.go
+++ b/internal/hubserver/database.go
@@ -22,6 +22,8 @@ type database struct {
 	lock          *instancelock.Lock
 	path          string
 	schemaVersion int64
+	now           func() time.Time
+	newLeaseID    func() string
 	closeOnce     sync.Once
 	closeErr      error
 }
@@ -50,7 +52,7 @@ func openDatabase(ctx context.Context, cfg Config) (*database, error) {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 
-	store := &database{db: db, lock: lock, path: path}
+	store := &database{db: db, lock: lock, path: path, now: cfg.now, newLeaseID: cfg.newLeaseID}
 	if err := store.configure(ctx, cfg.BusyTimeout); err != nil {
 		return nil, errors.Join(err, store.Close())
 	}

--- a/internal/hubserver/tracker_mutations.go
+++ b/internal/hubserver/tracker_mutations.go
@@ -1,0 +1,637 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+type leaseRecord struct {
+	issueID tracker.WorkItemID
+	session tracker.SessionSummary
+}
+
+func (d *database) Claim(ctx context.Context, request tracker.ClaimRequest) (lease tracker.Lease, resultErr error) {
+	request, err := normalizeClaimRequest(request)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	now, err := d.currentTime()
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return tracker.Lease{}, fmt.Errorf("begin hub claim: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+
+	if err := requireWorkItem(ctx, tx, request.WorkItemID); err != nil {
+		return tracker.Lease{}, err
+	}
+	machine, err := requireMachine(ctx, tx, request.MachineID)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+
+	current, found, err := readUnreleasedLease(ctx, tx, request.WorkItemID)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	if found && current.session.ExpiresAt.After(now) {
+		if current.session.Machine.ID == request.MachineID && current.session.SessionID == request.SessionID {
+			if err := tx.Commit(); err != nil {
+				return tracker.Lease{}, fmt.Errorf("commit idempotent hub claim: %w", err)
+			}
+			return leaseFromRecord(current), nil
+		}
+		return tracker.Lease{}, fmt.Errorf("%w: work item %d is held by lease %s", tracker.ErrLeaseConflict, request.WorkItemID, current.session.ID)
+	}
+	if err := requireUnusedSession(ctx, tx, request.SessionID); err != nil {
+		return tracker.Lease{}, err
+	}
+
+	var previous *tracker.SessionSummary
+	if found {
+		previous, err = sessionSummary(ctx, tx, current)
+		if err != nil {
+			return tracker.Lease{}, err
+		}
+		if err := expireLease(ctx, tx, current, now); err != nil {
+			return tracker.Lease{}, err
+		}
+		releasedAt := now
+		previous.ReleasedAt = &releasedAt
+	} else {
+		prior, priorFound, readErr := readLatestLease(ctx, tx, request.WorkItemID)
+		if readErr != nil {
+			return tracker.Lease{}, readErr
+		}
+		if priorFound {
+			previous, err = sessionSummary(ctx, tx, prior)
+			if err != nil {
+				return tracker.Lease{}, err
+			}
+		}
+	}
+
+	leaseID := strings.TrimSpace(d.newLeaseID())
+	if leaseID == "" {
+		return tracker.Lease{}, errors.New("generate hub lease ID: empty value")
+	}
+	expiresAt := now.Add(request.TTL)
+	result, err := tx.ExecContext(ctx, `
+INSERT INTO leases (lease_id, issue_id, machine_id, session_id, expires_at, acquired_at, renewed_at, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		leaseID,
+		request.WorkItemID,
+		request.MachineID,
+		request.SessionID,
+		formatHubTime(expiresAt),
+		formatHubTime(now),
+		formatHubTime(now),
+		formatHubTime(now),
+		formatHubTime(now),
+	)
+	if err != nil {
+		return tracker.Lease{}, fmt.Errorf("insert hub claim: %w", err)
+	}
+	token, err := result.LastInsertId()
+	if err != nil {
+		return tracker.Lease{}, fmt.Errorf("read hub fencing token: %w", err)
+	}
+	if err := heartbeatMachine(ctx, tx, request.MachineID, now); err != nil {
+		return tracker.Lease{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return tracker.Lease{}, fmt.Errorf("commit hub claim: %w", err)
+	}
+	return tracker.Lease{
+		LeaseSummary: tracker.LeaseSummary{
+			ID:           tracker.LeaseID(leaseID),
+			FencingToken: tracker.FencingToken(token),
+			Machine:      machine,
+			SessionID:    request.SessionID,
+			AcquiredAt:   now,
+			RenewedAt:    now,
+			ExpiresAt:    expiresAt,
+		},
+		WorkItemID:      request.WorkItemID,
+		PreviousSession: previous,
+	}, nil
+}
+
+func (d *database) Renew(ctx context.Context, request tracker.RenewRequest) (lease tracker.Lease, resultErr error) {
+	request, err := normalizeRenewRequest(request)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	now, err := d.currentTime()
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return tracker.Lease{}, fmt.Errorf("begin hub lease renewal: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+
+	record, found, err := readLeaseByID(ctx, tx, request.LeaseID)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	if !found {
+		return tracker.Lease{}, fmt.Errorf("%w: %s", tracker.ErrLeaseNotFound, request.LeaseID)
+	}
+	if err := requireCurrentLease(record, request.FencingToken, now); err != nil {
+		return tracker.Lease{}, err
+	}
+
+	expiresAt := now.Add(request.TTL)
+	result, err := tx.ExecContext(ctx, `
+UPDATE leases
+SET expires_at = ?, renewed_at = ?, updated_at = ?
+WHERE lease_id = ? AND fencing_token = ? AND released_at IS NULL`,
+		formatHubTime(expiresAt),
+		formatHubTime(now),
+		formatHubTime(now),
+		request.LeaseID,
+		request.FencingToken,
+	)
+	if err != nil {
+		return tracker.Lease{}, fmt.Errorf("renew hub lease: %w", err)
+	}
+	if err := requireOneLeaseMutation(result, request.LeaseID); err != nil {
+		return tracker.Lease{}, err
+	}
+	if err := heartbeatMachine(ctx, tx, record.session.Machine.ID, now); err != nil {
+		return tracker.Lease{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return tracker.Lease{}, fmt.Errorf("commit hub lease renewal: %w", err)
+	}
+	record.session.RenewedAt = now
+	record.session.ExpiresAt = expiresAt
+	return leaseFromRecord(record), nil
+}
+
+func (d *database) Release(ctx context.Context, request tracker.ReleaseRequest) (resultErr error) {
+	request, err := normalizeReleaseRequest(request)
+	if err != nil {
+		return err
+	}
+	now, err := d.currentTime()
+	if err != nil {
+		return err
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin hub lease release: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+
+	record, found, err := readLeaseByID(ctx, tx, request.LeaseID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("%w: %s", tracker.ErrLeaseNotFound, request.LeaseID)
+	}
+	if err := requireCurrentLease(record, request.FencingToken, now); err != nil {
+		return err
+	}
+
+	payload := map[string]any{}
+	if request.Reason != "" {
+		payload["reason"] = request.Reason
+	}
+	if err := insertWorkEvent(ctx, tx, tracker.WorkEvent{
+		WorkItemID:   record.issueID,
+		FencingToken: request.FencingToken,
+		MachineID:    record.session.Machine.ID,
+		SessionID:    record.session.SessionID,
+		Kind:         "lease_released",
+		Payload:      payload,
+		OccurredAt:   now,
+	}, now); err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, `
+UPDATE leases
+SET released_at = ?, updated_at = ?
+WHERE lease_id = ? AND fencing_token = ? AND released_at IS NULL`,
+		formatHubTime(now),
+		formatHubTime(now),
+		request.LeaseID,
+		request.FencingToken,
+	)
+	if err != nil {
+		return fmt.Errorf("release hub lease: %w", err)
+	}
+	if err := requireOneLeaseMutation(result, request.LeaseID); err != nil {
+		return err
+	}
+	if err := heartbeatMachine(ctx, tx, record.session.Machine.ID, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit hub lease release: %w", err)
+	}
+	return nil
+}
+
+func (d *database) AppendEvent(ctx context.Context, event tracker.WorkEvent) (resultErr error) {
+	event, err := normalizeWorkEvent(event)
+	if err != nil {
+		return err
+	}
+	now, err := d.currentTime()
+	if err != nil {
+		return err
+	}
+	if event.OccurredAt.IsZero() {
+		event.OccurredAt = now
+	} else {
+		event.OccurredAt = event.OccurredAt.UTC()
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin hub work event: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+
+	current, found, err := readUnreleasedLease(ctx, tx, event.WorkItemID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("%w: work item %d", tracker.ErrStaleFencingToken, event.WorkItemID)
+	}
+	if err := requireCurrentLease(current, event.FencingToken, now); err != nil {
+		return err
+	}
+	if event.MachineID != "" && event.MachineID != current.session.Machine.ID {
+		return fmt.Errorf("%w: machine %s does not own lease %s", tracker.ErrInvalidWorkEvent, event.MachineID, current.session.ID)
+	}
+	if event.SessionID != "" && event.SessionID != current.session.SessionID {
+		return fmt.Errorf("%w: session %s does not own lease %s", tracker.ErrInvalidWorkEvent, event.SessionID, current.session.ID)
+	}
+	event.MachineID = current.session.Machine.ID
+	event.SessionID = current.session.SessionID
+	if err := insertWorkEvent(ctx, tx, event, now); err != nil {
+		return err
+	}
+	if err := heartbeatMachine(ctx, tx, current.session.Machine.ID, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit hub work event: %w", err)
+	}
+	return nil
+}
+
+func normalizeClaimRequest(request tracker.ClaimRequest) (tracker.ClaimRequest, error) {
+	request.MachineID = tracker.MachineID(strings.TrimSpace(string(request.MachineID)))
+	request.SessionID = strings.TrimSpace(request.SessionID)
+	switch {
+	case request.WorkItemID <= 0:
+		return tracker.ClaimRequest{}, fmt.Errorf("%w: work item ID must be positive", tracker.ErrInvalidClaimRequest)
+	case request.MachineID == "":
+		return tracker.ClaimRequest{}, fmt.Errorf("%w: machine ID is required", tracker.ErrInvalidClaimRequest)
+	case request.SessionID == "":
+		return tracker.ClaimRequest{}, fmt.Errorf("%w: session ID is required", tracker.ErrInvalidClaimRequest)
+	case request.TTL <= 0:
+		return tracker.ClaimRequest{}, fmt.Errorf("%w: TTL must be positive", tracker.ErrInvalidClaimRequest)
+	default:
+		return request, nil
+	}
+}
+
+func normalizeRenewRequest(request tracker.RenewRequest) (tracker.RenewRequest, error) {
+	request.LeaseID = tracker.LeaseID(strings.TrimSpace(string(request.LeaseID)))
+	switch {
+	case request.LeaseID == "":
+		return tracker.RenewRequest{}, fmt.Errorf("%w: lease ID is required", tracker.ErrInvalidLeaseRequest)
+	case request.FencingToken <= 0:
+		return tracker.RenewRequest{}, fmt.Errorf("%w: fencing token must be positive", tracker.ErrInvalidLeaseRequest)
+	case request.TTL <= 0:
+		return tracker.RenewRequest{}, fmt.Errorf("%w: TTL must be positive", tracker.ErrInvalidLeaseRequest)
+	default:
+		return request, nil
+	}
+}
+
+func normalizeReleaseRequest(request tracker.ReleaseRequest) (tracker.ReleaseRequest, error) {
+	request.LeaseID = tracker.LeaseID(strings.TrimSpace(string(request.LeaseID)))
+	request.Reason = strings.TrimSpace(request.Reason)
+	if request.LeaseID == "" {
+		return tracker.ReleaseRequest{}, fmt.Errorf("%w: lease ID is required", tracker.ErrInvalidLeaseRequest)
+	}
+	if request.FencingToken <= 0 {
+		return tracker.ReleaseRequest{}, fmt.Errorf("%w: fencing token must be positive", tracker.ErrInvalidLeaseRequest)
+	}
+	return request, nil
+}
+
+func normalizeWorkEvent(event tracker.WorkEvent) (tracker.WorkEvent, error) {
+	event.MachineID = tracker.MachineID(strings.TrimSpace(string(event.MachineID)))
+	event.SessionID = strings.TrimSpace(event.SessionID)
+	event.RunID = strings.TrimSpace(event.RunID)
+	event.Kind = strings.TrimSpace(event.Kind)
+	if event.WorkItemID <= 0 {
+		return tracker.WorkEvent{}, fmt.Errorf("%w: work item ID must be positive", tracker.ErrInvalidWorkEvent)
+	}
+	if event.FencingToken <= 0 {
+		return tracker.WorkEvent{}, fmt.Errorf("%w: fencing token is required", tracker.ErrInvalidWorkEvent)
+	}
+	if event.Kind == "" {
+		return tracker.WorkEvent{}, fmt.Errorf("%w: kind is required", tracker.ErrInvalidWorkEvent)
+	}
+	if _, err := json.Marshal(event.Payload); err != nil {
+		return tracker.WorkEvent{}, fmt.Errorf("%w: encode payload: %w", tracker.ErrInvalidWorkEvent, err)
+	}
+	return event, nil
+}
+
+func (d *database) currentTime() (time.Time, error) {
+	now := d.now().UTC()
+	if now.IsZero() {
+		return time.Time{}, ErrInvalidClock
+	}
+	return now, nil
+}
+
+func requireWorkItem(ctx context.Context, tx *sql.Tx, workItemID tracker.WorkItemID) error {
+	var exists bool
+	if err := tx.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM issues WHERE id = ?)", workItemID).Scan(&exists); err != nil {
+		return fmt.Errorf("verify hub work item: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%w: %d", tracker.ErrWorkItemNotFound, workItemID)
+	}
+	return nil
+}
+
+func requireMachine(ctx context.Context, tx *sql.Tx, machineID tracker.MachineID) (tracker.MachineSummary, error) {
+	machine := tracker.MachineSummary{ID: machineID}
+	if err := tx.QueryRowContext(ctx, "SELECT hostname, display_name FROM machines WHERE id = ?", machineID).Scan(&machine.Hostname, &machine.DisplayName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return tracker.MachineSummary{}, fmt.Errorf("%w: %s", tracker.ErrMachineNotFound, machineID)
+		}
+		return tracker.MachineSummary{}, fmt.Errorf("read hub machine: %w", err)
+	}
+	return machine, nil
+}
+
+func requireUnusedSession(ctx context.Context, tx *sql.Tx, sessionID string) error {
+	var leaseID tracker.LeaseID
+	err := tx.QueryRowContext(ctx, "SELECT lease_id FROM leases WHERE session_id = ?", sessionID).Scan(&leaseID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("verify hub lease session: %w", err)
+	}
+	return fmt.Errorf("%w: session %s already belongs to lease %s", tracker.ErrLeaseConflict, sessionID, leaseID)
+}
+
+func readUnreleasedLease(ctx context.Context, tx *sql.Tx, workItemID tracker.WorkItemID) (leaseRecord, bool, error) {
+	return scanLeaseRecord(tx.QueryRowContext(ctx, `
+SELECT l.issue_id, l.lease_id, l.fencing_token, l.machine_id, m.hostname, m.display_name, l.session_id, l.acquired_at, l.renewed_at, l.expires_at, l.released_at
+FROM leases l
+JOIN machines m ON m.id = l.machine_id
+WHERE l.issue_id = ? AND l.released_at IS NULL
+LIMIT 1`, workItemID))
+}
+
+func readLatestLease(ctx context.Context, tx *sql.Tx, workItemID tracker.WorkItemID) (leaseRecord, bool, error) {
+	return scanLeaseRecord(tx.QueryRowContext(ctx, `
+SELECT l.issue_id, l.lease_id, l.fencing_token, l.machine_id, m.hostname, m.display_name, l.session_id, l.acquired_at, l.renewed_at, l.expires_at, l.released_at
+FROM leases l
+JOIN machines m ON m.id = l.machine_id
+WHERE l.issue_id = ?
+ORDER BY l.fencing_token DESC
+LIMIT 1`, workItemID))
+}
+
+func readLeaseByID(ctx context.Context, tx *sql.Tx, leaseID tracker.LeaseID) (leaseRecord, bool, error) {
+	return scanLeaseRecord(tx.QueryRowContext(ctx, `
+SELECT l.issue_id, l.lease_id, l.fencing_token, l.machine_id, m.hostname, m.display_name, l.session_id, l.acquired_at, l.renewed_at, l.expires_at, l.released_at
+FROM leases l
+JOIN machines m ON m.id = l.machine_id
+WHERE l.lease_id = ?`, leaseID))
+}
+
+func scanLeaseRecord(row interface{ Scan(...any) error }) (leaseRecord, bool, error) {
+	var record leaseRecord
+	var acquiredAt string
+	var renewedAt string
+	var expiresAt string
+	var releasedAt sql.NullString
+	err := row.Scan(
+		&record.issueID,
+		&record.session.ID,
+		&record.session.FencingToken,
+		&record.session.Machine.ID,
+		&record.session.Machine.Hostname,
+		&record.session.Machine.DisplayName,
+		&record.session.SessionID,
+		&acquiredAt,
+		&renewedAt,
+		&expiresAt,
+		&releasedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return leaseRecord{}, false, nil
+	}
+	if err != nil {
+		return leaseRecord{}, false, fmt.Errorf("scan hub lease: %w", err)
+	}
+	if record.session.AcquiredAt, err = parseTimeValue(acquiredAt); err != nil {
+		return leaseRecord{}, false, fmt.Errorf("decode hub lease acquired timestamp: %w", err)
+	}
+	if record.session.RenewedAt, err = parseTimeValue(renewedAt); err != nil {
+		return leaseRecord{}, false, fmt.Errorf("decode hub lease renewed timestamp: %w", err)
+	}
+	if record.session.ExpiresAt, err = parseTimeValue(expiresAt); err != nil {
+		return leaseRecord{}, false, fmt.Errorf("decode hub lease expiry timestamp: %w", err)
+	}
+	if releasedAt.Valid {
+		released, parseErr := parseTimeValue(releasedAt.String)
+		if parseErr != nil {
+			return leaseRecord{}, false, fmt.Errorf("decode hub lease release timestamp: %w", parseErr)
+		}
+		record.session.ReleasedAt = &released
+	}
+	return record, true, nil
+}
+
+func sessionSummary(ctx context.Context, tx *sql.Tx, record leaseRecord) (*tracker.SessionSummary, error) {
+	event, found, err := readLastWorkEvent(ctx, tx, record.session.FencingToken)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		record.session.LastEvent = &event
+	}
+	return &record.session, nil
+}
+
+func readLastWorkEvent(ctx context.Context, tx *sql.Tx, token tracker.FencingToken) (tracker.WorkEvent, bool, error) {
+	var event tracker.WorkEvent
+	var machineID sql.NullString
+	var sessionID sql.NullString
+	var runID sql.NullString
+	var payloadJSON string
+	var occurredAt string
+	err := tx.QueryRowContext(ctx, `
+SELECT issue_id, fencing_token, machine_id, session_id, run_id, kind, payload_json, occurred_at
+FROM work_events
+WHERE fencing_token = ?
+ORDER BY id DESC
+LIMIT 1`, token).Scan(
+		&event.WorkItemID,
+		&event.FencingToken,
+		&machineID,
+		&sessionID,
+		&runID,
+		&event.Kind,
+		&payloadJSON,
+		&occurredAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return tracker.WorkEvent{}, false, nil
+	}
+	if err != nil {
+		return tracker.WorkEvent{}, false, fmt.Errorf("read latest hub work event: %w", err)
+	}
+	event.MachineID = tracker.MachineID(machineID.String)
+	event.SessionID = sessionID.String
+	event.RunID = runID.String
+	if err := json.Unmarshal([]byte(payloadJSON), &event.Payload); err != nil {
+		return tracker.WorkEvent{}, false, fmt.Errorf("decode latest hub work event payload: %w", err)
+	}
+	if event.OccurredAt, err = parseTimeValue(occurredAt); err != nil {
+		return tracker.WorkEvent{}, false, fmt.Errorf("decode latest hub work event timestamp: %w", err)
+	}
+	return event, true, nil
+}
+
+func expireLease(ctx context.Context, tx *sql.Tx, record leaseRecord, now time.Time) error {
+	result, err := tx.ExecContext(ctx, `
+UPDATE leases
+SET released_at = ?, updated_at = ?
+WHERE lease_id = ? AND fencing_token = ? AND released_at IS NULL`,
+		formatHubTime(now),
+		formatHubTime(now),
+		record.session.ID,
+		record.session.FencingToken,
+	)
+	if err != nil {
+		return fmt.Errorf("expire replaced hub lease: %w", err)
+	}
+	if err := requireOneLeaseMutation(result, record.session.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func requireCurrentLease(record leaseRecord, token tracker.FencingToken, now time.Time) error {
+	if record.session.FencingToken != token || record.session.ReleasedAt != nil || !record.session.ExpiresAt.After(now) {
+		return fmt.Errorf("%w: lease %s", tracker.ErrStaleFencingToken, record.session.ID)
+	}
+	return nil
+}
+
+func requireOneLeaseMutation(result sql.Result, leaseID tracker.LeaseID) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read hub lease mutation result: %w", err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("%w: lease %s changed concurrently", tracker.ErrStaleFencingToken, leaseID)
+	}
+	return nil
+}
+
+func heartbeatMachine(ctx context.Context, tx *sql.Tx, machineID tracker.MachineID, now time.Time) error {
+	result, err := tx.ExecContext(ctx, "UPDATE machines SET last_heartbeat_at = ?, updated_at = ? WHERE id = ?", formatHubTime(now), formatHubTime(now), machineID)
+	if err != nil {
+		return fmt.Errorf("heartbeat hub machine: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read hub machine heartbeat result: %w", err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("%w: %s", tracker.ErrMachineNotFound, machineID)
+	}
+	return nil
+}
+
+func insertWorkEvent(ctx context.Context, tx *sql.Tx, event tracker.WorkEvent, recordedAt time.Time) error {
+	payload, err := json.Marshal(event.Payload)
+	if err != nil {
+		return fmt.Errorf("encode hub work event payload: %w", err)
+	}
+	if string(payload) == "null" {
+		payload = []byte("{}")
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO work_events (issue_id, fencing_token, machine_id, session_id, run_id, kind, payload_json, occurred_at, recorded_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		event.WorkItemID,
+		event.FencingToken,
+		event.MachineID,
+		event.SessionID,
+		nullString(event.RunID),
+		event.Kind,
+		string(payload),
+		formatHubTime(event.OccurredAt),
+		formatHubTime(recordedAt),
+	); err != nil {
+		return fmt.Errorf("append hub work event: %w", err)
+	}
+	return nil
+}
+
+func leaseFromRecord(record leaseRecord) tracker.Lease {
+	return tracker.Lease{LeaseSummary: record.session.LeaseSummary, WorkItemID: record.issueID}
+}
+
+func formatHubTime(value time.Time) string {
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func nullString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/hubserver/tracker_mutations.go
+++ b/internal/hubserver/tracker_mutations.go
@@ -22,11 +22,6 @@ func (d *database) Claim(ctx context.Context, request tracker.ClaimRequest) (lea
 	if err != nil {
 		return tracker.Lease{}, err
 	}
-	now, err := d.currentTime()
-	if err != nil {
-		return tracker.Lease{}, err
-	}
-
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return tracker.Lease{}, fmt.Errorf("begin hub claim: %w", err)
@@ -36,6 +31,10 @@ func (d *database) Claim(ctx context.Context, request tracker.ClaimRequest) (lea
 			resultErr = errors.Join(resultErr, tx.Rollback())
 		}
 	}()
+	now, err := d.currentTime()
+	if err != nil {
+		return tracker.Lease{}, err
+	}
 
 	if err := requireWorkItem(ctx, tx, request.WorkItemID); err != nil {
 		return tracker.Lease{}, err
@@ -137,11 +136,6 @@ func (d *database) Renew(ctx context.Context, request tracker.RenewRequest) (lea
 	if err != nil {
 		return tracker.Lease{}, err
 	}
-	now, err := d.currentTime()
-	if err != nil {
-		return tracker.Lease{}, err
-	}
-
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return tracker.Lease{}, fmt.Errorf("begin hub lease renewal: %w", err)
@@ -151,6 +145,10 @@ func (d *database) Renew(ctx context.Context, request tracker.RenewRequest) (lea
 			resultErr = errors.Join(resultErr, tx.Rollback())
 		}
 	}()
+	now, err := d.currentTime()
+	if err != nil {
+		return tracker.Lease{}, err
+	}
 
 	record, found, err := readLeaseByID(ctx, tx, request.LeaseID)
 	if err != nil {
@@ -196,11 +194,6 @@ func (d *database) Release(ctx context.Context, request tracker.ReleaseRequest) 
 	if err != nil {
 		return err
 	}
-	now, err := d.currentTime()
-	if err != nil {
-		return err
-	}
-
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin hub lease release: %w", err)
@@ -210,6 +203,10 @@ func (d *database) Release(ctx context.Context, request tracker.ReleaseRequest) 
 			resultErr = errors.Join(resultErr, tx.Rollback())
 		}
 	}()
+	now, err := d.currentTime()
+	if err != nil {
+		return err
+	}
 
 	record, found, err := readLeaseByID(ctx, tx, request.LeaseID)
 	if err != nil {
@@ -266,16 +263,6 @@ func (d *database) AppendEvent(ctx context.Context, event tracker.WorkEvent) (re
 	if err != nil {
 		return err
 	}
-	now, err := d.currentTime()
-	if err != nil {
-		return err
-	}
-	if event.OccurredAt.IsZero() {
-		event.OccurredAt = now
-	} else {
-		event.OccurredAt = event.OccurredAt.UTC()
-	}
-
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin hub work event: %w", err)
@@ -285,6 +272,15 @@ func (d *database) AppendEvent(ctx context.Context, event tracker.WorkEvent) (re
 			resultErr = errors.Join(resultErr, tx.Rollback())
 		}
 	}()
+	now, err := d.currentTime()
+	if err != nil {
+		return err
+	}
+	if event.OccurredAt.IsZero() {
+		event.OccurredAt = now
+	} else {
+		event.OccurredAt = event.OccurredAt.UTC()
+	}
 
 	current, found, err := readUnreleasedLease(ctx, tx, event.WorkItemID)
 	if err != nil {

--- a/internal/hubserver/tracker_mutations_test.go
+++ b/internal/hubserver/tracker_mutations_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -93,6 +94,91 @@ func TestConcurrentClaimsProduceOneFencedWinner(t *testing.T) {
 	}
 	if total != 2 || active != 1 || maximumToken != winner.FencingToken {
 		t.Fatalf("persisted leases = total %d active %d max token %d; want total 2 active 1 max token %d", total, active, maximumToken, winner.FencingToken)
+	}
+}
+
+func TestLeaseOperationsSampleClockAfterTransactionAcquisition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("claim timestamps", func(t *testing.T) {
+		now := time.Date(2026, 9, 2, 12, 15, 0, 0, time.UTC)
+		clock := &leaseTestClock{value: now}
+		service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: clock.Now})
+		_, issueID := seedProjection(t, service.database.db)
+		seedHubMachine(t, service, "machine-a", now)
+
+		var claimed tracker.Lease
+		err := runQueuedHubMutation(t, service, func() {
+			clock.Advance(2 * time.Minute)
+		}, func() (claimErr error) {
+			claimed, claimErr = service.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+				WorkItemID: tracker.WorkItemID(issueID),
+				MachineID:  "machine-a",
+				SessionID:  "session-a",
+				TTL:        time.Minute,
+			})
+			return claimErr
+		})
+		if err != nil {
+			t.Fatalf("Claim() error = %v", err)
+		}
+		acquiredAt := now.Add(2 * time.Minute)
+		if !claimed.AcquiredAt.Equal(acquiredAt) || !claimed.ExpiresAt.Equal(acquiredAt.Add(time.Minute)) {
+			t.Fatalf("Claim() timestamps = acquired %s expires %s, want acquired %s expires %s", claimed.AcquiredAt, claimed.ExpiresAt, acquiredAt, acquiredAt.Add(time.Minute))
+		}
+	})
+
+	tests := []struct {
+		name   string
+		mutate func(*Service, tracker.WorkItemID, tracker.Lease) error
+	}{
+		{
+			name: "renew",
+			mutate: func(service *Service, _ tracker.WorkItemID, lease tracker.Lease) error {
+				_, err := service.Tracker().Renew(t.Context(), tracker.RenewRequest{LeaseID: lease.ID, FencingToken: lease.FencingToken, TTL: time.Minute})
+				return err
+			},
+		},
+		{
+			name: "release",
+			mutate: func(service *Service, _ tracker.WorkItemID, lease tracker.Lease) error {
+				return service.Tracker().Release(t.Context(), tracker.ReleaseRequest{LeaseID: lease.ID, FencingToken: lease.FencingToken})
+			},
+		},
+		{
+			name: "append event",
+			mutate: func(service *Service, workItemID tracker.WorkItemID, lease tracker.Lease) error {
+				return service.Tracker().AppendEvent(t.Context(), tracker.WorkEvent{WorkItemID: workItemID, FencingToken: lease.FencingToken, Kind: "late_progress"})
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 2, 12, 20, 0, 0, time.UTC)
+			clock := &leaseTestClock{value: now}
+			service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: clock.Now})
+			_, issueID := seedProjection(t, service.database.db)
+			seedHubMachine(t, service, "machine-a", now)
+			workItemID := tracker.WorkItemID(issueID)
+			lease, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+				WorkItemID: workItemID,
+				MachineID:  "machine-a",
+				SessionID:  "session-a",
+				TTL:        time.Minute,
+			})
+			if err != nil {
+				t.Fatalf("Claim() error = %v", err)
+			}
+
+			err = runQueuedHubMutation(t, service, func() {
+				clock.Advance(2 * time.Minute)
+			}, func() error {
+				return test.mutate(service, workItemID, lease)
+			})
+			if !errors.Is(err, tracker.ErrStaleFencingToken) {
+				t.Fatalf("queued mutation error = %v, want ErrStaleFencingToken", err)
+			}
+		})
 	}
 }
 
@@ -407,6 +493,42 @@ INSERT INTO machines (id, hostname, display_name, capacity, version, last_heartb
 VALUES (?, ?, ?, 1, 'test', ?, ?, ?)`, machineID, machineID, machineID, formatHubTime(now), formatHubTime(now), formatHubTime(now)); err != nil {
 		t.Fatalf("insert machine %s: %v", machineID, err)
 	}
+}
+
+func runQueuedHubMutation(t *testing.T, service *Service, afterQueued func(), mutate func() error) error {
+	t.Helper()
+	blocker, err := service.database.db.BeginTx(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("begin blocking transaction: %v", err)
+	}
+	defer func() { _ = blocker.Rollback() }()
+
+	waitsBefore := service.database.db.Stats().WaitCount
+	finished := make(chan error, 1)
+	go func() {
+		finished <- mutate()
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for service.database.db.Stats().WaitCount == waitsBefore {
+		select {
+		case mutationErr := <-finished:
+			t.Fatalf("queued mutation completed before the blocking transaction was released: %v", mutationErr)
+			return mutationErr
+		case <-timer.C:
+			t.Fatal("queued mutation did not wait for the blocking transaction")
+			return nil
+		default:
+			runtime.Gosched()
+		}
+	}
+
+	afterQueued()
+	if err := blocker.Rollback(); err != nil {
+		t.Fatalf("release blocking transaction: %v", err)
+	}
+	return <-finished
 }
 
 type leaseTestClock struct {

--- a/internal/hubserver/tracker_mutations_test.go
+++ b/internal/hubserver/tracker_mutations_test.go
@@ -1,0 +1,427 @@
+package hubserver
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func TestConcurrentClaimsProduceOneFencedWinner(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	clock := &leaseTestClock{value: now}
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: clock.Now})
+	_, issueID := seedProjection(t, service.database.db)
+	seedHubMachine(t, service, "machine-prior", now)
+	prior, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+		WorkItemID: tracker.WorkItemID(issueID),
+		MachineID:  "machine-prior",
+		SessionID:  "session-prior",
+		TTL:        time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Claim(prior) error = %v", err)
+	}
+	if err := service.Tracker().Release(t.Context(), tracker.ReleaseRequest{LeaseID: prior.ID, FencingToken: prior.FencingToken}); err != nil {
+		t.Fatalf("Release(prior) error = %v", err)
+	}
+
+	const contenders = 10
+	for i := range contenders {
+		seedHubMachine(t, service, tracker.MachineID(fmt.Sprintf("machine-%d", i)), now)
+	}
+	type claimResult struct {
+		lease tracker.Lease
+		err   error
+	}
+	start := make(chan struct{})
+	results := make(chan claimResult, contenders)
+	var group sync.WaitGroup
+	for i := range contenders {
+		group.Add(1)
+		go func(index int) {
+			defer group.Done()
+			<-start
+			lease, claimErr := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+				WorkItemID: tracker.WorkItemID(issueID),
+				MachineID:  tracker.MachineID(fmt.Sprintf("machine-%d", index)),
+				SessionID:  fmt.Sprintf("session-%d", index),
+				TTL:        time.Minute,
+			})
+			results <- claimResult{lease: lease, err: claimErr}
+		}(i)
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	winners := make([]tracker.Lease, 0, 1)
+	conflicts := 0
+	for result := range results {
+		switch {
+		case result.err == nil:
+			winners = append(winners, result.lease)
+		case errors.Is(result.err, tracker.ErrLeaseConflict):
+			conflicts++
+		default:
+			t.Errorf("Claim() error = %v, want lease conflict", result.err)
+		}
+	}
+	if len(winners) != 1 || conflicts != contenders-1 {
+		t.Fatalf("claim results = %d winners, %d conflicts; want 1 winner, %d conflicts", len(winners), conflicts, contenders-1)
+	}
+	winner := winners[0]
+	if winner.FencingToken <= prior.FencingToken {
+		t.Errorf("winner fencing token = %d, want greater than prior token %d", winner.FencingToken, prior.FencingToken)
+	}
+	if winner.PreviousSession == nil || winner.PreviousSession.SessionID != prior.SessionID {
+		t.Errorf("winner previous session = %#v, want session %q", winner.PreviousSession, prior.SessionID)
+	}
+
+	var total int
+	var active int
+	var maximumToken tracker.FencingToken
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*), COUNT(*) FILTER (WHERE released_at IS NULL), MAX(fencing_token) FROM leases WHERE issue_id = ?", issueID).Scan(&total, &active, &maximumToken); err != nil {
+		t.Fatalf("query claim results: %v", err)
+	}
+	if total != 2 || active != 1 || maximumToken != winner.FencingToken {
+		t.Fatalf("persisted leases = total %d active %d max token %d; want total 2 active 1 max token %d", total, active, maximumToken, winner.FencingToken)
+	}
+}
+
+func TestLeaseLifecycleRenewsHeartbeatsAndPreservesReleaseReason(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 12, 30, 0, 0, time.UTC)
+	clock := &leaseTestClock{value: now}
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: clock.Now})
+	_, issueID := seedProjection(t, service.database.db)
+	seedHubMachine(t, service, "machine-a", now)
+	request := tracker.ClaimRequest{WorkItemID: tracker.WorkItemID(issueID), MachineID: "machine-a", SessionID: "session-a", TTL: time.Minute}
+	claimed, err := service.Tracker().Claim(t.Context(), request)
+	if err != nil {
+		t.Fatalf("Claim() error = %v", err)
+	}
+	retried, err := service.Tracker().Claim(t.Context(), request)
+	if err != nil {
+		t.Fatalf("Claim(idempotent) error = %v", err)
+	}
+	if retried.ID != claimed.ID || retried.FencingToken != claimed.FencingToken || retried.PreviousSession != nil {
+		t.Fatalf("Claim(idempotent) = %#v, want original lease without previous session", retried)
+	}
+
+	clock.Advance(20 * time.Second)
+	renewedAt := clock.Now()
+	renewed, err := service.Tracker().Renew(t.Context(), tracker.RenewRequest{LeaseID: claimed.ID, FencingToken: claimed.FencingToken, TTL: 2 * time.Minute})
+	if err != nil {
+		t.Fatalf("Renew() error = %v", err)
+	}
+	if !renewed.RenewedAt.Equal(renewedAt) || !renewed.ExpiresAt.Equal(renewedAt.Add(2*time.Minute)) {
+		t.Errorf("Renew() timestamps = renewed %s expires %s", renewed.RenewedAt, renewed.ExpiresAt)
+	}
+	var heartbeatAt string
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT last_heartbeat_at FROM machines WHERE id = 'machine-a'").Scan(&heartbeatAt); err != nil {
+		t.Fatalf("read renewed heartbeat: %v", err)
+	}
+	if heartbeatAt != formatHubTime(renewedAt) {
+		t.Errorf("machine heartbeat = %q, want %q", heartbeatAt, formatHubTime(renewedAt))
+	}
+
+	if err := service.Tracker().Release(t.Context(), tracker.ReleaseRequest{LeaseID: renewed.ID, FencingToken: renewed.FencingToken, Reason: "completed"}); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	replacement, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{WorkItemID: tracker.WorkItemID(issueID), MachineID: "machine-a", SessionID: "session-b", TTL: time.Minute})
+	if err != nil {
+		t.Fatalf("Claim(replacement) error = %v", err)
+	}
+	if replacement.PreviousSession == nil || replacement.PreviousSession.LastEvent == nil || replacement.PreviousSession.LastEvent.Kind != "lease_released" || replacement.PreviousSession.LastEvent.Payload["reason"] != "completed" {
+		t.Errorf("replacement previous session = %#v, want release reason", replacement.PreviousSession)
+	}
+	if _, err := service.Tracker().Claim(t.Context(), request); !errors.Is(err, tracker.ErrLeaseConflict) {
+		t.Errorf("Claim(reused session) error = %v, want ErrLeaseConflict", err)
+	}
+}
+
+func TestExpiredLeaseReassignmentRejectsEveryStaleMutation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+	clock := &leaseTestClock{value: now}
+	var leaseIDs atomic.Int64
+	service := openTestService(t, Config{
+		DatabasePath: filepath.Join(t.TempDir(), "hub.db"),
+		now:          clock.Now,
+		newLeaseID: func() string {
+			return fmt.Sprintf("lease-%d", leaseIDs.Add(1))
+		},
+	})
+	_, issueID := seedProjection(t, service.database.db)
+	seedHubMachine(t, service, "machine-a", now)
+	seedHubMachine(t, service, "machine-b", now)
+
+	first, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+		WorkItemID: tracker.WorkItemID(issueID),
+		MachineID:  "machine-a",
+		SessionID:  "session-a",
+		TTL:        time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Claim(first) error = %v", err)
+	}
+	if err := service.Tracker().AppendEvent(t.Context(), tracker.WorkEvent{
+		WorkItemID:   tracker.WorkItemID(issueID),
+		FencingToken: first.FencingToken,
+		RunID:        "run-a",
+		Kind:         "progress",
+		Payload: map[string]any{
+			"summary":   "implementation in progress",
+			"workspace": "/workspaces/session-a",
+		},
+	}); err != nil {
+		t.Fatalf("AppendEvent(first) error = %v", err)
+	}
+
+	clock.Advance(2 * time.Minute)
+	items, err := service.Tracker().GetWorkItems(t.Context(), []tracker.WorkItemID{tracker.WorkItemID(issueID)})
+	if err != nil {
+		t.Fatalf("GetWorkItems(expired) error = %v", err)
+	}
+	if len(items) != 1 || items[0].ActiveLease != nil {
+		t.Fatalf("expired work item = %#v, want no active lease", items)
+	}
+	var leaseRows int
+	var eventRows int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM leases WHERE issue_id = ?", issueID).Scan(&leaseRows); err != nil {
+		t.Fatalf("count expired lease rows: %v", err)
+	}
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM work_events WHERE issue_id = ?", issueID).Scan(&eventRows); err != nil {
+		t.Fatalf("count expired session events: %v", err)
+	}
+	if leaseRows != 1 || eventRows != 1 {
+		t.Fatalf("metadata after expiry = %d leases, %d events; want 1 lease and 1 event", leaseRows, eventRows)
+	}
+
+	second, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+		WorkItemID: tracker.WorkItemID(issueID),
+		MachineID:  "machine-b",
+		SessionID:  "session-b",
+		TTL:        2 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Claim(second) error = %v", err)
+	}
+	if second.FencingToken <= first.FencingToken {
+		t.Errorf("second fencing token = %d, want greater than %d", second.FencingToken, first.FencingToken)
+	}
+	previous := second.PreviousSession
+	if previous == nil || previous.SessionID != "session-a" || previous.ReleasedAt == nil || previous.LastEvent == nil {
+		t.Fatalf("second previous session = %#v, want released session-a with its last event", previous)
+	}
+	if previous.LastEvent.Kind != "progress" || previous.LastEvent.Payload["workspace"] != "/workspaces/session-a" || previous.LastEvent.Payload["summary"] != "implementation in progress" {
+		t.Errorf("previous session event = %#v, want durable recovery payload", previous.LastEvent)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func() error
+	}{
+		{
+			name: "renew",
+			mutate: func() error {
+				_, renewErr := service.Tracker().Renew(t.Context(), tracker.RenewRequest{LeaseID: first.ID, FencingToken: first.FencingToken, TTL: time.Minute})
+				return renewErr
+			},
+		},
+		{
+			name: "release",
+			mutate: func() error {
+				return service.Tracker().Release(t.Context(), tracker.ReleaseRequest{LeaseID: first.ID, FencingToken: first.FencingToken})
+			},
+		},
+		{
+			name: "append event",
+			mutate: func() error {
+				return service.Tracker().AppendEvent(t.Context(), tracker.WorkEvent{WorkItemID: tracker.WorkItemID(issueID), FencingToken: first.FencingToken, Kind: "late_progress"})
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.mutate(); !errors.Is(err, tracker.ErrStaleFencingToken) {
+				t.Fatalf("stale mutation error = %v, want ErrStaleFencingToken", err)
+			}
+		})
+	}
+
+	if err := service.Tracker().AppendEvent(t.Context(), tracker.WorkEvent{WorkItemID: tracker.WorkItemID(issueID), FencingToken: second.FencingToken, Kind: "recovered"}); err != nil {
+		t.Fatalf("AppendEvent(second) error = %v", err)
+	}
+	var lateEvents int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM work_events WHERE kind = 'late_progress'").Scan(&lateEvents); err != nil {
+		t.Fatalf("count late events: %v", err)
+	}
+	if lateEvents != 0 {
+		t.Fatalf("late stale events = %d, want 0", lateEvents)
+	}
+}
+
+func TestClaimRecoversDisappearedMachineSessionAfterHubRestart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 14, 0, 0, 0, time.UTC)
+	clock := &leaseTestClock{value: now}
+	path := filepath.Join(t.TempDir(), "hub.db")
+	config := Config{DatabasePath: path, now: clock.Now}
+	service := openTestService(t, config)
+	_, issueID := seedProjection(t, service.database.db)
+	seedHubMachine(t, service, "machine-a", now)
+	seedHubMachine(t, service, "machine-b", now)
+	first, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+		WorkItemID: tracker.WorkItemID(issueID),
+		MachineID:  "machine-a",
+		SessionID:  "session-a",
+		TTL:        time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Claim(first) error = %v", err)
+	}
+	if err := service.Tracker().AppendEvent(t.Context(), tracker.WorkEvent{
+		WorkItemID:   tracker.WorkItemID(issueID),
+		FencingToken: first.FencingToken,
+		Kind:         "session_summary",
+		Payload:      map[string]any{"provider_session_id": "provider-a", "workspace": "/workspace/a"},
+	}); err != nil {
+		t.Fatalf("AppendEvent(session summary) error = %v", err)
+	}
+	clock.Advance(2 * time.Minute)
+	if err := service.Close(); err != nil {
+		t.Fatalf("Close(first hub) error = %v", err)
+	}
+
+	restarted := openTestService(t, config)
+	replacement, err := restarted.Tracker().Claim(t.Context(), tracker.ClaimRequest{
+		WorkItemID: tracker.WorkItemID(issueID),
+		MachineID:  "machine-b",
+		SessionID:  "session-b",
+		TTL:        time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Claim(replacement) error = %v", err)
+	}
+	previous := replacement.PreviousSession
+	if previous == nil || previous.SessionID != "session-a" || previous.LastEvent == nil {
+		t.Fatalf("replacement previous session = %#v, want durable session-a summary", previous)
+	}
+	if previous.LastEvent.Payload["provider_session_id"] != "provider-a" || previous.LastEvent.Payload["workspace"] != "/workspace/a" {
+		t.Errorf("replacement recovery payload = %#v", previous.LastEvent.Payload)
+	}
+}
+
+func TestLeaseMutationValidation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 15, 0, 0, 0, time.UTC)
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }})
+	_, issueID := seedProjection(t, service.database.db)
+	seedHubMachine(t, service, "machine-a", now)
+	token := tracker.FencingToken(1)
+	tests := []struct {
+		name   string
+		mutate func() error
+		want   error
+	}{
+		{
+			name: "invalid claim TTL",
+			mutate: func() error {
+				_, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{WorkItemID: tracker.WorkItemID(issueID), MachineID: "machine-a", SessionID: "session-a"})
+				return err
+			},
+			want: tracker.ErrInvalidClaimRequest,
+		},
+		{
+			name: "missing work item",
+			mutate: func() error {
+				_, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{WorkItemID: 999, MachineID: "machine-a", SessionID: "session-a", TTL: time.Minute})
+				return err
+			},
+			want: tracker.ErrWorkItemNotFound,
+		},
+		{
+			name: "missing machine",
+			mutate: func() error {
+				_, err := service.Tracker().Claim(t.Context(), tracker.ClaimRequest{WorkItemID: tracker.WorkItemID(issueID), MachineID: "missing", SessionID: "session-a", TTL: time.Minute})
+				return err
+			},
+			want: tracker.ErrMachineNotFound,
+		},
+		{
+			name: "missing lease",
+			mutate: func() error {
+				_, err := service.Tracker().Renew(t.Context(), tracker.RenewRequest{LeaseID: "missing", FencingToken: token, TTL: time.Minute})
+				return err
+			},
+			want: tracker.ErrLeaseNotFound,
+		},
+		{
+			name: "invalid release token",
+			mutate: func() error {
+				return service.Tracker().Release(t.Context(), tracker.ReleaseRequest{LeaseID: "lease-a"})
+			},
+			want: tracker.ErrInvalidLeaseRequest,
+		},
+		{
+			name: "event requires token",
+			mutate: func() error {
+				return service.Tracker().AppendEvent(t.Context(), tracker.WorkEvent{WorkItemID: tracker.WorkItemID(issueID), Kind: "progress"})
+			},
+			want: tracker.ErrInvalidWorkEvent,
+		},
+		{
+			name: "event payload must encode",
+			mutate: func() error {
+				return service.Tracker().AppendEvent(t.Context(), tracker.WorkEvent{WorkItemID: tracker.WorkItemID(issueID), FencingToken: token, Kind: "progress", Payload: map[string]any{"invalid": make(chan int)}})
+			},
+			want: tracker.ErrInvalidWorkEvent,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.mutate(); !errors.Is(err, test.want) {
+				t.Fatalf("mutation error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func seedHubMachine(t *testing.T, service *Service, machineID tracker.MachineID, now time.Time) {
+	t.Helper()
+	if _, err := service.database.db.ExecContext(t.Context(), `
+INSERT INTO machines (id, hostname, display_name, capacity, version, last_heartbeat_at, registered_at, updated_at)
+VALUES (?, ?, ?, 1, 'test', ?, ?, ?)`, machineID, machineID, machineID, formatHubTime(now), formatHubTime(now), formatHubTime(now)); err != nil {
+		t.Fatalf("insert machine %s: %v", machineID, err)
+	}
+}
+
+type leaseTestClock struct {
+	mu    sync.Mutex
+	value time.Time
+}
+
+func (c *leaseTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.value
+}
+
+func (c *leaseTestClock) Advance(duration time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value = c.value.Add(duration)
+}

--- a/internal/tracker/normalize_test.go
+++ b/internal/tracker/normalize_test.go
@@ -199,17 +199,19 @@ func TestStoreTrackerReadsNormalizedItems(t *testing.T) {
 		t.Fatalf("ListDispatchQueue() = %#v, want one dispatchable item", queue)
 	}
 
-	mutationErrors := []error{}
-	_, err = backend.Claim(t.Context(), ClaimRequest{})
-	mutationErrors = append(mutationErrors, err)
-	_, err = backend.Renew(t.Context(), RenewRequest{})
-	mutationErrors = append(mutationErrors, err)
-	mutationErrors = append(mutationErrors, backend.Release(t.Context(), ReleaseRequest{}))
-	mutationErrors = append(mutationErrors, backend.AppendEvent(t.Context(), WorkEvent{}))
-	for i, mutationErr := range mutationErrors {
-		if !errors.Is(mutationErr, ErrNotImplemented) {
-			t.Errorf("mutation error %d = %v, want ErrNotImplemented", i, mutationErr)
-		}
+	claimed, err := backend.Claim(t.Context(), ClaimRequest{WorkItemID: 1})
+	if err != nil || claimed.ID != "lease-a" || store.claimRequest.WorkItemID != 1 {
+		t.Errorf("Claim() = %#v, %v; request = %#v", claimed, err, store.claimRequest)
+	}
+	renewed, err := backend.Renew(t.Context(), RenewRequest{LeaseID: "lease-a"})
+	if err != nil || renewed.ID != "lease-a" || store.renewRequest.LeaseID != "lease-a" {
+		t.Errorf("Renew() = %#v, %v; request = %#v", renewed, err, store.renewRequest)
+	}
+	if err := backend.Release(t.Context(), ReleaseRequest{LeaseID: "lease-a"}); err != nil || store.releaseRequest.LeaseID != "lease-a" {
+		t.Errorf("Release() error = %v; request = %#v", err, store.releaseRequest)
+	}
+	if err := backend.AppendEvent(t.Context(), WorkEvent{WorkItemID: 1, FencingToken: 7, Kind: "progress"}); err != nil || store.workEvent.Kind != "progress" || store.workEvent.FencingToken != 7 {
+		t.Errorf("AppendEvent() error = %v; event = %#v", err, store.workEvent)
 	}
 }
 
@@ -224,6 +226,10 @@ type fakeStore struct {
 	records        []Record
 	candidateQuery CandidateQuery
 	workItemIDs    []WorkItemID
+	claimRequest   ClaimRequest
+	renewRequest   RenewRequest
+	releaseRequest ReleaseRequest
+	workEvent      WorkEvent
 }
 
 func (s *fakeStore) ListCandidateRecords(_ context.Context, query CandidateQuery) ([]Record, error) {
@@ -234,6 +240,26 @@ func (s *fakeStore) ListCandidateRecords(_ context.Context, query CandidateQuery
 func (s *fakeStore) GetWorkItemRecords(_ context.Context, ids []WorkItemID) ([]Record, error) {
 	s.workItemIDs = append([]WorkItemID(nil), ids...)
 	return s.records, nil
+}
+
+func (s *fakeStore) Claim(_ context.Context, request ClaimRequest) (Lease, error) {
+	s.claimRequest = request
+	return Lease{LeaseSummary: LeaseSummary{ID: "lease-a"}}, nil
+}
+
+func (s *fakeStore) Renew(_ context.Context, request RenewRequest) (Lease, error) {
+	s.renewRequest = request
+	return Lease{LeaseSummary: LeaseSummary{ID: "lease-a"}}, nil
+}
+
+func (s *fakeStore) Release(_ context.Context, request ReleaseRequest) error {
+	s.releaseRequest = request
+	return nil
+}
+
+func (s *fakeStore) AppendEvent(_ context.Context, event WorkEvent) error {
+	s.workEvent = event
+	return nil
 }
 
 func dispatchReasonCodes(reasons []DispatchReason) []string {

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -17,9 +17,16 @@ const (
 
 var (
 	ErrInvalidCandidateQuery = errors.New("invalid tracker candidate query")
+	ErrInvalidClaimRequest   = errors.New("invalid tracker claim request")
+	ErrInvalidLeaseRequest   = errors.New("invalid tracker lease request")
+	ErrInvalidWorkEvent      = errors.New("invalid tracker work event")
 	ErrInvalidWorkItemID     = errors.New("invalid tracker work item ID")
-	ErrNotImplemented        = errors.New("tracker operation not implemented")
+	ErrLeaseConflict         = errors.New("tracker lease conflict")
+	ErrLeaseNotFound         = errors.New("tracker lease not found")
+	ErrStaleFencingToken     = errors.New("stale tracker fencing token")
 	ErrStoreRequired         = errors.New("tracker store is required")
+	ErrWorkItemNotFound      = errors.New("tracker work item not found")
+	ErrMachineNotFound       = errors.New("tracker machine not found")
 )
 
 type WorkItemID int64
@@ -268,12 +275,19 @@ type ReleaseRequest struct {
 
 type Lease struct {
 	LeaseSummary
-	WorkItemID WorkItemID `json:"work_item_id"`
+	WorkItemID      WorkItemID      `json:"work_item_id"`
+	PreviousSession *SessionSummary `json:"previous_session,omitempty"`
+}
+
+type SessionSummary struct {
+	LeaseSummary
+	ReleasedAt *time.Time `json:"released_at,omitempty"`
+	LastEvent  *WorkEvent `json:"last_event,omitempty"`
 }
 
 type WorkEvent struct {
 	WorkItemID   WorkItemID     `json:"work_item_id"`
-	FencingToken *FencingToken  `json:"fencing_token,omitempty"`
+	FencingToken FencingToken   `json:"fencing_token"`
 	MachineID    MachineID      `json:"machine_id,omitempty"`
 	SessionID    string         `json:"session_id,omitempty"`
 	RunID        string         `json:"run_id,omitempty"`
@@ -295,6 +309,10 @@ type Tracker interface {
 type Store interface {
 	ListCandidateRecords(context.Context, CandidateQuery) ([]Record, error)
 	GetWorkItemRecords(context.Context, []WorkItemID) ([]Record, error)
+	Claim(context.Context, ClaimRequest) (Lease, error)
+	Renew(context.Context, RenewRequest) (Lease, error)
+	Release(context.Context, ReleaseRequest) error
+	AppendEvent(context.Context, WorkEvent) error
 }
 
 func NewStore(store Store) (Tracker, error) {
@@ -336,18 +354,18 @@ func (t *storeTracker) GetWorkItems(ctx context.Context, ids []WorkItemID) ([]Wo
 	return normalizeRecords(records), nil
 }
 
-func (*storeTracker) Claim(context.Context, ClaimRequest) (Lease, error) {
-	return Lease{}, ErrNotImplemented
+func (t *storeTracker) Claim(ctx context.Context, request ClaimRequest) (Lease, error) {
+	return t.store.Claim(ctx, request)
 }
 
-func (*storeTracker) Renew(context.Context, RenewRequest) (Lease, error) {
-	return Lease{}, ErrNotImplemented
+func (t *storeTracker) Renew(ctx context.Context, request RenewRequest) (Lease, error) {
+	return t.store.Renew(ctx, request)
 }
 
-func (*storeTracker) Release(context.Context, ReleaseRequest) error {
-	return ErrNotImplemented
+func (t *storeTracker) Release(ctx context.Context, request ReleaseRequest) error {
+	return t.store.Release(ctx, request)
 }
 
-func (*storeTracker) AppendEvent(context.Context, WorkEvent) error {
-	return ErrNotImplemented
+func (t *storeTracker) AppendEvent(ctx context.Context, event WorkEvent) error {
+	return t.store.AppendEvent(ctx, event)
 }


### PR DESCRIPTION
## Summary

- implement atomic SQLite claim, renew, and release operations with monotonically increasing fencing tokens
- reject expired, released, or superseded writers on every lease and work-event mutation
- preserve historical session events and return prior session recovery context to replacement claims
- add concurrent contention, stale-writer, lifecycle, and restart-recovery regressions
- document the reusable SQLite fenced-lease protocol as a candidate Detent skill

Fixes #2073

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR makes no visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/tracker ./internal/hubserver`
- [x] CI-aligned Go 1.26.6 / golangci-lint 2.9.0 focused lint
- [x] `make check` after rebasing onto current `origin/main` (78.8% total coverage; package and file floors pass)
