### PR TITLE
feat(hub): serve authenticated versioned API

### DIFF
--- a/docs/hub-api.md
+++ b/docs/hub-api.md
@@ -1,0 +1,74 @@
+# Detent Hub API
+
+Detent Hub owns its SQLite database and exposes fleet coordination through an authenticated HTTP API. Clients must never open or copy the live database files.
+
+## Start the Hub
+
+Set a high-entropy bootstrap administrator token, then start the service on its loopback default:
+
+```sh
+export DETENT_HUB_ADMIN_TOKEN="$(openssl rand -hex 32)"
+detent hub serve --database /var/lib/detent/hub.db
+```
+
+The bootstrap token is inserted only when the Hub database has no bootstrap credential. Later restarts do not replace a token that was rotated or revoked through the API.
+
+The default listener is `127.0.0.1:7777`. A non-loopback `--listen` value is rejected unless either `--tls-cert` and `--tls-key` are both set or `--trusted-proxy` explicitly declares that a trusted reverse proxy terminates TLS. The proxy or host firewall must prevent clients from bypassing that proxy.
+
+## Authentication
+
+Send a bearer token with every control-plane and health request:
+
+```text
+Authorization: Bearer <token>
+```
+
+Tokens have one of three scopes:
+
+- `worker` registers and heartbeats machines, claims work, renews or releases leases, and appends fenced events.
+- `operator` reads state and performs typed workflow, dependency, priority, and queue-order mutations.
+- `admin` can perform all operations and create, rotate, or revoke tokens.
+
+Only SHA-256 token hashes and hash-derived fingerprints are stored. Plaintext is returned once by token creation or rotation responses, which carry `Cache-Control: no-store`. Token values are never included in Hub logs.
+
+Create and rotate scoped tokens with:
+
+```text
+POST   /api/v1/tokens
+POST   /api/v1/tokens/{id}/rotate
+DELETE /api/v1/tokens/{id}
+```
+
+The GitHub webhook route is the only transport-specific exception to bearer authentication. `/api/v1/webhooks/github` uses GitHub's `X-Hub-Signature-256` HMAC authentication and never accepts a Hub token as a substitute.
+
+## Work and fleet endpoints
+
+| Endpoint | Minimum scope | Purpose |
+| --- | --- | --- |
+| `GET /health` | any scoped token | Service, schema, repository, and outbox health |
+| `GET /api/v1/work-items` | any scoped token | Filtered, sorted work-item page |
+| `GET /api/v1/work-items/{id}` | any scoped token | Normalized item, graph, PRs, lease, workpad, and event timeline |
+| `POST /api/v1/claims` | worker | Atomically claim a requested item or the next compatible item |
+| `POST /api/v1/leases/{id}/renew` | worker | Renew with the exact fencing token |
+| `POST /api/v1/leases/{id}/release` | worker | Release with the exact fencing token |
+| `POST /api/v1/work-items/{id}/events` | worker | Append a session event with the exact fencing token |
+| `POST /api/v1/machines/register` | worker | Register or refresh a machine |
+| `POST /api/v1/machines/{id}/heartbeat` | worker | Update heartbeat, capacity, version, or capabilities |
+| `POST /api/v1/work-items/{id}/workflow` | operator | Change workflow state and enqueue its managed GitHub label |
+| `POST /api/v1/work-items/{id}/dependencies` | operator | Add or remove a Hub-authoritative dependency |
+| `POST /api/v1/work-items/{id}/priority` | operator | Change priority and enqueue its managed GitHub label |
+| `POST /api/v1/work-items/{id}/order` | operator | Change Hub-authoritative queue rank |
+| `GET /api/v1/repositories/freshness` | any scoped token | Repository synchronization health page |
+| `GET /api/v1/outbox/health` | any scoped token | Outbox counts and operator-action page |
+
+Worker events and operator mutations expose typed state changes only. They do not provide a generic GitHub request or arbitrary mutation surface.
+
+## Work-item queries and cursors
+
+`GET /api/v1/work-items` accepts repeatable or comma-separated filters: `repository`, `workflow_state`, `readiness`, `priority`, `label`, `assignee`, `machine`, `lease`, `pr`, and `sync_health`.
+
+Supported sort values are `priority`, `created`, `updated`, `identifier`, and `workflow_state`; `order` is `asc` or `desc`. The default priority order uses priority, queue-rank presence, queue rank, creation time, repository owner/name, issue number, and internal ID. Every other sort also ends with repository owner/name, issue number, and internal ID, giving every page a stable total order.
+
+List responses contain an opaque `next_cursor`. Pass it back with the same sort and order. `limit` defaults to 50 and may not exceed 200. Repository freshness and outbox health use the same `limit` and opaque `cursor` convention. Work-item detail timelines use `timeline_limit` and `timeline_cursor`.
+
+Omit `work_item_id` from `POST /api/v1/claims` to claim next. Candidate selection and lease creation execute in one SQLite transaction; clients must not list candidates and then attempt a separate specific claim. Renew, release, and event requests must carry the positive `fencing_token` returned by the claim.

