### PR TITLE
feat(hub): reconcile GitHub mirror drift

### DIFF
--- a/docs/webhook-freshness.md
+++ b/docs/webhook-freshness.md
@@ -60,7 +60,10 @@ skipped.
 A full repair compares complete issue and pull-request inventories. It updates
 labels and repository transfers, imports items missed during a webhook gap, and
 marks source records absent from GitHub as deleted so they stop participating in
-scheduling.
+scheduling. It also refreshes mergeability, checks, statuses, and reviews for
+every open pull request. Incremental passes fetch those details only for the
+exact webhook hydration requests captured when the pass starts; requests added
+or coalesced during the fetch remain pending for the next pass.
 
 Query `GET /api/v1/repositories/freshness` for each repository's latest
 successful sync, webhook receipt, reconciliation, full repair, and most recent

--- a/docs/webhook-freshness.md
+++ b/docs/webhook-freshness.md
@@ -45,3 +45,26 @@ For a persistent host without public ingress, an outbound tunnel such as a
 can route a public HTTPS hostname to Detent. Configure relays and reverse proxies
 to preserve the raw request body and GitHub signature headers; modifying either
 causes signature verification to fail.
+
+## Hub reconciliation
+
+`detent hub serve` repairs deliveries that never reach the webhook endpoint. It
+runs a full repository repair at startup, incremental repairs every 10 minutes,
+and a full repair every 24 hours by default. Configure the intervals with
+`--reconcile-interval` and `--full-repair-interval`. Incremental issue reads use
+the repository update cursor, while repository and pull-request reads reuse
+GitHub ETags through conditional requests. A pending targeted hydration request
+rewinds the next incremental cursor so a delayed partial webhook cannot be
+skipped.
+
+A full repair compares complete issue and pull-request inventories. It updates
+labels and repository transfers, imports items missed during a webhook gap, and
+marks source records absent from GitHub as deleted so they stop participating in
+scheduling.
+
+Query `GET /api/v1/repositories/freshness` for each repository's latest
+successful sync, webhook receipt, reconciliation, full repair, and most recent
+webhook/reconciliation errors. `GET /health` returns `status: degraded` with
+fresh, stale, and error repository counts whenever any mirror is older than two
+incremental intervals or has an unresolved sync error. The Hub remains available
+for local reads while degraded.

--- a/internal/cli/hub.go
+++ b/internal/cli/hub.go
@@ -31,6 +31,7 @@ func newHubCommand(opts options) *cobra.Command {
 			return fmt.Errorf("configure github hub outbox client: %w", err)
 		}
 		cfg.OutboxBackend = hubgithub.NewWriter(client)
+		cfg.ReconcileBackend = hubgithub.NewReconciler(client)
 		return hubserver.Run(ctx, cfg)
 	}
 	return newHubCommandWithRun(opts.version, opts.lookupEnv, run)
@@ -58,6 +59,8 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 	var githubWebhookSecretEnv string
 	var webhookPayloadRetention time.Duration
 	var webhookMaintenanceInterval time.Duration
+	var reconcileInterval time.Duration
+	var fullRepairInterval time.Duration
 
 	cmd := &cobra.Command{
 		Use:          "serve",
@@ -87,6 +90,8 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 				GitHubWebhookSecret:        []byte(strings.TrimSpace(lookupEnv(githubWebhookSecretEnv))),
 				WebhookPayloadRetention:    webhookPayloadRetention,
 				WebhookMaintenanceInterval: webhookMaintenanceInterval,
+				ReconcileInterval:          reconcileInterval,
+				FullRepairInterval:         fullRepairInterval,
 				Logger:                     slog.Default(),
 				Version:                    version,
 			})
@@ -99,5 +104,7 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 	cmd.Flags().StringVar(&githubWebhookSecretEnv, "github-webhook-secret-env", "DETENT_HUB_GITHUB_WEBHOOK_SECRET", "environment variable containing the GitHub webhook secret")
 	cmd.Flags().DurationVar(&webhookPayloadRetention, "webhook-payload-retention", hubserver.DefaultWebhookPayloadRetention, "retention period for raw GitHub webhook payloads")
 	cmd.Flags().DurationVar(&webhookMaintenanceInterval, "webhook-maintenance-interval", hubserver.DefaultWebhookMaintenanceInterval, "GitHub webhook retry and retention interval")
+	cmd.Flags().DurationVar(&reconcileInterval, "reconcile-interval", hubserver.DefaultReconcileInterval, "incremental GitHub mirror reconciliation interval")
+	cmd.Flags().DurationVar(&fullRepairInterval, "full-repair-interval", hubserver.DefaultFullRepairInterval, "full GitHub mirror repair interval")
 	return cmd
 }

--- a/internal/cli/hub_test.go
+++ b/internal/cli/hub_test.go
@@ -40,6 +40,8 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 		"--github-webhook-secret-env", "TEST_HUB_WEBHOOK_SECRET",
 		"--webhook-payload-retention", "48h",
 		"--webhook-maintenance-interval", "30s",