--- a/internal/cli/hub.go
+++ b/internal/cli/hub.go
@@ -54,6 +54,10 @@ func newHubCommandWithRun(version string, lookupEnv func(string) string, run hub
 func newHubServeCommand(version string, lookupEnv func(string) string, run hubRunFunc) *cobra.Command {
 	var databasePath string
 	var listenAddress string
+	var tlsCertificateFile string
+	var tlsKeyFile string
+	var trustedProxy bool
+	var adminTokenEnv string
 	var busyTimeout time.Duration
 	var shutdownTimeout time.Duration
 	var githubWebhookSecretEnv string
@@ -78,6 +82,14 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 			if strings.TrimSpace(listenAddress) == "" {
 				return NewValidationError("hub listen address is required", "Use --listen 127.0.0.1:7777 or another explicit address.", nil)
 			}
+			adminTokenEnv = strings.TrimSpace(adminTokenEnv)
+			if !validEnvName(adminTokenEnv) {
+				return NewValidationError("Hub administrator token environment variable name is invalid", "Use an environment variable name such as DETENT_HUB_ADMIN_TOKEN.", nil)
+			}
+			adminToken := strings.TrimSpace(lookupEnv(adminTokenEnv))
+			if adminToken == "" {
+				return NewValidationError("Hub administrator token is required", "Set "+adminTokenEnv+" to a high-entropy API token.", nil)
+			}
 			githubWebhookSecretEnv = strings.TrimSpace(githubWebhookSecretEnv)
 			if githubWebhookSecretEnv != "" && !validEnvName(githubWebhookSecretEnv) {
 				return NewValidationError("Hub GitHub webhook secret environment variable name is invalid", "Use an environment variable name such as DETENT_HUB_GITHUB_WEBHOOK_SECRET.", nil)
@@ -85,6 +97,10 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 			return run(cmd.Context(), hubserver.Config{
 				DatabasePath:               databasePath,
 				ListenAddress:              listenAddress,
+				TLSCertFile:                strings.TrimSpace(tlsCertificateFile),
+				TLSKeyFile:                 strings.TrimSpace(tlsKeyFile),
+				TrustedProxy:               trustedProxy,
+				InitialAdminToken:          []byte(adminToken),
 				BusyTimeout:                busyTimeout,
 				ShutdownTimeout:            shutdownTimeout,
 				GitHubWebhookSecret:        []byte(strings.TrimSpace(lookupEnv(githubWebhookSecretEnv))),
@@ -99,6 +115,10 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 	}
 	cmd.Flags().StringVar(&databasePath, "database", "", "local filesystem path to the Hub SQLite database")
 	cmd.Flags().StringVar(&listenAddress, "listen", hubserver.DefaultListenAddress, "Hub listen address")
+	cmd.Flags().StringVar(&tlsCertificateFile, "tls-cert", "", "TLS certificate file")
+	cmd.Flags().StringVar(&tlsKeyFile, "tls-key", "", "TLS private key file")
+	cmd.Flags().BoolVar(&trustedProxy, "trusted-proxy", false, "declare that a trusted reverse proxy terminates TLS")
+	cmd.Flags().StringVar(&adminTokenEnv, "admin-token-env", "DETENT_HUB_ADMIN_TOKEN", "environment variable containing the initial Hub administrator token")
 	cmd.Flags().DurationVar(&busyTimeout, "busy-timeout", 5*time.Second, "SQLite busy timeout")
 	cmd.Flags().DurationVar(&shutdownTimeout, "shutdown-timeout", 5*time.Second, "graceful HTTP shutdown timeout")
 	cmd.Flags().StringVar(&githubWebhookSecretEnv, "github-webhook-secret-env", "DETENT_HUB_GITHUB_WEBHOOK_SECRET", "environment variable containing the GitHub webhook secret")

--- a/internal/cli/hub_test.go
+++ b/internal/cli/hub_test.go
@@ -24,6 +24,9 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 		return nil
 	}
 	cmd := newHubCommandWithRun("v-test", func(name string) string {
+		if name == "TEST_HUB_ADMIN_TOKEN" {
+			return "hub-admin-token"
+		}
 		if name == "TEST_HUB_WEBHOOK_SECRET" {
 			return "webhook-secret"
 		}
@@ -35,6 +38,10 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 		"serve",
 		"--database", wantDatabase,
 		"--listen", "127.0.0.1:0",
+		"--tls-cert", "server.crt",
+		"--tls-key", "server.key",
+		"--trusted-proxy",
+		"--admin-token-env", "TEST_HUB_ADMIN_TOKEN",
 		"--busy-timeout", "2s",
 		"--shutdown-timeout", "3s",
 		"--github-webhook-secret-env", "TEST_HUB_WEBHOOK_SECRET",
@@ -55,6 +62,9 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 	if gotConfig.ListenAddress != "127.0.0.1:0" {
 		t.Fatalf("listen address = %q, want ephemeral loopback", gotConfig.ListenAddress)
 	}
+	if gotConfig.TLSCertFile != "server.crt" || gotConfig.TLSKeyFile != "server.key" || !gotConfig.TrustedProxy {
+		t.Fatalf("transport security = cert %q key %q trusted proxy %t", gotConfig.TLSCertFile, gotConfig.TLSKeyFile, gotConfig.TrustedProxy)
+	}
 	if gotConfig.BusyTimeout != 2*time.Second {
 		t.Fatalf("busy timeout = %s, want 2s", gotConfig.BusyTimeout)
 	}
@@ -63,6 +73,9 @@ func TestHubServeCommandPassesConfiguration(t *testing.T) {
 	}
 	if string(gotConfig.GitHubWebhookSecret) != "webhook-secret" {
 		t.Fatalf("GitHub webhook secret = %q, want resolved secret", gotConfig.GitHubWebhookSecret)
+	}
+	if string(gotConfig.InitialAdminToken) != "hub-admin-token" {
+		t.Fatalf("Hub administrator token was not resolved from its environment variable")
 	}
 	if gotConfig.WebhookPayloadRetention != 48*time.Hour {
 		t.Fatalf("webhook payload retention = %s, want 48h", gotConfig.WebhookPayloadRetention)
@@ -88,7 +101,7 @@ func TestHubServeCommandValidatesDatabase(t *testing.T) {
 	run := func(context.Context, hubserver.Config) error {
 		return runErr
 	}
-	cmd := newHubCommandWithRun("v-test", nil, run)
+	cmd := newHubCommandWithRun("v-test", func(string) string { return "hub-admin-token" }, run)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"serve"})
@@ -108,7 +121,7 @@ func TestHubServeCommandValidatesWebhookSecretEnvironmentName(t *testing.T) {
 	run := func(context.Context, hubserver.Config) error {
 		return runErr
 	}
-	cmd := newHubCommandWithRun("v-test", nil, run)
+	cmd := newHubCommandWithRun("v-test", func(string) string { return "hub-admin-token" }, run)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{
@@ -116,6 +129,26 @@ func TestHubServeCommandValidatesWebhookSecretEnvironmentName(t *testing.T) {
 		"--database", filepath.Join(t.TempDir(), "hub.db"),
 		"--github-webhook-secret-env", "INVALID-NAME",
 	})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("ExecuteContext() error = nil, want validation error")
+	}
+	if errors.Is(err, runErr) {
+		t.Fatalf("ExecuteContext() error = %v, runner was called", err)
+	}
+}
+
+func TestHubServeCommandRequiresAdministratorToken(t *testing.T) {
+	t.Parallel()
+
+	runErr := errors.New("runner should not be called")
+	run := func(context.Context, hubserver.Config) error {
+		return runErr
+	}
+	cmd := newHubCommandWithRun("v-test", func(string) string { return "" }, run)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"serve", "--database", filepath.Join(t.TempDir(), "hub.db")})
 	err := cmd.ExecuteContext(context.Background())
 	if err == nil {
 		t.Fatal("ExecuteContext() error = nil, want validation error")

--- a/internal/hubserver/api_auth.go
+++ b/internal/hubserver/api_auth.go
@@ -1,0 +1,250 @@
+package hubserver
+
+import (
+	"context"
+	"crypto/subtle"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/apikey"
+)
+
+type apiScope string
+
+const (
+	apiScopeWorker      apiScope = "worker"
+	apiScopeOperator    apiScope = "operator"
+	apiScopeAdmin       apiScope = "admin"
+	bootstrapTokenID             = "bootstrap-admin"
+	maxBearerTokenBytes          = 4096
+)
+
+type apiCredential struct {
+	ID    string
+	Name  string
+	Scope apiScope
+}
+
+type apiErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type tokenRequest struct {
+	Name  string   `json:"name"`
+	Scope apiScope `json:"scope"`
+}
+
+type tokenResponse struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Scope       apiScope  `json:"scope"`
+	Token       string    `json:"token"`
+	Fingerprint string    `json:"fingerprint"`
+	CreatedAt   time.Time `json:"created_at"`
+	RotatedAt   time.Time `json:"rotated_at,omitempty"`
+}
+
+func (d *database) ensureInitialAdminToken(ctx context.Context, token []byte) error {
+	value := strings.TrimSpace(string(token))
+	if value == "" {
+		return nil
+	}
+	now, err := d.currentTime()
+	if err != nil {
+		return err
+	}
+	formatted := formatHubTime(now)
+	_, err = d.db.ExecContext(ctx, `
+INSERT INTO api_tokens (id, name, token_hash, token_fingerprint, scope, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO NOTHING`,
+		bootstrapTokenID, "Bootstrap administrator", apikey.HashToken(value), tokenFingerprint(apikey.HashToken(value)), apiScopeAdmin, formatted, formatted,
+	)
+	if err != nil {
+		return fmt.Errorf("store initial hub administrator token: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) requireAPIScope(allowed ...apiScope) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			credential, status, err := s.authenticateAPIRequest(c)
+			if err != nil {
+				return c.JSON(status, apiErrorResponse{Code: "unauthorized", Message: "Valid scoped API token is required"})
+			}
+			for _, scope := range allowed {
+				if credential.Scope == scope || credential.Scope == apiScopeAdmin {
+					c.Set("hub_api_credential", credential)
+					return next(c)
+				}
+			}
+			return c.JSON(http.StatusForbidden, apiErrorResponse{Code: "insufficient_scope", Message: "API token scope does not permit this operation"})
+		}
+	}
+}
+
+func (s *Service) authenticateAPIRequest(c echo.Context) (apiCredential, int, error) {
+	if c == nil || c.Request() == nil {
+		return apiCredential{}, http.StatusUnauthorized, errors.New("request is required")
+	}
+	authorizations := c.Request().Header.Values(echo.HeaderAuthorization)
+	if len(authorizations) != 1 {
+		return apiCredential{}, http.StatusUnauthorized, errors.New("one authorization header is required")
+	}
+	value := strings.TrimSpace(authorizations[0])
+	scheme, token, ok := strings.Cut(value, " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return apiCredential{}, http.StatusUnauthorized, errors.New("bearer authorization is required")
+	}
+	token = strings.TrimSpace(token)
+	if token == "" || len(token) > maxBearerTokenBytes {
+		return apiCredential{}, http.StatusUnauthorized, errors.New("bearer token is invalid")
+	}
+	hash := apikey.HashToken(token)
+	var credential apiCredential
+	var storedHash string
+	var revokedAt sql.NullString
+	err := s.database.db.QueryRowContext(c.Request().Context(), `
+SELECT id, name, scope, token_hash, revoked_at
+FROM api_tokens
+WHERE token_hash = ?`, hash).Scan(&credential.ID, &credential.Name, &credential.Scope, &storedHash, &revokedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return apiCredential{}, http.StatusUnauthorized, errors.New("token was not found")
+	}
+	if err != nil {
+		return apiCredential{}, http.StatusServiceUnavailable, fmt.Errorf("read hub API token: %w", err)
+	}
+	if subtle.ConstantTimeCompare([]byte(storedHash), []byte(hash)) != 1 || revokedAt.Valid {
+		return apiCredential{}, http.StatusUnauthorized, errors.New("token is inactive")
+	}
+	now, err := s.database.currentTime()
+	if err != nil {
+		return apiCredential{}, http.StatusServiceUnavailable, err
+	}
+	if _, err := s.database.db.ExecContext(c.Request().Context(), "UPDATE api_tokens SET last_used_at = ? WHERE id = ?", formatHubTime(now), credential.ID); err != nil {
+		return apiCredential{}, http.StatusServiceUnavailable, fmt.Errorf("record hub API token use: %w", err)
+	}
+	return credential, http.StatusOK, nil
+}
+
+func (s *Service) createAPIToken(c echo.Context) error {
+	var request tokenRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	request.Name = strings.TrimSpace(request.Name)
+	if request.Name == "" || !validAPIScope(request.Scope) {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_token", Message: "Token name and scope are required"})
+	}
+	token, err := s.config.generateToken()
+	if err != nil {
+		return s.internalAPIError(c, "token_create_failed", "API token could not be created", err)
+	}
+	now, err := s.database.currentTime()
+	if err != nil {
+		return s.internalAPIError(c, "token_create_failed", "API token could not be created", err)
+	}
+	id := strings.TrimSpace(s.config.newTokenID())
+	if id == "" {
+		return s.internalAPIError(c, "token_create_failed", "API token could not be created", errors.New("generated token ID is empty"))
+	}
+	hash := apikey.HashToken(token)
+	_, err = s.database.db.ExecContext(c.Request().Context(), `
+INSERT INTO api_tokens (id, name, token_hash, token_fingerprint, scope, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, request.Name, hash, tokenFingerprint(hash), request.Scope, formatHubTime(now), formatHubTime(now),
+	)
+	if err != nil {
+		return c.JSON(http.StatusConflict, apiErrorResponse{Code: "token_conflict", Message: "API token name already exists"})
+	}
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return c.JSON(http.StatusCreated, tokenResponse{ID: id, Name: request.Name, Scope: request.Scope, Token: token, Fingerprint: tokenFingerprint(hash), CreatedAt: now})
+}
+
+func (s *Service) rotateAPIToken(c echo.Context) error {
+	id := strings.TrimSpace(c.Param("id"))
+	if id == "" {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "token_not_found", Message: "API token was not found"})
+	}
+	token, err := s.config.generateToken()
+	if err != nil {
+		return s.internalAPIError(c, "token_rotate_failed", "API token could not be rotated", err)
+	}
+	now, err := s.database.currentTime()
+	if err != nil {
+		return s.internalAPIError(c, "token_rotate_failed", "API token could not be rotated", err)
+	}
+	result, err := s.database.db.ExecContext(c.Request().Context(), `
+UPDATE api_tokens
+SET token_hash = ?, token_fingerprint = ?, rotated_at = ?, revoked_at = NULL, updated_at = ?
+WHERE id = ?`, apikey.HashToken(token), tokenFingerprint(apikey.HashToken(token)), formatHubTime(now), formatHubTime(now), id)
+	if err != nil {
+		return s.internalAPIError(c, "token_rotate_failed", "API token could not be rotated", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return s.internalAPIError(c, "token_rotate_failed", "API token could not be rotated", err)
+	}
+	if rows != 1 {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "token_not_found", Message: "API token was not found"})
+	}
+	var response tokenResponse
+	var createdAt string
+	err = s.database.db.QueryRowContext(c.Request().Context(), "SELECT id, name, scope, token_fingerprint, created_at FROM api_tokens WHERE id = ?", id).Scan(&response.ID, &response.Name, &response.Scope, &response.Fingerprint, &createdAt)
+	if err != nil {
+		return s.internalAPIError(c, "token_rotate_failed", "API token could not be rotated", err)
+	}
+	response.CreatedAt, err = parseTimeValue(createdAt)
+	if err != nil {
+		return s.internalAPIError(c, "token_rotate_failed", "API token could not be rotated", err)
+	}
+	response.Token = token
+	response.RotatedAt = now
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return c.JSON(http.StatusOK, response)
+}
+
+func (s *Service) revokeAPIToken(c echo.Context) error {
+	id := strings.TrimSpace(c.Param("id"))
+	now, err := s.database.currentTime()
+	if err != nil {
+		return s.internalAPIError(c, "token_revoke_failed", "API token could not be revoked", err)
+	}
+	result, err := s.database.db.ExecContext(c.Request().Context(), "UPDATE api_tokens SET revoked_at = ?, updated_at = ? WHERE id = ? AND revoked_at IS NULL", formatHubTime(now), formatHubTime(now), id)
+	if err != nil {
+		return s.internalAPIError(c, "token_revoke_failed", "API token could not be revoked", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return s.internalAPIError(c, "token_revoke_failed", "API token could not be revoked", err)
+	}
+	if rows != 1 {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "token_not_found", Message: "Active API token was not found"})
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func validAPIScope(scope apiScope) bool {
+	switch scope {
+	case apiScopeWorker, apiScopeOperator, apiScopeAdmin:
+		return true
+	default:
+		return false
+	}
+}
+
+func tokenFingerprint(hash string) string {
+	hash = strings.TrimSpace(hash)
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12]
+}

--- a/internal/hubserver/api_http.go
+++ b/internal/hubserver/api_http.go
@@ -1,0 +1,138 @@
+package hubserver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+const maxAPIRequestBodyBytes = 1 << 20
+
+func (s *Service) registerRoutes(e *echo.Echo) {
+	read := s.requireAPIScope(apiScopeWorker, apiScopeOperator, apiScopeAdmin)
+	worker := s.requireAPIScope(apiScopeWorker)
+	operator := s.requireAPIScope(apiScopeOperator)
+	admin := s.requireAPIScope(apiScopeAdmin)
+
+	e.GET("/health", s.health, read)
+	e.GET("/api/v1/work-items", s.listWorkItems, read)
+	e.GET("/api/v1/work-items/:id", s.getWorkItem, read)
+	e.POST("/api/v1/claims", s.claimWorkItem, worker)
+	e.POST("/api/v1/leases/:id/renew", s.renewLease, worker)
+	e.POST("/api/v1/leases/:id/release", s.releaseLease, worker)
+	e.POST("/api/v1/work-items/:id/events", s.appendWorkItemEvent, worker)
+	e.POST("/api/v1/work-items/:id/workflow", s.changeWorkItemWorkflow, operator)
+	e.POST("/api/v1/work-items/:id/dependencies", s.changeWorkItemDependency, operator)
+	e.POST("/api/v1/work-items/:id/priority", s.changeWorkItemPriority, operator)
+	e.POST("/api/v1/work-items/:id/order", s.changeWorkItemOrder, operator)
+	e.POST("/api/v1/machines/register", s.registerMachine, worker)
+	e.POST("/api/v1/machines/:id/heartbeat", s.heartbeatMachine, worker)
+	e.GET("/api/v1/repositories/freshness", s.repositoryFreshness, read)
+	e.GET("/api/v1/outbox/health", s.outboxHealth, read)
+	e.POST("/api/v1/tokens", s.createAPIToken, admin)
+	e.POST("/api/v1/tokens/:id/rotate", s.rotateAPIToken, admin)
+	e.DELETE("/api/v1/tokens/:id", s.revokeAPIToken, admin)
+	e.POST("/api/v1/webhooks/github", s.githubWebhook)
+}
+
+func decodeAPIJSON(c echo.Context, target any) error {
+	if c == nil || c.Request() == nil {
+		return errors.New("request is required")
+	}
+	request := c.Request()
+	request.Body = http.MaxBytesReader(c.Response(), request.Body, maxAPIRequestBodyBytes)
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("request body must contain one JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func invalidAPIRequest(c echo.Context, err error) error {
+	var maxBytesError *http.MaxBytesError
+	if errors.As(err, &maxBytesError) {
+		return c.JSON(http.StatusRequestEntityTooLarge, apiErrorResponse{Code: "payload_too_large", Message: "Request body is too large"})
+	}
+	return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_request", Message: "Request body is invalid"})
+}
+
+func (s *Service) internalAPIError(c echo.Context, code string, message string, err error) error {
+	s.config.Logger.Error(message, "error", err)
+	return c.JSON(http.StatusInternalServerError, apiErrorResponse{Code: code, Message: message})
+}
+
+func apiWorkItemID(c echo.Context) (tracker.WorkItemID, error) {
+	value, err := strconv.ParseInt(strings.TrimSpace(c.Param("id")), 10, 64)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%w: %q", tracker.ErrInvalidWorkItemID, c.Param("id"))
+	}
+	return tracker.WorkItemID(value), nil
+}
+
+func apiLeaseID(c echo.Context) (tracker.LeaseID, error) {
+	value := strings.TrimSpace(c.Param("id"))
+	if value == "" {
+		return "", tracker.ErrLeaseNotFound
+	}
+	return tracker.LeaseID(value), nil
+}
+
+func apiTTL(seconds int64) (time.Duration, error) {
+	if seconds <= 0 || seconds > int64((24*time.Hour)/time.Second) {
+		return 0, errors.New("ttl_seconds must be between 1 and 86400")
+	}
+	return time.Duration(seconds) * time.Second, nil
+}
+
+func (s *Service) outboxHealth(c echo.Context) error {
+	health, err := s.OutboxHealth(c.Request().Context())
+	if err != nil {
+		return s.internalAPIError(c, "outbox_health_unavailable", "Outbox health could not be read", err)
+	}
+	limit, err := parsePageLimit(c.QueryParam("limit"))
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_query", Message: "limit must be between 1 and 200"})
+	}
+	cursor, err := decodeTimelineCursor(c.QueryParam("cursor"))
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_cursor", Message: "Outbox cursor is invalid"})
+	}
+	actions := health.OperatorActions[:0]
+	for _, action := range health.OperatorActions {
+		if action.ID > cursor.ID {
+			actions = append(actions, action)
+		}
+	}
+	health.OperatorActions = actions
+	response := outboxHealthResponse{OutboxHealth: health}
+	if len(response.OperatorActions) > limit {
+		response.OperatorActions = response.OperatorActions[:limit]
+		response.NextCursor, err = encodeTimelineCursor(timelineCursor{Version: 1, ID: response.OperatorActions[len(response.OperatorActions)-1].ID})
+		if err != nil {
+			return s.internalAPIError(c, "outbox_health_unavailable", "Outbox health could not be read", err)
+		}
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+type outboxHealthResponse struct {
+	OutboxHealth
+	NextCursor string `json:"next_cursor,omitempty"`
+}

--- a/internal/hubserver/api_operator.go
+++ b/internal/hubserver/api_operator.go
@@ -1,0 +1,343 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+type workflowMutationRequest struct {
+	WorkflowStateID int64  `json:"workflow_state_id"`
+	Label           string `json:"label"`
+	IdempotencyKey  string `json:"idempotency_key"`
+}
+
+type dependencyMutationRequest struct {
+	Action            string             `json:"action"`
+	BlockerWorkItemID tracker.WorkItemID `json:"blocker_work_item_id"`
+	Provenance        string             `json:"provenance,omitempty"`
+}
+
+type priorityMutationRequest struct {
+	Scope          string `json:"scope"`
+	State          string `json:"state"`
+	Priority       string `json:"priority"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+type orderMutationRequest struct {
+	Scope string `json:"scope"`
+	State string `json:"state"`
+	Rank  string `json:"rank"`
+}
+
+type mutationResponse struct {
+	WorkItemID tracker.WorkItemID `json:"work_item_id"`
+	Kind       string             `json:"kind"`
+	Status     string             `json:"status"`
+	OutboxID   int64              `json:"outbox_id,omitempty"`
+}
+
+func (s *Service) changeWorkItemWorkflow(c echo.Context) error {
+	id, err := apiWorkItemID(c)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	var request workflowMutationRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	repositoryID, err := s.database.workItemRepositoryID(c.Request().Context(), id)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	item, err := s.ChangeWorkflowState(c.Request().Context(), WorkflowStateChange{
+		IssueID:         int64(id),
+		WorkflowStateID: request.WorkflowStateID,
+		Mutation: WorkflowLabelMutation{
+			IdempotencyKey: request.IdempotencyKey,
+			RepositoryID:   repositoryID,
+			IssueID:        int64(id),
+			Label:          request.Label,
+		},
+	})
+	if err != nil {
+		return operatorAPIError(c, err)
+	}
+	return c.JSON(http.StatusAccepted, mutationResponse{WorkItemID: id, Kind: "workflow", Status: "pending", OutboxID: item.ID})
+}
+
+func (s *Service) changeWorkItemDependency(c echo.Context) error {
+	id, err := apiWorkItemID(c)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	var request dependencyMutationRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	request.Action = strings.ToLower(strings.TrimSpace(request.Action))
+	request.Provenance = strings.TrimSpace(request.Provenance)
+	if request.Provenance == "" {
+		request.Provenance = "hub"
+	}
+	if request.BlockerWorkItemID <= 0 || request.BlockerWorkItemID == id || (request.Action != "add" && request.Action != "remove") {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_dependency", Message: "Dependency action and a distinct positive blocker_work_item_id are required"})
+	}
+	err = s.database.changeDependency(c.Request().Context(), id, request)
+	if err != nil {
+		return operatorAPIError(c, err)
+	}
+	return c.JSON(http.StatusOK, mutationResponse{WorkItemID: id, Kind: "dependency", Status: "applied"})
+}
+
+func (s *Service) changeWorkItemPriority(c echo.Context) error {
+	id, err := apiWorkItemID(c)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	var request priorityMutationRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	request.Scope = strings.TrimSpace(request.Scope)
+	request.State = strings.TrimSpace(request.State)
+	request.Priority = strings.ToLower(strings.TrimSpace(request.Priority))
+	priority, ok := queuePriority(request.Priority)
+	if request.Scope == "" || request.State == "" || !ok {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_priority", Message: "Scope, state, and a valid priority are required"})
+	}
+	repositoryID, err := s.database.workItemRepositoryID(c.Request().Context(), id)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	record, err := (WorkflowLabelMutation{
+		IdempotencyKey: request.IdempotencyKey,
+		RepositoryID:   repositoryID,
+		IssueID:        int64(id),
+		Label:          "priority:" + request.Priority,
+		ManagedPrefix:  "priority:",
+	}).outboxRecord()
+	if err != nil {
+		return operatorAPIError(c, err)
+	}
+	item, err := s.commitOutbox(c.Request().Context(), record, func(tx *sql.Tx, now string) error {
+		return upsertQueueEntry(c.Request().Context(), tx, id, request.Scope, request.State, "", &priority, now)
+	})
+	if err != nil {
+		return operatorAPIError(c, err)
+	}
+	return c.JSON(http.StatusAccepted, mutationResponse{WorkItemID: id, Kind: "priority", Status: "pending", OutboxID: item.ID})
+}
+
+func (s *Service) changeWorkItemOrder(c echo.Context) error {
+	id, err := apiWorkItemID(c)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	var request orderMutationRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	request.Scope = strings.TrimSpace(request.Scope)
+	request.State = strings.TrimSpace(request.State)
+	request.Rank = strings.TrimSpace(request.Rank)
+	if request.Scope == "" || request.State == "" || request.Rank == "" {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_order", Message: "Scope, state, and rank are required"})
+	}
+	if err := s.database.changeQueueOrder(c.Request().Context(), id, request); err != nil {
+		return operatorAPIError(c, err)
+	}
+	return c.JSON(http.StatusOK, mutationResponse{WorkItemID: id, Kind: "order", Status: "applied"})
+}
+
+func operatorAPIError(c echo.Context, err error) error {
+	status := http.StatusUnprocessableEntity
+	code := "invalid_mutation"
+	message := "Mutation is invalid"
+	switch {
+	case errors.Is(err, tracker.ErrWorkItemNotFound):
+		status, code, message = http.StatusNotFound, "work_item_not_found", "Work item was not found"
+	case errors.Is(err, ErrIdempotencyConflict):
+		status, code, message = http.StatusConflict, "idempotency_conflict", "Idempotency key conflicts with an earlier mutation"
+	case strings.Contains(err.Error(), "not found"):
+		status, code, message = http.StatusNotFound, "mutation_target_not_found", "Mutation target was not found"
+	}
+	return c.JSON(status, apiErrorResponse{Code: code, Message: message})
+}
+
+func (d *database) workItemRepositoryID(ctx context.Context, id tracker.WorkItemID) (int64, error) {
+	var repositoryID int64
+	if err := d.db.QueryRowContext(ctx, "SELECT repository_id FROM issues WHERE id = ?", id).Scan(&repositoryID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("%w: %d", tracker.ErrWorkItemNotFound, id)
+		}
+		return 0, fmt.Errorf("read hub work item repository: %w", err)
+	}
+	return repositoryID, nil
+}
+
+func (d *database) changeDependency(ctx context.Context, id tracker.WorkItemID, request dependencyMutationRequest) (resultErr error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin hub dependency mutation: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+	if err := requireWorkItem(ctx, tx, id); err != nil {
+		return err
+	}
+	if err := requireWorkItem(ctx, tx, request.BlockerWorkItemID); err != nil {
+		return err
+	}
+	now, err := d.currentTime()
+	if err != nil {
+		return err
+	}
+	if request.Action == "add" {
+		var createsCycle bool
+		if err := tx.QueryRowContext(ctx, `
+WITH RECURSIVE descendants(id) AS (
+  SELECT dependent_issue_id FROM issue_dependencies WHERE blocker_issue_id = ?
+  UNION
+  SELECT dependency.dependent_issue_id
+  FROM issue_dependencies dependency
+  JOIN descendants ON dependency.blocker_issue_id = descendants.id
+)
+SELECT EXISTS(SELECT 1 FROM descendants WHERE id = ?)`, id, request.BlockerWorkItemID).Scan(&createsCycle); err != nil {
+			return fmt.Errorf("validate hub dependency graph: %w", err)
+		}
+		if createsCycle {
+			return errors.New("dependency would create a cycle")
+		}
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO issue_dependencies (blocker_issue_id, dependent_issue_id, provenance, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(blocker_issue_id, dependent_issue_id) DO UPDATE SET provenance = excluded.provenance, updated_at = excluded.updated_at`,
+			request.BlockerWorkItemID, id, request.Provenance, formatHubTime(now), formatHubTime(now))
+	} else {
+		_, err = tx.ExecContext(ctx, "DELETE FROM issue_dependencies WHERE blocker_issue_id = ? AND dependent_issue_id = ?", request.BlockerWorkItemID, id)
+	}
+	if err != nil {
+		return fmt.Errorf("apply hub dependency mutation: %w", err)
+	}
+	if err := insertOperatorEvent(ctx, tx, id, "dependency_"+request.Action, map[string]any{"blocker_work_item_id": request.BlockerWorkItemID, "provenance": request.Provenance}, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit hub dependency mutation: %w", err)
+	}
+	return nil
+}
+
+func (d *database) changeQueueOrder(ctx context.Context, id tracker.WorkItemID, request orderMutationRequest) (resultErr error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin hub order mutation: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+	now, err := d.currentTime()
+	if err != nil {
+		return err
+	}
+	if err := upsertQueueEntry(ctx, tx, id, request.Scope, request.State, request.Rank, nil, formatHubTime(now)); err != nil {
+		return err
+	}
+	if err := insertOperatorEvent(ctx, tx, id, "queue_order_changed", map[string]any{"scope": request.Scope, "state": request.State, "rank": request.Rank}, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit hub order mutation: %w", err)
+	}
+	return nil
+}
+
+func upsertQueueEntry(ctx context.Context, tx *sql.Tx, id tracker.WorkItemID, scope string, state string, rank string, priority *int, now string) error {
+	var workflowStateID sql.NullInt64
+	if err := tx.QueryRowContext(ctx, "SELECT workflow_state_id FROM issues WHERE id = ?", id).Scan(&workflowStateID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("%w: %d", tracker.ErrWorkItemNotFound, id)
+		}
+		return fmt.Errorf("read hub queue work item: %w", err)
+	}
+	var existingRank string
+	var existingPriority sql.NullInt64
+	err := tx.QueryRowContext(ctx, "SELECT rank, priority_override FROM queue_entries WHERE scope = ? AND issue_id = ?", scope, id).Scan(&existingRank, &existingPriority)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("read hub queue entry: %w", err)
+	}
+	if rank == "" {
+		if err == nil {
+			rank = existingRank
+		} else {
+			rank = fmt.Sprintf("issue-%020d", id)
+		}
+	}
+	var priorityValue any
+	if priority != nil {
+		priorityValue = *priority
+	} else if existingPriority.Valid {
+		priorityValue = existingPriority.Int64
+	}
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO queue_entries (issue_id, workflow_state_id, scope, state, rank, priority_override, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(scope, issue_id) DO UPDATE SET
+  workflow_state_id = excluded.workflow_state_id,
+  state = excluded.state,
+  rank = excluded.rank,
+  priority_override = excluded.priority_override,
+  updated_at = excluded.updated_at`,
+		id, workflowStateID, scope, state, rank, priorityValue, now, now)
+	if err != nil {
+		return fmt.Errorf("upsert hub queue entry: %w", err)
+	}
+	return nil
+}
+
+func insertOperatorEvent(ctx context.Context, tx *sql.Tx, id tracker.WorkItemID, kind string, payload map[string]any, now time.Time) error {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode hub operator event: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO work_events (issue_id, fencing_token, machine_id, session_id, run_id, kind, payload_json, occurred_at, recorded_at)
+VALUES (?, NULL, NULL, NULL, NULL, ?, ?, ?, ?)`, id, kind, string(encoded), formatHubTime(now), formatHubTime(now))
+	if err != nil {
+		return fmt.Errorf("append hub operator event: %w", err)
+	}
+	return nil
+}
+
+func queuePriority(value string) (int, bool) {
+	switch value {
+	case "urgent":
+		return tracker.QueuePriorityUrgent, true
+	case "high":
+		return tracker.QueuePriorityHigh, true
+	case "normal":
+		return tracker.QueuePriorityNormal, true
+	case "low":
+		return tracker.QueuePriorityLow, true
+	case "unset":
+		return 4, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/hubserver/api_test.go
+++ b/internal/hubserver/api_test.go
@@ -1,0 +1,534 @@
+package hubserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/apikey"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func TestAPITokensAreHashedScopedRotatableAndRedacted(t *testing.T) {
+	t.Parallel()
+
+	const (
+		adminToken   = "hub-admin-token-that-is-never-persisted-in-plaintext"
+		workerToken  = "hub-worker-token-that-is-never-persisted-in-plaintext"
+		rotatedToken = "hub-rotated-token-that-is-never-persisted-in-plaintext"
+	)
+	generated := []string{workerToken, rotatedToken}
+	var generatedIndex int
+	var logs bytes.Buffer
+	databasePath := filepath.Join(t.TempDir(), "hub.db")
+	service, err := Open(t.Context(), Config{
+		DatabasePath:      databasePath,
+		InitialAdminToken: []byte(adminToken),
+		Logger:            slog.New(slog.NewJSONHandler(&logs, nil)),
+		newTokenID:        func() string { return "worker-token-id" },
+		generateToken: func() (string, error) {
+			token := generated[generatedIndex]
+			generatedIndex++
+			return token, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := service.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	var storedHash string
+	var fingerprint string
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT token_hash, token_fingerprint FROM api_tokens WHERE id = ?", bootstrapTokenID).Scan(&storedHash, &fingerprint); err != nil {
+		t.Fatalf("read initial token: %v", err)
+	}
+	if storedHash != apikey.HashToken(adminToken) || fingerprint != tokenFingerprint(storedHash) {
+		t.Fatalf("stored token metadata = hash %q fingerprint %q", storedHash, fingerprint)
+	}
+	if strings.Contains(storedHash, adminToken) || strings.Contains(fingerprint, adminToken) {
+		t.Fatal("initial token plaintext was persisted")
+	}
+
+	unauthorized := performHubAPIRequest(t, service, http.MethodGet, "/health", "wrong-secret-token", nil)
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status = %d body = %s", unauthorized.Code, unauthorized.Body.String())
+	}
+	createdResponse := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/tokens", adminToken, map[string]any{"name": "Worker", "scope": "worker"})
+	if createdResponse.Code != http.StatusCreated || createdResponse.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("create token status = %d headers = %v body = %s", createdResponse.Code, createdResponse.Header(), createdResponse.Body.String())
+	}
+	var created tokenResponse
+	decodeHubResponse(t, createdResponse, &created)
+	if created.Token != workerToken || created.Scope != apiScopeWorker {
+		t.Fatalf("created token = %#v", created)
+	}
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT token_hash FROM api_tokens WHERE id = ?", created.ID).Scan(&storedHash); err != nil {
+		t.Fatalf("read worker token hash: %v", err)
+	}
+	if storedHash != apikey.HashToken(workerToken) || strings.Contains(storedHash, workerToken) {
+		t.Fatalf("stored worker token hash = %q", storedHash)
+	}
+
+	if response := performHubAPIRequest(t, service, http.MethodGet, "/health", workerToken, nil); response.Code != http.StatusOK {
+		t.Fatalf("worker read status = %d body = %s", response.Code, response.Body.String())
+	}
+	if response := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/tokens", workerToken, map[string]any{"name": "Denied", "scope": "worker"}); response.Code != http.StatusForbidden {
+		t.Fatalf("worker admin status = %d body = %s", response.Code, response.Body.String())
+	}
+	rotatedResponse := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/tokens/"+created.ID+"/rotate", adminToken, map[string]any{})
+	if rotatedResponse.Code != http.StatusOK || rotatedResponse.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("rotate token status = %d body = %s", rotatedResponse.Code, rotatedResponse.Body.String())
+	}
+	var rotated tokenResponse
+	decodeHubResponse(t, rotatedResponse, &rotated)
+	if rotated.Token != rotatedToken || rotated.RotatedAt.IsZero() {
+		t.Fatalf("rotated token = %#v", rotated)
+	}
+	if response := performHubAPIRequest(t, service, http.MethodGet, "/health", workerToken, nil); response.Code != http.StatusUnauthorized {
+		t.Fatalf("old worker token status = %d, want 401", response.Code)
+	}
+	if response := performHubAPIRequest(t, service, http.MethodGet, "/health", rotatedToken, nil); response.Code != http.StatusOK {
+		t.Fatalf("rotated worker token status = %d body = %s", response.Code, response.Body.String())
+	}
+	for _, secret := range []string{adminToken, workerToken, rotatedToken, "wrong-secret-token"} {
+		if strings.Contains(logs.String(), secret) {
+			t.Fatalf("logs contain API token %q", secret)
+		}
+	}
+	if err := service.Close(); err != nil {
+		t.Fatalf("close before restart: %v", err)
+	}
+	restarted, err := Open(t.Context(), Config{DatabasePath: databasePath, InitialAdminToken: []byte("different-startup-token-must-not-undo-rotation"), Logger: discardLogger()})
+	if err != nil {
+		t.Fatalf("restart Hub: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := restarted.Close(); err != nil {
+			t.Fatalf("close restarted Hub: %v", err)
+		}
+	})
+	if response := performHubAPIRequest(t, restarted, http.MethodGet, "/health", rotatedToken, nil); response.Code != http.StatusOK {
+		t.Fatalf("rotated token after restart status = %d body = %s", response.Code, response.Body.String())
+	}
+	if err := restarted.database.db.QueryRowContext(t.Context(), "SELECT token_hash FROM api_tokens WHERE id = ?", bootstrapTokenID).Scan(&storedHash); err != nil {
+		t.Fatalf("read bootstrap token after restart: %v", err)
+	}
+	if storedHash != apikey.HashToken(adminToken) {
+		t.Fatalf("restart replaced bootstrap token hash = %q", storedHash)
+	}
+}
+
+func TestWorkItemAPIUsesStableFilteredCursorsAndDetailTimeline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }})
+	repositoryID, firstID := seedProjection(t, service.database.db)
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE repositories SET last_reconciled_at = ? WHERE id = ?", formatHubTime(now), repositoryID); err != nil {
+		t.Fatalf("mark repository fresh: %v", err)
+	}
+	var workflowID int64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues WHERE id = ?", firstID).Scan(&workflowID); err != nil {
+		t.Fatalf("read workflow state: %v", err)
+	}
+	secondID := insertHubTestIssue(t, service, repositoryID, 2, "I_second", "open", &workflowID)
+	thirdID := insertHubTestIssue(t, service, repositoryID, 3, "I_third", "open", &workflowID)
+	entries := []struct {
+		id       int64
+		rank     string
+		priority int
+	}{
+		{firstID, "m", tracker.QueuePriorityLow},
+		{secondID, "z", tracker.QueuePriorityUrgent},
+		{thirdID, "a", tracker.QueuePriorityUrgent},
+	}
+	for _, entry := range entries {
+		if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO queue_entries (issue_id, workflow_state_id, scope, state, rank, priority_override, created_at, updated_at) VALUES (?, ?, 'fleet', 'Todo', ?, ?, ?, ?)", entry.id, workflowID, entry.rank, entry.priority, testTimestamp, testTimestamp); err != nil {
+			t.Fatalf("insert queue entry: %v", err)
+		}
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE issues SET labels_json = '[\"api\"]', assignees_json = '[\"worker-a\"]' WHERE id = ?", thirdID); err != nil {
+		t.Fatalf("update filters: %v", err)
+	}
+
+	firstPage := performHubAPIRequest(t, service, http.MethodGet, "/api/v1/work-items?repository=digitaldrywood%2Fdetent&readiness=ready&priority=urgent&limit=1", testHubAdminToken, nil)
+	if firstPage.Code != http.StatusOK {
+		t.Fatalf("first page status = %d body = %s", firstPage.Code, firstPage.Body.String())
+	}
+	var page workItemListResponse
+	decodeHubResponse(t, firstPage, &page)
+	if len(page.Items) != 1 || page.Items[0].ID != tracker.WorkItemID(thirdID) || page.NextCursor == "" {
+		t.Fatalf("first page = %#v", page)
+	}
+	secondPagePath := "/api/v1/work-items?repository=digitaldrywood%2Fdetent&readiness=ready&priority=urgent&limit=1&cursor=" + url.QueryEscape(page.NextCursor)
+	secondPage := performHubAPIRequest(t, service, http.MethodGet, secondPagePath, testHubAdminToken, nil)
+	page = workItemListResponse{}
+	decodeHubResponse(t, secondPage, &page)
+	if len(page.Items) != 1 || page.Items[0].ID != tracker.WorkItemID(secondID) || page.NextCursor != "" {
+		t.Fatalf("second page = %#v", page)
+	}
+	filtered := performHubAPIRequest(t, service, http.MethodGet, "/api/v1/work-items?label=api&assignee=worker-a&sort=identifier", testHubAdminToken, nil)
+	page = workItemListResponse{}
+	decodeHubResponse(t, filtered, &page)
+	if len(page.Items) != 1 || page.Items[0].ID != tracker.WorkItemID(thirdID) {
+		t.Fatalf("filtered page = %#v", page)
+	}
+	invalidCursor := performHubAPIRequest(t, service, http.MethodGet, secondPagePath+"&sort=updated", testHubAdminToken, nil)
+	if invalidCursor.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("mismatched cursor status = %d body = %s", invalidCursor.Code, invalidCursor.Body.String())
+	}
+
+	for index := 1; index <= 2; index++ {
+		if _, err := service.database.db.ExecContext(t.Context(), `
+INSERT INTO work_events (issue_id, kind, payload_json, occurred_at, recorded_at)
+VALUES (?, ?, '{}', ?, ?)`, thirdID, fmt.Sprintf("event_%d", index), formatHubTime(now.Add(time.Duration(index)*time.Minute)), formatHubTime(now)); err != nil {
+			t.Fatalf("insert timeline event: %v", err)
+		}
+	}
+	desired, err := json.Marshal(WorkpadDesired{Phase: "implementation", Body: "Hub API workpad", Marker: workpadMarker})
+	if err != nil {
+		t.Fatalf("marshal workpad: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), `
+INSERT INTO github_outbox (idempotency_key, repository_id, issue_id, mutation_kind, desired_json, status, created_at, updated_at)
+VALUES ('workpad-api', ?, ?, ?, ?, 'pending', ?, ?)`, repositoryID, thirdID, MutationWorkpad, string(desired), formatHubTime(now), formatHubTime(now)); err != nil {
+		t.Fatalf("insert workpad: %v", err)
+	}
+	detailResponse := performHubAPIRequest(t, service, http.MethodGet, fmt.Sprintf("/api/v1/work-items/%d?timeline_limit=1", thirdID), testHubAdminToken, nil)
+	var detail workItemDetailResponse
+	decodeHubResponse(t, detailResponse, &detail)
+	if detail.ID != tracker.WorkItemID(thirdID) || detail.Workpad == nil || detail.Workpad.Body != "Hub API workpad" || len(detail.Timeline) != 1 || detail.TimelineNextCursor == "" {
+		t.Fatalf("detail response = %#v", detail)
+	}
+	nextTimeline := performHubAPIRequest(t, service, http.MethodGet, fmt.Sprintf("/api/v1/work-items/%d?timeline_limit=1&timeline_cursor=%s", thirdID, url.QueryEscape(detail.TimelineNextCursor)), testHubAdminToken, nil)
+	detail = workItemDetailResponse{}
+	decodeHubResponse(t, nextTimeline, &detail)
+	if len(detail.Timeline) != 1 || detail.Timeline[0].Kind != "event_2" || detail.TimelineNextCursor != "" {
+		t.Fatalf("next timeline = %#v", detail.Timeline)
+	}
+}
+
+func TestClaimNextAPIIsAtomicAndFenced(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 13, 0, 0, 0, time.UTC)
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }})
+	_, issueID := seedProjection(t, service.database.db)
+	registered := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/machines/register", testHubAdminToken, map[string]any{
+		"id": "machine-a", "hostname": "worker-a", "display_name": "Worker A", "capacity": 10, "version": "v1", "capabilities": map[string]any{"go": true},
+	})
+	if registered.Code != http.StatusOK {
+		t.Fatalf("register machine status = %d body = %s", registered.Code, registered.Body.String())
+	}
+
+	const attempts = 10
+	statuses := make(chan int, attempts)
+	bodies := make(chan []byte, attempts)
+	var wait sync.WaitGroup
+	for index := range attempts {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			payload, _ := json.Marshal(map[string]any{"machine_id": "machine-a", "session_id": fmt.Sprintf("session-%d", index), "ttl_seconds": 90})
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/claims", bytes.NewReader(payload))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Authorization", "Bearer "+testHubAdminToken)
+			response := httptest.NewRecorder()
+			service.Handler().ServeHTTP(response, request)
+			statuses <- response.Code
+			bodies <- append([]byte(nil), response.Body.Bytes()...)
+		}(index)
+	}
+	wait.Wait()
+	close(statuses)
+	close(bodies)
+	successes := 0
+	var lease tracker.Lease
+	for status := range statuses {
+		if status == http.StatusCreated {
+			successes++
+		}
+	}
+	for body := range bodies {
+		var candidate tracker.Lease
+		if json.Unmarshal(body, &candidate) == nil && candidate.ID != "" {
+			lease = candidate
+		}
+	}
+	if successes != 1 || lease.WorkItemID != tracker.WorkItemID(issueID) || lease.FencingToken <= 0 {
+		t.Fatalf("claim results = %d successes lease %#v", successes, lease)
+	}
+	var active int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM leases WHERE issue_id = ? AND released_at IS NULL", issueID).Scan(&active); err != nil {
+		t.Fatalf("count active leases: %v", err)
+	}
+	if active != 1 {
+		t.Fatalf("active leases = %d, want 1", active)
+	}
+
+	staleEvent := performHubAPIRequest(t, service, http.MethodPost, fmt.Sprintf("/api/v1/work-items/%d/events", issueID), testHubAdminToken, map[string]any{"fencing_token": lease.FencingToken + 1, "kind": "progress"})
+	if staleEvent.Code != http.StatusConflict {
+		t.Fatalf("stale event status = %d body = %s", staleEvent.Code, staleEvent.Body.String())
+	}
+	validEvent := performHubAPIRequest(t, service, http.MethodPost, fmt.Sprintf("/api/v1/work-items/%d/events", issueID), testHubAdminToken, map[string]any{"fencing_token": lease.FencingToken, "kind": "progress", "payload": map[string]any{"step": "test"}})
+	if validEvent.Code != http.StatusCreated {
+		t.Fatalf("valid event status = %d body = %s", validEvent.Code, validEvent.Body.String())
+	}
+	renewed := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/leases/"+string(lease.ID)+"/renew", testHubAdminToken, map[string]any{"fencing_token": lease.FencingToken, "ttl_seconds": 120})
+	if renewed.Code != http.StatusOK {
+		t.Fatalf("renew status = %d body = %s", renewed.Code, renewed.Body.String())
+	}
+	released := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/leases/"+string(lease.ID)+"/release", testHubAdminToken, map[string]any{"fencing_token": lease.FencingToken, "reason": "complete"})
+	if released.Code != http.StatusNoContent {
+		t.Fatalf("release status = %d body = %s", released.Code, released.Body.String())
+	}
+	heartbeat := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/machines/machine-a/heartbeat", testHubAdminToken, map[string]any{"capacity": 4, "version": "v2"})
+	if heartbeat.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d body = %s", heartbeat.Code, heartbeat.Body.String())
+	}
+	var machine machineResponse
+	decodeHubResponse(t, heartbeat, &machine)
+	if machine.Capacity != 4 || machine.Version != "v2" || machine.Capabilities["go"] != true {
+		t.Fatalf("heartbeat machine = %#v", machine)
+	}
+	specific := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/claims", testHubAdminToken, map[string]any{
+		"work_item_id": issueID, "machine_id": "machine-a", "session_id": "specific-session", "ttl_seconds": 90,
+	})
+	if specific.Code != http.StatusCreated {
+		t.Fatalf("specific claim status = %d body = %s", specific.Code, specific.Body.String())
+	}
+}
+
+func TestOperatorMutationsAreTypedAuditedAndScoped(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	var workflowID int64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues WHERE id = ?", issueID).Scan(&workflowID); err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	blockerID := insertHubTestIssue(t, service, repositoryID, 2, "I_blocker_api", "open", &workflowID)
+	result, err := service.database.db.ExecContext(t.Context(), "INSERT INTO workflow_states (repository_id, source_name, detent_state, dispatchable, created_at, updated_at) VALUES (?, 'In Progress', 'In Progress', 0, ?, ?)", repositoryID, testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert workflow: %v", err)
+	}
+	inProgressID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("workflow ID: %v", err)
+	}
+	seedHubAPIToken(t, service, "operator-token", "operator-secret-token", apiScopeOperator)
+	seedHubAPIToken(t, service, "worker-token", "worker-secret-token", apiScopeWorker)
+
+	denied := performHubAPIRequest(t, service, http.MethodPost, fmt.Sprintf("/api/v1/work-items/%d/order", issueID), "worker-secret-token", map[string]any{"scope": "fleet", "state": "Todo", "rank": "a"})
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("worker operator mutation status = %d body = %s", denied.Code, denied.Body.String())
+	}
+	requests := []struct {
+		path    string
+		payload map[string]any
+		status  int
+	}{
+		{fmt.Sprintf("/api/v1/work-items/%d/workflow", issueID), map[string]any{"workflow_state_id": inProgressID, "label": "detent:in-progress", "idempotency_key": "workflow-api"}, http.StatusAccepted},
+		{fmt.Sprintf("/api/v1/work-items/%d/dependencies", issueID), map[string]any{"action": "add", "blocker_work_item_id": blockerID, "provenance": "operator"}, http.StatusOK},
+		{fmt.Sprintf("/api/v1/work-items/%d/order", issueID), map[string]any{"scope": "fleet", "state": "In Progress", "rank": "rank-a"}, http.StatusOK},
+		{fmt.Sprintf("/api/v1/work-items/%d/priority", issueID), map[string]any{"scope": "fleet", "state": "In Progress", "priority": "high", "idempotency_key": "priority-api"}, http.StatusAccepted},
+	}
+	for _, request := range requests {
+		response := performHubAPIRequest(t, service, http.MethodPost, request.path, "operator-secret-token", request.payload)
+		if response.Code != request.status {
+			t.Fatalf("POST %s status = %d body = %s", request.path, response.Code, response.Body.String())
+		}
+	}
+	var gotWorkflowID int64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues WHERE id = ?", issueID).Scan(&gotWorkflowID); err != nil || gotWorkflowID != inProgressID {
+		t.Fatalf("workflow state = %d error = %v, want %d", gotWorkflowID, err, inProgressID)
+	}
+	var dependencies int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM issue_dependencies WHERE blocker_issue_id = ? AND dependent_issue_id = ?", blockerID, issueID).Scan(&dependencies); err != nil || dependencies != 1 {
+		t.Fatalf("dependency count = %d error = %v", dependencies, err)
+	}
+	var rank string
+	var priority int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT rank, priority_override FROM queue_entries WHERE issue_id = ? AND scope = 'fleet'", issueID).Scan(&rank, &priority); err != nil {
+		t.Fatalf("read queue entry: %v", err)
+	}
+	if rank != "rank-a" || priority != tracker.QueuePriorityHigh {
+		t.Fatalf("queue entry = rank %q priority %d", rank, priority)
+	}
+	var outboxCount int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM github_outbox WHERE idempotency_key IN ('workflow-api', 'priority-api')").Scan(&outboxCount); err != nil || outboxCount != 2 {
+		t.Fatalf("outbox count = %d error = %v", outboxCount, err)
+	}
+	var auditCount int
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM work_events WHERE issue_id = ? AND kind IN ('dependency_add', 'queue_order_changed')", issueID).Scan(&auditCount); err != nil || auditCount != 2 {
+		t.Fatalf("operator audit count = %d error = %v", auditCount, err)
+	}
+	cycle := performHubAPIRequest(t, service, http.MethodPost, fmt.Sprintf("/api/v1/work-items/%d/dependencies", blockerID), "operator-secret-token", map[string]any{"action": "add", "blocker_work_item_id": issueID})
+	if cycle.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("dependency cycle status = %d body = %s", cycle.Code, cycle.Body.String())
+	}
+}
+
+func TestListenerSecurityRequiresLoopbackTLSOrTrustedProxy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{name: "IPv4 loopback", config: Config{ListenAddress: "127.0.0.1:7777"}},
+		{name: "IPv6 loopback", config: Config{ListenAddress: "[::1]:7777"}},
+		{name: "localhost", config: Config{ListenAddress: "localhost:7777"}},
+		{name: "wildcard rejected", config: Config{ListenAddress: "0.0.0.0:7777"}, wantErr: true},
+		{name: "public TLS", config: Config{ListenAddress: "0.0.0.0:7777", TLSCertFile: "server.crt", TLSKeyFile: "server.key"}},
+		{name: "trusted proxy", config: Config{ListenAddress: "0.0.0.0:7777", TrustedProxy: true}},
+		{name: "incomplete TLS", config: Config{ListenAddress: "127.0.0.1:7777", TLSCertFile: "server.crt"}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateListenerSecurity(test.config)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validateListenerSecurity() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestControlPlaneRoutesRequireAuthentication(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/health"},
+		{http.MethodGet, "/api/v1/work-items"},
+		{http.MethodGet, "/api/v1/work-items/1"},
+		{http.MethodPost, "/api/v1/claims"},
+		{http.MethodPost, "/api/v1/leases/lease/renew"},
+		{http.MethodPost, "/api/v1/leases/lease/release"},
+		{http.MethodPost, "/api/v1/work-items/1/events"},
+		{http.MethodPost, "/api/v1/work-items/1/workflow"},
+		{http.MethodPost, "/api/v1/work-items/1/dependencies"},
+		{http.MethodPost, "/api/v1/work-items/1/priority"},
+		{http.MethodPost, "/api/v1/work-items/1/order"},
+		{http.MethodPost, "/api/v1/machines/register"},
+		{http.MethodPost, "/api/v1/machines/machine/heartbeat"},
+		{http.MethodGet, "/api/v1/repositories/freshness"},
+		{http.MethodGet, "/api/v1/outbox/health"},
+		{http.MethodPost, "/api/v1/tokens"},
+		{http.MethodPost, "/api/v1/tokens/token/rotate"},
+		{http.MethodDelete, "/api/v1/tokens/token"},
+	}
+	for _, route := range routes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			response := performHubAPIRequest(t, service, route.method, route.path, "", nil)
+			if response.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d body = %s, want 401", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestHealthListsUseStableCursors(t *testing.T) {
+	t.Parallel()
+
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db")})
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	if _, err := service.database.db.ExecContext(t.Context(), `
+INSERT INTO repositories (github_node_id, github_owner, github_name, created_at, updated_at)
+VALUES ('R_second', 'example', 'second', ?, ?)`, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert second repository: %v", err)
+	}
+	first := performHubAPIRequest(t, service, http.MethodGet, "/api/v1/repositories/freshness?limit=1", testHubAdminToken, nil)
+	var repositories repositoryFreshnessResponse
+	decodeHubResponse(t, first, &repositories)
+	if len(repositories.Repositories) != 1 || repositories.NextCursor == "" || repositories.Summary.Total != 2 {
+		t.Fatalf("repository first page = %#v", repositories)
+	}
+	second := performHubAPIRequest(t, service, http.MethodGet, "/api/v1/repositories/freshness?limit=1&cursor="+url.QueryEscape(repositories.NextCursor), testHubAdminToken, nil)
+	repositories = repositoryFreshnessResponse{}
+	decodeHubResponse(t, second, &repositories)
+	if len(repositories.Repositories) != 1 || repositories.NextCursor != "" || repositories.Summary.Total != 2 {
+		t.Fatalf("repository second page = %#v", repositories)
+	}
+
+	for index := 1; index <= 2; index++ {
+		if _, err := service.database.db.ExecContext(t.Context(), `
+INSERT INTO github_outbox (
+  idempotency_key, repository_id, issue_id, mutation_kind, desired_json,
+  status, terminal_error, operator_action, created_at, updated_at
+) VALUES (?, ?, ?, ?, '{}', 'dead_letter', 'failed', ?, ?, ?)`,
+			fmt.Sprintf("dead-letter-%d", index), repositoryID, issueID, MutationWorkpad,
+			fmt.Sprintf("retry action %d", index), testTimestamp, testTimestamp); err != nil {
+			t.Fatalf("insert dead letter: %v", err)
+		}
+	}
+	outboxFirst := performHubAPIRequest(t, service, http.MethodGet, "/api/v1/outbox/health?limit=1", testHubAdminToken, nil)
+	var outbox outboxHealthResponse
+	decodeHubResponse(t, outboxFirst, &outbox)
+	if len(outbox.OperatorActions) != 1 || outbox.NextCursor == "" || outbox.DeadLetters != 2 {
+		t.Fatalf("outbox first page = %#v", outbox)
+	}
+	outboxSecond := performHubAPIRequest(t, service, http.MethodGet, "/api/v1/outbox/health?limit=1&cursor="+url.QueryEscape(outbox.NextCursor), testHubAdminToken, nil)
+	outbox = outboxHealthResponse{}
+	decodeHubResponse(t, outboxSecond, &outbox)
+	if len(outbox.OperatorActions) != 1 || outbox.NextCursor != "" || outbox.DeadLetters != 2 {
+		t.Fatalf("outbox second page = %#v", outbox)
+	}
+}
+
+func performHubAPIRequest(t *testing.T, service *Service, method string, path string, token string, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+	var body []byte
+	var err error
+	if payload != nil {
+		body, err = json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+	}
+	request := httptest.NewRequest(method, path, bytes.NewReader(body))
+	if payload != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	return response
+}
+
+func decodeHubResponse(t *testing.T, response *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	if err := json.Unmarshal(response.Body.Bytes(), target); err != nil {
+		t.Fatalf("decode response status %d body %s: %v", response.Code, response.Body.String(), err)
+	}
+}
+
+func seedHubAPIToken(t *testing.T, service *Service, id string, token string, scope apiScope) {
+	t.Helper()
+	hash := apikey.HashToken(token)
+	if _, err := service.database.db.ExecContext(t.Context(), `
+INSERT INTO api_tokens (id, name, token_hash, token_fingerprint, scope, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)`, id, id, hash, tokenFingerprint(hash), scope, testTimestamp, testTimestamp); err != nil {
+		t.Fatalf("insert Hub API token: %v", err)
+	}
+}

--- a/internal/hubserver/api_test.go
+++ b/internal/hubserver/api_test.go
@@ -3,6 +3,7 @@ package hubserver
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -226,7 +227,10 @@ func TestClaimNextAPIIsAtomicAndFenced(t *testing.T) {
 
 	now := time.Date(2026, 9, 3, 13, 0, 0, 0, time.UTC)
 	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }})
-	_, issueID := seedProjection(t, service.database.db)
+	repositoryID, issueID := seedProjection(t, service.database.db)
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE repositories SET last_reconciled_at = ? WHERE id = ?", formatHubTime(now), repositoryID); err != nil {
+		t.Fatalf("mark repository fresh: %v", err)
+	}
 	registered := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/machines/register", testHubAdminToken, map[string]any{
 		"id": "machine-a", "hostname": "worker-a", "display_name": "Worker A", "capacity": 10, "version": "v1", "capabilities": map[string]any{"go": true},
 	})
@@ -309,6 +313,68 @@ func TestClaimNextAPIIsAtomicAndFenced(t *testing.T) {
 	})
 	if specific.Code != http.StatusCreated {
 		t.Fatalf("specific claim status = %d body = %s", specific.Code, specific.Body.String())
+	}
+	var workflowID int64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues WHERE id = ?", issueID).Scan(&workflowID); err != nil {
+		t.Fatalf("read workflow state: %v", err)
+	}
+	otherID := insertHubTestIssue(t, service, repositoryID, 2, "I_other_claim", "open", &workflowID)
+	mismatched := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/claims", testHubAdminToken, map[string]any{
+		"work_item_id": otherID, "machine_id": "machine-a", "session_id": "specific-session", "ttl_seconds": 90,
+	})
+	if mismatched.Code != http.StatusConflict {
+		t.Fatalf("mismatched specific retry status = %d body = %s", mismatched.Code, mismatched.Body.String())
+	}
+}
+
+func TestClaimNextAPIRejectsUnsafeRepositorySyncHealth(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 13, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		setup func(*testing.T, *Service, int64)
+	}{
+		{
+			name: "stale",
+			setup: func(t *testing.T, service *Service, repositoryID int64) {
+				t.Helper()
+				if _, err := service.database.db.ExecContext(t.Context(), "UPDATE repositories SET last_reconciled_at = NULL WHERE id = ?", repositoryID); err != nil {
+					t.Fatalf("mark repository stale: %v", err)
+				}
+			},
+		},
+		{
+			name: "error",
+			setup: func(t *testing.T, service *Service, repositoryID int64) {
+				t.Helper()
+				if _, err := service.database.db.ExecContext(t.Context(), "UPDATE repositories SET last_reconciled_at = ? WHERE id = ?", formatHubTime(now), repositoryID); err != nil {
+					t.Fatalf("mark repository reconciled: %v", err)
+				}
+				if err := service.database.recordCheckpointFailure(t.Context(), repositoryID, checkpointIncremental, now, errors.New("sync failed")); err != nil {
+					t.Fatalf("record sync failure: %v", err)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }})
+			repositoryID, _ := seedProjection(t, service.database.db)
+			test.setup(t, service, repositoryID)
+			registered := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/machines/register", testHubAdminToken, map[string]any{
+				"id": "machine-a", "hostname": "worker-a", "capacity": 1, "version": "v1",
+			})
+			if registered.Code != http.StatusOK {
+				t.Fatalf("register machine status = %d body = %s", registered.Code, registered.Body.String())
+			}
+			claimed := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/claims", testHubAdminToken, map[string]any{
+				"machine_id": "machine-a", "session_id": "unsafe-sync-session", "ttl_seconds": 90,
+			})
+			if claimed.Code != http.StatusConflict {
+				t.Fatalf("claim status = %d body = %s", claimed.Code, claimed.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/hubserver/api_work_items.go
+++ b/internal/hubserver/api_work_items.go
@@ -1,0 +1,651 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+const (
+	defaultAPIPageLimit = 50
+	maxAPIPageLimit     = 200
+)
+
+type workItemListResponse struct {
+	Items      []tracker.WorkItem `json:"items"`
+	NextCursor string             `json:"next_cursor,omitempty"`
+}
+
+type workItemListQuery struct {
+	Repositories  map[string]struct{}
+	WorkflowState map[string]struct{}
+	Readiness     map[string]struct{}
+	Priorities    map[string]struct{}
+	Labels        map[string]struct{}
+	Assignees     map[string]struct{}
+	Machines      map[string]struct{}
+	Leases        map[string]struct{}
+	PullRequests  map[string]struct{}
+	SyncHealth    map[string]struct{}
+	Sort          string
+	Order         string
+	Limit         int
+	Cursor        workItemCursor
+}
+
+type workItemCursor struct {
+	Version int      `json:"v"`
+	Sort    string   `json:"sort"`
+	Order   string   `json:"order"`
+	Values  []string `json:"values"`
+}
+
+type workpadProjection struct {
+	Phase     string    `json:"phase"`
+	Body      string    `json:"body"`
+	SyncState string    `json:"sync_state"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type timelineEvent struct {
+	ID int64 `json:"id"`
+	tracker.WorkEvent
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
+type workItemDetailResponse struct {
+	tracker.WorkItem
+	Workpad            *workpadProjection `json:"workpad,omitempty"`
+	Timeline           []timelineEvent    `json:"timeline"`
+	TimelineNextCursor string             `json:"timeline_next_cursor,omitempty"`
+}
+
+type timelineCursor struct {
+	Version int   `json:"v"`
+	ID      int64 `json:"id"`
+}
+
+func (s *Service) listWorkItems(c echo.Context) error {
+	query, err := parseWorkItemListQuery(c)
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_query", Message: err.Error()})
+	}
+	items, err := s.allWorkItems(c.Request().Context())
+	if err != nil {
+		return s.internalAPIError(c, "work_items_unavailable", "Work items could not be read", err)
+	}
+	items = filterWorkItems(items, query)
+	sortWorkItems(items, query.Sort, query.Order)
+	items = workItemsAfterCursor(items, query)
+	response := workItemListResponse{Items: items}
+	if len(response.Items) > query.Limit {
+		response.Items = response.Items[:query.Limit]
+		response.NextCursor, err = encodeWorkItemCursor(workItemCursor{
+			Version: 1,
+			Sort:    query.Sort,
+			Order:   query.Order,
+			Values:  workItemSortValues(response.Items[len(response.Items)-1], query.Sort),
+		})
+		if err != nil {
+			return s.internalAPIError(c, "work_items_unavailable", "Work items could not be read", err)
+		}
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (s *Service) getWorkItem(c echo.Context) error {
+	id, err := apiWorkItemID(c)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "work_item_not_found", Message: "Work item was not found"})
+	}
+	items, err := s.tracker.GetWorkItems(c.Request().Context(), []tracker.WorkItemID{id})
+	if err != nil {
+		return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
+	}
+	if len(items) != 1 {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "work_item_not_found", Message: "Work item was not found"})
+	}
+	if err := s.applyRepositorySyncHealth(c.Request().Context(), items); err != nil {
+		return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
+	}
+	timelineLimit, err := parsePageLimit(c.QueryParam("timeline_limit"))
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_query", Message: "timeline_limit must be between 1 and 200"})
+	}
+	cursor, err := decodeTimelineCursor(c.QueryParam("timeline_cursor"))
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_cursor", Message: "Timeline cursor is invalid"})
+	}
+	workpad, hasWorkpad, err := s.database.latestWorkpad(c.Request().Context(), id)
+	if err != nil {
+		return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
+	}
+	timeline, err := s.database.workItemTimeline(c.Request().Context(), id, cursor.ID, timelineLimit+1)
+	if err != nil {
+		return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
+	}
+	response := workItemDetailResponse{WorkItem: items[0], Timeline: timeline}
+	if hasWorkpad {
+		response.Workpad = &workpad
+	}
+	if len(response.Timeline) > timelineLimit {
+		response.Timeline = response.Timeline[:timelineLimit]
+		response.TimelineNextCursor, err = encodeTimelineCursor(timelineCursor{Version: 1, ID: response.Timeline[len(response.Timeline)-1].ID})
+		if err != nil {
+			return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
+		}
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (s *Service) allWorkItems(ctx context.Context) ([]tracker.WorkItem, error) {
+	ids, err := s.database.allWorkItemIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	items, err := s.tracker.GetWorkItems(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.applyRepositorySyncHealth(ctx, items); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (d *database) allWorkItemIDs(ctx context.Context) ([]tracker.WorkItemID, error) {
+	rows, err := d.db.QueryContext(ctx, "SELECT id FROM issues ORDER BY id")
+	if err != nil {
+		return nil, fmt.Errorf("query hub work item IDs: %w", err)
+	}
+	defer rows.Close()
+	var ids []tracker.WorkItemID
+	for rows.Next() {
+		var id tracker.WorkItemID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan hub work item ID: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate hub work item IDs: %w", err)
+	}
+	return ids, nil
+}
+
+func (s *Service) applyRepositorySyncHealth(ctx context.Context, items []tracker.WorkItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	result, err := s.database.repositoryFreshness(ctx, s.config.now().UTC(), s.config.ReconcileInterval)
+	if err != nil {
+		return err
+	}
+	statuses := make(map[tracker.RepositoryID]string, len(result.Repositories))
+	for _, repository := range result.Repositories {
+		statuses[tracker.RepositoryID(repository.ID)] = repository.Status
+	}
+	for i := range items {
+		if items[i].SyncStatus != tracker.SyncStatusSynced {
+			continue
+		}
+		switch statuses[items[i].Repository.ID] {
+		case "error":
+			items[i].SyncStatus = tracker.SyncStatusError
+			appendSyncDispatchReason(&items[i], tracker.DispatchReasonSyncError, "GitHub synchronization has an error")
+		case "stale":
+			items[i].SyncStatus = tracker.SyncStatusStale
+			appendSyncDispatchReason(&items[i], tracker.DispatchReasonSyncStale, "GitHub projection is stale")
+		}
+	}
+	return nil
+}
+
+func appendSyncDispatchReason(item *tracker.WorkItem, code tracker.DispatchReasonCode, message string) {
+	item.Dispatchability.Dispatchable = false
+	for _, reason := range item.Dispatchability.Reasons {
+		if reason.Code == code {
+			return
+		}
+	}
+	item.Dispatchability.Reasons = append(item.Dispatchability.Reasons, tracker.DispatchReason{Code: code, Message: message})
+}
+
+func parseWorkItemListQuery(c echo.Context) (workItemListQuery, error) {
+	query := workItemListQuery{
+		Repositories:  querySet(c, "repository"),
+		WorkflowState: querySet(c, "workflow_state"),
+		Readiness:     querySet(c, "readiness"),
+		Priorities:    querySet(c, "priority"),
+		Labels:        querySet(c, "label"),
+		Assignees:     querySet(c, "assignee"),
+		Machines:      querySet(c, "machine"),
+		Leases:        querySet(c, "lease"),
+		PullRequests:  querySet(c, "pr"),
+		SyncHealth:    querySet(c, "sync_health"),
+		Sort:          strings.ToLower(strings.TrimSpace(c.QueryParam("sort"))),
+		Order:         strings.ToLower(strings.TrimSpace(c.QueryParam("order"))),
+	}
+	if query.Sort == "" {
+		query.Sort = "priority"
+	}
+	if query.Order == "" {
+		query.Order = "asc"
+	}
+	validSort := map[string]bool{"priority": true, "created": true, "updated": true, "identifier": true, "workflow_state": true}
+	if !validSort[query.Sort] {
+		return workItemListQuery{}, errors.New("sort must be priority, created, updated, identifier, or workflow_state")
+	}
+	if query.Order != "asc" && query.Order != "desc" {
+		return workItemListQuery{}, errors.New("order must be asc or desc")
+	}
+	var err error
+	query.Limit, err = parsePageLimit(c.QueryParam("limit"))
+	if err != nil {
+		return workItemListQuery{}, errors.New("limit must be between 1 and 200")
+	}
+	query.Cursor, err = decodeWorkItemCursor(c.QueryParam("cursor"))
+	if err != nil {
+		return workItemListQuery{}, errors.New("cursor is invalid")
+	}
+	if query.Cursor.Version != 0 && (query.Cursor.Sort != query.Sort || query.Cursor.Order != query.Order) {
+		return workItemListQuery{}, errors.New("cursor does not match sort and order")
+	}
+	validFilters := []struct {
+		values map[string]struct{}
+		valid  map[string]bool
+		name   string
+	}{
+		{query.Readiness, map[string]bool{"ready": true, "waiting": true}, "readiness"},
+		{query.Priorities, map[string]bool{"urgent": true, "high": true, "normal": true, "low": true, "unset": true}, "priority"},
+		{query.Leases, map[string]bool{"active": true, "unclaimed": true}, "lease"},
+		{query.PullRequests, map[string]bool{"linked": true, "unlinked": true, "open": true, "closed": true, "merged": true}, "pr"},
+		{query.SyncHealth, map[string]bool{"synced": true, "pending": true, "retrying": true, "error": true, "stale": true}, "sync_health"},
+	}
+	for _, filter := range validFilters {
+		for value := range filter.values {
+			if !filter.valid[value] {
+				return workItemListQuery{}, fmt.Errorf("%s filter value %q is invalid", filter.name, value)
+			}
+		}
+	}
+	return query, nil
+}
+
+func parsePageLimit(value string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultAPIPageLimit, nil
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit < 1 || limit > maxAPIPageLimit {
+		return 0, errors.New("page limit is invalid")
+	}
+	return limit, nil
+}
+
+func querySet(c echo.Context, name string) map[string]struct{} {
+	result := map[string]struct{}{}
+	for _, value := range c.QueryParams()[name] {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.ToLower(strings.TrimSpace(part))
+			if part != "" {
+				result[part] = struct{}{}
+			}
+		}
+	}
+	return result
+}
+
+func filterWorkItems(items []tracker.WorkItem, query workItemListQuery) []tracker.WorkItem {
+	result := make([]tracker.WorkItem, 0, len(items))
+	for _, item := range items {
+		if !workItemMatches(item, query) {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func workItemMatches(item tracker.WorkItem, query workItemListQuery) bool {
+	repository := strings.ToLower(item.Repository.Owner + "/" + item.Repository.Name)
+	if !matchesAny(query.Repositories, repository, strconv.FormatInt(int64(item.Repository.ID), 10)) {
+		return false
+	}
+	workflow := ""
+	if item.WorkflowState != nil {
+		workflow = strings.ToLower(item.WorkflowState.Name)
+	}
+	workflowSource := ""
+	if item.WorkflowState != nil {
+		workflowSource = strings.ToLower(item.WorkflowState.SourceName)
+	}
+	if !matchesAny(query.WorkflowState, workflow, workflowSource) {
+		return false
+	}
+	readiness := "waiting"
+	if item.Dispatchability.Dispatchable {
+		readiness = "ready"
+	}
+	if !matchesAny(query.Readiness, readiness) || !matchesAny(query.Priorities, workItemPriority(item)) {
+		return false
+	}
+	if !matchesCollection(query.Labels, item.Labels) || !matchesCollection(query.Assignees, item.Assignees) {
+		return false
+	}
+	machine := ""
+	lease := "unclaimed"
+	if item.ActiveLease != nil {
+		machine = strings.ToLower(string(item.ActiveLease.Machine.ID))
+		lease = "active"
+	}
+	machineHostname := ""
+	machineDisplayName := ""
+	if item.ActiveLease != nil {
+		machineHostname = strings.ToLower(item.ActiveLease.Machine.Hostname)
+		machineDisplayName = strings.ToLower(item.ActiveLease.Machine.DisplayName)
+	}
+	if !matchesAny(query.Machines, machine, machineHostname, machineDisplayName) || !matchesAny(query.Leases, lease) {
+		return false
+	}
+	if !matchesPullRequest(query.PullRequests, item.PullRequests) {
+		return false
+	}
+	return matchesAny(query.SyncHealth, strings.ToLower(string(item.SyncStatus)))
+}
+
+func matchesAny(filter map[string]struct{}, values ...string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for _, value := range values {
+		if _, ok := filter[strings.ToLower(strings.TrimSpace(value))]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesCollection(filter map[string]struct{}, values []string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for _, value := range values {
+		if _, ok := filter[strings.ToLower(strings.TrimSpace(value))]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesPullRequest(filter map[string]struct{}, pullRequests []tracker.PullRequestSummary) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	if len(pullRequests) == 0 {
+		_, ok := filter["unlinked"]
+		return ok
+	}
+	if _, ok := filter["linked"]; ok {
+		return true
+	}
+	for _, pullRequest := range pullRequests {
+		state := strings.ToLower(strings.TrimSpace(pullRequest.State))
+		if _, ok := filter[state]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func workItemPriority(item tracker.WorkItem) string {
+	if item.Queue == nil || item.Queue.PriorityRank == nil {
+		return "unset"
+	}
+	switch *item.Queue.PriorityRank {
+	case tracker.QueuePriorityUrgent:
+		return "urgent"
+	case tracker.QueuePriorityHigh:
+		return "high"
+	case tracker.QueuePriorityNormal:
+		return "normal"
+	case tracker.QueuePriorityLow:
+		return "low"
+	default:
+		return "unset"
+	}
+}
+
+func sortWorkItems(items []tracker.WorkItem, sortName string, order string) {
+	sort.SliceStable(items, func(i int, j int) bool {
+		comparison := compareStringSlices(workItemSortValues(items[i], sortName), workItemSortValues(items[j], sortName))
+		if order == "desc" {
+			return comparison > 0
+		}
+		return comparison < 0
+	})
+}
+
+func workItemSortValues(item tracker.WorkItem, sortName string) []string {
+	identifier := []string{
+		strings.ToLower(item.Repository.Owner),
+		strings.ToLower(item.Repository.Name),
+		fmt.Sprintf("%020d", item.GitHub.Number),
+		fmt.Sprintf("%020d", item.ID),
+	}
+	switch sortName {
+	case "created":
+		return append([]string{sortableTime(item.CreatedAt)}, identifier...)
+	case "updated":
+		return append([]string{sortableTime(item.UpdatedAt)}, identifier...)
+	case "identifier":
+		return identifier
+	case "workflow_state":
+		workflow := ""
+		if item.WorkflowState != nil {
+			workflow = strings.ToLower(item.WorkflowState.Name)
+		}
+		return append([]string{workflow}, identifier...)
+	default:
+		priority := 4
+		rankMissing := 1
+		rank := ""
+		if item.Queue != nil {
+			rank = strings.TrimSpace(item.Queue.Rank)
+			if rank != "" {
+				rankMissing = 0
+			}
+			if item.Queue.PriorityRank != nil && *item.Queue.PriorityRank >= tracker.QueuePriorityUrgent && *item.Queue.PriorityRank <= tracker.QueuePriorityLow {
+				priority = *item.Queue.PriorityRank
+			}
+		}
+		created := sortableTime(item.CreatedAt)
+		return append([]string{strconv.Itoa(priority), strconv.Itoa(rankMissing), rank, created}, identifier...)
+	}
+}
+
+func sortableTime(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func compareStringSlices(left []string, right []string) int {
+	length := len(left)
+	if len(right) < length {
+		length = len(right)
+	}
+	for index := range length {
+		if left[index] < right[index] {
+			return -1
+		}
+		if left[index] > right[index] {
+			return 1
+		}
+	}
+	if len(left) < len(right) {
+		return -1
+	}
+	if len(left) > len(right) {
+		return 1
+	}
+	return 0
+}
+
+func workItemsAfterCursor(items []tracker.WorkItem, query workItemListQuery) []tracker.WorkItem {
+	if query.Cursor.Version == 0 {
+		return items
+	}
+	for index, item := range items {
+		comparison := compareStringSlices(workItemSortValues(item, query.Sort), query.Cursor.Values)
+		if query.Order == "desc" {
+			comparison = -comparison
+		}
+		if comparison > 0 {
+			return items[index:]
+		}
+	}
+	return []tracker.WorkItem{}
+}
+
+func encodeWorkItemCursor(cursor workItemCursor) (string, error) {
+	value, err := json.Marshal(cursor)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func decodeWorkItemCursor(value string) (workItemCursor, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return workItemCursor{}, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return workItemCursor{}, err
+	}
+	var cursor workItemCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil || cursor.Version != 1 || cursor.Sort == "" || cursor.Order == "" || len(cursor.Values) == 0 {
+		return workItemCursor{}, errors.New("invalid work item cursor")
+	}
+	return cursor, nil
+}
+
+func encodeTimelineCursor(cursor timelineCursor) (string, error) {
+	value, err := json.Marshal(cursor)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func decodeTimelineCursor(value string) (timelineCursor, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return timelineCursor{}, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return timelineCursor{}, err
+	}
+	var cursor timelineCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil || cursor.Version != 1 || cursor.ID <= 0 {
+		return timelineCursor{}, errors.New("invalid timeline cursor")
+	}
+	return cursor, nil
+}
+
+func (d *database) latestWorkpad(ctx context.Context, id tracker.WorkItemID) (workpadProjection, bool, error) {
+	var desiredJSON string
+	var status string
+	var updatedAt string
+	err := d.db.QueryRowContext(ctx, `
+SELECT desired_json, status, updated_at
+FROM github_outbox
+WHERE issue_id = ? AND mutation_kind = ?
+ORDER BY id DESC
+LIMIT 1`, id, MutationWorkpad).Scan(&desiredJSON, &status, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return workpadProjection{}, false, nil
+	}
+	if err != nil {
+		return workpadProjection{}, false, fmt.Errorf("query hub workpad: %w", err)
+	}
+	var desired WorkpadDesired
+	if err := json.Unmarshal([]byte(desiredJSON), &desired); err != nil {
+		return workpadProjection{}, false, fmt.Errorf("decode hub workpad: %w", err)
+	}
+	parsed, err := parseTimeValue(updatedAt)
+	if err != nil {
+		return workpadProjection{}, false, fmt.Errorf("decode hub workpad timestamp: %w", err)
+	}
+	return workpadProjection{Phase: desired.Phase, Body: desired.Body, SyncState: status, UpdatedAt: parsed}, true, nil
+}
+
+func (d *database) workItemTimeline(ctx context.Context, id tracker.WorkItemID, afterID int64, limit int) ([]timelineEvent, error) {
+	rows, err := d.db.QueryContext(ctx, `
+SELECT id, fencing_token, machine_id, session_id, run_id, kind, payload_json, occurred_at, recorded_at
+FROM work_events
+WHERE issue_id = ? AND id > ?
+ORDER BY id
+LIMIT ?`, id, afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query hub work item timeline: %w", err)
+	}
+	defer rows.Close()
+	events := make([]timelineEvent, 0)
+	for rows.Next() {
+		var event timelineEvent
+		var fencingToken sql.NullInt64
+		var machineID sql.NullString
+		var sessionID sql.NullString
+		var runID sql.NullString
+		var payloadJSON string
+		var occurredAt string
+		var recordedAt string
+		if err := rows.Scan(&event.ID, &fencingToken, &machineID, &sessionID, &runID, &event.Kind, &payloadJSON, &occurredAt, &recordedAt); err != nil {
+			return nil, fmt.Errorf("scan hub work item timeline: %w", err)
+		}
+		event.WorkItemID = id
+		if fencingToken.Valid {
+			event.FencingToken = tracker.FencingToken(fencingToken.Int64)
+		}
+		if machineID.Valid {
+			event.MachineID = tracker.MachineID(machineID.String)
+		}
+		event.SessionID = sessionID.String
+		event.RunID = runID.String
+		if err := json.Unmarshal([]byte(payloadJSON), &event.Payload); err != nil {
+			return nil, fmt.Errorf("decode hub timeline event payload: %w", err)
+		}
+		var err error
+		event.OccurredAt, err = parseTimeValue(occurredAt)
+		if err != nil {
+			return nil, fmt.Errorf("decode hub timeline event occurrence: %w", err)
+		}
+		event.RecordedAt, err = parseTimeValue(recordedAt)
+		if err != nil {
+			return nil, fmt.Errorf("decode hub timeline event recording: %w", err)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate hub work item timeline: %w", err)
+	}
+	return events, nil
+}

--- a/internal/hubserver/api_worker.go
+++ b/internal/hubserver/api_worker.go
@@ -92,7 +92,7 @@ func (s *Service) claimWorkItem(c echo.Context) error {
 		RepositoryIDs:  request.RepositoryIDs,
 		WorkflowStates: request.WorkflowState,
 		Scope:          request.Scope,
-	})
+	}, s.config.ReconcileInterval)
 	if err != nil {
 		return trackerAPIError(c, err)
 	}
@@ -181,7 +181,7 @@ func trackerAPIError(c echo.Context, err error) error {
 	return c.JSON(status, apiErrorResponse{Code: code, Message: message})
 }
 
-func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, query tracker.CandidateQuery) (lease tracker.Lease, resultErr error) {
+func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, query tracker.CandidateQuery, reconcileInterval time.Duration) (lease tracker.Lease, resultErr error) {
 	request.MachineID = tracker.MachineID(strings.TrimSpace(string(request.MachineID)))
 	request.SessionID = strings.TrimSpace(request.SessionID)
 	query.Scope = strings.TrimSpace(query.Scope)
@@ -215,6 +215,9 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 		if existing.session.Machine.ID != request.MachineID || !existing.session.ExpiresAt.After(now) {
 			return tracker.Lease{}, fmt.Errorf("%w: session is no longer claimable", tracker.ErrLeaseConflict)
 		}
+		if request.WorkItemID > 0 && existing.issueID != request.WorkItemID {
+			return tracker.Lease{}, fmt.Errorf("%w: session is already assigned to work item %d", tracker.ErrLeaseConflict, existing.issueID)
+		}
 		if err := tx.Commit(); err != nil {
 			return tracker.Lease{}, fmt.Errorf("commit idempotent hub claim next: %w", err)
 		}
@@ -232,7 +235,17 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 	if capacity <= 0 {
 		return tracker.Lease{}, ErrNoClaimableWork
 	}
-	ids, err := claimCandidateIDs(ctx, tx, query.Scope, repositoryIDs, workflowStates)
+	freshness, err := queryRepositoryFreshness(ctx, tx, now, reconcileInterval)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	claimableRepositories := make(map[tracker.RepositoryID]struct{}, freshness.Summary.Fresh)
+	for _, repository := range freshness.Repositories {
+		if repository.Status == "fresh" {
+			claimableRepositories[tracker.RepositoryID(repository.ID)] = struct{}{}
+		}
+	}
+	ids, err := claimCandidateIDs(ctx, tx, query.Scope, repositoryIDs, workflowStates, claimableRepositories)
 	if err != nil {
 		return tracker.Lease{}, err
 	}
@@ -305,7 +318,7 @@ func machineClaimCapacity(ctx context.Context, tx *sql.Tx, machineID tracker.Mac
 	return capacity - active, nil
 }
 
-func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repositoryIDs []tracker.RepositoryID, workflowStates []string) ([]tracker.WorkItemID, error) {
+func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repositoryIDs []tracker.RepositoryID, workflowStates []string, claimableRepositories map[tracker.RepositoryID]struct{}) ([]tracker.WorkItemID, error) {
 	repositoryFilter := make(map[tracker.RepositoryID]struct{}, len(repositoryIDs))
 	for _, id := range repositoryIDs {
 		repositoryFilter[id] = struct{}{}
@@ -356,6 +369,9 @@ ORDER BY
 		var workflowState string
 		if err := rows.Scan(&id, &repositoryID, &workflowState); err != nil {
 			return nil, fmt.Errorf("scan hub claim candidate: %w", err)
+		}
+		if _, ok := claimableRepositories[repositoryID]; !ok {
+			continue
 		}
 		if len(repositoryFilter) > 0 {
 			if _, ok := repositoryFilter[repositoryID]; !ok {

--- a/internal/hubserver/api_worker.go
+++ b/internal/hubserver/api_worker.go
@@ -1,0 +1,516 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+var ErrNoClaimableWork = errors.New("no compatible work item is claimable")
+
+type claimAPIRequest struct {
+	WorkItemID    tracker.WorkItemID     `json:"work_item_id,omitempty"`
+	MachineID     tracker.MachineID      `json:"machine_id"`
+	SessionID     string                 `json:"session_id"`
+	TTLSeconds    int64                  `json:"ttl_seconds"`
+	RepositoryIDs []tracker.RepositoryID `json:"repository_ids,omitempty"`
+	WorkflowState []string               `json:"workflow_states,omitempty"`
+	Scope         string                 `json:"scope,omitempty"`
+}
+
+type renewLeaseAPIRequest struct {
+	FencingToken tracker.FencingToken `json:"fencing_token"`
+	TTLSeconds   int64                `json:"ttl_seconds"`
+}
+
+type releaseLeaseAPIRequest struct {
+	FencingToken tracker.FencingToken `json:"fencing_token"`
+	Reason       string               `json:"reason,omitempty"`
+}
+
+type workEventAPIRequest struct {
+	FencingToken tracker.FencingToken `json:"fencing_token"`
+	MachineID    tracker.MachineID    `json:"machine_id,omitempty"`
+	SessionID    string               `json:"session_id,omitempty"`
+	RunID        string               `json:"run_id,omitempty"`
+	Kind         string               `json:"kind"`
+	Payload      map[string]any       `json:"payload,omitempty"`
+	OccurredAt   time.Time            `json:"occurred_at,omitempty"`
+}
+
+type machineRequest struct {
+	ID           tracker.MachineID `json:"id"`
+	Hostname     string            `json:"hostname"`
+	DisplayName  string            `json:"display_name,omitempty"`
+	Capabilities map[string]any    `json:"capabilities,omitempty"`
+	Capacity     int               `json:"capacity"`
+	Version      string            `json:"version"`
+}
+
+type machineHeartbeatRequest struct {
+	DisplayName  *string         `json:"display_name,omitempty"`
+	Capabilities *map[string]any `json:"capabilities,omitempty"`
+	Capacity     *int            `json:"capacity,omitempty"`
+	Version      *string         `json:"version,omitempty"`
+}
+
+type machineResponse struct {
+	ID              tracker.MachineID `json:"id"`
+	Hostname        string            `json:"hostname"`
+	DisplayName     string            `json:"display_name"`
+	Capabilities    map[string]any    `json:"capabilities"`
+	Capacity        int               `json:"capacity"`
+	Version         string            `json:"version"`
+	LastHeartbeatAt time.Time         `json:"last_heartbeat_at"`
+	RegisteredAt    time.Time         `json:"registered_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+}
+
+func (s *Service) claimWorkItem(c echo.Context) error {
+	var request claimAPIRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	if request.WorkItemID < 0 {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_claim", Message: "work_item_id must be positive when supplied"})
+	}
+	ttl, err := apiTTL(request.TTLSeconds)
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_claim", Message: err.Error()})
+	}
+	claim := tracker.ClaimRequest{WorkItemID: request.WorkItemID, MachineID: request.MachineID, SessionID: request.SessionID, TTL: ttl}
+	lease, err := s.database.claimNext(c.Request().Context(), claim, tracker.CandidateQuery{
+		RepositoryIDs:  request.RepositoryIDs,
+		WorkflowStates: request.WorkflowState,
+		Scope:          request.Scope,
+	})
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	return c.JSON(http.StatusCreated, lease)
+}
+
+func (s *Service) renewLease(c echo.Context) error {
+	leaseID, err := apiLeaseID(c)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	var request renewLeaseAPIRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	ttl, err := apiTTL(request.TTLSeconds)
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_lease", Message: err.Error()})
+	}
+	lease, err := s.tracker.Renew(c.Request().Context(), tracker.RenewRequest{LeaseID: leaseID, FencingToken: request.FencingToken, TTL: ttl})
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	return c.JSON(http.StatusOK, lease)
+}
+
+func (s *Service) releaseLease(c echo.Context) error {
+	leaseID, err := apiLeaseID(c)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	var request releaseLeaseAPIRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	err = s.tracker.Release(c.Request().Context(), tracker.ReleaseRequest{LeaseID: leaseID, FencingToken: request.FencingToken, Reason: request.Reason})
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (s *Service) appendWorkItemEvent(c echo.Context) error {
+	id, err := apiWorkItemID(c)
+	if err != nil {
+		return trackerAPIError(c, err)
+	}
+	var request workEventAPIRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	event := tracker.WorkEvent{
+		WorkItemID: id, FencingToken: request.FencingToken, MachineID: request.MachineID,
+		SessionID: request.SessionID, RunID: request.RunID, Kind: request.Kind,
+		Payload: request.Payload, OccurredAt: request.OccurredAt,
+	}
+	if event.OccurredAt.IsZero() {
+		event.OccurredAt = s.config.now().UTC()
+	}
+	if err := s.tracker.AppendEvent(c.Request().Context(), event); err != nil {
+		return trackerAPIError(c, err)
+	}
+	return c.JSON(http.StatusCreated, event)
+}
+
+func trackerAPIError(c echo.Context, err error) error {
+	status := http.StatusInternalServerError
+	code := "hub_operation_failed"
+	message := "Hub operation failed"
+	switch {
+	case errors.Is(err, ErrNoClaimableWork):
+		status, code, message = http.StatusConflict, "no_claimable_work", "No compatible work item is claimable"
+	case errors.Is(err, tracker.ErrWorkItemNotFound), errors.Is(err, tracker.ErrInvalidWorkItemID):
+		status, code, message = http.StatusNotFound, "work_item_not_found", "Work item was not found"
+	case errors.Is(err, tracker.ErrMachineNotFound):
+		status, code, message = http.StatusNotFound, "machine_not_found", "Machine was not found"
+	case errors.Is(err, tracker.ErrLeaseNotFound):
+		status, code, message = http.StatusNotFound, "lease_not_found", "Lease was not found"
+	case errors.Is(err, tracker.ErrLeaseConflict):
+		status, code, message = http.StatusConflict, "lease_conflict", "Work item is already leased"
+	case errors.Is(err, tracker.ErrStaleFencingToken):
+		status, code, message = http.StatusConflict, "stale_fencing_token", "Lease fencing token is stale"
+	case errors.Is(err, tracker.ErrInvalidClaimRequest), errors.Is(err, tracker.ErrInvalidLeaseRequest), errors.Is(err, tracker.ErrInvalidWorkEvent), errors.Is(err, tracker.ErrInvalidCandidateQuery):
+		status, code, message = http.StatusUnprocessableEntity, "invalid_request", "Request is invalid"
+	}
+	return c.JSON(status, apiErrorResponse{Code: code, Message: message})
+}
+
+func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, query tracker.CandidateQuery) (lease tracker.Lease, resultErr error) {
+	request.MachineID = tracker.MachineID(strings.TrimSpace(string(request.MachineID)))
+	request.SessionID = strings.TrimSpace(request.SessionID)
+	query.Scope = strings.TrimSpace(query.Scope)
+	if request.MachineID == "" || request.SessionID == "" || request.TTL <= 0 {
+		return tracker.Lease{}, tracker.ErrInvalidClaimRequest
+	}
+	repositoryIDs, err := normalizedRepositoryIDs(query.RepositoryIDs)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	workflowStates := normalizedQueryStrings(query.WorkflowStates)
+	if len(query.WorkflowStates) > 0 && len(workflowStates) == 0 {
+		return tracker.Lease{}, tracker.ErrInvalidCandidateQuery
+	}
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return tracker.Lease{}, fmt.Errorf("begin hub claim next: %w", err)
+	}
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, tx.Rollback())
+		}
+	}()
+	now, err := d.currentTime()
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	if existing, found, err := readLeaseBySession(ctx, tx, request.SessionID); err != nil {
+		return tracker.Lease{}, err
+	} else if found {
+		if existing.session.Machine.ID != request.MachineID || !existing.session.ExpiresAt.After(now) {
+			return tracker.Lease{}, fmt.Errorf("%w: session is no longer claimable", tracker.ErrLeaseConflict)
+		}
+		if err := tx.Commit(); err != nil {
+			return tracker.Lease{}, fmt.Errorf("commit idempotent hub claim next: %w", err)
+		}
+		return leaseFromRecord(existing), nil
+	}
+	if request.WorkItemID > 0 {
+		if err := requireWorkItem(ctx, tx, request.WorkItemID); err != nil {
+			return tracker.Lease{}, err
+		}
+	}
+	capacity, err := machineClaimCapacity(ctx, tx, request.MachineID, now)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	if capacity <= 0 {
+		return tracker.Lease{}, ErrNoClaimableWork
+	}
+	ids, err := claimCandidateIDs(ctx, tx, query.Scope, repositoryIDs, workflowStates)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	for _, id := range ids {
+		if request.WorkItemID > 0 && id != request.WorkItemID {
+			continue
+		}
+		current, found, err := readUnreleasedLease(ctx, tx, id)
+		if err != nil {
+			return tracker.Lease{}, err
+		}
+		if found && current.session.ExpiresAt.After(now) {
+			if request.WorkItemID > 0 {
+				return tracker.Lease{}, fmt.Errorf("%w: work item %d is held by lease %s", tracker.ErrLeaseConflict, id, current.session.ID)
+			}
+			continue
+		}
+		request.WorkItemID = id
+		lease, err = d.claimInTransaction(ctx, tx, request, now)
+		if err != nil {
+			return tracker.Lease{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return tracker.Lease{}, fmt.Errorf("commit hub claim next: %w", err)
+		}
+		return lease, nil
+	}
+	return tracker.Lease{}, ErrNoClaimableWork
+}
+
+func readLeaseBySession(ctx context.Context, tx *sql.Tx, sessionID string) (leaseRecord, bool, error) {
+	return scanLeaseRecord(tx.QueryRowContext(ctx, `
+SELECT l.issue_id, l.lease_id, l.fencing_token, l.machine_id, m.hostname, m.display_name,
+       l.session_id, l.acquired_at, l.renewed_at, l.expires_at, l.released_at
+FROM leases l
+JOIN machines m ON m.id = l.machine_id
+WHERE l.session_id = ?`, sessionID))
+}
+
+func machineClaimCapacity(ctx context.Context, tx *sql.Tx, machineID tracker.MachineID, now time.Time) (int, error) {
+	var capacity int
+	if err := tx.QueryRowContext(ctx, "SELECT capacity FROM machines WHERE id = ?", machineID).Scan(&capacity); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("%w: %s", tracker.ErrMachineNotFound, machineID)
+		}
+		return 0, fmt.Errorf("read hub machine capacity: %w", err)
+	}
+	rows, err := tx.QueryContext(ctx, "SELECT expires_at FROM leases WHERE machine_id = ? AND released_at IS NULL", machineID)
+	if err != nil {
+		return 0, fmt.Errorf("query hub machine leases: %w", err)
+	}
+	defer rows.Close()
+	active := 0
+	for rows.Next() {
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			return 0, fmt.Errorf("scan hub machine lease expiry: %w", err)
+		}
+		expiresAt, err := parseTimeValue(value)
+		if err != nil {
+			return 0, fmt.Errorf("parse hub machine lease expiry: %w", err)
+		}
+		if expiresAt.After(now) {
+			active++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate hub machine leases: %w", err)
+	}
+	return capacity - active, nil
+}
+
+func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repositoryIDs []tracker.RepositoryID, workflowStates []string) ([]tracker.WorkItemID, error) {
+	repositoryFilter := make(map[tracker.RepositoryID]struct{}, len(repositoryIDs))
+	for _, id := range repositoryIDs {
+		repositoryFilter[id] = struct{}{}
+	}
+	workflowFilter := make(map[string]struct{}, len(workflowStates))
+	for _, state := range workflowStates {
+		workflowFilter[state] = struct{}{}
+	}
+	rows, err := tx.QueryContext(ctx, `
+SELECT i.id, r.id, lower(trim(ws.detent_state))
+FROM issues i
+JOIN repositories r ON r.id = i.repository_id
+LEFT JOIN workflow_states ws ON ws.id = i.workflow_state_id
+LEFT JOIN queue_entries q ON q.id = (
+  SELECT candidate.id
+  FROM queue_entries candidate
+  WHERE candidate.issue_id = i.id
+    AND (? = '' OR candidate.scope = ?)
+  ORDER BY CASE WHEN candidate.scope = ? THEN 0 ELSE 1 END, candidate.scope, candidate.id
+  LIMIT 1
+)
+WHERE lower(trim(i.github_state)) = 'open'
+  AND ws.id IS NOT NULL
+  AND ws.terminal = 0
+  AND lower(trim(ws.detent_state)) <> 'cancelled'
+  AND ws.dispatchable = 1
+  AND (? = '' OR q.id IS NOT NULL)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM issue_dependencies dependency
+    JOIN issues blocker ON blocker.id = dependency.blocker_issue_id
+    LEFT JOIN workflow_states blocker_state ON blocker_state.id = blocker.workflow_state_id
+    WHERE dependency.dependent_issue_id = i.id
+      AND (blocker_state.id IS NULL OR blocker_state.terminal = 0)
+  )
+ORDER BY
+  CASE q.priority_override WHEN 0 THEN 0 WHEN 1 THEN 1 WHEN 2 THEN 2 WHEN 3 THEN 3 ELSE 4 END,
+  CASE WHEN q.rank IS NULL OR trim(q.rank) = '' THEN 1 ELSE 0 END,
+  trim(q.rank), i.created_at, lower(trim(r.github_owner)), lower(trim(r.github_name)), i.github_number, i.id`, scope, scope, scope, scope)
+	if err != nil {
+		return nil, fmt.Errorf("query hub claim candidates: %w", err)
+	}
+	defer rows.Close()
+	var ids []tracker.WorkItemID
+	for rows.Next() {
+		var id tracker.WorkItemID
+		var repositoryID tracker.RepositoryID
+		var workflowState string
+		if err := rows.Scan(&id, &repositoryID, &workflowState); err != nil {
+			return nil, fmt.Errorf("scan hub claim candidate: %w", err)
+		}
+		if len(repositoryFilter) > 0 {
+			if _, ok := repositoryFilter[repositoryID]; !ok {
+				continue
+			}
+		}
+		if len(workflowFilter) > 0 {
+			if _, ok := workflowFilter[workflowState]; !ok {
+				continue
+			}
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate hub claim candidates: %w", err)
+	}
+	return ids, nil
+}
+
+func (s *Service) registerMachine(c echo.Context) error {
+	var request machineRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	request.ID = tracker.MachineID(strings.TrimSpace(string(request.ID)))
+	request.Hostname = strings.TrimSpace(request.Hostname)
+	request.DisplayName = strings.TrimSpace(request.DisplayName)
+	request.Version = strings.TrimSpace(request.Version)
+	if request.ID == "" || request.Hostname == "" || request.Version == "" || request.Capacity < 0 {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_machine", Message: "Machine ID, hostname, version, and non-negative capacity are required"})
+	}
+	capabilities, err := json.Marshal(request.Capabilities)
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_machine", Message: "Machine capabilities are invalid"})
+	}
+	if string(capabilities) == "null" {
+		capabilities = []byte("{}")
+	}
+	now, err := s.database.currentTime()
+	if err != nil {
+		return s.internalAPIError(c, "machine_register_failed", "Machine could not be registered", err)
+	}
+	_, err = s.database.db.ExecContext(c.Request().Context(), `
+INSERT INTO machines (id, hostname, display_name, capabilities_json, capacity, version, last_heartbeat_at, registered_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  hostname = excluded.hostname,
+  display_name = excluded.display_name,
+  capabilities_json = excluded.capabilities_json,
+  capacity = excluded.capacity,
+  version = excluded.version,
+  last_heartbeat_at = excluded.last_heartbeat_at,
+  updated_at = excluded.updated_at`,
+		request.ID, request.Hostname, request.DisplayName, string(capabilities), request.Capacity, request.Version,
+		formatHubTime(now), formatHubTime(now), formatHubTime(now),
+	)
+	if err != nil {
+		return s.internalAPIError(c, "machine_register_failed", "Machine could not be registered", err)
+	}
+	response, err := s.database.machine(c.Request().Context(), request.ID)
+	if err != nil {
+		return s.internalAPIError(c, "machine_register_failed", "Machine could not be registered", err)
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (s *Service) heartbeatMachine(c echo.Context) error {
+	id := tracker.MachineID(strings.TrimSpace(c.Param("id")))
+	if id == "" {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "machine_not_found", Message: "Machine was not found"})
+	}
+	var request machineHeartbeatRequest
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	if request.Capacity != nil && *request.Capacity < 0 {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_machine", Message: "Machine capacity must be non-negative"})
+	}
+	current, err := s.database.machine(c.Request().Context(), id)
+	if errors.Is(err, tracker.ErrMachineNotFound) {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "machine_not_found", Message: "Machine was not found"})
+	}
+	if err != nil {
+		return s.internalAPIError(c, "machine_heartbeat_failed", "Machine heartbeat could not be recorded", err)
+	}
+	if request.DisplayName != nil {
+		current.DisplayName = strings.TrimSpace(*request.DisplayName)
+	}
+	if request.Capabilities != nil {
+		current.Capabilities = *request.Capabilities
+	}
+	if request.Capacity != nil {
+		current.Capacity = *request.Capacity
+	}
+	if request.Version != nil {
+		current.Version = strings.TrimSpace(*request.Version)
+		if current.Version == "" {
+			return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_machine", Message: "Machine version must not be empty"})
+		}
+	}
+	capabilities, err := json.Marshal(current.Capabilities)
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_machine", Message: "Machine capabilities are invalid"})
+	}
+	now, err := s.database.currentTime()
+	if err != nil {
+		return s.internalAPIError(c, "machine_heartbeat_failed", "Machine heartbeat could not be recorded", err)
+	}
+	result, err := s.database.db.ExecContext(c.Request().Context(), `
+UPDATE machines
+SET display_name = ?, capabilities_json = ?, capacity = ?, version = ?, last_heartbeat_at = ?, updated_at = ?
+WHERE id = ?`, current.DisplayName, string(capabilities), current.Capacity, current.Version, formatHubTime(now), formatHubTime(now), id)
+	if err != nil {
+		return s.internalAPIError(c, "machine_heartbeat_failed", "Machine heartbeat could not be recorded", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil || rows != 1 {
+		return c.JSON(http.StatusNotFound, apiErrorResponse{Code: "machine_not_found", Message: "Machine was not found"})
+	}
+	current.LastHeartbeatAt = now
+	current.UpdatedAt = now
+	return c.JSON(http.StatusOK, current)
+}
+
+func (d *database) machine(ctx context.Context, id tracker.MachineID) (machineResponse, error) {
+	var response machineResponse
+	var capabilitiesJSON string
+	var heartbeatAt string
+	var registeredAt string
+	var updatedAt string
+	err := d.db.QueryRowContext(ctx, `
+SELECT id, hostname, display_name, capabilities_json, capacity, version, last_heartbeat_at, registered_at, updated_at
+FROM machines WHERE id = ?`, id).Scan(
+		&response.ID, &response.Hostname, &response.DisplayName, &capabilitiesJSON, &response.Capacity,
+		&response.Version, &heartbeatAt, &registeredAt, &updatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return machineResponse{}, fmt.Errorf("%w: %s", tracker.ErrMachineNotFound, id)
+	}
+	if err != nil {
+		return machineResponse{}, fmt.Errorf("read hub machine: %w", err)
+	}
+	if err := json.Unmarshal([]byte(capabilitiesJSON), &response.Capabilities); err != nil {
+		return machineResponse{}, fmt.Errorf("decode hub machine capabilities: %w", err)
+	}
+	var parseErr error
+	response.LastHeartbeatAt, parseErr = parseTimeValue(heartbeatAt)
+	if parseErr == nil {
+		response.RegisteredAt, parseErr = parseTimeValue(registeredAt)
+	}
+	if parseErr == nil {
+		response.UpdatedAt, parseErr = parseTimeValue(updatedAt)
+	}
+	if parseErr != nil {
+		return machineResponse{}, fmt.Errorf("decode hub machine timestamp: %w", parseErr)
+	}
+	return response, nil
+}

--- a/internal/hubserver/config.go
+++ b/internal/hubserver/config.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/digitaldrywood/detent/internal/apikey"
 )
 
 const (
@@ -27,6 +29,7 @@ var (
 	ErrBackupSource            = errors.New("hub backup destination matches the source database")
 	ErrDatabaseIdentity        = errors.New("database is not a Detent Hub database")
 	ErrInvalidClock            = errors.New("hub clock returned a zero time")
+	ErrInsecureListener        = errors.New("non-loopback hub listener requires TLS or a trusted reverse proxy")
 	ErrNetworkFilesystem       = errors.New("hub database requires a local filesystem")
 	ErrNotReady                = errors.New("hub service is not ready")
 	ErrOutboxDisabled          = errors.New("hub github outbox is disabled")
@@ -37,6 +40,10 @@ var (
 type Config struct {
 	DatabasePath               string
 	ListenAddress              string
+	TLSCertFile                string
+	TLSKeyFile                 string
+	TrustedProxy               bool
+	InitialAdminToken          []byte
 	BusyTimeout                time.Duration
 	ShutdownTimeout            time.Duration
 	GitHubWebhookSecret        []byte
@@ -58,6 +65,8 @@ type Config struct {
 	now                        func() time.Time
 	jitter                     func() float64
 	newLeaseID                 func() string
+	newTokenID                 func() string
+	generateToken              func() (string, error)
 }
 
 func (c Config) normalized() Config {
@@ -115,6 +124,13 @@ func (c Config) normalized() Config {
 	if c.newLeaseID == nil {
 		c.newLeaseID = uuid.NewString
 	}
+	if c.newTokenID == nil {
+		c.newTokenID = uuid.NewString
+	}
+	if c.generateToken == nil {
+		c.generateToken = apikey.GenerateToken
+	}
 	c.GitHubWebhookSecret = append([]byte(nil), c.GitHubWebhookSecret...)
+	c.InitialAdminToken = append([]byte(nil), c.InitialAdminToken...)
 	return c
 }

--- a/internal/hubserver/database_test.go
+++ b/internal/hubserver/database_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +25,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/instancelock"
 )
 
-const testTimestamp = "2026-09-01T12:00:00Z"
+const (
+	testTimestamp     = "2026-09-01T12:00:00Z"
+	testHubAdminToken = "detent_test_hub_admin_token_00000000000000000000000000000000"
+)
 
 func TestOpenCreatesHubSchemaAndConfiguresSQLite(t *testing.T) {
 	t.Parallel()
@@ -53,6 +57,7 @@ func TestOpenCreatesHubSchemaAndConfiguresSQLite(t *testing.T) {
 	}
 
 	wantTables := []string{
+		"api_tokens",
 		"github_hydration_requests",
 		"github_outbox",
 		"github_webhook_inbox",
@@ -633,6 +638,9 @@ func TestBackupCancellationRemovesPartialDestination(t *testing.T) {
 func openTestService(t *testing.T, cfg Config) *Service {
 	t.Helper()
 	cfg.Logger = discardLogger()
+	if len(cfg.InitialAdminToken) == 0 {
+		cfg.InitialAdminToken = []byte(testHubAdminToken)
+	}
 	service, err := Open(t.Context(), cfg)
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
@@ -643,6 +651,10 @@ func openTestService(t *testing.T, cfg Config) *Service {
 		}
 	})
 	return service
+}
+
+func authorizeHubTestRequest(request *http.Request) {
+	request.Header.Set("Authorization", "Bearer "+testHubAdminToken)
 }
 
 func seedProjection(t *testing.T, db *sql.DB) (int64, int64) {

--- a/internal/hubserver/freshness.go
+++ b/internal/hubserver/freshness.go
@@ -48,6 +48,10 @@ type checkpointFreshness struct {
 	lastError      *SyncError
 }
 
+type freshnessQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
 func (s *Service) repositoryFreshness(c echo.Context) error {
 	result, err := s.database.repositoryFreshness(c.Request().Context(), s.config.now().UTC(), s.config.ReconcileInterval)
 	if err != nil {
@@ -90,7 +94,11 @@ func repositoryFreshnessSortValues(repository RepositoryFreshness) []string {
 }
 
 func (d *database) repositoryFreshness(ctx context.Context, now time.Time, reconcileInterval time.Duration) (repositoryFreshnessResponse, error) {
-	rows, err := d.db.QueryContext(ctx, `
+	return queryRepositoryFreshness(ctx, d.db, now, reconcileInterval)
+}
+
+func queryRepositoryFreshness(ctx context.Context, queryer freshnessQueryer, now time.Time, reconcileInterval time.Duration) (repositoryFreshnessResponse, error) {
+	rows, err := queryer.QueryContext(ctx, `
 		SELECT r.id, r.github_node_id, r.github_owner, r.github_name,
 			r.last_webhook_at, r.last_reconciled_at,
 			c.checkpoint_name, c.last_successful_at, c.last_error, c.state_json

--- a/internal/hubserver/freshness.go
+++ b/internal/hubserver/freshness.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -39,6 +40,7 @@ type RepositoryHealthSummary struct {
 type repositoryFreshnessResponse struct {
 	Repositories []RepositoryFreshness   `json:"repositories"`
 	Summary      RepositoryHealthSummary `json:"summary"`
+	NextCursor   string                  `json:"next_cursor,omitempty"`
 }
 
 type checkpointFreshness struct {
@@ -54,7 +56,37 @@ func (s *Service) repositoryFreshness(c echo.Context) error {
 			Message: "Repository freshness could not be read",
 		})
 	}
+	limit, err := parsePageLimit(c.QueryParam("limit"))
+	if err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_query", Message: "limit must be between 1 and 200"})
+	}
+	cursor, err := decodeWorkItemCursor(c.QueryParam("cursor"))
+	if err != nil || cursor.Version != 0 && (cursor.Sort != "repository" || cursor.Order != "asc") {
+		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_cursor", Message: "Repository cursor is invalid"})
+	}
+	if cursor.Version != 0 {
+		for index, repository := range result.Repositories {
+			if compareStringSlices(repositoryFreshnessSortValues(repository), cursor.Values) > 0 {
+				result.Repositories = result.Repositories[index:]
+				break
+			}
+			if index == len(result.Repositories)-1 {
+				result.Repositories = []RepositoryFreshness{}
+			}
+		}
+	}
+	if len(result.Repositories) > limit {
+		result.Repositories = result.Repositories[:limit]
+		result.NextCursor, err = encodeWorkItemCursor(workItemCursor{Version: 1, Sort: "repository", Order: "asc", Values: repositoryFreshnessSortValues(result.Repositories[len(result.Repositories)-1])})
+		if err != nil {
+			return s.internalAPIError(c, "freshness_unavailable", "Repository freshness could not be read", err)
+		}
+	}
 	return c.JSON(http.StatusOK, result)
+}
+
+func repositoryFreshnessSortValues(repository RepositoryFreshness) []string {
+	return []string{strings.ToLower(strings.TrimSpace(repository.Repository)), fmt.Sprintf("%020d", repository.ID)}
 }
 
 func (d *database) repositoryFreshness(ctx context.Context, now time.Time, reconcileInterval time.Duration) (repositoryFreshnessResponse, error) {

--- a/internal/hubserver/migrate.go
+++ b/internal/hubserver/migrate.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	hubSchemaTable         = "hub_schema_version"
-	supportedSchemaVersion = int64(5)
+	supportedSchemaVersion = int64(6)
 )
 
 //go:embed migrations/*.sql

--- a/internal/hubserver/migrations/00006_create_api_tokens.sql
+++ b/internal/hubserver/migrations/00006_create_api_tokens.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+CREATE TABLE api_tokens (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  token_hash TEXT NOT NULL UNIQUE CHECK (length(token_hash) = 64),
+  token_fingerprint TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('worker', 'operator', 'admin')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  last_used_at TEXT,
+  rotated_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE INDEX api_tokens_status_idx
+ON api_tokens(revoked_at, scope, id);

--- a/internal/hubserver/outbox.go
+++ b/internal/hubserver/outbox.go
@@ -195,7 +195,7 @@ func (m WorkflowLabelMutation) outboxRecord() (outboxRecord, error) {
 		issueID:        m.IssueID,
 		kind:           MutationWorkflowLabel,
 		desired:        desired,
-		coalesceKey:    fmt.Sprintf("workflow-label:%d:%d", m.RepositoryID, m.IssueID),
+		coalesceKey:    fmt.Sprintf("managed-label:%d:%d:%s", m.RepositoryID, m.IssueID, strings.ToLower(prefix)),
 	}
 	return record, record.validate()
 }

--- a/internal/hubserver/reconcile_test.go
+++ b/internal/hubserver/reconcile_test.go
@@ -265,6 +265,7 @@ func TestIncrementalReconcileUsesOldestCursorAndExposesFailures(t *testing.T) {
 	}
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/freshness", nil)
+	authorizeHubTestRequest(request)
 	response := httptest.NewRecorder()
 	service.Handler().ServeHTTP(response, request)
 	if response.Code != http.StatusOK {

--- a/internal/hubserver/service.go
+++ b/internal/hubserver/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -54,6 +55,10 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := database.ensureInitialAdminToken(ctx, cfg.InitialAdminToken); err != nil {
+		return nil, errors.Join(err, database.Close())
+	}
+	cfg.InitialAdminToken = nil
 	workTracker, err := tracker.NewStore(database)
 	if err != nil {
 		return nil, errors.Join(err, database.Close())
@@ -79,9 +84,7 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 	if cfg.OutboxBackend != nil {
 		service.outbox = newOutboxWorker(service)
 	}
-	e.GET("/health", service.health)
-	e.GET("/api/v1/repositories/freshness", service.repositoryFreshness)
-	e.POST("/api/v1/webhooks/github", service.githubWebhook)
+	service.registerRoutes(e)
 	service.maintainGitHubWebhooks(ctx)
 	go service.runGitHubWebhookMaintenance(workerContext)
 	go service.runGitHubReconciliation(reconcileContext)
@@ -101,6 +104,9 @@ func Run(ctx context.Context, cfg Config) (resultErr error) {
 		ctx = context.Background()
 	}
 	cfg = cfg.normalized()
+	if err := validateListenerSecurity(cfg); err != nil {
+		return err
+	}
 	service, err := Open(ctx, cfg)
 	if err != nil {
 		return err
@@ -118,6 +124,10 @@ func Run(ctx context.Context, cfg Config) (resultErr error) {
 
 	serveResult := make(chan error, 1)
 	go func() {
+		if cfg.TLSCertFile != "" {
+			serveResult <- service.ServeTLS(listener, cfg.TLSCertFile, cfg.TLSKeyFile)
+			return
+		}
 		serveResult <- service.Serve(listener)
 	}()
 
@@ -135,6 +145,31 @@ func Run(ctx context.Context, cfg Config) (resultErr error) {
 	}
 }
 
+func validateListenerSecurity(cfg Config) error {
+	certFile := strings.TrimSpace(cfg.TLSCertFile)
+	keyFile := strings.TrimSpace(cfg.TLSKeyFile)
+	if (certFile == "") != (keyFile == "") {
+		return errors.New("hub TLS certificate and key must be configured together")
+	}
+	if listenerAddressLoopback(cfg.ListenAddress) || certFile != "" || cfg.TrustedProxy {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrInsecureListener, cfg.ListenAddress)
+}
+
+func listenerAddressLoopback(address string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(address))
+	if err != nil {
+		return false
+	}
+	host = strings.Trim(strings.TrimSpace(host), "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
 func (s *Service) Handler() http.Handler {
 	return s.echo
 }
@@ -149,6 +184,20 @@ func (s *Service) Serve(listener net.Listener) error {
 	}
 	if err != nil {
 		return fmt.Errorf("serve hub requests: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) ServeTLS(listener net.Listener, certificateFile string, keyFile string) error {
+	if listener == nil {
+		return errors.New("hub listener is required")
+	}
+	err := s.echo.Server.ServeTLS(listener, strings.TrimSpace(certificateFile), strings.TrimSpace(keyFile))
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("serve TLS hub requests: %w", err)
 	}
 	return nil
 }

--- a/internal/hubserver/service_test.go
+++ b/internal/hubserver/service_test.go
@@ -52,7 +52,7 @@ func TestHealthEndpoint(t *testing.T) {
 		},
 		{
 			name:       "unregistered route",
-			path:       "/api/v1/work-items",
+			path:       "/api/v1/not-found",
 			ready:      true,
 			wantStatus: http.StatusNotFound,
 		},
@@ -61,6 +61,7 @@ func TestHealthEndpoint(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			service.ready.Store(test.ready)
 			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			authorizeHubTestRequest(request)
 			response := httptest.NewRecorder()
 			service.Handler().ServeHTTP(response, request)
 			if response.Code != test.wantStatus {
@@ -96,6 +97,7 @@ func TestHealthEndpointDegradesForStaleRepository(t *testing.T) {
 		t.Fatalf("insert stale repository: %v", err)
 	}
 	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	authorizeHubTestRequest(request)
 	response := httptest.NewRecorder()
 	service.Handler().ServeHTTP(response, request)
 	if response.Code != http.StatusOK {
@@ -129,6 +131,7 @@ func TestServeShutsDownGracefully(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequestWithContext() error = %v", err)
 	}
+	authorizeHubTestRequest(request)
 	response, err := client.Do(request)
 	if err != nil {
 		t.Fatalf("GET /health error = %v", err)

--- a/internal/hubserver/tracker_mutations.go
+++ b/internal/hubserver/tracker_mutations.go
@@ -35,7 +35,17 @@ func (d *database) Claim(ctx context.Context, request tracker.ClaimRequest) (lea
 	if err != nil {
 		return tracker.Lease{}, err
 	}
+	lease, err = d.claimInTransaction(ctx, tx, request, now)
+	if err != nil {
+		return tracker.Lease{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return tracker.Lease{}, fmt.Errorf("commit hub claim: %w", err)
+	}
+	return lease, nil
+}
 
+func (d *database) claimInTransaction(ctx context.Context, tx *sql.Tx, request tracker.ClaimRequest, now time.Time) (tracker.Lease, error) {
 	if err := requireWorkItem(ctx, tx, request.WorkItemID); err != nil {
 		return tracker.Lease{}, err
 	}
@@ -50,9 +60,6 @@ func (d *database) Claim(ctx context.Context, request tracker.ClaimRequest) (lea
 	}
 	if found && current.session.ExpiresAt.After(now) {
 		if current.session.Machine.ID == request.MachineID && current.session.SessionID == request.SessionID {
-			if err := tx.Commit(); err != nil {
-				return tracker.Lease{}, fmt.Errorf("commit idempotent hub claim: %w", err)
-			}
 			return leaseFromRecord(current), nil
 		}
 		return tracker.Lease{}, fmt.Errorf("%w: work item %d is held by lease %s", tracker.ErrLeaseConflict, request.WorkItemID, current.session.ID)
@@ -112,9 +119,6 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	}
 	if err := heartbeatMachine(ctx, tx, request.MachineID, now); err != nil {
 		return tracker.Lease{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return tracker.Lease{}, fmt.Errorf("commit hub claim: %w", err)
 	}
 	return tracker.Lease{
 		LeaseSummary: tracker.LeaseSummary{


### PR DESCRIPTION
## Summary

- expose the Hub through a versioned Echo API with scoped, hashed, rotatable bearer tokens
- add atomic claim-next, fenced lease, machine, work-item, mutation, sync-health, and outbox endpoints
- enforce loopback-by-default transport safety and document the API contract

Fixes #2074

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual operator-screen changes.

## Test Plan

- [x] `PATH="$TMPDIR/golangci-bin:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] `go test -race ./internal/hubserver`
- [x] concurrent claim-next regression test proves one winner