+		"--reconcile-interval", "2m",
+		"--full-repair-interval", "6h",
 	})
 	if err := cmd.ExecuteContext(wantContext); err != nil {
 		t.Fatalf("ExecuteContext() error = %v", err)
@@ -67,6 +69,12 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 	}
 	if gotConfig.WebhookMaintenanceInterval != 30*time.Second {
 		t.Fatalf("webhook maintenance interval = %s, want 30s", gotConfig.WebhookMaintenanceInterval)
+	}
+	if gotConfig.ReconcileInterval != 2*time.Minute {
+		t.Fatalf("reconcile interval = %s, want 2m", gotConfig.ReconcileInterval)
+	}
+	if gotConfig.FullRepairInterval != 6*time.Hour {
+		t.Fatalf("full repair interval = %s, want 6h", gotConfig.FullRepairInterval)
 	}
 	if gotConfig.Version != "v-test" {
 		t.Fatalf("version = %q, want v-test", gotConfig.Version)

--- a/internal/hubgithub/reconciler.go
+++ b/internal/hubgithub/reconciler.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	connectorgithub "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/hubserver"
+	"github.com/digitaldrywood/detent/internal/reviewseverity"
+	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
 type Reconciler struct {
@@ -78,7 +81,155 @@ func (r *Reconciler) Reconcile(ctx context.Context, request hubserver.ReconcileR
 		}
 		snapshot.PullRequests = append(snapshot.PullRequests, source)
 	}
+	if err := r.hydratePullRequestDetails(ctx, repositoryRESTPath(repository.Owner.Login, repository.Name), request.Mode, request.Hydrations, &snapshot); err != nil {
+		return hubserver.ReconcileSnapshot{}, err
+	}
 	return snapshot, nil
+}
+
+type pullRequestDetailNeed struct {
+	checks  bool
+	reviews bool
+}
+
+func (r *Reconciler) hydratePullRequestDetails(ctx context.Context, repositoryPath string, mode hubserver.ReconcileMode, hydrations []hubserver.HydrationRequest, snapshot *hubserver.ReconcileSnapshot) error {
+	needs := make(map[int]pullRequestDetailNeed)
+	commitChecks := make(map[string]struct{})
+	for _, hydration := range hydrations {
+		number := hydration.GitHubNumber
+		if number <= 0 && strings.TrimSpace(hydration.GitHubNodeID) != "" {
+			for _, pullRequest := range snapshot.PullRequests {
+				if pullRequest.NodeID == strings.TrimSpace(hydration.GitHubNodeID) {
+					number = pullRequest.Number
+					break
+				}
+			}
+		}
+		switch hydration.ObjectKind {
+		case "pull_request_checks":
+			if number > 0 {
+				need := needs[number]
+				need.checks = true
+				needs[number] = need
+			}
+		case "pull_request_reviews":
+			if number > 0 {
+				need := needs[number]
+				need.reviews = true
+				needs[number] = need
+			}
+		case "commit_checks":
+			if headSHA := strings.TrimSpace(hydration.HeadSHA); headSHA != "" {
+				commitChecks[headSHA] = struct{}{}
+			}
+		}
+	}
+	if mode == hubserver.ReconcileFullRepair {
+		for _, pullRequest := range snapshot.PullRequests {
+			if !strings.EqualFold(strings.TrimSpace(pullRequest.State), "open") {
+				continue
+			}
+			needs[pullRequest.Number] = pullRequestDetailNeed{checks: true, reviews: true}
+		}
+	}
+	matchedCommitChecks := make(map[string]struct{})
+	for _, pullRequest := range snapshot.PullRequests {
+		if _, ok := commitChecks[strings.TrimSpace(pullRequest.HeadSHA)]; ok {
+			need := needs[pullRequest.Number]
+			need.checks = true
+			needs[pullRequest.Number] = need
+			matchedCommitChecks[strings.TrimSpace(pullRequest.HeadSHA)] = struct{}{}
+		}
+	}
+	numbers := make([]int, 0, len(needs))
+	for number := range needs {
+		numbers = append(numbers, number)
+	}
+	sort.Ints(numbers)
+	checksBySHA := make(map[string]tracker.CheckSummary)
+	for _, number := range numbers {
+		var pullRequest reconcilePullRequest
+		if err := r.client.REST(ctx, http.MethodGet, repositoryPath+"/pulls/"+strconv.Itoa(number), nil, &pullRequest); err != nil {
+			return fmt.Errorf("refresh github pull request %d: %w", number, err)
+		}
+		source := pullRequest.source()
+		if err := validatePullRequestSource(source); err != nil {
+			return err
+		}
+		replacePullRequestSource(&snapshot.PullRequests, source)
+		mergeableState := strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
+		details := hubserver.PullRequestDetailSource{
+			Number: number, HeadSHA: source.HeadSHA, MergeableState: &mergeableState,
+		}
+		need := needs[number]
+		if need.checks {
+			checks, ok := checksBySHA[source.HeadSHA]
+			if !ok {
+				var err error
+				checks, err = r.fetchCheckSummary(ctx, repositoryPath, source.HeadSHA)
+				if err != nil {
+					return err
+				}
+				checksBySHA[source.HeadSHA] = checks
+			}
+			details.Checks = &checks
+		}
+		if need.reviews {
+			reviews, err := r.fetchReviewSummary(ctx, repositoryPath, number)
+			if err != nil {
+				return err
+			}
+			details.Reviews = &reviews
+		}
+		snapshot.PullRequestDetails = append(snapshot.PullRequestDetails, details)
+	}
+	unmatchedSHAs := make([]string, 0, len(commitChecks))
+	for headSHA := range commitChecks {
+		if _, matched := matchedCommitChecks[headSHA]; !matched {
+			unmatchedSHAs = append(unmatchedSHAs, headSHA)
+		}
+	}
+	sort.Strings(unmatchedSHAs)
+	for _, headSHA := range unmatchedSHAs {
+		checks, err := r.fetchCheckSummary(ctx, repositoryPath, headSHA)
+		if err != nil {
+			return err
+		}
+		snapshot.PullRequestDetails = append(snapshot.PullRequestDetails, hubserver.PullRequestDetailSource{
+			HeadSHA: headSHA, Checks: &checks,
+		})
+	}
+	return nil
+}
+
+func replacePullRequestSource(sources *[]hubserver.PullRequestSource, replacement hubserver.PullRequestSource) {
+	for index := range *sources {
+		if (*sources)[index].Number == replacement.Number {
+			(*sources)[index] = replacement
+			return
+		}
+	}
+	*sources = append(*sources, replacement)
+}
+
+func (r *Reconciler) fetchCheckSummary(ctx context.Context, repositoryPath string, headSHA string) (tracker.CheckSummary, error) {
+	checkRuns, err := fetchRESTCheckRuns(ctx, r.client, repositoryPath+"/commits/"+url.PathEscape(headSHA)+"/check-runs?per_page=100")
+	if err != nil {
+		return tracker.CheckSummary{}, fmt.Errorf("fetch github check runs: %w", err)
+	}
+	statuses, err := fetchRESTList[restStatus](ctx, r.client, repositoryPath+"/commits/"+url.PathEscape(headSHA)+"/statuses?per_page=100")
+	if err != nil {
+		return tracker.CheckSummary{}, fmt.Errorf("fetch github commit statuses: %w", err)
+	}
+	return summarizeChecks(checkRuns, statuses), nil
+}
+
+func (r *Reconciler) fetchReviewSummary(ctx context.Context, repositoryPath string, number int) (tracker.ReviewSummary, error) {
+	reviews, err := fetchRESTList[restReview](ctx, r.client, repositoryPath+"/pulls/"+strconv.Itoa(number)+"/reviews?per_page=100")
+	if err != nil {
+		return tracker.ReviewSummary{}, fmt.Errorf("fetch github pull request reviews: %w", err)
+	}
+	return summarizeReviews(reviews), nil
 }
 
 func (r *Reconciler) fetchRepository(ctx context.Context, target hubserver.RepositoryTarget) (reconcileRepository, error) {
@@ -145,22 +296,146 @@ func (i reconcileIssue) source() hubserver.IssueSource {
 }
 
 type reconcilePullRequest struct {
-	ID        int64     `json:"id"`
-	NodeID    string    `json:"node_id"`
-	Number    int       `json:"number"`
-	Title     string    `json:"title"`
-	HTMLURL   string    `json:"html_url"`
-	State     string    `json:"state"`
-	Draft     bool      `json:"draft"`
-	Head      restRef   `json:"head"`
-	Base      restRef   `json:"base"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID             int64     `json:"id"`
+	NodeID         string    `json:"node_id"`
+	Number         int       `json:"number"`
+	Title          string    `json:"title"`
+	HTMLURL        string    `json:"html_url"`
+	State          string    `json:"state"`
+	Draft          bool      `json:"draft"`
+	MergeableState string    `json:"mergeable_state"`
+	Head           restRef   `json:"head"`
+	Base           restRef   `json:"base"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 type restRef struct {
 	Ref string `json:"ref"`
 	SHA string `json:"sha"`
+}
+
+func summarizeChecks(checkRuns []restCheckRun, statuses []restStatus) tracker.CheckSummary {
+	latestCheckRuns := make(map[string]restCheckRun)
+	for index, checkRun := range checkRuns {
+		key := strings.ToLower(strings.TrimSpace(checkRun.Name))
+		if key == "" {
+			key = strconv.Itoa(index)
+		}
+		current, ok := latestCheckRuns[key]
+		if !ok || checkRun.ID > current.ID {
+			latestCheckRuns[key] = checkRun
+		}
+	}
+	latestStatuses := make(map[string]restStatus)
+	for index, status := range statuses {
+		key := strings.ToLower(strings.TrimSpace(status.Context))
+		if key == "" {
+			key = strconv.Itoa(index)
+		}
+		if _, ok := latestStatuses[key]; !ok {
+			latestStatuses[key] = status
+		}
+	}
+	summary := tracker.CheckSummary{Total: len(latestCheckRuns) + len(latestStatuses)}
+	for _, checkRun := range latestCheckRuns {
+		status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+		if status != "completed" || conclusion == "" {
+			summary.Pending++
+			continue
+		}
+		switch conclusion {
+		case "success", "neutral", "skipped":
+			summary.Passed++
+		default:
+			summary.Failed++
+		}
+	}
+	for _, status := range latestStatuses {
+		switch strings.ToLower(strings.TrimSpace(status.State)) {
+		case "success":
+			summary.Passed++
+		case "failure", "error":
+			summary.Failed++
+		default:
+			summary.Pending++
+		}
+	}
+	if summary.Total == 0 {
+		return summary
+	}
+	if summary.Pending > 0 {
+		summary.Status = "pending"
+		summary.Conclusion = "pending"
+		return summary
+	}
+	summary.Status = "completed"
+	if summary.Failed > 0 {
+		summary.Conclusion = "failure"
+	} else {
+		summary.Conclusion = "success"
+	}
+	return summary
+}
+
+func summarizeReviews(reviews []restReview) tracker.ReviewSummary {
+	latestByAuthor := make(map[string]restReview)
+	for index, review := range reviews {
+		author := strings.ToLower(strings.TrimSpace(review.User.Login))
+		if author == "" {
+			author = strconv.Itoa(index)
+		}
+		current, ok := latestByAuthor[author]
+		if !ok || reviewAfter(review, current) {
+			latestByAuthor[author] = review
+		}
+	}
+	summary := tracker.ReviewSummary{}
+	var latest *restReview
+	blockingFinding := false
+	for _, review := range latestByAuthor {
+		state := strings.ToLower(strings.TrimSpace(review.State))
+		if state == "dismissed" {
+			continue
+		}
+		switch state {
+		case "approved":
+			summary.Approvals++
+		case "changes_requested":
+			summary.ChangesRequested++
+		case "commented":
+			summary.Comments++
+		}
+		if reviewseverity.Contains(review.Body, "P1") {
+			blockingFinding = true
+		}
+		if latest == nil || reviewAfter(review, *latest) {
+			value := review
+			latest = &value
+		}
+	}
+	if blockingFinding {
+		summary.State = "p1"
+	} else if latest != nil {
+		summary.State = strings.ToLower(strings.TrimSpace(latest.State))
+	}
+	switch {
+	case summary.ChangesRequested > 0 || blockingFinding:
+		summary.Decision = "changes_requested"
+	case summary.Approvals > 0:
+		summary.Decision = "approved"
+	case summary.Comments > 0:
+		summary.Decision = "commented"
+	}
+	return summary
+}
+
+func reviewAfter(left restReview, right restReview) bool {
+	if left.SubmittedAt == nil {
+		return right.SubmittedAt == nil
+	}
+	return right.SubmittedAt == nil || left.SubmittedAt.After(*right.SubmittedAt)
 }
 
 func (p reconcilePullRequest) source() hubserver.PullRequestSource {

--- a/internal/hubgithub/reconciler.go
+++ b/internal/hubgithub/reconciler.go
@@ -1,0 +1,203 @@
+package hubgithub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	connectorgithub "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/hubserver"
+)
+
+type Reconciler struct {
+	client restClient
+}
+
+func NewReconciler(client *connectorgithub.Client) *Reconciler {
+	return &Reconciler{client: client}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request hubserver.ReconcileRequest) (hubserver.ReconcileSnapshot, error) {
+	if r == nil || r.client == nil {
+		return hubserver.ReconcileSnapshot{}, errors.New("github reconciler is not configured")
+	}
+	repository, err := r.fetchRepository(ctx, request.Repository)
+	if err != nil {
+		return hubserver.ReconcileSnapshot{}, err
+	}
+	issuesPath := repositoryRESTPath(repository.Owner.Login, repository.Name) + "/issues"
+	issueQuery := url.Values{
+		"direction": {"asc"},
+		"per_page":  {"100"},
+		"sort":      {"updated"},
+		"state":     {"all"},
+	}
+	if request.Mode == hubserver.ReconcileIncremental && request.Since != nil {
+		issueQuery.Set("since", request.Since.UTC().Format(time.RFC3339Nano))
+	}
+	issuesPath += "?" + issueQuery.Encode()
+	remoteIssues, err := fetchRESTList[reconcileIssue](ctx, r.client, issuesPath)
+	if err != nil {
+		return hubserver.ReconcileSnapshot{}, fmt.Errorf("list github repository issues: %w", err)
+	}
+	pullsPath := repositoryRESTPath(repository.Owner.Login, repository.Name) + "/pulls?direction=asc&per_page=100&sort=updated&state=all"
+	remotePulls, err := fetchRESTList[reconcilePullRequest](ctx, r.client, pullsPath)
+	if err != nil {
+		return hubserver.ReconcileSnapshot{}, fmt.Errorf("list github repository pull requests: %w", err)
+	}
+	snapshot := hubserver.ReconcileSnapshot{
+		Repository: hubserver.RepositorySource{
+			NodeID: repository.NodeID, DatabaseID: positiveID(repository.ID),
+			Owner: repository.Owner.Login, Name: repository.Name, UpdatedAt: repository.UpdatedAt,
+		},
+		Issues:       make([]hubserver.IssueSource, 0, len(remoteIssues)),
+		PullRequests: make([]hubserver.PullRequestSource, 0, len(remotePulls)),
+	}
+	if err := validateRepositorySource(snapshot.Repository); err != nil {
+		return hubserver.ReconcileSnapshot{}, err
+	}
+	for _, issue := range remoteIssues {
+		if issue.PullRequest != nil {
+			continue
+		}
+		source := issue.source()
+		if err := validateIssueSource(source); err != nil {
+			return hubserver.ReconcileSnapshot{}, err
+		}
+		snapshot.Issues = append(snapshot.Issues, source)
+	}
+	for _, pullRequest := range remotePulls {
+		source := pullRequest.source()
+		if err := validatePullRequestSource(source); err != nil {
+			return hubserver.ReconcileSnapshot{}, err
+		}
+		snapshot.PullRequests = append(snapshot.PullRequests, source)
+	}
+	return snapshot, nil
+}
+
+func (r *Reconciler) fetchRepository(ctx context.Context, target hubserver.RepositoryTarget) (reconcileRepository, error) {
+	path := repositoryRESTPath(target.Owner, target.Name)
+	if target.DatabaseID != nil && *target.DatabaseID > 0 {
+		path = "/repositories/" + strconv.FormatInt(*target.DatabaseID, 10)
+	}
+	var repository reconcileRepository
+	if err := r.client.REST(ctx, http.MethodGet, path, nil, &repository); err != nil {
+		return reconcileRepository{}, fmt.Errorf("refresh github repository: %w", err)
+	}
+	return repository, nil
+}
+
+func repositoryRESTPath(owner string, name string) string {
+	return "/repos/" + url.PathEscape(strings.TrimSpace(owner)) + "/" + url.PathEscape(strings.TrimSpace(name))
+}
+
+type reconcileRepository struct {
+	ID        int64     `json:"id"`
+	NodeID    string    `json:"node_id"`
+	Name      string    `json:"name"`
+	Owner     restActor `json:"owner"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type restActor struct {
+	Login string `json:"login"`
+}
+
+type reconcileIssue struct {
+	ID          int64       `json:"id"`
+	NodeID      string      `json:"node_id"`
+	Number      int         `json:"number"`
+	Title       string      `json:"title"`
+	Body        *string     `json:"body"`
+	HTMLURL     string      `json:"html_url"`
+	State       string      `json:"state"`
+	Labels      []restLabel `json:"labels"`
+	Assignees   []restActor `json:"assignees"`
+	PullRequest *struct{}   `json:"pull_request"`
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
+}
+
+func (i reconcileIssue) source() hubserver.IssueSource {
+	body := ""
+	if i.Body != nil {
+		body = *i.Body
+	}
+	labels := make([]string, 0, len(i.Labels))
+	for _, label := range i.Labels {
+		labels = append(labels, label.Name)
+	}
+	assignees := make([]string, 0, len(i.Assignees))
+	for _, assignee := range i.Assignees {
+		assignees = append(assignees, assignee.Login)
+	}
+	return hubserver.IssueSource{
+		NodeID: i.NodeID, DatabaseID: positiveID(i.ID), Number: i.Number,
+		Title: i.Title, Body: body, URL: i.HTMLURL, State: i.State,
+		Labels: labels, Assignees: assignees, CreatedAt: i.CreatedAt, UpdatedAt: i.UpdatedAt,
+	}
+}
+
+type reconcilePullRequest struct {
+	ID        int64     `json:"id"`
+	NodeID    string    `json:"node_id"`
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	HTMLURL   string    `json:"html_url"`
+	State     string    `json:"state"`
+	Draft     bool      `json:"draft"`
+	Head      restRef   `json:"head"`
+	Base      restRef   `json:"base"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type restRef struct {
+	Ref string `json:"ref"`
+	SHA string `json:"sha"`
+}
+
+func (p reconcilePullRequest) source() hubserver.PullRequestSource {
+	return hubserver.PullRequestSource{
+		NodeID: p.NodeID, DatabaseID: positiveID(p.ID), Number: p.Number,
+		Title: p.Title, URL: p.HTMLURL, State: p.State, Draft: p.Draft,
+		HeadRef: p.Head.Ref, HeadSHA: p.Head.SHA, BaseRef: p.Base.Ref, BaseSHA: p.Base.SHA,
+		CreatedAt: p.CreatedAt, UpdatedAt: p.UpdatedAt,
+	}
+}
+
+func validateRepositorySource(source hubserver.RepositorySource) error {
+	if strings.TrimSpace(source.NodeID) == "" || strings.TrimSpace(source.Owner) == "" || strings.TrimSpace(source.Name) == "" || source.UpdatedAt.IsZero() {
+		return errors.New("github repository reconciliation returned an incomplete repository")
+	}
+	return nil
+}
+
+func validateIssueSource(source hubserver.IssueSource) error {
+	if strings.TrimSpace(source.NodeID) == "" || source.Number <= 0 || strings.TrimSpace(source.Title) == "" || strings.TrimSpace(source.URL) == "" || strings.TrimSpace(source.State) == "" || source.CreatedAt.IsZero() || source.UpdatedAt.IsZero() {
+		return fmt.Errorf("github repository reconciliation returned incomplete issue %d", source.Number)
+	}
+	return nil
+}
+
+func validatePullRequestSource(source hubserver.PullRequestSource) error {
+	if strings.TrimSpace(source.NodeID) == "" || source.Number <= 0 || strings.TrimSpace(source.Title) == "" || strings.TrimSpace(source.URL) == "" || strings.TrimSpace(source.State) == "" || strings.TrimSpace(source.HeadRef) == "" || strings.TrimSpace(source.HeadSHA) == "" || strings.TrimSpace(source.BaseRef) == "" || strings.TrimSpace(source.BaseSHA) == "" || source.CreatedAt.IsZero() || source.UpdatedAt.IsZero() {
+		return fmt.Errorf("github repository reconciliation returned incomplete pull request %d", source.Number)
+	}
+	return nil
+}
+
+func positiveID(value int64) *int64 {
+	if value <= 0 {
+		return nil
+	}
+	return &value
+}
+
+var _ hubserver.ReconcileBackend = (*Reconciler)(nil)

--- a/internal/hubgithub/reconciler_test.go
+++ b/internal/hubgithub/reconciler_test.go
@@ -1,0 +1,103 @@
+package hubgithub
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hubserver"
+)
+
+func TestReconcilerUsesCursorAndRepositoryIdentity(t *testing.T) {
+	t.Parallel()
+	since := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	updatedAt := since.Add(time.Hour)
+	issuesPath := "/repos/new-owner/renamed/issues?" + url.Values{
+		"direction": {"asc"},
+		"per_page":  {"100"},
+		"since":     {since.Format(time.RFC3339Nano)},
+		"sort":      {"updated"},
+		"state":     {"all"},
+	}.Encode()
+	pullsPath := "/repos/new-owner/renamed/pulls?direction=asc&per_page=100&sort=updated&state=all"
+	body := "Issue body"
+	client := &scriptedRESTClient{t: t, steps: []restStep{
+		{
+			method: http.MethodGet,
+			path:   "/repositories/100",
+			response: reconcileRepository{
+				ID: 100, NodeID: "R_repo", Name: "renamed", Owner: restActor{Login: "new-owner"}, UpdatedAt: updatedAt,
+			},
+		},
+		{
+			method: http.MethodGet,
+			path:   issuesPath,
+			response: []reconcileIssue{
+				{
+					ID: 200, NodeID: "I_issue", Number: 17, Title: "Issue", Body: &body,
+					HTMLURL: "https://github.test/new-owner/renamed/issues/17", State: "open",
+					Labels: []restLabel{{Name: "feature"}}, Assignees: []restActor{{Login: "alice"}},
+					CreatedAt: since.Add(-time.Hour), UpdatedAt: updatedAt,
+				},
+				{
+					ID: 201, NodeID: "PR_issue", Number: 18, Title: "Pull request issue", Body: &body,
+					HTMLURL: "https://github.test/new-owner/renamed/pull/18", State: "open", PullRequest: &struct{}{},
+					CreatedAt: since.Add(-time.Hour), UpdatedAt: updatedAt,
+				},
+			},
+		},
+		{
+			method: http.MethodGet,
+			path:   pullsPath,
+			response: []reconcilePullRequest{{
+				ID: 201, NodeID: "PR_issue", Number: 18, Title: "Pull request",
+				HTMLURL: "https://github.test/new-owner/renamed/pull/18", State: "open",
+				Head: restRef{Ref: "feature", SHA: "head"}, Base: restRef{Ref: "main", SHA: "base"},
+				CreatedAt: since.Add(-time.Hour), UpdatedAt: updatedAt,
+			}},
+		},
+	}}
+	databaseID := int64(100)
+	snapshot, err := (&Reconciler{client: client}).Reconcile(t.Context(), hubserver.ReconcileRequest{
+		Repository: hubserver.RepositoryTarget{ID: 1, NodeID: "R_repo", DatabaseID: &databaseID, Owner: "old-owner", Name: "old-name"},
+		Mode:       hubserver.ReconcileIncremental,
+		Since:      &since,
+		Through:    updatedAt,
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	client.assertDone()
+	wantRepository := hubserver.RepositorySource{NodeID: "R_repo", DatabaseID: &databaseID, Owner: "new-owner", Name: "renamed", UpdatedAt: updatedAt}
+	if !reflect.DeepEqual(snapshot.Repository, wantRepository) {
+		t.Fatalf("repository = %#v, want %#v", snapshot.Repository, wantRepository)
+	}
+	if len(snapshot.Issues) != 1 || snapshot.Issues[0].Number != 17 || !reflect.DeepEqual(snapshot.Issues[0].Labels, []string{"feature"}) || !reflect.DeepEqual(snapshot.Issues[0].Assignees, []string{"alice"}) {
+		t.Fatalf("issues = %#v, want one normalized issue", snapshot.Issues)
+	}
+	if len(snapshot.PullRequests) != 1 || snapshot.PullRequests[0].Number != 18 || snapshot.PullRequests[0].HeadSHA != "head" {
+		t.Fatalf("pull requests = %#v, want one normalized pull request", snapshot.PullRequests)
+	}
+}
+
+func TestReconcilerFullRepairOmitsIncrementalCursor(t *testing.T) {
+	t.Parallel()
+	updatedAt := time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+	client := &scriptedRESTClient{t: t, steps: []restStep{
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent", response: reconcileRepository{ID: 100, NodeID: "R_repo", Name: "detent", Owner: restActor{Login: "digitaldrywood"}, UpdatedAt: updatedAt}},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues?direction=asc&per_page=100&sort=updated&state=all", response: []reconcileIssue{}},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls?direction=asc&per_page=100&sort=updated&state=all", response: []reconcilePullRequest{}},
+	}}
+	_, err := (&Reconciler{client: client}).Reconcile(t.Context(), hubserver.ReconcileRequest{
+		Repository: hubserver.RepositoryTarget{ID: 1, NodeID: "R_repo", Owner: "digitaldrywood", Name: "detent"},
+		Mode:       hubserver.ReconcileFullRepair,
+		Since:      &updatedAt,
+		Through:    updatedAt,
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	client.assertDone()
+}

--- a/internal/hubgithub/reconciler_test.go
+++ b/internal/hubgithub/reconciler_test.go
@@ -85,12 +85,22 @@ func TestReconcilerUsesCursorAndRepositoryIdentity(t *testing.T) {
 func TestReconcilerFullRepairOmitsIncrementalCursor(t *testing.T) {
 	t.Parallel()
 	updatedAt := time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+	pullRequest := reconcilePullRequest{
+		ID: 201, NodeID: "PR_issue", Number: 18, Title: "Pull request", HTMLURL: "https://github.test/digitaldrywood/detent/pull/18", State: "open",
+		Head: restRef{Ref: "feature", SHA: "head"}, Base: restRef{Ref: "main", SHA: "base"}, CreatedAt: updatedAt.Add(-time.Hour), UpdatedAt: updatedAt,
+	}
+	detailedPullRequest := pullRequest
+	detailedPullRequest.MergeableState = "clean"
 	client := &scriptedRESTClient{t: t, steps: []restStep{
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent", response: reconcileRepository{ID: 100, NodeID: "R_repo", Name: "detent", Owner: restActor{Login: "digitaldrywood"}, UpdatedAt: updatedAt}},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues?direction=asc&per_page=100&sort=updated&state=all", response: []reconcileIssue{}},
-		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls?direction=asc&per_page=100&sort=updated&state=all", response: []reconcilePullRequest{}},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls?direction=asc&per_page=100&sort=updated&state=all", response: []reconcilePullRequest{pullRequest}},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/18", response: detailedPullRequest},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head/check-runs?per_page=100", response: restCheckRuns{}},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head/statuses?per_page=100", response: []restStatus{}},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/18/reviews?per_page=100", response: []restReview{}},
 	}}
-	_, err := (&Reconciler{client: client}).Reconcile(t.Context(), hubserver.ReconcileRequest{
+	snapshot, err := (&Reconciler{client: client}).Reconcile(t.Context(), hubserver.ReconcileRequest{
 		Repository: hubserver.RepositoryTarget{ID: 1, NodeID: "R_repo", Owner: "digitaldrywood", Name: "detent"},
 		Mode:       hubserver.ReconcileFullRepair,
 		Since:      &updatedAt,
@@ -100,4 +110,66 @@ func TestReconcilerFullRepairOmitsIncrementalCursor(t *testing.T) {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
 	client.assertDone()
+	if len(snapshot.PullRequestDetails) != 1 || snapshot.PullRequestDetails[0].Checks == nil || snapshot.PullRequestDetails[0].Reviews == nil {
+		t.Fatalf("full repair details = %#v, want every open pull request hydrated", snapshot.PullRequestDetails)
+	}
+}
+
+func TestReconcilerHydratesRequestedPullRequestDetails(t *testing.T) {
+	t.Parallel()
+	updatedAt := time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC)
+	reviewedAt := updatedAt.Add(time.Minute)
+	approvedAt := reviewedAt.Add(time.Minute)
+	commentedAt := approvedAt.Add(time.Minute)
+	changesRequested := restReview{State: "CHANGES_REQUESTED", SubmittedAt: &reviewedAt}
+	changesRequested.User.Login = "alice"
+	approved := restReview{State: "APPROVED", SubmittedAt: &approvedAt}
+	approved.User.Login = "alice"
+	commented := restReview{State: "COMMENTED", Body: "[P1] Blocking finding.", SubmittedAt: &commentedAt}
+	commented.User.Login = "codex"
+	pullRequest := reconcilePullRequest{
+		ID: 201, NodeID: "PR_issue", Number: 18, Title: "Pull request",
+		HTMLURL: "https://github.test/new-owner/renamed/pull/18", State: "open",
+		Head: restRef{Ref: "feature", SHA: "head"}, Base: restRef{Ref: "main", SHA: "base"},
+		CreatedAt: updatedAt.Add(-time.Hour), UpdatedAt: updatedAt,
+	}
+	detailedPullRequest := pullRequest
+	detailedPullRequest.MergeableState = "clean"
+	client := &scriptedRESTClient{t: t, steps: []restStep{
+		{method: http.MethodGet, path: "/repositories/100", response: reconcileRepository{ID: 100, NodeID: "R_repo", Name: "renamed", Owner: restActor{Login: "new-owner"}, UpdatedAt: updatedAt}},
+		{method: http.MethodGet, path: "/repos/new-owner/renamed/issues?direction=asc&per_page=100&sort=updated&state=all", response: []reconcileIssue{}},
+		{method: http.MethodGet, path: "/repos/new-owner/renamed/pulls?direction=asc&per_page=100&sort=updated&state=all", response: []reconcilePullRequest{pullRequest}},
+		{method: http.MethodGet, path: "/repos/new-owner/renamed/pulls/18", response: detailedPullRequest},
+		{method: http.MethodGet, path: "/repos/new-owner/renamed/commits/head/check-runs?per_page=100", response: restCheckRuns{CheckRuns: []restCheckRun{{ID: 1, Name: "CI", Status: "completed", Conclusion: "success"}}}},
+		{method: http.MethodGet, path: "/repos/new-owner/renamed/commits/head/statuses?per_page=100", response: []restStatus{{Context: "deploy", State: "success"}}},
+		{method: http.MethodGet, path: "/repos/new-owner/renamed/pulls/18/reviews?per_page=100", response: []restReview{changesRequested, approved, commented}},
+	}}
+	databaseID := int64(100)
+	snapshot, err := (&Reconciler{client: client}).Reconcile(t.Context(), hubserver.ReconcileRequest{
+		Repository: hubserver.RepositoryTarget{ID: 1, NodeID: "R_repo", DatabaseID: &databaseID, Owner: "old-owner", Name: "old-name"},
+		Mode:       hubserver.ReconcileIncremental,
+		Through:    updatedAt,
+		Hydrations: []hubserver.HydrationRequest{
+			{ID: 1, ObjectKind: "pull_request_checks", ObjectKey: "18", GitHubNumber: 18, RequestCount: 1},
+			{ID: 2, ObjectKind: "pull_request_reviews", ObjectKey: "18", GitHubNumber: 18, RequestCount: 1},
+			{ID: 3, ObjectKind: "commit_checks", ObjectKey: "head", HeadSHA: "head", RequestCount: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	client.assertDone()
+	if len(snapshot.PullRequestDetails) != 1 {
+		t.Fatalf("pull request details = %#v, want one", snapshot.PullRequestDetails)
+	}
+	details := snapshot.PullRequestDetails[0]
+	if details.MergeableState == nil || *details.MergeableState != "clean" || details.Checks == nil || details.Reviews == nil {
+		t.Fatalf("pull request details = %#v, want merge, checks, and reviews", details)
+	}
+	if details.Checks.Total != 2 || details.Checks.Passed != 2 || details.Checks.Conclusion != "success" {
+		t.Fatalf("checks = %#v, want two passing contexts", details.Checks)
+	}
+	if details.Reviews.Approvals != 1 || details.Reviews.ChangesRequested != 0 || details.Reviews.Comments != 1 || details.Reviews.Decision != "changes_requested" || details.Reviews.State != "p1" {
+		t.Fatalf("reviews = %#v, want current P1 to block the effective review summary", details.Reviews)
+	}
 }

--- a/internal/hubgithub/writer.go
+++ b/internal/hubgithub/writer.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	connectorgithub "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/hubserver"
@@ -443,8 +444,10 @@ type restPullRequest struct {
 }
 
 type restReview struct {
-	State string `json:"state"`
-	User  struct {
+	State       string     `json:"state"`
+	Body        string     `json:"body"`
+	SubmittedAt *time.Time `json:"submitted_at"`
+	User        struct {
 		Login string `json:"login"`
 	} `json:"user"`
 }

--- a/internal/hubserver/config.go
+++ b/internal/hubserver/config.go
@@ -19,6 +19,8 @@ const (
 	defaultOutboxMax                  = 15 * time.Minute
 	defaultOutboxStale                = 5 * time.Minute
 	defaultOutboxAttempts             = 8
+	DefaultReconcileInterval          = 10 * time.Minute
+	DefaultFullRepairInterval         = 24 * time.Hour
 )
 
 var (
@@ -48,6 +50,9 @@ type Config struct {
 	OutboxMaxBackoff           time.Duration
 	OutboxProcessingTimeout    time.Duration
 	OutboxMaxAttempts          int
+	ReconcileBackend           ReconcileBackend
+	ReconcileInterval          time.Duration
+	FullRepairInterval         time.Duration
 
 	validateDatabaseFilesystem func(string) error
 	now                        func() time.Time
@@ -88,6 +93,12 @@ func (c Config) normalized() Config {
 	}
 	if c.OutboxMaxAttempts <= 0 {
 		c.OutboxMaxAttempts = defaultOutboxAttempts
+	}
+	if c.ReconcileInterval <= 0 {
+		c.ReconcileInterval = DefaultReconcileInterval
+	}
+	if c.FullRepairInterval <= 0 {
+		c.FullRepairInterval = DefaultFullRepairInterval
 	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()

--- a/internal/hubserver/freshness.go
+++ b/internal/hubserver/freshness.go
@@ -1,0 +1,220 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+type SyncError struct {
+	Message string    `json:"message"`
+	At      time.Time `json:"at"`
+}
+
+type RepositoryFreshness struct {
+	ID                   int64      `json:"id"`
+	GitHubNodeID         string     `json:"github_node_id"`
+	Repository           string     `json:"repository"`
+	Status               string     `json:"status"`
+	LastSuccessfulSyncAt *time.Time `json:"last_successful_sync_at,omitempty"`
+	LastWebhookAt        *time.Time `json:"last_webhook_at,omitempty"`
+	LastReconciledAt     *time.Time `json:"last_reconciled_at,omitempty"`
+	LastFullRepairAt     *time.Time `json:"last_full_repair_at,omitempty"`
+	LastWebhookError     *SyncError `json:"last_webhook_error,omitempty"`
+	LastReconcileError   *SyncError `json:"last_reconcile_error,omitempty"`
+}
+
+type RepositoryHealthSummary struct {
+	Total int `json:"total"`
+	Fresh int `json:"fresh"`
+	Stale int `json:"stale"`
+	Error int `json:"error"`
+}
+
+type repositoryFreshnessResponse struct {
+	Repositories []RepositoryFreshness   `json:"repositories"`
+	Summary      RepositoryHealthSummary `json:"summary"`
+}
+
+type checkpointFreshness struct {
+	lastSuccessful *time.Time
+	lastError      *SyncError
+}
+
+func (s *Service) repositoryFreshness(c echo.Context) error {
+	result, err := s.database.repositoryFreshness(c.Request().Context(), s.config.now().UTC(), s.config.ReconcileInterval)
+	if err != nil {
+		return c.JSON(http.StatusServiceUnavailable, webhookErrorResponse{
+			Code:    "freshness_unavailable",
+			Message: "Repository freshness could not be read",
+		})
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+func (d *database) repositoryFreshness(ctx context.Context, now time.Time, reconcileInterval time.Duration) (repositoryFreshnessResponse, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT r.id, r.github_node_id, r.github_owner, r.github_name,
+			r.last_webhook_at, r.last_reconciled_at,
+			c.checkpoint_name, c.last_successful_at, c.last_error, c.state_json
+		FROM repositories r
+		LEFT JOIN sync_checkpoints c ON c.repository_id = r.id
+		ORDER BY lower(r.github_owner), lower(r.github_name), r.id, c.checkpoint_name
+	`)
+	if err != nil {
+		return repositoryFreshnessResponse{}, fmt.Errorf("query repository freshness: %w", err)
+	}
+	defer rows.Close()
+	type collected struct {
+		freshness   RepositoryFreshness
+		checkpoints map[string]checkpointFreshness
+	}
+	var repositories []*collected
+	byID := make(map[int64]*collected)
+	for rows.Next() {
+		var id int64
+		var nodeID string
+		var owner string
+		var name string
+		var lastWebhook sql.NullString
+		var lastReconciled sql.NullString
+		var checkpointName sql.NullString
+		var lastSuccessful sql.NullString
+		var lastError sql.NullString
+		var stateJSON sql.NullString
+		if err := rows.Scan(&id, &nodeID, &owner, &name, &lastWebhook, &lastReconciled, &checkpointName, &lastSuccessful, &lastError, &stateJSON); err != nil {
+			return repositoryFreshnessResponse{}, fmt.Errorf("scan repository freshness: %w", err)
+		}
+		entry := byID[id]
+		if entry == nil {
+			entry = &collected{
+				freshness:   RepositoryFreshness{ID: id, GitHubNodeID: nodeID, Repository: owner + "/" + name},
+				checkpoints: make(map[string]checkpointFreshness),
+			}
+			var parseErr error
+			webhookAt, webhookAtValid, parseErr := parseCheckpointTime(lastWebhook)
+			if parseErr != nil {
+				return repositoryFreshnessResponse{}, fmt.Errorf("parse repository webhook freshness: %w", parseErr)
+			}
+			if webhookAtValid {
+				entry.freshness.LastWebhookAt = &webhookAt
+			}
+			reconciledAt, reconciledAtValid, parseErr := parseCheckpointTime(lastReconciled)
+			if parseErr != nil {
+				return repositoryFreshnessResponse{}, fmt.Errorf("parse repository reconciliation freshness: %w", parseErr)
+			}
+			if reconciledAtValid {
+				entry.freshness.LastReconciledAt = &reconciledAt
+			}
+			byID[id] = entry
+			repositories = append(repositories, entry)
+		}
+		if checkpointName.Valid {
+			checkpoint, err := parseCheckpointFreshness(lastSuccessful, lastError, stateJSON)
+			if err != nil {
+				return repositoryFreshnessResponse{}, fmt.Errorf("parse repository %s checkpoint: %w", checkpointName.String, err)
+			}
+			entry.checkpoints[checkpointName.String] = checkpoint
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return repositoryFreshnessResponse{}, fmt.Errorf("iterate repository freshness: %w", err)
+	}
+
+	staleAfter := 2 * reconcileInterval
+	if staleAfter <= 0 {
+		staleAfter = 2 * DefaultReconcileInterval
+	}
+	result := repositoryFreshnessResponse{Repositories: make([]RepositoryFreshness, 0, len(repositories))}
+	for _, entry := range repositories {
+		freshness := entry.freshness
+		freshness.LastWebhookAt = latestTime(freshness.LastWebhookAt, entry.checkpoints[checkpointWebhook].lastSuccessful)
+		freshness.LastSuccessfulSyncAt = latestTime(freshness.LastWebhookAt, freshness.LastReconciledAt)
+		if checkpoint := entry.checkpoints[checkpointFullRepair]; checkpoint.lastSuccessful != nil {
+			freshness.LastFullRepairAt = checkpoint.lastSuccessful
+		}
+		freshness.LastWebhookError = entry.checkpoints[checkpointWebhook].lastError
+		freshness.LastReconcileError = latestSyncError(
+			entry.checkpoints[checkpointIncremental].lastError,
+			entry.checkpoints[checkpointFullRepair].lastError,
+		)
+		freshness.Status = "fresh"
+		if checkpointHasUnresolvedError(entry.checkpoints[checkpointWebhook]) ||
+			checkpointHasUnresolvedError(entry.checkpoints[checkpointIncremental]) ||
+			checkpointHasUnresolvedError(entry.checkpoints[checkpointFullRepair]) {
+			freshness.Status = "error"
+		} else if freshness.LastReconciledAt == nil || now.Sub(*freshness.LastReconciledAt) > staleAfter {
+			freshness.Status = "stale"
+		}
+		result.Repositories = append(result.Repositories, freshness)
+		result.Summary.Total++
+		switch freshness.Status {
+		case "fresh":
+			result.Summary.Fresh++
+		case "error":
+			result.Summary.Error++
+		default:
+			result.Summary.Stale++
+		}
+	}
+	return result, nil
+}
+
+func checkpointHasUnresolvedError(checkpoint checkpointFreshness) bool {
+	return checkpoint.lastError != nil &&
+		(checkpoint.lastSuccessful == nil || !checkpoint.lastError.At.Before(*checkpoint.lastSuccessful))
+}
+
+func parseCheckpointFreshness(lastSuccessful sql.NullString, lastError sql.NullString, stateJSON sql.NullString) (checkpointFreshness, error) {
+	result := checkpointFreshness{}
+	var err error
+	lastSuccessfulAt, lastSuccessfulValid, err := parseCheckpointTime(lastSuccessful)
+	if err != nil {
+		return checkpointFreshness{}, err
+	}
+	if lastSuccessfulValid {
+		result.lastSuccessful = &lastSuccessfulAt
+	}
+	if !lastError.Valid || lastError.String == "" {
+		return result, nil
+	}
+	var state struct {
+		LastErrorAt string `json:"last_error_at"`
+	}
+	if !stateJSON.Valid || json.Unmarshal([]byte(stateJSON.String), &state) != nil || state.LastErrorAt == "" {
+		return result, nil
+	}
+	errorAt, err := time.Parse(time.RFC3339Nano, state.LastErrorAt)
+	if err != nil {
+		return checkpointFreshness{}, err
+	}
+	result.lastError = &SyncError{Message: lastError.String, At: errorAt.UTC()}
+	return result, nil
+}
+
+func latestTime(values ...*time.Time) *time.Time {
+	var latest *time.Time
+	for _, value := range values {
+		if value != nil && (latest == nil || value.After(*latest)) {
+			copy := value.UTC()
+			latest = &copy
+		}
+	}
+	return latest
+}
+
+func latestSyncError(values ...*SyncError) *SyncError {
+	var latest *SyncError
+	for _, value := range values {
+		if value != nil && (latest == nil || value.At.After(latest.At)) {
+			copy := *value
+			latest = &copy
+		}
+	}
+	return latest
+}

--- a/internal/hubserver/github_webhook_apply.go
+++ b/internal/hubserver/github_webhook_apply.go
@@ -323,6 +323,10 @@ func applyOrResolveWebhookRepository(ctx context.Context, tx *sql.Tx, fullName s
 }
 
 func applyWebhookRepository(ctx context.Context, tx *sql.Tx, repository normalizedRepository, stamp sourceStamp, now time.Time) (int64, projectionApplyResult, error) {
+	return applyRepositoryProjection(ctx, tx, repository, stamp, now, true, false)
+}
+
+func applyRepositoryProjection(ctx context.Context, tx *sql.Tx, repository normalizedRepository, stamp sourceStamp, now time.Time, webhook bool, authoritative bool) (int64, projectionApplyResult, error) {
 	var repositoryID int64
 	var currentVersion string
 	var currentUpdatedAt sql.NullString
@@ -341,7 +345,7 @@ func applyWebhookRepository(ctx context.Context, tx *sql.Tx, repository normaliz
 				created_at, updated_at
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, repository.NodeID, optionalInt64(repository.DatabaseID), repository.Owner, repository.Name,
-			formatWebhookTime(now), stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+			optionalTime(webhook, now), stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
 			formatWebhookTime(now), formatWebhookTime(now))
 		if err != nil {
 			return 0, projectionApplyResult{}, fmt.Errorf("insert GitHub webhook repository: %w", err)
@@ -365,29 +369,32 @@ func applyWebhookRepository(ctx context.Context, tx *sql.Tx, repository normaliz
 		Stale:    comparison < 0,
 		Conflict: !current.UpdatedAt.IsZero() && stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version,
 	}
-	if comparison > 0 {
+	apply := comparison > 0 || authoritative && stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version
+	if apply {
 		if _, err := tx.ExecContext(ctx, `
 			UPDATE repositories
 			SET github_node_id = ?,
 				github_database_id = COALESCE(?, github_database_id),
 				github_owner = ?,
 				github_name = ?,
-				last_webhook_at = ?,
+				last_webhook_at = CASE WHEN ? THEN ? ELSE last_webhook_at END,
 				source_version = ?,
 				source_updated_at = ?,
 				synchronized_at = ?,
 				updated_at = ?
 			WHERE id = ?
 		`, repository.NodeID, optionalInt64(repository.DatabaseID), repository.Owner, repository.Name,
-			formatWebhookTime(now), stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
+			webhook, formatWebhookTime(now), stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
 			formatWebhookTime(now), repositoryID); err != nil {
 			return 0, projectionApplyResult{}, fmt.Errorf("update GitHub webhook repository: %w", err)
 		}
 		result.Changed = true
-	} else if _, err := tx.ExecContext(ctx, `
-		UPDATE repositories SET last_webhook_at = ? WHERE id = ?
-	`, formatWebhookTime(now), repositoryID); err != nil {
-		return 0, projectionApplyResult{}, fmt.Errorf("touch GitHub webhook repository: %w", err)
+	} else if webhook {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE repositories SET last_webhook_at = ? WHERE id = ?
+		`, formatWebhookTime(now), repositoryID); err != nil {
+			return 0, projectionApplyResult{}, fmt.Errorf("touch GitHub webhook repository: %w", err)
+		}
 	}
 	return repositoryID, result, nil
 }
@@ -412,16 +419,21 @@ func resolveWebhookRepositoryID(ctx context.Context, tx *sql.Tx, fullName string
 }
 
 func applyWebhookIssue(ctx context.Context, tx *sql.Tx, repositoryID int64, issue normalizedIssue, stamp sourceStamp, now time.Time) (projectionApplyResult, error) {
+	return applyIssueProjection(ctx, tx, repositoryID, issue, stamp, now, false)
+}
+
+func applyIssueProjection(ctx context.Context, tx *sql.Tx, repositoryID int64, issue normalizedIssue, stamp sourceStamp, now time.Time, authoritative bool) (projectionApplyResult, error) {
 	var issueID int64
 	var currentVersion string
 	var currentUpdatedAt string
+	var currentState string
 	queryErr := tx.QueryRowContext(ctx, `
-		SELECT id, source_version, source_updated_at
+		SELECT id, source_version, source_updated_at, github_state
 		FROM issues
 		WHERE github_node_id = ? OR (repository_id = ? AND github_number = ?)
 		ORDER BY CASE WHEN github_node_id = ? THEN 0 ELSE 1 END
 		LIMIT 1
-	`, issue.NodeID, repositoryID, issue.Number, issue.NodeID).Scan(&issueID, &currentVersion, &currentUpdatedAt)
+	`, issue.NodeID, repositoryID, issue.Number, issue.NodeID).Scan(&issueID, &currentVersion, &currentUpdatedAt, &currentState)
 	if queryErr != nil && !errors.Is(queryErr, sql.ErrNoRows) {
 		return projectionApplyResult{}, fmt.Errorf("read GitHub webhook issue: %w", queryErr)
 	}
@@ -467,7 +479,8 @@ func applyWebhookIssue(ctx context.Context, tx *sql.Tx, repositoryID int64, issu
 		Stale:    comparison < 0,
 		Conflict: stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version,
 	}
-	if comparison <= 0 {
+	force := authoritative && stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version
+	if !force && (comparison < 0 || comparison == 0 && !strings.EqualFold(currentState, "deleted")) {
 		return result, nil
 	}
 	if _, err := tx.ExecContext(ctx, `
@@ -526,16 +539,21 @@ func resolveWebhookWorkflowStateID(ctx context.Context, tx *sql.Tx, repositoryID
 }
 
 func applyWebhookPullRequest(ctx context.Context, tx *sql.Tx, repositoryID int64, pullRequest normalizedPullRequest, stamp sourceStamp, now time.Time) (projectionApplyResult, error) {
+	return applyPullRequestProjection(ctx, tx, repositoryID, pullRequest, stamp, now, false)
+}
+
+func applyPullRequestProjection(ctx context.Context, tx *sql.Tx, repositoryID int64, pullRequest normalizedPullRequest, stamp sourceStamp, now time.Time, authoritative bool) (projectionApplyResult, error) {
 	var pullRequestID int64
 	var currentVersion string
 	var currentUpdatedAt string
+	var currentState string
 	err := tx.QueryRowContext(ctx, `
-		SELECT id, source_version, source_updated_at
+		SELECT id, source_version, source_updated_at, github_state
 		FROM pull_requests
 		WHERE github_node_id = ? OR (repository_id = ? AND github_number = ?)
 		ORDER BY CASE WHEN github_node_id = ? THEN 0 ELSE 1 END
 		LIMIT 1
-	`, pullRequest.NodeID, repositoryID, pullRequest.Number, pullRequest.NodeID).Scan(&pullRequestID, &currentVersion, &currentUpdatedAt)
+	`, pullRequest.NodeID, repositoryID, pullRequest.Number, pullRequest.NodeID).Scan(&pullRequestID, &currentVersion, &currentUpdatedAt, &currentState)
 	if errors.Is(err, sql.ErrNoRows) {
 		_, err := tx.ExecContext(ctx, `
 			INSERT INTO pull_requests (
@@ -566,7 +584,8 @@ func applyWebhookPullRequest(ctx context.Context, tx *sql.Tx, repositoryID int64
 		Stale:    comparison < 0,
 		Conflict: stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version,
 	}
-	if comparison <= 0 {
+	force := authoritative && stamp.UpdatedAt.Equal(current.UpdatedAt) && stamp.Version != current.Version
+	if !force && (comparison < 0 || comparison == 0 && !strings.EqualFold(currentState, "deleted")) {
 		return result, nil
 	}
 	if _, err := tx.ExecContext(ctx, `
@@ -1071,6 +1090,13 @@ func optionalInt(value int) any {
 		return nil
 	}
 	return value
+}
+
+func optionalTime(enabled bool, value time.Time) any {
+	if !enabled {
+		return nil
+	}
+	return formatWebhookTime(value)
 }
 
 func optionalString(value string) any {

--- a/internal/hubserver/github_webhook_store.go
+++ b/internal/hubserver/github_webhook_store.go
@@ -3,8 +3,10 @@ package hubserver
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -187,6 +189,13 @@ func (d *database) processWebhook(ctx context.Context, inboxID int64, now time.T
 		failureErr := d.markWebhookFailed(ctx, inboxID, now, err)
 		return errors.Join(fmt.Errorf("complete GitHub webhook processing: %w", err), rollbackErr, failureErr)
 	}
+	if result.RepositoryID != nil {
+		if err := recordCheckpointSuccessTx(ctx, tx, *result.RepositoryID, checkpointWebhook, now, now); err != nil {
+			rollbackErr := tx.Rollback()
+			failureErr := d.markWebhookFailed(ctx, inboxID, now, err)
+			return errors.Join(err, rollbackErr, failureErr)
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		failureErr := d.markWebhookFailed(ctx, inboxID, now, err)
 		return errors.Join(fmt.Errorf("commit GitHub webhook processing: %w", err), failureErr)
@@ -209,7 +218,59 @@ func (d *database) markWebhookFailed(ctx context.Context, inboxID int64, now tim
 	if err != nil {
 		return fmt.Errorf("record GitHub webhook failure: %w", err)
 	}
-	return nil
+	repositoryID, found, err := d.webhookFailureRepository(ctx, inboxID)
+	if err != nil || !found {
+		return err
+	}
+	return d.recordCheckpointFailure(ctx, repositoryID, checkpointWebhook, now, processingErr)
+}
+
+func (d *database) webhookFailureRepository(ctx context.Context, inboxID int64) (int64, bool, error) {
+	var repositoryID sql.NullInt64
+	var payload []byte
+	if err := d.db.QueryRowContext(ctx, `
+		SELECT i.repository_id, p.body
+		FROM github_webhook_inbox i
+		LEFT JOIN github_webhook_payloads p ON p.inbox_id = i.id
+		WHERE i.id = ?
+	`, inboxID).Scan(&repositoryID, &payload); err != nil {
+		return 0, false, fmt.Errorf("read failed GitHub webhook repository: %w", err)
+	}
+	if repositoryID.Valid {
+		return repositoryID.Int64, true, nil
+	}
+	var webhook githubWebhookPayload
+	if json.Unmarshal(payload, &webhook) != nil || webhook.Repository == nil {
+		return 0, false, nil
+	}
+	fullName := webhookRepositoryFullName(webhook.Repository)
+	owner, name, ok := splitRepositoryFullName(fullName)
+	if !ok {
+		return 0, false, nil
+	}
+	var resolved int64
+	nodeID := optionalWebhookNodeID(webhook.Repository.NodeID)
+	err := d.db.QueryRowContext(ctx, `
+		SELECT id FROM repositories
+		WHERE (? IS NOT NULL AND github_node_id = ?)
+			OR (lower(github_owner) = lower(?) AND lower(github_name) = lower(?))
+		ORDER BY CASE WHEN ? IS NOT NULL AND github_node_id = ? THEN 0 ELSE 1 END
+		LIMIT 1
+	`, nodeID, nodeID, owner, name, nodeID, nodeID).Scan(&resolved)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("resolve failed GitHub webhook repository: %w", err)
+	}
+	return resolved, true, nil
+}
+
+func optionalWebhookNodeID(nodeID *string) any {
+	if nodeID == nil || strings.TrimSpace(*nodeID) == "" {
+		return nil
+	}
+	return strings.TrimSpace(*nodeID)
 }
 
 func (d *database) processPendingWebhooks(ctx context.Context, now time.Time) error {

--- a/internal/hubserver/github_webhook_test.go
+++ b/internal/hubserver/github_webhook_test.go
@@ -140,6 +140,31 @@ func TestGitHubWebhookAcknowledgesDurableReceiptWhenProcessingFails(t *testing.T
 	if status != "failed" || attempts != 1 || payloadCount != 1 {
 		t.Fatalf("durable receipt = status %q attempts %d payloads %d, want failed, 1, 1", status, attempts, payloadCount)
 	}
+	var checkpointError string
+	var checkpointState string
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT last_error, state_json
+		FROM sync_checkpoints
+		WHERE checkpoint_name = 'webhook'
+	`).Scan(&checkpointError, &checkpointState); err != nil {
+		t.Fatalf("read repository webhook error: %v", err)
+	}
+	if checkpointError == "" || !strings.Contains(checkpointState, "last_error_at") {
+		t.Fatalf("webhook checkpoint = error %q state %q, want visible repository error", checkpointError, checkpointState)
+	}
+	freshness, err := service.database.repositoryFreshness(t.Context(), time.Now().UTC(), time.Minute)
+	if err != nil {
+		t.Fatalf("read freshness after webhook failure: %v", err)
+	}
+	var exposed *SyncError
+	for _, repository := range freshness.Repositories {
+		if repository.GitHubNodeID == "R_conflicting_node" {
+			exposed = repository.LastWebhookError
+		}
+	}
+	if exposed == nil || exposed.Message != checkpointError {
+		t.Fatalf("exposed webhook error = %#v, want %q", exposed, checkpointError)
+	}
 }
 
 func TestGitHubWebhookSourceOrderingConverges(t *testing.T) {

--- a/internal/hubserver/reconcile.go
+++ b/internal/hubserver/reconcile.go
@@ -3,10 +3,13 @@ package hubserver
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
 const (
@@ -35,6 +38,17 @@ type ReconcileRequest struct {
 	Mode       ReconcileMode
 	Since      *time.Time
 	Through    time.Time
+	Hydrations []HydrationRequest
+}
+
+type HydrationRequest struct {
+	ID           int64
+	ObjectKind   string
+	ObjectKey    string
+	GitHubNodeID string
+	GitHubNumber int
+	HeadSHA      string
+	RequestCount int
 }
 
 type RepositorySource struct {
@@ -75,10 +89,19 @@ type PullRequestSource struct {
 	UpdatedAt  time.Time
 }
 
+type PullRequestDetailSource struct {
+	Number         int
+	HeadSHA        string
+	MergeableState *string
+	Checks         *tracker.CheckSummary
+	Reviews        *tracker.ReviewSummary
+}
+
 type ReconcileSnapshot struct {
-	Repository   RepositorySource
-	Issues       []IssueSource
-	PullRequests []PullRequestSource
+	Repository         RepositorySource
+	Issues             []IssueSource
+	PullRequests       []PullRequestSource
+	PullRequestDetails []PullRequestDetailSource
 }
 
 type ReconcileBackend interface {
@@ -89,6 +112,7 @@ type reconcileTarget struct {
 	RepositoryTarget
 	Cursor         *time.Time
 	HydrationSince *time.Time
+	Hydrations     []HydrationRequest
 }
 
 func (s *Service) runGitHubReconciliation(ctx context.Context) {
@@ -139,6 +163,7 @@ func (s *Service) reconcileRepository(ctx context.Context, target reconcileTarge
 		Repository: target.RepositoryTarget,
 		Mode:       mode,
 		Through:    startedAt,
+		Hydrations: append([]HydrationRequest(nil), target.Hydrations...),
 	}
 	if mode == ReconcileIncremental {
 		request.Since = earliestTime(target.Cursor, target.HydrationSince)
@@ -169,13 +194,9 @@ func (s *Service) stopGitHubReconciliation() error {
 
 func (d *database) reconcileTargets(ctx context.Context) ([]reconcileTarget, error) {
 	rows, err := d.db.QueryContext(ctx, `
-		SELECT r.id, r.github_node_id, r.github_database_id, r.github_owner, r.github_name,
-			r.reconcile_cursor,
-			MIN(CASE WHEN h.status = 'pending' THEN h.requested_source_updated_at END)
-		FROM repositories r
-		LEFT JOIN github_hydration_requests h ON h.repository_id = r.id
-		GROUP BY r.id
-		ORDER BY lower(r.github_owner), lower(r.github_name), r.id
+		SELECT id, github_node_id, github_database_id, github_owner, github_name, reconcile_cursor
+		FROM repositories
+		ORDER BY lower(github_owner), lower(github_name), id
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list GitHub reconciliation targets: %w", err)
@@ -186,8 +207,7 @@ func (d *database) reconcileTargets(ctx context.Context) ([]reconcileTarget, err
 		var target reconcileTarget
 		var databaseID sql.NullInt64
 		var cursor sql.NullString
-		var hydrationSince sql.NullString
-		if err := rows.Scan(&target.ID, &target.NodeID, &databaseID, &target.Owner, &target.Name, &cursor, &hydrationSince); err != nil {
+		if err := rows.Scan(&target.ID, &target.NodeID, &databaseID, &target.Owner, &target.Name, &cursor); err != nil {
 			return nil, fmt.Errorf("scan GitHub reconciliation target: %w", err)
 		}
 		if databaseID.Valid {
@@ -201,19 +221,69 @@ func (d *database) reconcileTargets(ctx context.Context) ([]reconcileTarget, err
 		if cursorValid {
 			target.Cursor = &cursorValue
 		}
-		hydrationValue, hydrationValid, parseErr := parseCheckpointTime(hydrationSince)
-		if parseErr != nil {
-			return nil, fmt.Errorf("parse GitHub hydration cursor for %s/%s: %w", target.Owner, target.Name, parseErr)
-		}
-		if hydrationValid {
-			target.HydrationSince = &hydrationValue
-		}
 		targets = append(targets, target)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close GitHub reconciliation targets: %w", err)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate GitHub reconciliation targets: %w", err)
 	}
+	for index := range targets {
+		hydrations, since, err := d.pendingHydrationRequests(ctx, targets[index].ID)
+		if err != nil {
+			return nil, fmt.Errorf("list GitHub hydration requests for %s/%s: %w", targets[index].Owner, targets[index].Name, err)
+		}
+		targets[index].Hydrations = hydrations
+		targets[index].HydrationSince = since
+	}
 	return targets, nil
+}
+
+func (d *database) pendingHydrationRequests(ctx context.Context, repositoryID int64) ([]HydrationRequest, *time.Time, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT id, object_kind, object_key, github_node_id, github_number, head_sha, request_count, requested_source_updated_at
+		FROM github_hydration_requests
+		WHERE repository_id = ? AND status = 'pending'
+		ORDER BY id
+	`, repositoryID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var requests []HydrationRequest
+	var since *time.Time
+	for rows.Next() {
+		var request HydrationRequest
+		var githubNodeID sql.NullString
+		var githubNumber sql.NullInt64
+		var headSHA sql.NullString
+		var requestedAt sql.NullString
+		if err := rows.Scan(&request.ID, &request.ObjectKind, &request.ObjectKey, &githubNodeID, &githubNumber, &headSHA, &request.RequestCount, &requestedAt); err != nil {
+			return nil, nil, err
+		}
+		if githubNodeID.Valid {
+			request.GitHubNodeID = githubNodeID.String
+		}
+		if githubNumber.Valid {
+			request.GitHubNumber = int(githubNumber.Int64)
+		}
+		if headSHA.Valid {
+			request.HeadSHA = headSHA.String
+		}
+		value, valid, err := parseCheckpointTime(requestedAt)
+		if err != nil {
+			return nil, nil, err
+		}
+		if valid {
+			since = earliestTime(since, &value)
+		}
+		requests = append(requests, request)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return requests, since, nil
 }
 
 func (d *database) applyReconcileSnapshot(ctx context.Context, target reconcileTarget, mode ReconcileMode, cursor time.Time, completedAt time.Time, snapshot ReconcileSnapshot) error {
@@ -267,6 +337,11 @@ func (d *database) applyReconcileSnapshot(ctx context.Context, target reconcileT
 		}
 		pullRequestNodeIDs[pullRequest.NodeID] = struct{}{}
 	}
+	for _, details := range snapshot.PullRequestDetails {
+		if err := applyPullRequestDetails(ctx, tx, repositoryID, details, completedAt); err != nil {
+			return err
+		}
+	}
 	if mode == ReconcileFullRepair {
 		if err := markMissingProjectionRows(ctx, tx, "issues", `
 			SELECT id, github_node_id FROM issues
@@ -295,15 +370,82 @@ func (d *database) applyReconcileSnapshot(ctx context.Context, target reconcileT
 	if err := recordCheckpointSuccessTx(ctx, tx, repositoryID, string(mode), cursor, completedAt); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE github_hydration_requests
-		SET status = 'completed', completed_at = ?, last_error = NULL, updated_at = ?
-		WHERE repository_id = ? AND status = 'pending'
-	`, formatWebhookTime(completedAt), formatWebhookTime(completedAt), repositoryID); err != nil {
-		return fmt.Errorf("complete GitHub hydration requests: %w", err)
+	for _, hydration := range target.Hydrations {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE github_hydration_requests
+			SET status = 'completed', completed_at = ?, last_error = NULL, updated_at = ?
+			WHERE id = ? AND repository_id = ? AND status = 'pending' AND request_count = ?
+		`, formatWebhookTime(completedAt), formatWebhookTime(completedAt), hydration.ID, repositoryID, hydration.RequestCount); err != nil {
+			return fmt.Errorf("complete GitHub hydration request %d: %w", hydration.ID, err)
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit GitHub reconciliation: %w", err)
+	}
+	return nil
+}
+
+func applyPullRequestDetails(ctx context.Context, tx *sql.Tx, repositoryID int64, details PullRequestDetailSource, now time.Time) error {
+	if details.Number <= 0 && strings.TrimSpace(details.HeadSHA) == "" {
+		return errors.New("GitHub reconciliation returned pull request details without an identity")
+	}
+	var pullRequestID int64
+	var state string
+	var draft bool
+	var mergeableState string
+	var checksJSON string
+	var reviewsJSON string
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, github_state, draft, mergeable_state, checks_summary_json, reviews_summary_json
+		FROM pull_requests
+		WHERE repository_id = ? AND (github_number = ? OR (? <> '' AND head_sha = ?))
+		ORDER BY CASE WHEN github_number = ? THEN 0 ELSE 1 END
+		LIMIT 1
+	`, repositoryID, details.Number, details.HeadSHA, details.HeadSHA, details.Number).Scan(
+		&pullRequestID, &state, &draft, &mergeableState, &checksJSON, &reviewsJSON,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read GitHub pull request details: %w", err)
+	}
+	var checks tracker.CheckSummary
+	if err := json.Unmarshal([]byte(checksJSON), &checks); err != nil {
+		return fmt.Errorf("decode GitHub pull request checks summary: %w", err)
+	}
+	var reviews tracker.ReviewSummary
+	if err := json.Unmarshal([]byte(reviewsJSON), &reviews); err != nil {
+		return fmt.Errorf("decode GitHub pull request reviews summary: %w", err)
+	}
+	if details.Checks != nil {
+		checks = *details.Checks
+	}
+	if details.Reviews != nil {
+		reviews = *details.Reviews
+	}
+	if details.MergeableState != nil {
+		mergeableState = strings.ToLower(strings.TrimSpace(*details.MergeableState))
+	}
+	checksBytes, err := json.Marshal(checks)
+	if err != nil {
+		return fmt.Errorf("encode GitHub pull request checks summary: %w", err)
+	}
+	reviewsBytes, err := json.Marshal(reviews)
+	if err != nil {
+		return fmt.Errorf("encode GitHub pull request reviews summary: %w", err)
+	}
+	mergeReady := strings.EqualFold(state, "open") && !draft && mergeableState == "clean" &&
+		checks.Total > 0 && checks.Pending == 0 && checks.Failed == 0 && strings.EqualFold(checks.Conclusion, "success") &&
+		reviews.ChangesRequested == 0 && !strings.EqualFold(reviews.Decision, "changes_requested")
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE pull_requests
+		SET mergeable_state = ?, checks_summary_json = ?, reviews_summary_json = ?,
+			merge_ready = ?, merge_readiness_refreshed_at = ?, synchronized_at = ?, updated_at = ?
+		WHERE id = ?
+	`, mergeableState, string(checksBytes), string(reviewsBytes), mergeReady,
+		formatWebhookTime(now), formatWebhookTime(now), formatWebhookTime(now), pullRequestID); err != nil {
+		return fmt.Errorf("update GitHub pull request details: %w", err)
 	}
 	return nil
 }

--- a/internal/hubserver/reconcile.go
+++ b/internal/hubserver/reconcile.go
@@ -1,0 +1,429 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	checkpointWebhook     = "webhook"
+	checkpointIncremental = "incremental"
+	checkpointFullRepair  = "full_repair"
+)
+
+type ReconcileMode string
+
+const (
+	ReconcileIncremental ReconcileMode = "incremental"
+	ReconcileFullRepair  ReconcileMode = "full_repair"
+)
+
+type RepositoryTarget struct {
+	ID         int64
+	NodeID     string
+	DatabaseID *int64
+	Owner      string
+	Name       string
+}
+
+type ReconcileRequest struct {
+	Repository RepositoryTarget
+	Mode       ReconcileMode
+	Since      *time.Time
+	Through    time.Time
+}
+
+type RepositorySource struct {
+	NodeID     string
+	DatabaseID *int64
+	Owner      string
+	Name       string
+	UpdatedAt  time.Time
+}
+
+type IssueSource struct {
+	NodeID     string
+	DatabaseID *int64
+	Number     int
+	Title      string
+	Body       string
+	URL        string
+	State      string
+	Labels     []string
+	Assignees  []string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+type PullRequestSource struct {
+	NodeID     string
+	DatabaseID *int64
+	Number     int
+	Title      string
+	URL        string
+	State      string
+	Draft      bool
+	HeadRef    string
+	HeadSHA    string
+	BaseRef    string
+	BaseSHA    string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+type ReconcileSnapshot struct {
+	Repository   RepositorySource
+	Issues       []IssueSource
+	PullRequests []PullRequestSource
+}
+
+type ReconcileBackend interface {
+	Reconcile(context.Context, ReconcileRequest) (ReconcileSnapshot, error)
+}
+
+type reconcileTarget struct {
+	RepositoryTarget
+	Cursor         *time.Time
+	HydrationSince *time.Time
+}
+
+func (s *Service) runGitHubReconciliation(ctx context.Context) {
+	defer close(s.reconcileDone)
+	if s.config.ReconcileBackend == nil {
+		return
+	}
+	s.reconcileAllRepositories(ctx, ReconcileFullRepair)
+	incrementalTicker := time.NewTicker(s.config.ReconcileInterval)
+	fullTicker := time.NewTicker(s.config.FullRepairInterval)
+	defer incrementalTicker.Stop()
+	defer fullTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-incrementalTicker.C:
+			s.reconcileAllRepositories(ctx, ReconcileIncremental)
+		case <-fullTicker.C:
+			s.reconcileAllRepositories(ctx, ReconcileFullRepair)
+		}
+	}
+}
+
+func (s *Service) reconcileAllRepositories(ctx context.Context, mode ReconcileMode) {
+	targets, err := s.database.reconcileTargets(ctx)
+	if err != nil {
+		s.config.Logger.Error("list GitHub repositories for reconciliation", "mode", mode, "error", err)
+		return
+	}
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if err := s.reconcileRepository(ctx, target, mode); err != nil && !errors.Is(err, context.Canceled) {
+			s.config.Logger.Error("reconcile GitHub repository", "repository", target.Owner+"/"+target.Name, "mode", mode, "error", err)
+		}
+	}
+}
+
+func (s *Service) reconcileRepository(ctx context.Context, target reconcileTarget, mode ReconcileMode) error {
+	startedAt := s.config.now().UTC()
+	checkpoint := string(mode)
+	if err := s.database.recordCheckpointStarted(ctx, target.ID, checkpoint, startedAt); err != nil {
+		return err
+	}
+	request := ReconcileRequest{
+		Repository: target.RepositoryTarget,
+		Mode:       mode,
+		Through:    startedAt,
+	}
+	if mode == ReconcileIncremental {
+		request.Since = earliestTime(target.Cursor, target.HydrationSince)
+	}
+	snapshot, err := s.config.ReconcileBackend.Reconcile(ctx, request)
+	if err != nil {
+		failureErr := s.database.recordCheckpointFailure(ctx, target.ID, checkpoint, s.config.now().UTC(), err)
+		return errors.Join(err, failureErr)
+	}
+	completedAt := s.config.now().UTC()
+	if err := s.database.applyReconcileSnapshot(ctx, target, mode, request.Through, completedAt, snapshot); err != nil {
+		failureErr := s.database.recordCheckpointFailure(ctx, target.ID, checkpoint, completedAt, err)
+		return errors.Join(err, failureErr)
+	}
+	return nil
+}
+
+func (s *Service) stopGitHubReconciliation() error {
+	if s == nil || s.reconcileCancel == nil || s.reconcileDone == nil {
+		return nil
+	}
+	s.reconcileStopOnce.Do(func() {
+		s.reconcileCancel()
+		<-s.reconcileDone
+	})
+	return nil
+}
+
+func (d *database) reconcileTargets(ctx context.Context) ([]reconcileTarget, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT r.id, r.github_node_id, r.github_database_id, r.github_owner, r.github_name,
+			r.reconcile_cursor,
+			MIN(CASE WHEN h.status = 'pending' THEN h.requested_source_updated_at END)
+		FROM repositories r
+		LEFT JOIN github_hydration_requests h ON h.repository_id = r.id
+		GROUP BY r.id
+		ORDER BY lower(r.github_owner), lower(r.github_name), r.id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list GitHub reconciliation targets: %w", err)
+	}
+	defer rows.Close()
+	var targets []reconcileTarget
+	for rows.Next() {
+		var target reconcileTarget
+		var databaseID sql.NullInt64
+		var cursor sql.NullString
+		var hydrationSince sql.NullString
+		if err := rows.Scan(&target.ID, &target.NodeID, &databaseID, &target.Owner, &target.Name, &cursor, &hydrationSince); err != nil {
+			return nil, fmt.Errorf("scan GitHub reconciliation target: %w", err)
+		}
+		if databaseID.Valid {
+			target.DatabaseID = &databaseID.Int64
+		}
+		var parseErr error
+		cursorValue, cursorValid, parseErr := parseCheckpointTime(cursor)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse GitHub reconciliation cursor for %s/%s: %w", target.Owner, target.Name, parseErr)
+		}
+		if cursorValid {
+			target.Cursor = &cursorValue
+		}
+		hydrationValue, hydrationValid, parseErr := parseCheckpointTime(hydrationSince)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse GitHub hydration cursor for %s/%s: %w", target.Owner, target.Name, parseErr)
+		}
+		if hydrationValid {
+			target.HydrationSince = &hydrationValue
+		}
+		targets = append(targets, target)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate GitHub reconciliation targets: %w", err)
+	}
+	return targets, nil
+}
+
+func (d *database) applyReconcileSnapshot(ctx context.Context, target reconcileTarget, mode ReconcileMode, cursor time.Time, completedAt time.Time, snapshot ReconcileSnapshot) error {
+	if err := validateReconcileSnapshot(snapshot); err != nil {
+		return err
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin GitHub reconciliation: %w", err)
+	}
+	defer tx.Rollback()
+	repository := normalizedRepository{
+		NodeID: snapshot.Repository.NodeID, DatabaseID: snapshot.Repository.DatabaseID,
+		Owner: snapshot.Repository.Owner, Name: snapshot.Repository.Name,
+	}
+	repositoryStamp, err := newSourceStamp(snapshot.Repository.UpdatedAt, repository)
+	if err != nil {
+		return err
+	}
+	repositoryID, _, err := applyRepositoryProjection(ctx, tx, repository, repositoryStamp, completedAt, false, true)
+	if err != nil {
+		return err
+	}
+	issueNodeIDs := make(map[string]struct{}, len(snapshot.Issues))
+	for _, source := range snapshot.Issues {
+		issue := normalizedIssue(source)
+		if issue.Labels == nil {
+			issue.Labels = []string{}
+		}
+		if issue.Assignees == nil {
+			issue.Assignees = []string{}
+		}
+		stamp, err := newSourceStamp(issue.UpdatedAt, issue)
+		if err != nil {
+			return err
+		}
+		if _, err := applyIssueProjection(ctx, tx, repositoryID, issue, stamp, completedAt, true); err != nil {
+			return err
+		}
+		issueNodeIDs[issue.NodeID] = struct{}{}
+	}
+	pullRequestNodeIDs := make(map[string]struct{}, len(snapshot.PullRequests))
+	for _, source := range snapshot.PullRequests {
+		pullRequest := normalizedPullRequest(source)
+		stamp, err := newSourceStamp(pullRequest.UpdatedAt, pullRequest)
+		if err != nil {
+			return err
+		}
+		if _, err := applyPullRequestProjection(ctx, tx, repositoryID, pullRequest, stamp, completedAt, true); err != nil {
+			return err
+		}
+		pullRequestNodeIDs[pullRequest.NodeID] = struct{}{}
+	}
+	if mode == ReconcileFullRepair {
+		if err := markMissingProjectionRows(ctx, tx, "issues", `
+			SELECT id, github_node_id FROM issues
+			WHERE repository_id = ? AND github_state <> 'deleted'
+		`, `
+			UPDATE issues SET github_state = 'deleted', synchronized_at = ?, updated_at = ? WHERE id = ?
+		`, repositoryID, issueNodeIDs, completedAt); err != nil {
+			return err
+		}
+		if err := markMissingProjectionRows(ctx, tx, "pull_requests", `
+			SELECT id, github_node_id FROM pull_requests
+			WHERE repository_id = ? AND github_state <> 'deleted'
+		`, `
+			UPDATE pull_requests SET github_state = 'deleted', synchronized_at = ?, updated_at = ? WHERE id = ?
+		`, repositoryID, pullRequestNodeIDs, completedAt); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE repositories
+		SET reconcile_cursor = ?, last_reconciled_at = ?, synchronized_at = ?, updated_at = ?
+		WHERE id = ?
+	`, formatWebhookTime(cursor), formatWebhookTime(completedAt), formatWebhookTime(completedAt), formatWebhookTime(completedAt), repositoryID); err != nil {
+		return fmt.Errorf("update GitHub reconciliation cursor: %w", err)
+	}
+	if err := recordCheckpointSuccessTx(ctx, tx, repositoryID, string(mode), cursor, completedAt); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE github_hydration_requests
+		SET status = 'completed', completed_at = ?, last_error = NULL, updated_at = ?
+		WHERE repository_id = ? AND status = 'pending'
+	`, formatWebhookTime(completedAt), formatWebhookTime(completedAt), repositoryID); err != nil {
+		return fmt.Errorf("complete GitHub hydration requests: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit GitHub reconciliation: %w", err)
+	}
+	return nil
+}
+
+func validateReconcileSnapshot(snapshot ReconcileSnapshot) error {
+	repository := snapshot.Repository
+	if strings.TrimSpace(repository.NodeID) == "" || strings.TrimSpace(repository.Owner) == "" || strings.TrimSpace(repository.Name) == "" || repository.UpdatedAt.IsZero() {
+		return errors.New("GitHub reconciliation returned an incomplete repository")
+	}
+	for _, issue := range snapshot.Issues {
+		if strings.TrimSpace(issue.NodeID) == "" || issue.Number <= 0 || strings.TrimSpace(issue.Title) == "" || strings.TrimSpace(issue.URL) == "" || strings.TrimSpace(issue.State) == "" || issue.CreatedAt.IsZero() || issue.UpdatedAt.IsZero() {
+			return fmt.Errorf("GitHub reconciliation returned incomplete issue %d", issue.Number)
+		}
+	}
+	for _, pullRequest := range snapshot.PullRequests {
+		if strings.TrimSpace(pullRequest.NodeID) == "" || pullRequest.Number <= 0 || strings.TrimSpace(pullRequest.Title) == "" || strings.TrimSpace(pullRequest.URL) == "" || strings.TrimSpace(pullRequest.State) == "" || strings.TrimSpace(pullRequest.HeadRef) == "" || strings.TrimSpace(pullRequest.HeadSHA) == "" || strings.TrimSpace(pullRequest.BaseRef) == "" || strings.TrimSpace(pullRequest.BaseSHA) == "" || pullRequest.CreatedAt.IsZero() || pullRequest.UpdatedAt.IsZero() {
+			return fmt.Errorf("GitHub reconciliation returned incomplete pull request %d", pullRequest.Number)
+		}
+	}
+	return nil
+}
+
+func markMissingProjectionRows(ctx context.Context, tx *sql.Tx, label string, selectStatement string, updateStatement string, repositoryID int64, present map[string]struct{}, now time.Time) error {
+	rows, err := tx.QueryContext(ctx, selectStatement, repositoryID)
+	if err != nil {
+		return fmt.Errorf("list %s for GitHub full repair: %w", label, err)
+	}
+	defer rows.Close()
+	var missing []int64
+	for rows.Next() {
+		var id int64
+		var nodeID string
+		if err := rows.Scan(&id, &nodeID); err != nil {
+			return fmt.Errorf("scan %s for GitHub full repair: %w", label, err)
+		}
+		if _, ok := present[nodeID]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close %s GitHub full repair rows: %w", label, err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate %s for GitHub full repair: %w", label, err)
+	}
+	for _, id := range missing {
+		if _, err := tx.ExecContext(ctx, updateStatement, formatWebhookTime(now), formatWebhookTime(now), id); err != nil {
+			return fmt.Errorf("mark missing %s row: %w", label, err)
+		}
+	}
+	return nil
+}
+
+func (d *database) recordCheckpointStarted(ctx context.Context, repositoryID int64, name string, now time.Time) error {
+	_, err := d.db.ExecContext(ctx, `
+		INSERT INTO sync_checkpoints (repository_id, checkpoint_name, last_started_at, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(repository_id, checkpoint_name) DO UPDATE SET
+			last_started_at = excluded.last_started_at,
+			updated_at = excluded.updated_at
+	`, repositoryID, name, formatWebhookTime(now), formatWebhookTime(now))
+	if err != nil {
+		return fmt.Errorf("record GitHub %s start: %w", name, err)
+	}
+	return nil
+}
+
+func (d *database) recordCheckpointFailure(ctx context.Context, repositoryID int64, name string, now time.Time, failure error) error {
+	state := fmt.Sprintf(`{"last_error_at":%q}`, formatWebhookTime(now))
+	_, err := d.db.ExecContext(ctx, `
+		INSERT INTO sync_checkpoints (repository_id, checkpoint_name, state_json, last_error, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(repository_id, checkpoint_name) DO UPDATE SET
+			state_json = excluded.state_json,
+			last_error = excluded.last_error,
+			updated_at = excluded.updated_at
+	`, repositoryID, name, state, failure.Error(), formatWebhookTime(now))
+	if err != nil {
+		return fmt.Errorf("record GitHub %s failure: %w", name, err)
+	}
+	return nil
+}
+
+func recordCheckpointSuccessTx(ctx context.Context, tx *sql.Tx, repositoryID int64, name string, cursor time.Time, now time.Time) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO sync_checkpoints (repository_id, checkpoint_name, cursor, last_successful_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(repository_id, checkpoint_name) DO UPDATE SET
+			cursor = excluded.cursor,
+			last_successful_at = excluded.last_successful_at,
+			updated_at = excluded.updated_at
+	`, repositoryID, name, formatWebhookTime(cursor), formatWebhookTime(now), formatWebhookTime(now))
+	if err != nil {
+		return fmt.Errorf("record GitHub %s success: %w", name, err)
+	}
+	return nil
+}
+
+func parseCheckpointTime(value sql.NullString) (time.Time, bool, error) {
+	if !value.Valid || value.String == "" {
+		return time.Time{}, false, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value.String)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	parsed = parsed.UTC()
+	return parsed, true, nil
+}
+
+func earliestTime(values ...*time.Time) *time.Time {
+	var earliest *time.Time
+	for _, value := range values {
+		if value == nil || value.IsZero() {
+			continue
+		}
+		if earliest == nil || value.Before(*earliest) {
+			copy := value.UTC()
+			earliest = &copy
+		}
+	}
+	return earliest
+}

--- a/internal/hubserver/reconcile_test.go
+++ b/internal/hubserver/reconcile_test.go
@@ -1,0 +1,292 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFullReconcileRepairsDroppedWebhookDrift(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 2, 14, 0, 0, 0, time.UTC)
+	updatedAt := now.Add(-time.Minute)
+	backend := &scriptedReconcileBackend{
+		steps: []reconcileStep{
+			{snapshot: ReconcileSnapshot{
+				Repository: RepositorySource{NodeID: "R_repo", DatabaseID: int64Pointer(100), Owner: "new-owner", Name: "renamed", UpdatedAt: updatedAt},
+				Issues: []IssueSource{
+					{
+						NodeID: "I_issue", DatabaseID: int64Pointer(200), Number: 1, Title: "Repaired title", Body: "Repaired body",
+						URL: "https://example.test/1", State: "closed", Labels: []string{"Done"}, Assignees: []string{"alice"},
+						CreatedAt: now.Add(-24 * time.Hour), UpdatedAt: updatedAt,
+					},
+					{
+						NodeID: "I_new", DatabaseID: int64Pointer(300), Number: 3, Title: "Missed issue", Body: "Created during webhook gap",
+						URL: "https://example.test/3", State: "open", Labels: []string{"feature"}, CreatedAt: updatedAt, UpdatedAt: updatedAt,
+					},
+				},
+			}},
+		},
+	}
+	service := openTestService(t, Config{
+		DatabasePath:     filepath.Join(t.TempDir(), "hub.db"),
+		ReconcileBackend: backend,
+		now:              func() time.Time { return now },
+	})
+	if err := service.stopGitHubReconciliation(); err != nil {
+		t.Fatalf("stop initial reconciliation: %v", err)
+	}
+	repositoryID, _ := seedProjection(t, service.database.db)
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO workflow_states (repository_id, github_node_id, source_name, detent_state, terminal, created_at, updated_at)
+		VALUES (?, 'WS_done', 'Done', 'Done', 1, ?, ?)
+	`, repositoryID, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert repaired workflow state: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO issues (
+			repository_id, github_node_id, github_number, title, url, github_state,
+			source_version, source_updated_at, synchronized_at, created_at, updated_at
+		) VALUES (?, 'I_missing', 2, 'Deleted upstream', 'https://example.test/2', 'open', 'v1', ?, ?, ?, ?)
+	`, repositoryID, testTimestamp, testTimestamp, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert missing issue: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO github_hydration_requests (
+			repository_id, repository_full_name, object_kind, object_key, github_number,
+			reason, requested_source_version, status, created_at, updated_at
+		) VALUES (?, 'digitaldrywood/detent', 'issue', '1', 1, 'partial_payload', 'v2', 'pending', ?, ?)
+	`, repositoryID, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert hydration request: %v", err)
+	}
+
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		UPDATE issues SET source_version = 'z:webhook-conflict', source_updated_at = ? WHERE github_node_id = 'I_issue'
+	`, formatWebhookTime(updatedAt)); err != nil {
+		t.Fatalf("seed equal-timestamp webhook conflict: %v", err)
+	}
+	targets, err := service.database.reconcileTargets(t.Context())
+	if err != nil {
+		t.Fatalf("reconcileTargets() error = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets = %d, want 1", len(targets))
+	}
+	if err := service.reconcileRepository(t.Context(), targets[0], ReconcileFullRepair); err != nil {
+		t.Fatalf("reconcileRepository() error = %v", err)
+	}
+	requests := backend.Requests()
+	if len(requests) != 1 || requests[0].Mode != ReconcileFullRepair {
+		t.Fatalf("reconcile requests = %#v, want one full repair", requests)
+	}
+
+	var owner string
+	var name string
+	var lastReconciled string
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT github_owner, github_name, last_reconciled_at FROM repositories WHERE id = ?
+	`, repositoryID).Scan(&owner, &name, &lastReconciled); err != nil {
+		t.Fatalf("read repaired repository: %v", err)
+	}
+	if owner != "new-owner" || name != "renamed" || lastReconciled != formatWebhookTime(now) {
+		t.Fatalf("repository = %s/%s synced %q, want transferred repository at %q", owner, name, lastReconciled, formatWebhookTime(now))
+	}
+	type issueState struct {
+		number   int
+		title    string
+		state    string
+		labels   string
+		workflow sql.NullString
+	}
+	rows, err := service.database.db.QueryContext(t.Context(), `
+		SELECT i.github_number, i.title, i.github_state, i.labels_json, ws.detent_state
+		FROM issues i LEFT JOIN workflow_states ws ON ws.id = i.workflow_state_id
+		ORDER BY i.github_number
+	`)
+	if err != nil {
+		t.Fatalf("read repaired issues: %v", err)
+	}
+	defer rows.Close()
+	var got []issueState
+	for rows.Next() {
+		var issue issueState
+		if err := rows.Scan(&issue.number, &issue.title, &issue.state, &issue.labels, &issue.workflow); err != nil {
+			t.Fatalf("scan repaired issue: %v", err)
+		}
+		got = append(got, issue)
+	}
+	want := []issueState{
+		{number: 1, title: "Repaired title", state: "closed", labels: `["Done"]`, workflow: sql.NullString{String: "Done", Valid: true}},
+		{number: 2, title: "Deleted upstream", state: "deleted", labels: `[]`},
+		{number: 3, title: "Missed issue", state: "open", labels: `["feature"]`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("issues = %#v, want %#v", got, want)
+	}
+	var pullState string
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT github_state FROM pull_requests WHERE github_node_id = 'PR_one'").Scan(&pullState); err != nil {
+		t.Fatalf("read missing pull request: %v", err)
+	}
+	if pullState != "deleted" {
+		t.Fatalf("missing pull request state = %q, want deleted", pullState)
+	}
+	var hydrationStatus string
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT status FROM github_hydration_requests").Scan(&hydrationStatus); err != nil {
+		t.Fatalf("read hydration status: %v", err)
+	}
+	if hydrationStatus != "completed" {
+		t.Fatalf("hydration status = %q, want completed", hydrationStatus)
+	}
+}
+
+func TestIncrementalReconcileUsesOldestCursorAndExposesFailures(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 9, 2, 14, 0, 0, 0, time.UTC)
+	recovery := start.Add(time.Minute)
+	clock := &leaseTestClock{value: start}
+	failure := errors.New("github unavailable")
+	backend := &scriptedReconcileBackend{steps: []reconcileStep{
+		{err: failure},
+		{snapshot: ReconcileSnapshot{
+			Repository: RepositorySource{NodeID: "R_repo", Owner: "digitaldrywood", Name: "detent", UpdatedAt: recovery},
+			Issues: []IssueSource{{
+				NodeID: "I_issue", Number: 1, Title: "Recovered", URL: "https://example.test/1", State: "open",
+				CreatedAt: recovery.Add(-time.Hour), UpdatedAt: recovery,
+			}},
+			PullRequests: []PullRequestSource{{
+				NodeID: "PR_one", Number: 1, Title: "PR", URL: "https://example.test/pr/1", State: "open",
+				HeadRef: "feature", HeadSHA: "abc", BaseRef: "main", BaseSHA: "base", CreatedAt: recovery.Add(-time.Hour), UpdatedAt: recovery,
+			}},
+		}},
+	}}
+	service := openTestService(t, Config{
+		DatabasePath:      filepath.Join(t.TempDir(), "hub.db"),
+		ReconcileInterval: time.Minute,
+		ReconcileBackend:  backend,
+		now:               clock.Now,
+	})
+	if err := service.stopGitHubReconciliation(); err != nil {
+		t.Fatalf("stop initial reconciliation: %v", err)
+	}
+	repositoryID, _ := seedProjection(t, service.database.db)
+	cursor := start.Add(-10 * time.Minute)
+	hydrationSince := start.Add(-20 * time.Minute)
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE repositories SET reconcile_cursor = ? WHERE id = ?", formatWebhookTime(cursor), repositoryID); err != nil {
+		t.Fatalf("set reconcile cursor: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO github_hydration_requests (
+			repository_id, repository_full_name, object_kind, object_key, github_number,
+			reason, requested_source_updated_at, requested_source_version, status, created_at, updated_at
+		) VALUES (?, 'digitaldrywood/detent', 'issue', '1', 1, 'partial_payload', ?, 'v2', 'pending', ?, ?)
+	`, repositoryID, formatWebhookTime(hydrationSince), testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert hydration request: %v", err)
+	}
+
+	targets, err := service.database.reconcileTargets(t.Context())
+	if err != nil {
+		t.Fatalf("reconcileTargets() error = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets = %d, want 1", len(targets))
+	}
+	if err := service.reconcileRepository(t.Context(), targets[0], ReconcileIncremental); !errors.Is(err, failure) {
+		t.Fatalf("reconcileRepository() error = %v, want failure", err)
+	}
+	requests := backend.Requests()
+	if len(requests) != 1 || requests[0].Since == nil || !requests[0].Since.Equal(hydrationSince) {
+		t.Fatalf("incremental request = %#v, want since %s", requests, hydrationSince)
+	}
+	result, err := service.database.repositoryFreshness(t.Context(), start, time.Minute)
+	if err != nil {
+		t.Fatalf("repositoryFreshness() error = %v", err)
+	}
+	if len(result.Repositories) != 1 || result.Repositories[0].Status != "error" || result.Repositories[0].LastReconcileError == nil || result.Repositories[0].LastReconcileError.Message != failure.Error() {
+		t.Fatalf("freshness after failure = %#v, want visible reconcile error", result)
+	}
+
+	clock.Advance(time.Minute)
+	targets, err = service.database.reconcileTargets(t.Context())
+	if err != nil {
+		t.Fatalf("reconcileTargets() after failure error = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets after failure = %d, want 1", len(targets))
+	}
+	if err := service.reconcileRepository(t.Context(), targets[0], ReconcileIncremental); err != nil {
+		t.Fatalf("reconcileRepository() recovery error = %v", err)
+	}
+	result, err = service.database.repositoryFreshness(t.Context(), recovery, time.Minute)
+	if err != nil {
+		t.Fatalf("repositoryFreshness() after recovery error = %v", err)
+	}
+	freshness := result.Repositories[0]
+	if freshness.Status != "fresh" || freshness.LastSuccessfulSyncAt == nil || !freshness.LastSuccessfulSyncAt.Equal(recovery) {
+		t.Fatalf("freshness after recovery = %#v, want fresh at %s", freshness, recovery)
+	}
+	if freshness.LastReconcileError == nil || freshness.LastReconcileError.Message != failure.Error() {
+		t.Fatalf("last reconcile error = %#v, want retained failure", freshness.LastReconcileError)
+	}
+	var storedCursor string
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT reconcile_cursor FROM repositories WHERE id = ?", repositoryID).Scan(&storedCursor); err != nil {
+		t.Fatalf("read advanced cursor: %v", err)
+	}
+	if storedCursor != formatWebhookTime(recovery) {
+		t.Fatalf("reconcile cursor = %q, want %q", storedCursor, formatWebhookTime(recovery))
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/freshness", nil)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("freshness endpoint status = %d body = %s", response.Code, response.Body.String())
+	}
+	var endpoint repositoryFreshnessResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &endpoint); err != nil {
+		t.Fatalf("decode freshness endpoint: %v", err)
+	}
+	if endpoint.Summary.Fresh != 1 || endpoint.Summary.Error != 0 {
+		t.Fatalf("freshness endpoint summary = %#v, want one fresh", endpoint.Summary)
+	}
+}
+
+type reconcileStep struct {
+	snapshot ReconcileSnapshot
+	err      error
+}
+
+type scriptedReconcileBackend struct {
+	mu       sync.Mutex
+	steps    []reconcileStep
+	requests []ReconcileRequest
+}
+
+func (b *scriptedReconcileBackend) Reconcile(_ context.Context, request ReconcileRequest) (ReconcileSnapshot, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.requests = append(b.requests, request)
+	if len(b.steps) == 0 {
+		return ReconcileSnapshot{}, errors.New("unexpected reconciliation request")
+	}
+	step := b.steps[0]
+	b.steps = b.steps[1:]
+	return step.snapshot, step.err
+}
+
+func (b *scriptedReconcileBackend) Requests() []ReconcileRequest {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]ReconcileRequest(nil), b.requests...)
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}

--- a/internal/hubserver/reconcile_test.go
+++ b/internal/hubserver/reconcile_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
 func TestFullReconcileRepairsDroppedWebhookDrift(t *testing.T) {
@@ -165,6 +167,11 @@ func TestIncrementalReconcileUsesOldestCursorAndExposesFailures(t *testing.T) {
 				NodeID: "PR_one", Number: 1, Title: "PR", URL: "https://example.test/pr/1", State: "open",
 				HeadRef: "feature", HeadSHA: "abc", BaseRef: "main", BaseSHA: "base", CreatedAt: recovery.Add(-time.Hour), UpdatedAt: recovery,
 			}},
+			PullRequestDetails: []PullRequestDetailSource{{
+				Number: 1, HeadSHA: "abc", MergeableState: stringPointer("clean"),
+				Checks:  &tracker.CheckSummary{Status: "completed", Conclusion: "success", Total: 1, Passed: 1},
+				Reviews: &tracker.ReviewSummary{State: "approved", Decision: "approved", Approvals: 1},
+			}},
 		}},
 	}}
 	service := openTestService(t, Config{
@@ -202,7 +209,7 @@ func TestIncrementalReconcileUsesOldestCursorAndExposesFailures(t *testing.T) {
 		t.Fatalf("reconcileRepository() error = %v, want failure", err)
 	}
 	requests := backend.Requests()
-	if len(requests) != 1 || requests[0].Since == nil || !requests[0].Since.Equal(hydrationSince) {
+	if len(requests) != 1 || requests[0].Since == nil || !requests[0].Since.Equal(hydrationSince) || len(requests[0].Hydrations) != 1 {
 		t.Fatalf("incremental request = %#v, want since %s", requests, hydrationSince)
 	}
 	result, err := service.database.repositoryFreshness(t.Context(), start, time.Minute)
@@ -242,6 +249,20 @@ func TestIncrementalReconcileUsesOldestCursorAndExposesFailures(t *testing.T) {
 	if storedCursor != formatWebhookTime(recovery) {
 		t.Fatalf("reconcile cursor = %q, want %q", storedCursor, formatWebhookTime(recovery))
 	}
+	var checksJSON string
+	var reviewsJSON string
+	var mergeableState string
+	var mergeReady bool
+	if err := service.database.db.QueryRowContext(t.Context(), `
+		SELECT checks_summary_json, reviews_summary_json, mergeable_state, merge_ready
+		FROM pull_requests WHERE github_node_id = 'PR_one'
+	`).Scan(&checksJSON, &reviewsJSON, &mergeableState, &mergeReady); err != nil {
+		t.Fatalf("read reconciled pull request details: %v", err)
+	}
+	if checksJSON != `{"status":"completed","conclusion":"success","total":1,"passed":1}` ||
+		reviewsJSON != `{"state":"approved","decision":"approved","approvals":1}` || mergeableState != "clean" || !mergeReady {
+		t.Fatalf("pull request details = checks %s reviews %s mergeable %q ready %t", checksJSON, reviewsJSON, mergeableState, mergeReady)
+	}
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/freshness", nil)
 	response := httptest.NewRecorder()
@@ -255,6 +276,69 @@ func TestIncrementalReconcileUsesOldestCursorAndExposesFailures(t *testing.T) {
 	}
 	if endpoint.Summary.Fresh != 1 || endpoint.Summary.Error != 0 {
 		t.Fatalf("freshness endpoint summary = %#v, want one fresh", endpoint.Summary)
+	}
+}
+
+func TestReconcileDoesNotCompleteHydrationCreatedAfterCapture(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 2, 14, 0, 0, 0, time.UTC)
+	backend := &scriptedReconcileBackend{steps: []reconcileStep{{snapshot: ReconcileSnapshot{
+		Repository: RepositorySource{NodeID: "R_repo", Owner: "digitaldrywood", Name: "detent", UpdatedAt: now},
+	}}}}
+	service := openTestService(t, Config{
+		DatabasePath: filepath.Join(t.TempDir(), "hub.db"), ReconcileBackend: backend, now: func() time.Time { return now },
+	})
+	if err := service.stopGitHubReconciliation(); err != nil {
+		t.Fatalf("stop initial reconciliation: %v", err)
+	}
+	repositoryID, _ := seedProjection(t, service.database.db)
+	result, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO github_hydration_requests (
+			repository_id, repository_full_name, object_kind, object_key, github_number,
+			reason, requested_source_version, status, created_at, updated_at
+		) VALUES (?, 'digitaldrywood/detent', 'issue', '1', 1, 'partial_payload', 'v1', 'pending', ?, ?)
+	`, repositoryID, testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert captured hydration request: %v", err)
+	}
+	capturedID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("captured hydration request ID: %v", err)
+	}
+	targets, err := service.database.reconcileTargets(t.Context())
+	if err != nil || len(targets) != 1 || len(targets[0].Hydrations) != 1 {
+		t.Fatalf("reconcileTargets() = %#v, %v, want one captured hydration", targets, err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE github_hydration_requests SET request_count = request_count + 1 WHERE id = ?", capturedID); err != nil {
+		t.Fatalf("coalesce captured hydration request: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO github_hydration_requests (
+			repository_id, repository_full_name, object_kind, object_key, github_number,
+			reason, requested_source_version, status, created_at, updated_at
+		) VALUES (?, 'digitaldrywood/detent', 'issue', '2', 2, 'partial_payload', 'v1', 'pending', ?, ?)
+	`, repositoryID, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert later hydration request: %v", err)
+	}
+	if err := service.reconcileRepository(t.Context(), targets[0], ReconcileFullRepair); err != nil {
+		t.Fatalf("reconcileRepository() error = %v", err)
+	}
+	rows, err := service.database.db.QueryContext(t.Context(), "SELECT object_key, status FROM github_hydration_requests ORDER BY id")
+	if err != nil {
+		t.Fatalf("read hydration statuses: %v", err)
+	}
+	defer rows.Close()
+	var statuses []string
+	for rows.Next() {
+		var key string
+		var status string
+		if err := rows.Scan(&key, &status); err != nil {
+			t.Fatalf("scan hydration status: %v", err)
+		}
+		statuses = append(statuses, key+":"+status)
+	}
+	if !reflect.DeepEqual(statuses, []string{"1:pending", "2:pending"}) {
+		t.Fatalf("hydration statuses = %#v, want both post-capture requests pending", statuses)
 	}
 }
 
@@ -288,5 +372,9 @@ func (b *scriptedReconcileBackend) Requests() []ReconcileRequest {
 }
 
 func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+func stringPointer(value string) *string {
 	return &value
 }

--- a/internal/hubserver/service.go
+++ b/internal/hubserver/service.go
@@ -21,24 +21,28 @@ const (
 )
 
 type Service struct {
-	echo           *echo.Echo
-	database       *database
-	tracker        tracker.Tracker
-	config         Config
-	outbox         *outboxWorker
-	ready          atomic.Bool
-	workerCancel   context.CancelFunc
-	workerDone     chan struct{}
-	workerStopOnce sync.Once
-	closeOnce      sync.Once
-	closeErr       error
+	echo              *echo.Echo
+	database          *database
+	tracker           tracker.Tracker
+	config            Config
+	outbox            *outboxWorker
+	ready             atomic.Bool
+	workerCancel      context.CancelFunc
+	workerDone        chan struct{}
+	workerStopOnce    sync.Once
+	reconcileCancel   context.CancelFunc
+	reconcileDone     chan struct{}
+	reconcileStopOnce sync.Once
+	closeOnce         sync.Once
+	closeErr          error
 }
 
 type healthResponse struct {
-	Status        string       `json:"status"`
-	SchemaVersion int64        `json:"schema_version,omitempty"`
-	Version       string       `json:"version,omitempty"`
-	Outbox        OutboxHealth `json:"outbox"`
+	Status        string                  `json:"status"`
+	SchemaVersion int64                   `json:"schema_version,omitempty"`
+	Version       string                  `json:"version,omitempty"`
+	Outbox        OutboxHealth            `json:"outbox"`
+	Repositories  RepositoryHealthSummary `json:"repositories"`
 }
 
 func Open(ctx context.Context, cfg Config) (*Service, error) {
@@ -61,21 +65,26 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 	e.Server.ReadHeaderTimeout = defaultHTTPReadHeaderTimeout
 	e.Server.IdleTimeout = defaultHTTPIdleTimeout
 	workerContext, workerCancel := context.WithCancel(context.Background())
+	reconcileContext, reconcileCancel := context.WithCancel(context.Background())
 	service := &Service{
-		echo:         e,
-		database:     database,
-		tracker:      workTracker,
-		config:       cfg,
-		workerCancel: workerCancel,
-		workerDone:   make(chan struct{}),
+		echo:            e,
+		database:        database,
+		tracker:         workTracker,
+		config:          cfg,
+		workerCancel:    workerCancel,
+		workerDone:      make(chan struct{}),
+		reconcileCancel: reconcileCancel,
+		reconcileDone:   make(chan struct{}),
 	}
 	if cfg.OutboxBackend != nil {
 		service.outbox = newOutboxWorker(service)
 	}
 	e.GET("/health", service.health)
+	e.GET("/api/v1/repositories/freshness", service.repositoryFreshness)
 	e.POST("/api/v1/webhooks/github", service.githubWebhook)
 	service.maintainGitHubWebhooks(ctx)
 	go service.runGitHubWebhookMaintenance(workerContext)
+	go service.runGitHubReconciliation(reconcileContext)
 	service.ready.Store(true)
 	if service.outbox != nil {
 		service.outbox.start(ctx)
@@ -156,7 +165,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 	if httpErr != nil {
 		httpErr = fmt.Errorf("shut down hub server: %w", httpErr)
 	}
-	return errors.Join(httpErr, s.stopGitHubWebhookMaintenance())
+	return errors.Join(httpErr, s.stopGitHubWebhookMaintenance(), s.stopGitHubReconciliation())
 }
 
 func (s *Service) Backup(ctx context.Context, destination string) error {
@@ -177,10 +186,11 @@ func (s *Service) Close() error {
 			httpErr = nil
 		}
 		webhookErr := s.stopGitHubWebhookMaintenance()
+		reconcileErr := s.stopGitHubReconciliation()
 		if s.outbox != nil {
 			s.outbox.stop()
 		}
-		s.closeErr = errors.Join(httpErr, webhookErr, s.database.Close())
+		s.closeErr = errors.Join(httpErr, webhookErr, reconcileErr, s.database.Close())
 	})
 	return s.closeErr
 }
@@ -228,10 +238,19 @@ func (s *Service) health(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusServiceUnavailable, healthResponse{Status: "unavailable"})
 	}
+	repositories, err := s.database.repositoryFreshness(c.Request().Context(), s.config.now().UTC(), s.config.ReconcileInterval)
+	if err != nil {
+		return c.JSON(http.StatusServiceUnavailable, healthResponse{Status: "unavailable"})
+	}
+	status := "ok"
+	if repositories.Summary.Stale > 0 || repositories.Summary.Error > 0 {
+		status = "degraded"
+	}
 	return c.JSON(http.StatusOK, healthResponse{
-		Status:        "ok",
+		Status:        status,
 		SchemaVersion: s.database.schemaVersion,
 		Version:       s.config.Version,
 		Outbox:        outbox,
+		Repositories:  repositories.Summary,
 	})
 }

--- a/internal/hubserver/service_test.go
+++ b/internal/hubserver/service_test.go
@@ -81,6 +81,35 @@ func TestHealthEndpoint(t *testing.T) {
 	service.ready.Store(true)
 }
 
+func TestHealthEndpointDegradesForStaleRepository(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 2, 14, 0, 0, 0, time.UTC)
+	service := openTestService(t, Config{
+		DatabasePath:      filepath.Join(t.TempDir(), "hub.db"),
+		ReconcileInterval: time.Minute,
+		now:               func() time.Time { return now },
+	})
+	if _, err := service.database.db.ExecContext(t.Context(), `
+		INSERT INTO repositories (github_node_id, github_owner, github_name, last_webhook_at, created_at, updated_at)
+		VALUES ('R_stale', 'digitaldrywood', 'detent', ?, ?, ?)
+	`, formatWebhookTime(now), testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert stale repository: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("health status = %d body = %s, want 200", response.Code, response.Body.String())
+	}
+	var got healthResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if got.Status != "degraded" || got.Repositories.Total != 1 || got.Repositories.Stale != 1 {
+		t.Fatalf("health response = %#v, want degraded stale repository", got)
+	}
+}
+
 func TestServeShutsDownGracefully(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- reconcile Hub repository mirrors incrementally with durable cursors and conditional GitHub REST reads
- run startup and scheduled full repairs for missed items, deletes, transfers, labels, and hydration gaps
- expose repository sync timestamps/errors and degrade health when reconciliation is stale or failing

Fixes #2070

## UI Surface Contract

- [x] N/A; this PR adds read-only Hub JSON health surfaces and no primary operator UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/hubserver ./internal/hubgithub`
- [x] `PATH="$TMPDIR/golangci-go1266:$PATH" GOTOOLCHAIN=go1.26.6 make check`