### PR TITLE
feat(hub): schedule machines against the Hub

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -41,6 +41,8 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 | API token | | `DETENT_API_TOKEN` | `api_token` | open on loopback, fail closed on non-loopback |
 | Loopback peer read trust | | | `trust_loopback_peer_read` | `false` |
 | Private dashboard URL | | | `dashboard_access` | disabled |
+| Hub scheduler | | | `client.hub_url` | disabled |
+| Hub worker token | | `DETENT_HUB_TOKEN` | `client.token_env` names the environment variable | required when Hub scheduling is enabled |
 | tmux window status | | `$TMUX` detection | `ops.tmux_window_status` | enabled inside tmux |
 | Web port | `--port` | `PORT` | `port` | `4000` |
 | Instance name | | | `instance_name` | short hostname |
@@ -90,6 +92,33 @@ from the first non-empty value in this order: top-level `instance_name` in
 single-project fallback mode without `global.yaml`, workflow top-level
 `identity.name` is used before the short hostname. Names are trimmed, must be a
 single line, and are capped at 40 characters in the web UI.
+
+Configure `client.hub_url` to move candidate discovery and claiming to a Detent
+Hub. The machine registers its identity, project and pool capabilities,
+capacity, operating system, architecture, and binary version. It then
+heartbeats while polling the Hub and renewing fenced work leases. The token is
+read from the environment variable named by `client.token_env`; the token is
+never stored in the configuration file.
+
+```yaml
+client:
+  hub_url: https://hub.example.com
+  token_env: DETENT_HUB_TOKEN
+  machine_id: build-mac-01
+  display_name: Build Mac 01
+  capacity: 4
+  heartbeat_interval_seconds: 30
+  lease_ttl_seconds: 90
+  request_timeout_ms: 10000
+```
+
+`machine_id` defaults to the configured global identity, instance name, or
+hostname. `capacity` defaults to `global.max_concurrent_agents`. The heartbeat
+interval must be shorter than the lease TTL. Hub outages mark project refresh
+health degraded and back off with the normal scheduling loop; they do not
+consume issue retry, no-progress, or work-failure budgets. GitHub remains in
+use for event ingestion, reconciliation, write-back, and fresh safety checks,
+but the scheduling claim cycle does not depend on a GitHub read.
 
 Health notifications deliver fleet and project needs-attention transitions to
 one generic webhook. They are disabled when

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -294,8 +294,16 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 		Jitter:             managerConfig.Startup.Jitter,
 		RampStarts:         startupDispatchRampStarts(globalDispatchGate),
 	})
+	var hubScheduling orchestrator.SchedulingSource
+	if cfg.Global.Client.Configured() {
+		hubScheduling, err = newHubScheduling(cfg.Global, cfg.Version)
+		if err != nil {
+			return err
+		}
+	}
 	projectFactory := withRunnerFactory(project.Dependencies{
 		Events:             events,
+		Scheduling:         hubScheduling,
 		Logger:             logger,
 		GlobalDispatchGate: globalDispatchGate,
 		DispatchPacer:      dispatchPacer,

--- a/internal/cli/hub_client.go
+++ b/internal/cli/hub_client.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/hubclient"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func newHubScheduling(cfg globalconfig.Config, version string) (orchestrator.SchedulingSource, error) {
+	clientConfig := cfg.Client
+	if !clientConfig.Configured() {
+		return nil, errors.New("hub client is not configured")
+	}
+	clientConfig = clientConfig.Normalized()
+	token := strings.TrimSpace(os.Getenv(clientConfig.TokenEnvironment))
+	if token == "" {
+		return nil, errors.New("hub worker token environment variable " + clientConfig.TokenEnvironment + " is empty")
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	machineID := firstNonBlankString(clientConfig.MachineID, cfg.Global.Identity.Name, cfg.InstanceName, hostname)
+	displayName := firstNonBlankString(clientConfig.DisplayName, cfg.Global.Identity.Name, cfg.InstanceName, machineID)
+	capacity := clientConfig.Capacity
+	if capacity <= 0 {
+		capacity = cfg.Global.MaxConcurrentAgents
+	}
+	version = firstNonBlankString(version, "dev")
+	client, err := hubclient.New(hubclient.Config{
+		URL:         clientConfig.URL,
+		TokenSource: func() string { return os.Getenv(clientConfig.TokenEnvironment) },
+		HTTPClient:  &http.Client{Timeout: clientConfig.RequestTimeout()},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return hubclient.NewScheduler(client, hubclient.SchedulerConfig{
+		Machine: hubclient.Machine{
+			ID: tracker.MachineID(machineID), Hostname: hostname, DisplayName: displayName,
+			Capabilities: hubMachineCapabilities(cfg), Capacity: capacity, Version: strings.TrimSpace(version),
+		},
+		HeartbeatInterval: clientConfig.HeartbeatInterval(),
+		LeaseTTL:          clientConfig.LeaseTTL(),
+	})
+}
+
+func hubMachineCapabilities(cfg globalconfig.Config) map[string]any {
+	projects := make([]map[string]string, 0, len(cfg.Projects))
+	for _, project := range cfg.Projects {
+		projects = append(projects, map[string]string{"id": project.ID, "pool": project.Pool})
+	}
+	pools := make([]map[string]any, 0, len(cfg.Global.AgentPools)+1)
+	pools = append(pools, map[string]any{"name": "default", "capacity": cfg.Global.MaxConcurrentAgents})
+	for _, pool := range cfg.Global.AgentPools {
+		pools = append(pools, map[string]any{"name": pool.Name, "capacity": pool.MaxConcurrentAgents, "burst_to": pool.BurstTo})
+	}
+	return map[string]any{
+		"projects": projects,
+		"pools":    pools,
+		"os":       runtime.GOOS,
+		"arch":     runtime.GOARCH,
+	}
+}
+
+func firstNonBlankString(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/cli/hub_client_test.go
+++ b/internal/cli/hub_client_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/hubclient"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+)
+
+func TestNewHubSchedulingRegistersRuntimeCapacityAndVersion(t *testing.T) {
+	t.Setenv("HUB_WORKER_TOKEN", "worker-token")
+	registered := make(chan hubclient.Machine, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/api/v1/machines/register":
+			var machine hubclient.Machine
+			if err := json.NewDecoder(request.Body).Decode(&machine); err != nil {
+				t.Errorf("decode machine: %v", err)
+			}
+			registered <- machine
+			_ = json.NewEncoder(response).Encode(machine)
+		case "/api/v1/claims":
+			response.WriteHeader(http.StatusConflict)
+			_, _ = response.Write([]byte(`{"code":"no_claimable_work","message":"none"}`))
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	cfg := globalconfig.Config{
+		Client: globalconfig.HubClient{URL: server.URL, TokenEnvironment: "HUB_WORKER_TOKEN", MachineID: "machine-a"},
+		Global: globalconfig.Settings{MaxConcurrentAgents: 4},
+	}
+	source, err := newHubScheduling(cfg, "")
+	if err != nil {
+		t.Fatalf("newHubScheduling() error = %v", err)
+	}
+	issues, err := source.FetchCandidateIssues(t.Context(), orchestrator.SchedulingRequest{Repository: "acme/widgets"})
+	if err != nil || len(issues) != 0 {
+		t.Fatalf("FetchCandidateIssues() = %#v, %v", issues, err)
+	}
+	machine := <-registered
+	if machine.ID != "machine-a" || machine.Capacity != 4 || machine.Version != "dev" || machine.Capabilities["os"] == "" || machine.Capabilities["arch"] == "" {
+		t.Fatalf("registered machine = %#v", machine)
+	}
+}
+
+func TestNewHubSchedulingRequiresConfiguredToken(t *testing.T) {
+	t.Setenv("EMPTY_HUB_TOKEN", "")
+	_, err := newHubScheduling(globalconfig.Config{Client: globalconfig.HubClient{URL: "https://hub.example.test", TokenEnvironment: "EMPTY_HUB_TOKEN"}}, "dev")
+	if err == nil {
+		t.Fatal("newHubScheduling() error = nil, want missing token error")
+	}
+}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	APIToken              string          `yaml:"api_token,omitempty"`
 	TrustLoopbackPeerRead bool            `yaml:"trust_loopback_peer_read,omitempty"`
 	DashboardAccess       DashboardAccess `yaml:"dashboard_access,omitempty"`
+	Client                HubClient       `yaml:"client,omitempty"`
 	Ops                   Ops             `yaml:"ops,omitempty"`
 	Port                  *int            `yaml:"port,omitempty"`
 	InstanceName          string          `yaml:"instance_name,omitempty"`
@@ -701,6 +702,7 @@ func (c Config) Validate(opts ...Option) error {
 	}
 	problems = append(problems, c.Notifications.Validate()...)
 	problems = append(problems, dashboardAccessProblems(c.DashboardAccess)...)
+	problems = append(problems, c.Client.Validate()...)
 	if c.Update.CheckIntervalHours < 0 {
 		problems = append(problems, "update.check_interval_hours: must be a positive integer")
 	}
@@ -1020,6 +1022,7 @@ func validateRaw(attrs map[string]any, opts options) []string {
 		problems = append(problems, err.Error())
 	}
 	problems = append(problems, dashboardAccessRawErrors(attrs["dashboard_access"])...)
+	problems = append(problems, hubClientRawErrors(attrs["client"])...)
 	problems = append(problems, opsRawErrors(attrs["ops"])...)
 	problems = append(problems, optionalStringTypeError(attrs, "instance_name")...)
 	problems = append(problems, optionalSingleLineStringError(attrs, "instance_name")...)
@@ -1873,6 +1876,10 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
+	client, err := buildHubClient(attrs["client"])
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
 	ops, err := buildOps(attrs["ops"])
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
@@ -1918,6 +1925,7 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 		APIToken:              apiToken,
 		TrustLoopbackPeerRead: trustLoopbackPeerRead,
 		DashboardAccess:       dashboardAccess,
+		Client:                client,
 		Ops:                   ops,
 		Port:                  port,
 		InstanceName:          instanceName,

--- a/internal/config/global/hub_client.go
+++ b/internal/config/global/hub_client.go
@@ -1,0 +1,158 @@
+package global
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultHubTokenEnvironment     = "DETENT_HUB_TOKEN"
+	DefaultHubHeartbeatSeconds     = 30
+	DefaultHubLeaseTTLSeconds      = 90
+	DefaultHubRequestTimeoutMillis = 10000
+)
+
+type HubClient struct {
+	URL                      string `yaml:"hub_url,omitempty"`
+	TokenEnvironment         string `yaml:"token_env,omitempty"`
+	MachineID                string `yaml:"machine_id,omitempty"`
+	DisplayName              string `yaml:"display_name,omitempty"`
+	Capacity                 int    `yaml:"capacity,omitempty"`
+	HeartbeatIntervalSeconds int    `yaml:"heartbeat_interval_seconds,omitempty"`
+	LeaseTTLSeconds          int    `yaml:"lease_ttl_seconds,omitempty"`
+	RequestTimeoutMS         int    `yaml:"request_timeout_ms,omitempty"`
+}
+
+func (c HubClient) IsZero() bool {
+	return strings.TrimSpace(c.URL) == "" && strings.TrimSpace(c.TokenEnvironment) == "" &&
+		strings.TrimSpace(c.MachineID) == "" && strings.TrimSpace(c.DisplayName) == "" && c.Capacity == 0 &&
+		c.HeartbeatIntervalSeconds == 0 && c.LeaseTTLSeconds == 0 && c.RequestTimeoutMS == 0
+}
+
+func (c HubClient) Configured() bool {
+	return strings.TrimSpace(c.URL) != ""
+}
+
+func (c HubClient) Normalized() HubClient {
+	c.URL = strings.TrimRight(strings.TrimSpace(c.URL), "/")
+	c.TokenEnvironment = strings.TrimSpace(c.TokenEnvironment)
+	if c.TokenEnvironment == "" {
+		c.TokenEnvironment = DefaultHubTokenEnvironment
+	}
+	c.MachineID = strings.TrimSpace(c.MachineID)
+	c.DisplayName = strings.TrimSpace(c.DisplayName)
+	if c.HeartbeatIntervalSeconds <= 0 {
+		c.HeartbeatIntervalSeconds = DefaultHubHeartbeatSeconds
+	}
+	if c.LeaseTTLSeconds <= 0 {
+		c.LeaseTTLSeconds = DefaultHubLeaseTTLSeconds
+	}
+	if c.RequestTimeoutMS <= 0 {
+		c.RequestTimeoutMS = DefaultHubRequestTimeoutMillis
+	}
+	return c
+}
+
+func (c HubClient) HeartbeatInterval() time.Duration {
+	return time.Duration(c.Normalized().HeartbeatIntervalSeconds) * time.Second
+}
+
+func (c HubClient) LeaseTTL() time.Duration {
+	return time.Duration(c.Normalized().LeaseTTLSeconds) * time.Second
+}
+
+func (c HubClient) RequestTimeout() time.Duration {
+	return time.Duration(c.Normalized().RequestTimeoutMS) * time.Millisecond
+}
+
+func (c HubClient) Validate() []string {
+	if !c.Configured() {
+		if !c.IsZero() {
+			return []string{"client.hub_url is required when Hub client settings are configured"}
+		}
+		return nil
+	}
+	var problems []string
+	parsed, err := url.Parse(strings.TrimSpace(c.URL))
+	if err != nil || !parsed.IsAbs() || strings.TrimSpace(parsed.Host) == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		problems = append(problems, "client.hub_url must be an absolute http or https URL")
+	}
+	if strings.ContainsAny(c.TokenEnvironment, "\r\n") || (strings.TrimSpace(c.TokenEnvironment) != "" && !validEnvironmentName(c.TokenEnvironment)) {
+		problems = append(problems, "client.token_env must be an environment variable name")
+	}
+	if strings.ContainsAny(c.MachineID, "\r\n") {
+		problems = append(problems, "client.machine_id must be a single line")
+	}
+	if c.Capacity < 0 {
+		problems = append(problems, "client.capacity must be greater than 0")
+	}
+	if c.HeartbeatIntervalSeconds < 0 {
+		problems = append(problems, "client.heartbeat_interval_seconds must be greater than 0")
+	}
+	if c.LeaseTTLSeconds < 0 {
+		problems = append(problems, "client.lease_ttl_seconds must be greater than 0")
+	}
+	if c.RequestTimeoutMS < 0 {
+		problems = append(problems, "client.request_timeout_ms must be greater than 0")
+	}
+	normalized := c.Normalized()
+	if normalized.HeartbeatIntervalSeconds >= normalized.LeaseTTLSeconds {
+		problems = append(problems, "client.heartbeat_interval_seconds must be shorter than client.lease_ttl_seconds")
+	}
+	return problems
+}
+
+func hubClientRawErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	attrs, ok := value.(map[string]any)
+	if !ok {
+		return []string{"client: must be a mapping"}
+	}
+	var problems []string
+	for _, name := range []string{"hub_url", "token_env", "machine_id", "display_name"} {
+		problems = append(problems, optionalStringTypeError(attrs, name)...)
+	}
+	for _, field := range []struct{ name, path string }{
+		{"capacity", "client.capacity"},
+		{"heartbeat_interval_seconds", "client.heartbeat_interval_seconds"},
+		{"lease_ttl_seconds", "client.lease_ttl_seconds"},
+		{"request_timeout_ms", "client.request_timeout_ms"},
+	} {
+		if value, configured := attrs[field.name]; configured && !positiveInteger(value) {
+			problems = append(problems, field.path+": must be a positive integer")
+		}
+	}
+	return problems
+}
+
+func buildHubClient(value any) (HubClient, error) {
+	if value == nil {
+		return HubClient{}, nil
+	}
+	if _, err := mapValue(value, "client"); err != nil {
+		return HubClient{}, err
+	}
+	var client HubClient
+	if err := decodeYAMLValue(value, &client); err != nil {
+		return HubClient{}, fmt.Errorf("client: %w", err)
+	}
+	return client, nil
+}
+
+func validEnvironmentName(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for index, char := range value {
+		if (char >= 'A' && char <= 'Z') || char == '_' || (index > 0 && char >= '0' && char <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/config/global/hub_client_test.go
+++ b/internal/config/global/hub_client_test.go
@@ -1,0 +1,68 @@
+package global
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseHubClient(t *testing.T) {
+	t.Parallel()
+	cfg, err := Parse([]byte(`apiVersion: detent/v1
+kind: GlobalConfig
+client:
+  hub_url: https://hub.example.test/
+  token_env: HUB_TOKEN
+  machine_id: machine-a
+  display_name: Worker A
+  capacity: 3
+  heartbeat_interval_seconds: 20
+  lease_ttl_seconds: 75
+  request_timeout_ms: 2500
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects: []
+`), "hub-client.yaml")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	client := cfg.Client.Normalized()
+	if client.URL != "https://hub.example.test" || client.TokenEnvironment != "HUB_TOKEN" || client.MachineID != "machine-a" || client.DisplayName != "Worker A" || client.Capacity != 3 {
+		t.Fatalf("Client = %#v", client)
+	}
+	if client.HeartbeatInterval() != 20*time.Second || client.LeaseTTL() != 75*time.Second || client.RequestTimeout() != 2500*time.Millisecond {
+		t.Fatalf("Client durations = heartbeat %s TTL %s timeout %s", client.HeartbeatInterval(), client.LeaseTTL(), client.RequestTimeout())
+	}
+}
+
+func TestHubClientValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{name: "mapping", config: "client: enabled", want: "client: must be a mapping"},
+		{name: "URL required", config: "client:\n  capacity: 2", want: "client.hub_url is required"},
+		{name: "absolute URL", config: "client:\n  hub_url: hub.internal", want: "client.hub_url must be an absolute"},
+		{name: "token environment", config: "client:\n  hub_url: https://hub.example.test\n  token_env: invalid-name", want: "client.token_env must be an environment variable name"},
+		{name: "heartbeat before lease", config: "client:\n  hub_url: https://hub.example.test\n  heartbeat_interval_seconds: 90\n  lease_ttl_seconds: 90", want: "client.heartbeat_interval_seconds must be shorter"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parse([]byte(`apiVersion: detent/v1
+kind: GlobalConfig
+`+test.config+`
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects: []
+`), test.name+".yaml")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Parse() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/hubclient/client.go
+++ b/internal/hubclient/client.go
@@ -1,0 +1,221 @@
+package hubclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+const maxResponseBytes = 1 << 20
+
+var (
+	ErrNoClaimableWork = errors.New("no Hub work is claimable")
+	ErrUnavailable     = errors.New("hub unavailable")
+)
+
+type Config struct {
+	URL         string
+	TokenSource func() string
+	HTTPClient  *http.Client
+}
+
+type Client struct {
+	baseURL     *url.URL
+	tokenSource func() string
+	httpClient  *http.Client
+}
+
+type Machine struct {
+	ID              tracker.MachineID `json:"id"`
+	Hostname        string            `json:"hostname"`
+	DisplayName     string            `json:"display_name,omitempty"`
+	Capabilities    map[string]any    `json:"capabilities,omitempty"`
+	Capacity        int               `json:"capacity"`
+	Version         string            `json:"version"`
+	LastHeartbeatAt time.Time         `json:"last_heartbeat_at,omitempty"`
+}
+
+type MachineHeartbeat struct {
+	DisplayName  *string         `json:"display_name,omitempty"`
+	Capabilities *map[string]any `json:"capabilities,omitempty"`
+	Capacity     *int            `json:"capacity,omitempty"`
+	Version      *string         `json:"version,omitempty"`
+}
+
+type WorkItem struct {
+	tracker.WorkItem
+	Body string `json:"body"`
+}
+
+type ClaimRequest struct {
+	MachineID     tracker.MachineID `json:"machine_id"`
+	SessionID     string            `json:"session_id"`
+	TTLSeconds    int64             `json:"ttl_seconds"`
+	Repositories  []string          `json:"repositories,omitempty"`
+	WorkflowState []string          `json:"workflow_states,omitempty"`
+}
+
+type LeaseRequest struct {
+	FencingToken tracker.FencingToken `json:"fencing_token"`
+	TTLSeconds   int64                `json:"ttl_seconds,omitempty"`
+	Reason       string               `json:"reason,omitempty"`
+}
+
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return "Hub request failed"
+	}
+	if e.Code == "" {
+		return fmt.Sprintf("Hub request failed with status %d", e.Status)
+	}
+	return fmt.Sprintf("Hub request failed with status %d (%s): %s", e.Status, e.Code, e.Message)
+}
+
+func New(config Config) (*Client, error) {
+	baseURL, err := url.Parse(strings.TrimSpace(config.URL))
+	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" || (baseURL.Scheme != "http" && baseURL.Scheme != "https") {
+		return nil, errors.New("hub URL must be an absolute HTTP or HTTPS URL")
+	}
+	if config.TokenSource == nil {
+		return nil, errors.New("hub token source is required")
+	}
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	baseURL.Path = strings.TrimRight(baseURL.Path, "/")
+	return &Client{baseURL: baseURL, tokenSource: config.TokenSource, httpClient: httpClient}, nil
+}
+
+func (c *Client) RegisterMachine(ctx context.Context, machine Machine) (Machine, error) {
+	var response Machine
+	err := c.request(ctx, http.MethodPost, "/api/v1/machines/register", machine, &response)
+	return response, err
+}
+
+func (c *Client) HeartbeatMachine(ctx context.Context, id tracker.MachineID, heartbeat MachineHeartbeat) (Machine, error) {
+	var response Machine
+	err := c.request(ctx, http.MethodPost, "/api/v1/machines/"+url.PathEscape(string(id))+"/heartbeat", heartbeat, &response)
+	return response, err
+}
+
+func (c *Client) Claim(ctx context.Context, request ClaimRequest) (tracker.Lease, error) {
+	var lease tracker.Lease
+	err := c.request(ctx, http.MethodPost, "/api/v1/claims", request, &lease)
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.Status == http.StatusConflict && apiErr.Code == "no_claimable_work" {
+		return tracker.Lease{}, ErrNoClaimableWork
+	}
+	return lease, err
+}
+
+func (c *Client) WorkItem(ctx context.Context, id tracker.WorkItemID) (WorkItem, error) {
+	var response WorkItem
+	err := c.request(ctx, http.MethodGet, "/api/v1/work-items/"+strconv.FormatInt(int64(id), 10), nil, &response)
+	return response, err
+}
+
+func (c *Client) Renew(ctx context.Context, lease tracker.Lease, ttl time.Duration) (tracker.Lease, error) {
+	var renewed tracker.Lease
+	err := c.request(ctx, http.MethodPost, "/api/v1/leases/"+url.PathEscape(string(lease.ID))+"/renew", LeaseRequest{
+		FencingToken: lease.FencingToken,
+		TTLSeconds:   int64(ttl / time.Second),
+	}, &renewed)
+	return renewed, err
+}
+
+func (c *Client) Release(ctx context.Context, lease tracker.Lease, reason string) error {
+	return c.request(ctx, http.MethodPost, "/api/v1/leases/"+url.PathEscape(string(lease.ID))+"/release", LeaseRequest{
+		FencingToken: lease.FencingToken,
+		Reason:       strings.TrimSpace(reason),
+	}, nil)
+}
+
+func (c *Client) request(ctx context.Context, method string, path string, input any, output any) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var body io.Reader
+	if input != nil {
+		encoded, err := json.Marshal(input)
+		if err != nil {
+			return fmt.Errorf("encode Hub request: %w", err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+	endpoint := *c.baseURL
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), body)
+	if err != nil {
+		return fmt.Errorf("build Hub request: %w", err)
+	}
+	token := strings.TrimSpace(c.tokenSource())
+	if token == "" {
+		return errors.New("hub token is unavailable")
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Accept", "application/json")
+	if input != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrUnavailable, err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("%w: read response: %w", ErrUnavailable, err)
+	}
+	if len(payload) > maxResponseBytes {
+		return fmt.Errorf("%w: response exceeds %d bytes", ErrUnavailable, maxResponseBytes)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		apiErr := &APIError{Status: response.StatusCode}
+		if len(payload) > 0 {
+			if err := json.Unmarshal(payload, apiErr); err != nil {
+				return fmt.Errorf("%w: decode error response: %w", ErrUnavailable, err)
+			}
+		}
+		if response.StatusCode >= 500 {
+			return errors.Join(ErrUnavailable, apiErr)
+		}
+		return apiErr
+	}
+	if output == nil || response.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if err := json.Unmarshal(payload, output); err != nil {
+		return fmt.Errorf("%w: decode response: %w", ErrUnavailable, err)
+	}
+	return nil
+}
+
+func (e *APIError) UnmarshalJSON(data []byte) error {
+	var value struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	e.Code = value.Code
+	e.Message = value.Message
+	return nil
+}

--- a/internal/hubclient/client.go
+++ b/internal/hubclient/client.go
@@ -63,6 +63,10 @@ type ClaimRequest struct {
 	TTLSeconds    int64             `json:"ttl_seconds"`
 	Repositories  []string          `json:"repositories,omitempty"`
 	WorkflowState []string          `json:"workflow_states,omitempty"`
+	Authors       []string          `json:"authors,omitempty"`
+	Assignees     []string          `json:"assignees,omitempty"`
+	LabelInclude  []string          `json:"label_include,omitempty"`
+	LabelExclude  []string          `json:"label_exclude,omitempty"`
 }
 
 type LeaseRequest struct {

--- a/internal/hubclient/scheduler.go
+++ b/internal/hubclient/scheduler.go
@@ -84,6 +84,10 @@ func (s *Scheduler) FetchCandidateIssues(ctx context.Context, request orchestrat
 	claimRequest := ClaimRequest{
 		MachineID: s.machine.ID, SessionID: sessionID, TTLSeconds: int64(s.leaseTTL / time.Second),
 		WorkflowState: append([]string(nil), request.WorkflowStates...),
+		Authors:       append([]string(nil), request.Filter.Authors...),
+		Assignees:     append([]string(nil), request.Filter.Assignees...),
+		LabelInclude:  append([]string(nil), request.Filter.LabelInclude...),
+		LabelExclude:  append([]string(nil), request.Filter.LabelExclude...),
 	}
 	if repository := strings.TrimSpace(request.Repository); repository != "" {
 		claimRequest.Repositories = []string{repository}
@@ -149,8 +153,7 @@ func (s *Scheduler) RenewClaim(ctx context.Context, issueID string, _ time.Time)
 	s.mu.Lock()
 	s.claims[strings.TrimSpace(issueID)] = renewed
 	s.mu.Unlock()
-	issue := connector.NewIssue()
-	issue.ID = strings.TrimSpace(issueID)
+	issue := connector.Issue{ID: strings.TrimSpace(issueID)}
 	return claimedIssue(issue, renewed), nil
 }
 
@@ -228,6 +231,7 @@ func issueFromWorkItem(item WorkItem) connector.Issue {
 	}
 	issue.URL = item.URL
 	issue.Closed = item.SourceState == tracker.SourceStateClosed
+	issue.AuthorID = item.AuthorID
 	issue.Labels = append([]string(nil), item.Labels...)
 	issue.Assignees = append([]string(nil), item.Assignees...)
 	issue.CreatedAt = cloneTime(item.CreatedAt)
@@ -268,6 +272,9 @@ func issueFromWorkItem(item WorkItem) connector.Issue {
 }
 
 func claimedIssue(issue connector.Issue, lease tracker.Lease) orchestrator.Claimed {
+	if issue.Metadata == nil {
+		issue.Metadata = make(map[string]string)
+	}
 	issue.Metadata["hub_lease_id"] = string(lease.ID)
 	issue.Metadata["hub_fencing_token"] = strconv.FormatInt(int64(lease.FencingToken), 10)
 	issue.Metadata["hub_session_id"] = lease.SessionID

--- a/internal/hubclient/scheduler.go
+++ b/internal/hubclient/scheduler.go
@@ -1,0 +1,328 @@
+package hubclient
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+const hubWorkItemField = "detent_hub_work_item_id"
+
+type SchedulerConfig struct {
+	Machine           Machine
+	HeartbeatInterval time.Duration
+	LeaseTTL          time.Duration
+	Now               func() time.Time
+	SessionID         func() (string, error)
+}
+
+type Scheduler struct {
+	client            *Client
+	machine           Machine
+	heartbeatInterval time.Duration
+	leaseTTL          time.Duration
+	now               func() time.Time
+	sessionID         func() (string, error)
+	mu                sync.Mutex
+	registered        bool
+	lastHeartbeat     time.Time
+	claims            map[string]tracker.Lease
+}
+
+func NewScheduler(client *Client, config SchedulerConfig) (*Scheduler, error) {
+	if client == nil {
+		return nil, errors.New("hub client is required")
+	}
+	config.Machine.ID = tracker.MachineID(strings.TrimSpace(string(config.Machine.ID)))
+	config.Machine.Hostname = strings.TrimSpace(config.Machine.Hostname)
+	if config.Machine.ID == "" || config.Machine.Hostname == "" || config.Machine.Capacity <= 0 || strings.TrimSpace(config.Machine.Version) == "" {
+		return nil, errors.New("hub machine ID, hostname, positive capacity, and version are required")
+	}
+	if config.HeartbeatInterval <= 0 || config.LeaseTTL <= 0 || config.HeartbeatInterval >= config.LeaseTTL {
+		return nil, errors.New("hub heartbeat interval must be positive and shorter than the lease TTL")
+	}
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	sessionID := config.SessionID
+	if sessionID == nil {
+		sessionID = randomSessionID
+	}
+	return &Scheduler{
+		client: client, machine: config.Machine, heartbeatInterval: config.HeartbeatInterval,
+		leaseTTL: config.LeaseTTL, now: now, sessionID: sessionID, claims: make(map[string]tracker.Lease),
+	}, nil
+}
+
+func (s *Scheduler) HeartbeatInterval() time.Duration {
+	if s == nil {
+		return 0
+	}
+	return s.heartbeatInterval
+}
+
+func (s *Scheduler) FetchCandidateIssues(ctx context.Context, request orchestrator.SchedulingRequest) ([]connector.Issue, error) {
+	if err := s.ensureMachine(ctx); err != nil {
+		return nil, schedulingError(err)
+	}
+	sessionID, err := s.sessionID()
+	if err != nil {
+		return nil, fmt.Errorf("create Hub claim session: %w", err)
+	}
+	claimRequest := ClaimRequest{
+		MachineID: s.machine.ID, SessionID: sessionID, TTLSeconds: int64(s.leaseTTL / time.Second),
+		WorkflowState: append([]string(nil), request.WorkflowStates...),
+	}
+	if repository := strings.TrimSpace(request.Repository); repository != "" {
+		claimRequest.Repositories = []string{repository}
+	}
+	lease, err := s.client.Claim(ctx, claimRequest)
+	if errors.Is(err, ErrNoClaimableWork) {
+		return []connector.Issue{}, nil
+	}
+	if err != nil {
+		return nil, schedulingError(err)
+	}
+	item, err := s.client.WorkItem(ctx, lease.WorkItemID)
+	if err != nil {
+		return nil, s.releaseAfterCandidateFailure(ctx, lease, "work_item_hydration_failed", schedulingError(err))
+	}
+	issue := issueFromWorkItem(item)
+	if issue.ID == "" {
+		return nil, s.releaseAfterCandidateFailure(ctx, lease, "work_item_identity_missing", errors.New("hub work item has no GitHub node ID"))
+	}
+	s.mu.Lock()
+	s.claims[issue.ID] = lease
+	s.mu.Unlock()
+	return []connector.Issue{issue}, nil
+}
+
+func (s *Scheduler) AdoptClaim(_ context.Context, issue connector.Issue, _ time.Time) (orchestrator.Claimed, error) {
+	s.mu.Lock()
+	lease, ok := s.claims[strings.TrimSpace(issue.ID)]
+	s.mu.Unlock()
+	if !ok {
+		return orchestrator.Claimed{}, errors.New("hub claim was not found for candidate")
+	}
+	return claimedIssue(issue, lease), nil
+}
+
+func (s *Scheduler) releaseAfterCandidateFailure(ctx context.Context, lease tracker.Lease, reason string, cause error) error {
+	if err := s.client.Release(context.WithoutCancel(ctx), lease, reason); err != nil {
+		return errors.Join(cause, fmt.Errorf("release Hub claim after %s: %w", reason, err))
+	}
+	return cause
+}
+
+func (s *Scheduler) RenewClaim(ctx context.Context, issueID string, _ time.Time) (orchestrator.Claimed, error) {
+	if err := s.ensureMachine(ctx); err != nil {
+		return orchestrator.Claimed{}, err
+	}
+	s.mu.Lock()
+	lease, ok := s.claims[strings.TrimSpace(issueID)]
+	s.mu.Unlock()
+	if !ok {
+		return orchestrator.Claimed{}, orchestrator.ErrSchedulingClaimLost
+	}
+	renewed, err := s.client.Renew(ctx, lease, s.leaseTTL)
+	if err != nil {
+		if claimLost(err) {
+			s.mu.Lock()
+			delete(s.claims, strings.TrimSpace(issueID))
+			s.mu.Unlock()
+			return orchestrator.Claimed{}, errors.Join(orchestrator.ErrSchedulingClaimLost, err)
+		}
+		return orchestrator.Claimed{}, err
+	}
+	s.mu.Lock()
+	s.claims[strings.TrimSpace(issueID)] = renewed
+	s.mu.Unlock()
+	issue := connector.NewIssue()
+	issue.ID = strings.TrimSpace(issueID)
+	return claimedIssue(issue, renewed), nil
+}
+
+func (s *Scheduler) ReleaseClaim(ctx context.Context, issueID string, reason string) error {
+	issueID = strings.TrimSpace(issueID)
+	s.mu.Lock()
+	lease, ok := s.claims[issueID]
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	err := s.client.Release(ctx, lease, reason)
+	if err != nil && !claimLost(err) {
+		return err
+	}
+	s.mu.Lock()
+	delete(s.claims, issueID)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Scheduler) ensureMachine(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now().UTC()
+	if !s.registered {
+		registered, err := s.client.RegisterMachine(ctx, s.machine)
+		if err != nil {
+			return err
+		}
+		s.machine = registered
+		s.registered = true
+		s.lastHeartbeat = now
+		return nil
+	}
+	if now.Before(s.lastHeartbeat.Add(s.heartbeatInterval)) {
+		return nil
+	}
+	displayName := s.machine.DisplayName
+	capabilities := s.machine.Capabilities
+	capacity := s.machine.Capacity
+	version := s.machine.Version
+	updated, err := s.client.HeartbeatMachine(ctx, s.machine.ID, MachineHeartbeat{
+		DisplayName: &displayName, Capabilities: &capabilities, Capacity: &capacity, Version: &version,
+	})
+	if err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound && apiErr.Code == "machine_not_found" {
+			s.registered = false
+			registered, registerErr := s.client.RegisterMachine(ctx, s.machine)
+			if registerErr != nil {
+				return registerErr
+			}
+			s.machine = registered
+			s.registered = true
+			s.lastHeartbeat = now
+			return nil
+		}
+		return err
+	}
+	s.machine = updated
+	s.lastHeartbeat = now
+	return nil
+}
+
+func issueFromWorkItem(item WorkItem) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = strings.TrimSpace(item.GitHub.NodeID)
+	issue.Identifier = strings.TrimSpace(item.Repository.Owner) + "/" + strings.TrimSpace(item.Repository.Name) + "#" + strconv.Itoa(item.GitHub.Number)
+	issue.Number = item.GitHub.Number
+	issue.Title = item.Title
+	issue.Description = strings.TrimSpace(item.Body)
+	if issue.Description == "" {
+		issue.Description = item.BodyExcerpt
+	}
+	issue.URL = item.URL
+	issue.Closed = item.SourceState == tracker.SourceStateClosed
+	issue.Labels = append([]string(nil), item.Labels...)
+	issue.Assignees = append([]string(nil), item.Assignees...)
+	issue.CreatedAt = cloneTime(item.CreatedAt)
+	issue.UpdatedAt = cloneTime(item.UpdatedAt)
+	issue.AssignedToWorker = true
+	issue.Fields[hubWorkItemField] = strconv.FormatInt(int64(item.ID), 10)
+	issue.Metadata[hubWorkItemField] = strconv.FormatInt(int64(item.ID), 10)
+	issue.Metadata["hub_sync_status"] = string(item.SyncStatus)
+	if item.WorkflowState != nil {
+		issue.State = item.WorkflowState.Name
+	}
+	if item.Queue != nil && item.Queue.PriorityRank != nil {
+		priority := *item.Queue.PriorityRank
+		issue.Priority = &priority
+		issue.PriorityName = queuePriorityName(priority)
+	}
+	for _, blocker := range item.Blockers {
+		state := ""
+		if blocker.WorkflowState != nil {
+			state = blocker.WorkflowState.Name
+		}
+		issue.BlockedBy = append(issue.BlockedBy, connector.BlockedRef{
+			ID: strconv.FormatInt(int64(blocker.ID), 10), Identifier: blocker.Repository + "#" + strconv.Itoa(blocker.IssueNumber),
+			State: state, TrackerState: string(blocker.SourceState), Source: connector.BlockedRefSourceNative,
+		})
+	}
+	if len(item.PullRequests) > 0 {
+		pull := item.PullRequests[0]
+		issue.PRNumber = intPointer(pull.Number)
+		issue.PRRepository = strings.TrimSpace(item.Repository.Owner) + "/" + strings.TrimSpace(item.Repository.Name)
+		issue.PullRequest = &connector.PullRequest{
+			NodeID: pull.GitHubNodeID, Number: pull.Number, URL: pull.URL, BranchName: pull.HeadRef,
+			BaseRef: pull.BaseRef, State: pull.State, Draft: pull.Draft, HeadSHA: pull.HeadSHA, BaseSHA: pull.BaseSHA,
+			CIStatus: pull.Checks.Status, CheckRunCount: pull.Checks.Total, CodexReviewState: pull.Reviews.Decision,
+		}
+	}
+	return issue
+}
+
+func claimedIssue(issue connector.Issue, lease tracker.Lease) orchestrator.Claimed {
+	issue.Metadata["hub_lease_id"] = string(lease.ID)
+	issue.Metadata["hub_fencing_token"] = strconv.FormatInt(int64(lease.FencingToken), 10)
+	issue.Metadata["hub_session_id"] = lease.SessionID
+	return orchestrator.Claimed{
+		Issue: issue, ClaimedAt: lease.AcquiredAt, Owner: string(lease.Machine.ID),
+		LeaseRenewedAt: lease.RenewedAt, LeaseExpiresAt: lease.ExpiresAt,
+	}
+}
+
+func claimLost(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.Code == "stale_fencing_token" || apiErr.Code == "lease_not_found" || apiErr.Code == "lease_conflict"
+}
+
+func schedulingError(err error) error {
+	if err == nil || !errors.Is(err, ErrUnavailable) {
+		return err
+	}
+	return errors.Join(orchestrator.ErrSchedulingUnavailable, err)
+}
+
+func queuePriorityName(priority int) string {
+	switch priority {
+	case tracker.QueuePriorityUrgent:
+		return "urgent"
+	case tracker.QueuePriorityHigh:
+		return "high"
+	case tracker.QueuePriorityNormal:
+		return "normal"
+	case tracker.QueuePriorityLow:
+		return "low"
+	default:
+		return ""
+	}
+}
+
+func randomSessionID() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func intPointer(value int) *int {
+	return &value
+}

--- a/internal/hubclient/scheduler_test.go
+++ b/internal/hubclient/scheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
@@ -28,7 +29,7 @@ func TestSchedulerDispatchCycleUsesHub(t *testing.T) {
 		GitHub: tracker.GitHubIssueReference{NodeID: "I_42", Number: 17}, Title: "Ship Hub scheduling",
 		BodyExcerpt: "```detent-agent\nschema: 1\neffort: high\n```", URL: "https://github.com/acme/widgets/issues/17",
 		SourceState: tracker.SourceStateOpen, WorkflowState: &tracker.WorkflowState{Name: "Todo", Dispatchable: true},
-		Labels: []string{"detent:todo"}, Dispatchability: tracker.Dispatchability{Dispatchable: true}, SyncStatus: tracker.SyncStatusSynced,
+		AuthorID: "alice", Labels: []string{"detent:todo"}, Dispatchability: tracker.Dispatchability{Dispatchable: true}, SyncStatus: tracker.SyncStatusSynced,
 	}, Body: "Full issue body from the Hub"}
 	var mu sync.Mutex
 	var paths []string
@@ -80,11 +81,15 @@ func TestSchedulerDispatchCycleUsesHub(t *testing.T) {
 	}
 	issues, err := scheduler.FetchCandidateIssues(t.Context(), orchestrator.SchedulingRequest{
 		ProjectID: "widgets", Repository: "acme/widgets", WorkflowStates: []string{"Todo"},
+		Filter: connector.IssueFilterHint{
+			Authors: []string{"alice"}, Assignees: []string{"worker-a"},
+			LabelInclude: []string{"detent:todo"}, LabelExclude: []string{"hold"},
+		},
 	})
 	if err != nil || len(issues) != 1 {
 		t.Fatalf("FetchCandidateIssues() = %#v, %v", issues, err)
 	}
-	if issues[0].ID != "I_42" || issues[0].Identifier != "acme/widgets#17" || issues[0].Description != item.Body {
+	if issues[0].ID != "I_42" || issues[0].Identifier != "acme/widgets#17" || issues[0].Description != item.Body || issues[0].AuthorID != "alice" {
 		t.Fatalf("candidate = %#v", issues[0])
 	}
 	claimed, err := scheduler.AdoptClaim(t.Context(), issues[0], now)
@@ -95,6 +100,9 @@ func TestSchedulerDispatchCycleUsesHub(t *testing.T) {
 	renewed, err := scheduler.RenewClaim(t.Context(), issues[0].ID, now)
 	if err != nil || renewed.LeaseRenewedAt != now {
 		t.Fatalf("RenewClaim() = %#v, %v", renewed, err)
+	}
+	if renewed.Issue.Labels != nil || renewed.Issue.Assignees != nil || renewed.Issue.BlockedBy != nil || renewed.Issue.Fields != nil {
+		t.Fatalf("RenewClaim() issue = %#v, want sparse lease metadata", renewed.Issue)
 	}
 	if err := scheduler.ReleaseClaim(t.Context(), issues[0].ID, "completed"); err != nil {
 		t.Fatalf("ReleaseClaim() error = %v", err)
@@ -111,7 +119,9 @@ func TestSchedulerDispatchCycleUsesHub(t *testing.T) {
 	if !reflect.DeepEqual(paths, wantPaths) {
 		t.Fatalf("Hub requests = %v, want %v", paths, wantPaths)
 	}
-	if len(claims) != 1 || !reflect.DeepEqual(claims[0].Repositories, []string{"acme/widgets"}) || claims[0].SessionID != "session-1" {
+	if len(claims) != 1 || !reflect.DeepEqual(claims[0].Repositories, []string{"acme/widgets"}) || claims[0].SessionID != "session-1" ||
+		!reflect.DeepEqual(claims[0].Authors, []string{"alice"}) || !reflect.DeepEqual(claims[0].Assignees, []string{"worker-a"}) ||
+		!reflect.DeepEqual(claims[0].LabelInclude, []string{"detent:todo"}) || !reflect.DeepEqual(claims[0].LabelExclude, []string{"hold"}) {
 		t.Fatalf("claims = %#v", claims)
 	}
 }

--- a/internal/hubclient/scheduler_test.go
+++ b/internal/hubclient/scheduler_test.go
@@ -1,0 +1,162 @@
+package hubclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func TestSchedulerDispatchCycleUsesHub(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	lease := tracker.Lease{LeaseSummary: tracker.LeaseSummary{
+		ID: "lease-1", FencingToken: 7, Machine: tracker.MachineSummary{ID: "machine-a", Hostname: "host-a"},
+		SessionID: "session-1", AcquiredAt: now, RenewedAt: now, ExpiresAt: now.Add(90 * time.Second),
+	}, WorkItemID: 42}
+	machine := Machine{ID: "machine-a", Hostname: "host-a", DisplayName: "Build Mac", Capacity: 2, Version: "v1.2.3"}
+	item := WorkItem{WorkItem: tracker.WorkItem{
+		ID: 42, Repository: tracker.RepositoryReference{ID: 4, Owner: "acme", Name: "widgets"},
+		GitHub: tracker.GitHubIssueReference{NodeID: "I_42", Number: 17}, Title: "Ship Hub scheduling",
+		BodyExcerpt: "```detent-agent\nschema: 1\neffort: high\n```", URL: "https://github.com/acme/widgets/issues/17",
+		SourceState: tracker.SourceStateOpen, WorkflowState: &tracker.WorkflowState{Name: "Todo", Dispatchable: true},
+		Labels: []string{"detent:todo"}, Dispatchability: tracker.Dispatchability{Dispatchable: true}, SyncStatus: tracker.SyncStatusSynced,
+	}, Body: "Full issue body from the Hub"}
+	var mu sync.Mutex
+	var paths []string
+	var claims []ClaimRequest
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer worker-token" {
+			t.Errorf("Authorization = %q", request.Header.Get("Authorization"))
+		}
+		mu.Lock()
+		paths = append(paths, request.Method+" "+request.URL.Path)
+		mu.Unlock()
+		response.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/api/v1/machines/register", "/api/v1/machines/machine-a/heartbeat":
+			_ = json.NewEncoder(response).Encode(machine)
+		case "/api/v1/claims":
+			var claim ClaimRequest
+			if err := json.NewDecoder(request.Body).Decode(&claim); err != nil {
+				t.Errorf("decode claim: %v", err)
+			}
+			claims = append(claims, claim)
+			response.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(response).Encode(lease)
+		case "/api/v1/work-items/42":
+			_ = json.NewEncoder(response).Encode(item)
+		case "/api/v1/leases/lease-1/renew":
+			renewed := lease
+			renewed.RenewedAt = now
+			renewed.ExpiresAt = now.Add(90 * time.Second)
+			_ = json.NewEncoder(response).Encode(renewed)
+		case "/api/v1/leases/lease-1/release":
+			response.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(Config{URL: server.URL, TokenSource: func() string { return "worker-token" }})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	scheduler, err := NewScheduler(client, SchedulerConfig{
+		Machine: machine, HeartbeatInterval: 30 * time.Second, LeaseTTL: 90 * time.Second,
+		Now: func() time.Time { return now }, SessionID: func() (string, error) { return "session-1", nil },
+	})
+	if err != nil {
+		t.Fatalf("NewScheduler() error = %v", err)
+	}
+	issues, err := scheduler.FetchCandidateIssues(t.Context(), orchestrator.SchedulingRequest{
+		ProjectID: "widgets", Repository: "acme/widgets", WorkflowStates: []string{"Todo"},
+	})
+	if err != nil || len(issues) != 1 {
+		t.Fatalf("FetchCandidateIssues() = %#v, %v", issues, err)
+	}
+	if issues[0].ID != "I_42" || issues[0].Identifier != "acme/widgets#17" || issues[0].Description != item.Body {
+		t.Fatalf("candidate = %#v", issues[0])
+	}
+	claimed, err := scheduler.AdoptClaim(t.Context(), issues[0], now)
+	if err != nil || claimed.Owner != "machine-a" || claimed.LeaseExpiresAt != lease.ExpiresAt {
+		t.Fatalf("AdoptClaim() = %#v, %v", claimed, err)
+	}
+	now = now.Add(31 * time.Second)
+	renewed, err := scheduler.RenewClaim(t.Context(), issues[0].ID, now)
+	if err != nil || renewed.LeaseRenewedAt != now {
+		t.Fatalf("RenewClaim() = %#v, %v", renewed, err)
+	}
+	if err := scheduler.ReleaseClaim(t.Context(), issues[0].ID, "completed"); err != nil {
+		t.Fatalf("ReleaseClaim() error = %v", err)
+	}
+
+	wantPaths := []string{
+		"POST /api/v1/machines/register",
+		"POST /api/v1/claims",
+		"GET /api/v1/work-items/42",
+		"POST /api/v1/machines/machine-a/heartbeat",
+		"POST /api/v1/leases/lease-1/renew",
+		"POST /api/v1/leases/lease-1/release",
+	}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("Hub requests = %v, want %v", paths, wantPaths)
+	}
+	if len(claims) != 1 || !reflect.DeepEqual(claims[0].Repositories, []string{"acme/widgets"}) || claims[0].SessionID != "session-1" {
+		t.Fatalf("claims = %#v", claims)
+	}
+}
+
+func TestSchedulerHubOutageIsUnavailableBeforeClaim(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.Handler
+	}{
+		{
+			name: "service unavailable",
+			handler: http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				response.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = response.Write([]byte(`{"code":"database_unavailable","message":"try later"}`))
+			}),
+		},
+		{
+			name: "invalid response",
+			handler: http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				_, _ = response.Write([]byte("not-json"))
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.handler)
+			defer server.Close()
+			client, err := New(Config{URL: server.URL, TokenSource: func() string { return "worker-token" }})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			scheduler, err := NewScheduler(client, SchedulerConfig{
+				Machine:           Machine{ID: "machine-a", Hostname: "host-a", Capacity: 1, Version: "dev"},
+				HeartbeatInterval: 30 * time.Second, LeaseTTL: 90 * time.Second,
+			})
+			if err != nil {
+				t.Fatalf("NewScheduler() error = %v", err)
+			}
+			issues, err := scheduler.FetchCandidateIssues(context.Background(), orchestrator.SchedulingRequest{Repository: "acme/widgets"})
+			if !errors.Is(err, ErrUnavailable) || !errors.Is(err, orchestrator.ErrSchedulingUnavailable) || len(issues) != 0 {
+				t.Fatalf("FetchCandidateIssues() = %#v, %v", issues, err)
+			}
+			if strings.Contains(err.Error(), "worker-token") {
+				t.Fatalf("error leaked token: %v", err)
+			}
+		})
+	}
+}

--- a/internal/hubgithub/reconciler.go
+++ b/internal/hubgithub/reconciler.go
@@ -268,6 +268,7 @@ type reconcileIssue struct {
 	Body        *string     `json:"body"`
 	HTMLURL     string      `json:"html_url"`
 	State       string      `json:"state"`
+	User        restActor   `json:"user"`
 	Labels      []restLabel `json:"labels"`
 	Assignees   []restActor `json:"assignees"`
 	PullRequest *struct{}   `json:"pull_request"`
@@ -290,7 +291,7 @@ func (i reconcileIssue) source() hubserver.IssueSource {
 	}
 	return hubserver.IssueSource{
 		NodeID: i.NodeID, DatabaseID: positiveID(i.ID), Number: i.Number,
-		Title: i.Title, Body: body, URL: i.HTMLURL, State: i.State,
+		Title: i.Title, Body: body, URL: i.HTMLURL, State: i.State, AuthorID: i.User.Login,
 		Labels: labels, Assignees: assignees, CreatedAt: i.CreatedAt, UpdatedAt: i.UpdatedAt,
 	}
 }

--- a/internal/hubgithub/reconciler_test.go
+++ b/internal/hubgithub/reconciler_test.go
@@ -38,6 +38,7 @@ func TestReconcilerUsesCursorAndRepositoryIdentity(t *testing.T) {
 				{
 					ID: 200, NodeID: "I_issue", Number: 17, Title: "Issue", Body: &body,
 					HTMLURL: "https://github.test/new-owner/renamed/issues/17", State: "open",
+					User:   restActor{Login: "octocat"},
 					Labels: []restLabel{{Name: "feature"}}, Assignees: []restActor{{Login: "alice"}},
 					CreatedAt: since.Add(-time.Hour), UpdatedAt: updatedAt,
 				},
@@ -74,7 +75,7 @@ func TestReconcilerUsesCursorAndRepositoryIdentity(t *testing.T) {
 	if !reflect.DeepEqual(snapshot.Repository, wantRepository) {
 		t.Fatalf("repository = %#v, want %#v", snapshot.Repository, wantRepository)
 	}
-	if len(snapshot.Issues) != 1 || snapshot.Issues[0].Number != 17 || !reflect.DeepEqual(snapshot.Issues[0].Labels, []string{"feature"}) || !reflect.DeepEqual(snapshot.Issues[0].Assignees, []string{"alice"}) {
+	if len(snapshot.Issues) != 1 || snapshot.Issues[0].Number != 17 || snapshot.Issues[0].AuthorID != "octocat" || !reflect.DeepEqual(snapshot.Issues[0].Labels, []string{"feature"}) || !reflect.DeepEqual(snapshot.Issues[0].Assignees, []string{"alice"}) {
 		t.Fatalf("issues = %#v, want one normalized issue", snapshot.Issues)
 	}
 	if len(snapshot.PullRequests) != 1 || snapshot.PullRequests[0].Number != 18 || snapshot.PullRequests[0].HeadSHA != "head" {

--- a/internal/hubserver/api_test.go
+++ b/internal/hubserver/api_test.go
@@ -147,6 +147,9 @@ func TestWorkItemAPIUsesStableFilteredCursorsAndDetailTimeline(t *testing.T) {
 	}
 	secondID := insertHubTestIssue(t, service, repositoryID, 2, "I_second", "open", &workflowID)
 	thirdID := insertHubTestIssue(t, service, repositoryID, 3, "I_third", "open", &workflowID)
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE issues SET body = ? WHERE id = ?", "Complete issue body", thirdID); err != nil {
+		t.Fatalf("set complete issue body: %v", err)
+	}
 	entries := []struct {
 		id       int64
 		rank     string
@@ -211,7 +214,7 @@ VALUES ('workpad-api', ?, ?, ?, ?, 'pending', ?, ?)`, repositoryID, thirdID, Mut
 	detailResponse := performHubAPIRequest(t, service, http.MethodGet, fmt.Sprintf("/api/v1/work-items/%d?timeline_limit=1", thirdID), testHubAdminToken, nil)
 	var detail workItemDetailResponse
 	decodeHubResponse(t, detailResponse, &detail)
-	if detail.ID != tracker.WorkItemID(thirdID) || detail.Workpad == nil || detail.Workpad.Body != "Hub API workpad" || len(detail.Timeline) != 1 || detail.TimelineNextCursor == "" {
+	if detail.ID != tracker.WorkItemID(thirdID) || detail.Body != "Complete issue body" || detail.Workpad == nil || detail.Workpad.Body != "Hub API workpad" || len(detail.Timeline) != 1 || detail.TimelineNextCursor == "" {
 		t.Fatalf("detail response = %#v", detail)
 	}
 	nextTimeline := performHubAPIRequest(t, service, http.MethodGet, fmt.Sprintf("/api/v1/work-items/%d?timeline_limit=1&timeline_cursor=%s", thirdID, url.QueryEscape(detail.TimelineNextCursor)), testHubAdminToken, nil)
@@ -298,6 +301,37 @@ func TestClaimNextAPIIsAtomicAndFenced(t *testing.T) {
 	released := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/leases/"+string(lease.ID)+"/release", testHubAdminToken, map[string]any{"fencing_token": lease.FencingToken, "reason": "complete"})
 	if released.Code != http.StatusNoContent {
 		t.Fatalf("release status = %d body = %s", released.Code, released.Body.String())
+	}
+	otherRepository, err := service.database.db.ExecContext(t.Context(), "INSERT INTO repositories (github_node_id, github_owner, github_name, last_reconciled_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)", "R_other", "Acme", "Other", formatHubTime(now), testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert other repository: %v", err)
+	}
+	otherRepositoryID, err := otherRepository.LastInsertId()
+	if err != nil {
+		t.Fatalf("other repository ID: %v", err)
+	}
+	otherWorkflow, err := service.database.db.ExecContext(t.Context(), "INSERT INTO workflow_states (repository_id, github_node_id, source_name, detent_state, dispatchable, created_at, updated_at) VALUES (?, ?, ?, ?, 1, ?, ?)", otherRepositoryID, "WS_other_todo", "Todo", "Todo", testTimestamp, testTimestamp)
+	if err != nil {
+		t.Fatalf("insert other workflow state: %v", err)
+	}
+	otherWorkflowID, err := otherWorkflow.LastInsertId()
+	if err != nil {
+		t.Fatalf("other workflow state ID: %v", err)
+	}
+	otherRepositoryIssueID := insertHubTestIssue(t, service, otherRepositoryID, 1, "I_other_repository", "open", &otherWorkflowID)
+	repositoryScoped := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/claims", testHubAdminToken, map[string]any{
+		"machine_id": "machine-a", "session_id": "repository-session", "ttl_seconds": 90, "repositories": []string{"acme/other"},
+	})
+	if repositoryScoped.Code != http.StatusCreated {
+		t.Fatalf("repository-scoped claim status = %d body = %s", repositoryScoped.Code, repositoryScoped.Body.String())
+	}
+	var repositoryLease tracker.Lease
+	decodeHubResponse(t, repositoryScoped, &repositoryLease)
+	if repositoryLease.WorkItemID != tracker.WorkItemID(otherRepositoryIssueID) {
+		t.Fatalf("repository-scoped work item = %d, want %d", repositoryLease.WorkItemID, otherRepositoryIssueID)
+	}
+	if response := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/leases/"+string(repositoryLease.ID)+"/release", testHubAdminToken, map[string]any{"fencing_token": repositoryLease.FencingToken}); response.Code != http.StatusNoContent {
+		t.Fatalf("release repository-scoped claim status = %d body = %s", response.Code, response.Body.String())
 	}
 	heartbeat := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/machines/machine-a/heartbeat", testHubAdminToken, map[string]any{"capacity": 4, "version": "v2"})
 	if heartbeat.Code != http.StatusOK {

--- a/internal/hubserver/api_test.go
+++ b/internal/hubserver/api_test.go
@@ -361,6 +361,47 @@ func TestClaimNextAPIIsAtomicAndFenced(t *testing.T) {
 	}
 }
 
+func TestClaimNextAPIAppliesAuthorizationFiltersBeforeClaim(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 13, 0, 0, 0, time.UTC)
+	service := openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }})
+	repositoryID, rejectedID := seedProjection(t, service.database.db)
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE repositories SET last_reconciled_at = ? WHERE id = ?", formatHubTime(now), repositoryID); err != nil {
+		t.Fatalf("mark repository fresh: %v", err)
+	}
+	var workflowID int64
+	if err := service.database.db.QueryRowContext(t.Context(), "SELECT workflow_state_id FROM issues WHERE id = ?", rejectedID).Scan(&workflowID); err != nil {
+		t.Fatalf("read workflow state: %v", err)
+	}
+	acceptedID := insertHubTestIssue(t, service, repositoryID, 2, "I_authorized", "open", &workflowID)
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE issues SET author_login = 'mallory', labels_json = '[\"detent:todo\",\"hold\"]', assignees_json = '[\"worker-b\"]' WHERE id = ?", rejectedID); err != nil {
+		t.Fatalf("update rejected issue: %v", err)
+	}
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE issues SET author_login = 'Alice', labels_json = '[\"detent:todo\",\"backend\"]', assignees_json = '[\"worker-a\"]' WHERE id = ?", acceptedID); err != nil {
+		t.Fatalf("update accepted issue: %v", err)
+	}
+	registered := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/machines/register", testHubAdminToken, map[string]any{
+		"id": "machine-a", "hostname": "worker-a", "capacity": 1, "version": "v1",
+	})
+	if registered.Code != http.StatusOK {
+		t.Fatalf("register machine status = %d body = %s", registered.Code, registered.Body.String())
+	}
+	response := performHubAPIRequest(t, service, http.MethodPost, "/api/v1/claims", testHubAdminToken, map[string]any{
+		"machine_id": "machine-a", "session_id": "filtered-session", "ttl_seconds": 90,
+		"authors": []string{"alice"}, "assignees": []string{"worker-a"},
+		"label_include": []string{"detent:todo", "backend"}, "label_exclude": []string{"hold"},
+	})
+	if response.Code != http.StatusCreated {
+		t.Fatalf("filtered claim status = %d body = %s", response.Code, response.Body.String())
+	}
+	var lease tracker.Lease
+	decodeHubResponse(t, response, &lease)
+	if lease.WorkItemID != tracker.WorkItemID(acceptedID) {
+		t.Fatalf("filtered claim work item = %d, want %d", lease.WorkItemID, acceptedID)
+	}
+}
+
 func TestClaimNextAPIRejectsUnsafeRepositorySyncHealth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/hubserver/api_work_items.go
+++ b/internal/hubserver/api_work_items.go
@@ -67,6 +67,7 @@ type timelineEvent struct {
 
 type workItemDetailResponse struct {
 	tracker.WorkItem
+	Body               string             `json:"body"`
 	Workpad            *workpadProjection `json:"workpad,omitempty"`
 	Timeline           []timelineEvent    `json:"timeline"`
 	TimelineNextCursor string             `json:"timeline_next_cursor,omitempty"`
@@ -120,6 +121,10 @@ func (s *Service) getWorkItem(c echo.Context) error {
 	if err := s.applyRepositorySyncHealth(c.Request().Context(), items); err != nil {
 		return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
 	}
+	body, err := s.database.workItemBody(c.Request().Context(), id)
+	if err != nil {
+		return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
+	}
 	timelineLimit, err := parsePageLimit(c.QueryParam("timeline_limit"))
 	if err != nil {
 		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_query", Message: "timeline_limit must be between 1 and 200"})
@@ -136,7 +141,7 @@ func (s *Service) getWorkItem(c echo.Context) error {
 	if err != nil {
 		return s.internalAPIError(c, "work_item_unavailable", "Work item could not be read", err)
 	}
-	response := workItemDetailResponse{WorkItem: items[0], Timeline: timeline}
+	response := workItemDetailResponse{WorkItem: items[0], Body: body, Timeline: timeline}
 	if hasWorkpad {
 		response.Workpad = &workpad
 	}
@@ -148,6 +153,14 @@ func (s *Service) getWorkItem(c echo.Context) error {
 		}
 	}
 	return c.JSON(http.StatusOK, response)
+}
+
+func (d *database) workItemBody(ctx context.Context, id tracker.WorkItemID) (string, error) {
+	var body sql.NullString
+	if err := d.db.QueryRowContext(ctx, "SELECT body FROM issues WHERE id = ?", id).Scan(&body); err != nil {
+		return "", fmt.Errorf("read work item body: %w", err)
+	}
+	return body.String, nil
 }
 
 func (s *Service) allWorkItems(ctx context.Context) ([]tracker.WorkItem, error) {

--- a/internal/hubserver/api_worker.go
+++ b/internal/hubserver/api_worker.go
@@ -25,6 +25,10 @@ type claimAPIRequest struct {
 	RepositoryIDs []tracker.RepositoryID `json:"repository_ids,omitempty"`
 	Repositories  []string               `json:"repositories,omitempty"`
 	WorkflowState []string               `json:"workflow_states,omitempty"`
+	Authors       []string               `json:"authors,omitempty"`
+	Assignees     []string               `json:"assignees,omitempty"`
+	LabelInclude  []string               `json:"label_include,omitempty"`
+	LabelExclude  []string               `json:"label_exclude,omitempty"`
 	Scope         string                 `json:"scope,omitempty"`
 }
 
@@ -32,6 +36,10 @@ type claimCandidateQuery struct {
 	RepositoryIDs  []tracker.RepositoryID
 	Repositories   []string
 	WorkflowStates []string
+	Authors        []string
+	Assignees      []string
+	LabelInclude   []string
+	LabelExclude   []string
 	Scope          string
 }
 
@@ -100,6 +108,10 @@ func (s *Service) claimWorkItem(c echo.Context) error {
 		RepositoryIDs:  request.RepositoryIDs,
 		Repositories:   request.Repositories,
 		WorkflowStates: request.WorkflowState,
+		Authors:        request.Authors,
+		Assignees:      request.Assignees,
+		LabelInclude:   request.LabelInclude,
+		LabelExclude:   request.LabelExclude,
 		Scope:          request.Scope,
 	}, s.config.ReconcileInterval)
 	if err != nil {
@@ -209,6 +221,22 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 	if len(query.WorkflowStates) > 0 && len(workflowStates) == 0 {
 		return tracker.Lease{}, tracker.ErrInvalidCandidateQuery
 	}
+	authors := normalizedQueryStrings(query.Authors)
+	if len(query.Authors) > 0 && len(authors) == 0 {
+		return tracker.Lease{}, tracker.ErrInvalidCandidateQuery
+	}
+	assignees := normalizedQueryStrings(query.Assignees)
+	if len(query.Assignees) > 0 && len(assignees) == 0 {
+		return tracker.Lease{}, tracker.ErrInvalidCandidateQuery
+	}
+	labelInclude := normalizedQueryStrings(query.LabelInclude)
+	if len(query.LabelInclude) > 0 && len(labelInclude) == 0 {
+		return tracker.Lease{}, tracker.ErrInvalidCandidateQuery
+	}
+	labelExclude := normalizedQueryStrings(query.LabelExclude)
+	if len(query.LabelExclude) > 0 && len(labelExclude) == 0 {
+		return tracker.Lease{}, tracker.ErrInvalidCandidateQuery
+	}
 	tx, err := d.db.BeginTx(ctx, nil)
 	if err != nil {
 		return tracker.Lease{}, fmt.Errorf("begin hub claim next: %w", err)
@@ -258,7 +286,7 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 			claimableRepositories[tracker.RepositoryID(repository.ID)] = struct{}{}
 		}
 	}
-	ids, err := claimCandidateIDs(ctx, tx, query.Scope, repositoryIDs, repositories, workflowStates, claimableRepositories)
+	ids, err := claimCandidateIDs(ctx, tx, query.Scope, repositoryIDs, repositories, workflowStates, authors, assignees, labelInclude, labelExclude, claimableRepositories)
 	if err != nil {
 		return tracker.Lease{}, err
 	}
@@ -331,7 +359,7 @@ func machineClaimCapacity(ctx context.Context, tx *sql.Tx, machineID tracker.Mac
 	return capacity - active, nil
 }
 
-func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repositoryIDs []tracker.RepositoryID, repositories []string, workflowStates []string, claimableRepositories map[tracker.RepositoryID]struct{}) ([]tracker.WorkItemID, error) {
+func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repositoryIDs []tracker.RepositoryID, repositories []string, workflowStates []string, authors []string, assignees []string, labelInclude []string, labelExclude []string, claimableRepositories map[tracker.RepositoryID]struct{}) ([]tracker.WorkItemID, error) {
 	repositoryFilter := make(map[tracker.RepositoryID]struct{}, len(repositoryIDs))
 	for _, id := range repositoryIDs {
 		repositoryFilter[id] = struct{}{}
@@ -340,12 +368,14 @@ func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repository
 	for _, repository := range repositories {
 		repositoryNameFilter[strings.ToLower(repository)] = struct{}{}
 	}
-	workflowFilter := make(map[string]struct{}, len(workflowStates))
-	for _, state := range workflowStates {
-		workflowFilter[state] = struct{}{}
-	}
+	workflowFilter := stringSet(workflowStates)
+	authorFilter := stringSet(authors)
+	assigneeFilter := stringSet(assignees)
+	labelIncludeFilter := stringSet(labelInclude)
+	labelExcludeFilter := stringSet(labelExclude)
 	rows, err := tx.QueryContext(ctx, `
-SELECT i.id, r.id, r.github_owner, r.github_name, lower(trim(ws.detent_state))
+SELECT i.id, r.id, r.github_owner, r.github_name, lower(trim(ws.detent_state)),
+       lower(trim(i.author_login)), i.labels_json, i.assignees_json
 FROM issues i
 JOIN repositories r ON r.id = i.repository_id
 LEFT JOIN workflow_states ws ON ws.id = i.workflow_state_id
@@ -386,7 +416,10 @@ ORDER BY
 		var repositoryOwner string
 		var repositoryName string
 		var workflowState string
-		if err := rows.Scan(&id, &repositoryID, &repositoryOwner, &repositoryName, &workflowState); err != nil {
+		var authorID string
+		var labelsJSON string
+		var assigneesJSON string
+		if err := rows.Scan(&id, &repositoryID, &repositoryOwner, &repositoryName, &workflowState, &authorID, &labelsJSON, &assigneesJSON); err != nil {
 			return nil, fmt.Errorf("scan hub claim candidate: %w", err)
 		}
 		if _, ok := claimableRepositories[repositoryID]; !ok {
@@ -407,12 +440,67 @@ ORDER BY
 				continue
 			}
 		}
+		if len(authorFilter) > 0 {
+			if _, ok := authorFilter[authorID]; !ok {
+				continue
+			}
+		}
+		labels, err := normalizedJSONStringSet(labelsJSON)
+		if err != nil {
+			return nil, fmt.Errorf("decode hub claim candidate labels: %w", err)
+		}
+		candidateAssignees, err := normalizedJSONStringSet(assigneesJSON)
+		if err != nil {
+			return nil, fmt.Errorf("decode hub claim candidate assignees: %w", err)
+		}
+		if len(assigneeFilter) > 0 && !setsIntersect(candidateAssignees, assigneeFilter) {
+			continue
+		}
+		if !setContainsAll(labels, labelIncludeFilter) || setsIntersect(labels, labelExcludeFilter) {
+			continue
+		}
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate hub claim candidates: %w", err)
 	}
 	return ids, nil
+}
+
+func stringSet(values []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = strings.ToLower(strings.TrimSpace(value)); value != "" {
+			result[value] = struct{}{}
+		}
+	}
+	return result
+}
+
+func normalizedJSONStringSet(value string) (map[string]struct{}, error) {
+	var values []string
+	if err := json.Unmarshal([]byte(value), &values); err != nil {
+		return nil, err
+	}
+	return stringSet(values), nil
+}
+
+func setsIntersect(left map[string]struct{}, right map[string]struct{}) bool {
+	for value := range left {
+		if _, ok := right[value]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func setContainsAll(haystack map[string]struct{}, needles map[string]struct{}) bool {
+	for value := range needles {
+		if _, ok := haystack[value]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Service) registerMachine(c echo.Context) error {

--- a/internal/hubserver/api_worker.go
+++ b/internal/hubserver/api_worker.go
@@ -23,8 +23,16 @@ type claimAPIRequest struct {
 	SessionID     string                 `json:"session_id"`
 	TTLSeconds    int64                  `json:"ttl_seconds"`
 	RepositoryIDs []tracker.RepositoryID `json:"repository_ids,omitempty"`
+	Repositories  []string               `json:"repositories,omitempty"`
 	WorkflowState []string               `json:"workflow_states,omitempty"`
 	Scope         string                 `json:"scope,omitempty"`
+}
+
+type claimCandidateQuery struct {
+	RepositoryIDs  []tracker.RepositoryID
+	Repositories   []string
+	WorkflowStates []string
+	Scope          string
 }
 
 type renewLeaseAPIRequest struct {
@@ -88,8 +96,9 @@ func (s *Service) claimWorkItem(c echo.Context) error {
 		return c.JSON(http.StatusUnprocessableEntity, apiErrorResponse{Code: "invalid_claim", Message: err.Error()})
 	}
 	claim := tracker.ClaimRequest{WorkItemID: request.WorkItemID, MachineID: request.MachineID, SessionID: request.SessionID, TTL: ttl}
-	lease, err := s.database.claimNext(c.Request().Context(), claim, tracker.CandidateQuery{
+	lease, err := s.database.claimNext(c.Request().Context(), claim, claimCandidateQuery{
 		RepositoryIDs:  request.RepositoryIDs,
+		Repositories:   request.Repositories,
 		WorkflowStates: request.WorkflowState,
 		Scope:          request.Scope,
 	}, s.config.ReconcileInterval)
@@ -181,7 +190,7 @@ func trackerAPIError(c echo.Context, err error) error {
 	return c.JSON(status, apiErrorResponse{Code: code, Message: message})
 }
 
-func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, query tracker.CandidateQuery, reconcileInterval time.Duration) (lease tracker.Lease, resultErr error) {
+func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, query claimCandidateQuery, reconcileInterval time.Duration) (lease tracker.Lease, resultErr error) {
 	request.MachineID = tracker.MachineID(strings.TrimSpace(string(request.MachineID)))
 	request.SessionID = strings.TrimSpace(request.SessionID)
 	query.Scope = strings.TrimSpace(query.Scope)
@@ -191,6 +200,10 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 	repositoryIDs, err := normalizedRepositoryIDs(query.RepositoryIDs)
 	if err != nil {
 		return tracker.Lease{}, err
+	}
+	repositories := normalizedQueryStrings(query.Repositories)
+	if len(query.Repositories) > 0 && len(repositories) == 0 {
+		return tracker.Lease{}, tracker.ErrInvalidCandidateQuery
 	}
 	workflowStates := normalizedQueryStrings(query.WorkflowStates)
 	if len(query.WorkflowStates) > 0 && len(workflowStates) == 0 {
@@ -245,7 +258,7 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 			claimableRepositories[tracker.RepositoryID(repository.ID)] = struct{}{}
 		}
 	}
-	ids, err := claimCandidateIDs(ctx, tx, query.Scope, repositoryIDs, workflowStates, claimableRepositories)
+	ids, err := claimCandidateIDs(ctx, tx, query.Scope, repositoryIDs, repositories, workflowStates, claimableRepositories)
 	if err != nil {
 		return tracker.Lease{}, err
 	}
@@ -318,17 +331,21 @@ func machineClaimCapacity(ctx context.Context, tx *sql.Tx, machineID tracker.Mac
 	return capacity - active, nil
 }
 
-func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repositoryIDs []tracker.RepositoryID, workflowStates []string, claimableRepositories map[tracker.RepositoryID]struct{}) ([]tracker.WorkItemID, error) {
+func claimCandidateIDs(ctx context.Context, tx *sql.Tx, scope string, repositoryIDs []tracker.RepositoryID, repositories []string, workflowStates []string, claimableRepositories map[tracker.RepositoryID]struct{}) ([]tracker.WorkItemID, error) {
 	repositoryFilter := make(map[tracker.RepositoryID]struct{}, len(repositoryIDs))
 	for _, id := range repositoryIDs {
 		repositoryFilter[id] = struct{}{}
+	}
+	repositoryNameFilter := make(map[string]struct{}, len(repositories))
+	for _, repository := range repositories {
+		repositoryNameFilter[strings.ToLower(repository)] = struct{}{}
 	}
 	workflowFilter := make(map[string]struct{}, len(workflowStates))
 	for _, state := range workflowStates {
 		workflowFilter[state] = struct{}{}
 	}
 	rows, err := tx.QueryContext(ctx, `
-SELECT i.id, r.id, lower(trim(ws.detent_state))
+SELECT i.id, r.id, r.github_owner, r.github_name, lower(trim(ws.detent_state))
 FROM issues i
 JOIN repositories r ON r.id = i.repository_id
 LEFT JOIN workflow_states ws ON ws.id = i.workflow_state_id
@@ -366,8 +383,10 @@ ORDER BY
 	for rows.Next() {
 		var id tracker.WorkItemID
 		var repositoryID tracker.RepositoryID
+		var repositoryOwner string
+		var repositoryName string
 		var workflowState string
-		if err := rows.Scan(&id, &repositoryID, &workflowState); err != nil {
+		if err := rows.Scan(&id, &repositoryID, &repositoryOwner, &repositoryName, &workflowState); err != nil {
 			return nil, fmt.Errorf("scan hub claim candidate: %w", err)
 		}
 		if _, ok := claimableRepositories[repositoryID]; !ok {
@@ -375,6 +394,11 @@ ORDER BY
 		}
 		if len(repositoryFilter) > 0 {
 			if _, ok := repositoryFilter[repositoryID]; !ok {
+				continue
+			}
+		}
+		if len(repositoryNameFilter) > 0 {
+			if _, ok := repositoryNameFilter[strings.ToLower(strings.TrimSpace(repositoryOwner)+"/"+strings.TrimSpace(repositoryName))]; !ok {
 				continue
 			}
 		}

--- a/internal/hubserver/github_webhook_apply.go
+++ b/internal/hubserver/github_webhook_apply.go
@@ -49,17 +49,18 @@ type githubWebhookActor struct {
 }
 
 type githubWebhookIssue struct {
-	DatabaseID *int64          `json:"id"`
-	NodeID     *string         `json:"node_id"`
-	Number     *int            `json:"number"`
-	Title      *string         `json:"title"`
-	Body       json.RawMessage `json:"body"`
-	HTMLURL    *string         `json:"html_url"`
-	State      *string         `json:"state"`
-	Labels     json.RawMessage `json:"labels"`
-	Assignees  json.RawMessage `json:"assignees"`
-	CreatedAt  json.RawMessage `json:"created_at"`
-	UpdatedAt  json.RawMessage `json:"updated_at"`
+	DatabaseID *int64              `json:"id"`
+	NodeID     *string             `json:"node_id"`
+	Number     *int                `json:"number"`
+	Title      *string             `json:"title"`
+	Body       json.RawMessage     `json:"body"`
+	HTMLURL    *string             `json:"html_url"`
+	State      *string             `json:"state"`
+	User       *githubWebhookActor `json:"user"`
+	Labels     json.RawMessage     `json:"labels"`
+	Assignees  json.RawMessage     `json:"assignees"`
+	CreatedAt  json.RawMessage     `json:"created_at"`
+	UpdatedAt  json.RawMessage     `json:"updated_at"`
 }
 
 type githubWebhookPullRequest struct {
@@ -107,6 +108,7 @@ type normalizedIssue struct {
 	Body       string    `json:"body"`
 	URL        string    `json:"url"`
 	State      string    `json:"state"`
+	AuthorID   string    `json:"author_id"`
 	Labels     []string  `json:"labels"`
 	Assignees  []string  `json:"assignees"`
 	CreatedAt  time.Time `json:"created_at"`
@@ -457,11 +459,11 @@ func applyIssueProjection(ctx context.Context, tx *sql.Tx, repositoryID int64, i
 		_, err := tx.ExecContext(ctx, `
 			INSERT INTO issues (
 				repository_id, workflow_state_id, github_node_id, github_database_id, github_number,
-				title, body, url, github_state, labels_json, assignees_json,
+				title, body, url, github_state, author_login, labels_json, assignees_json,
 				source_version, source_updated_at, synchronized_at, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, repositoryID, optionalInt64(workflowStateID), issue.NodeID, optionalInt64(issue.DatabaseID), issue.Number,
-			issue.Title, issue.Body, issue.URL, issue.State, string(labelsJSON), string(assigneesJSON),
+			issue.Title, issue.Body, issue.URL, issue.State, issue.AuthorID, string(labelsJSON), string(assigneesJSON),
 			stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
 			formatWebhookTime(issue.CreatedAt), formatWebhookTime(issue.UpdatedAt))
 		if err != nil {
@@ -494,6 +496,7 @@ func applyIssueProjection(ctx context.Context, tx *sql.Tx, repositoryID int64, i
 			body = ?,
 			url = ?,
 			github_state = ?,
+			author_login = ?,
 			labels_json = ?,
 			assignees_json = ?,
 			source_version = ?,
@@ -503,7 +506,7 @@ func applyIssueProjection(ctx context.Context, tx *sql.Tx, repositoryID int64, i
 			updated_at = ?
 		WHERE id = ?
 	`, repositoryID, optionalInt64(workflowStateID), issue.NodeID, optionalInt64(issue.DatabaseID), issue.Number,
-		issue.Title, issue.Body, issue.URL, issue.State, string(labelsJSON), string(assigneesJSON),
+		issue.Title, issue.Body, issue.URL, issue.State, issue.AuthorID, string(labelsJSON), string(assigneesJSON),
 		stamp.Version, formatWebhookTime(stamp.UpdatedAt), formatWebhookTime(now),
 		formatWebhookTime(issue.CreatedAt), formatWebhookTime(issue.UpdatedAt), issueID); err != nil {
 		return projectionApplyResult{}, fmt.Errorf("update GitHub webhook issue: %w", err)
@@ -733,6 +736,10 @@ func normalizeWebhookIssue(issue *githubWebhookIssue) (normalizedIssue, sourceSt
 	body, bodyOK := webhookNullableString(issue.Body)
 	labels, labelsOK := webhookStringList(issue.Labels, "name")
 	assignees, assigneesOK := webhookStringList(issue.Assignees, "login")
+	authorID := ""
+	if issue.User != nil && issue.User.Login != nil {
+		authorID = strings.TrimSpace(*issue.User.Login)
+	}
 	createdAt, createdOK := parseWebhookTime(issue.CreatedAt)
 	updatedAt, updatedOK := parseWebhookTime(issue.UpdatedAt)
 	if strings.TrimSpace(*issue.NodeID) == "" || *issue.Number <= 0 || strings.TrimSpace(*issue.Title) == "" ||
@@ -748,6 +755,7 @@ func normalizeWebhookIssue(issue *githubWebhookIssue) (normalizedIssue, sourceSt
 		Body:       body,
 		URL:        strings.TrimSpace(*issue.HTMLURL),
 		State:      strings.ToLower(strings.TrimSpace(*issue.State)),
+		AuthorID:   authorID,
 		Labels:     labels,
 		Assignees:  assignees,
 		CreatedAt:  createdAt,

--- a/internal/hubserver/github_webhook_test.go
+++ b/internal/hubserver/github_webhook_test.go
@@ -192,7 +192,7 @@ func TestGitHubWebhookSourceOrderingConverges(t *testing.T) {
 				}
 			}
 			got := readIssueProjectionSnapshot(t, service)
-			if got.Title != "Newer title" || got.SourceUpdatedAt != "2026-09-02T12:00:00.000000000Z" {
+			if got.Title != "Newer title" || got.AuthorID != "octocat" || got.SourceUpdatedAt != "2026-09-02T12:00:00.000000000Z" {
 				t.Fatalf("projection = %#v, want newer source", got)
 			}
 			if index == 0 {
@@ -637,6 +637,7 @@ type issueProjectionSnapshot struct {
 	Title           string
 	Body            string
 	State           string
+	AuthorID        string
 	LabelsJSON      string
 	AssigneesJSON   string
 	SourceVersion   string
@@ -647,12 +648,13 @@ func readIssueProjectionSnapshot(t *testing.T, service *Service) issueProjection
 	t.Helper()
 	var snapshot issueProjectionSnapshot
 	if err := service.database.db.QueryRowContext(t.Context(), `
-		SELECT title, body, github_state, labels_json, assignees_json, source_version, source_updated_at
+		SELECT title, body, github_state, author_login, labels_json, assignees_json, source_version, source_updated_at
 		FROM issues WHERE github_node_id = 'I_issue'
 	`).Scan(
 		&snapshot.Title,
 		&snapshot.Body,
 		&snapshot.State,
+		&snapshot.AuthorID,
 		&snapshot.LabelsJSON,
 		&snapshot.AssigneesJSON,
 		&snapshot.SourceVersion,
@@ -716,6 +718,7 @@ func completeIssueWebhookPayload(t *testing.T, title string, updatedAt string) s
 			"body":       "Issue body",
 			"html_url":   "https://github.com/digitaldrywood/detent/issues/2069",
 			"state":      "open",
+			"user":       map[string]any{"login": "octocat"},
 			"labels":     []any{map[string]any{"name": "feature"}, map[string]any{"name": "detent:todo"}},
 			"assignees":  []any{map[string]any{"login": "corylanou"}},
 			"created_at": "2026-09-01T12:00:00Z",

--- a/internal/hubserver/migrate.go
+++ b/internal/hubserver/migrate.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	hubSchemaTable         = "hub_schema_version"
-	supportedSchemaVersion = int64(6)
+	supportedSchemaVersion = int64(7)
 )
 
 //go:embed migrations/*.sql

--- a/internal/hubserver/migrations/00007_add_issue_author.sql
+++ b/internal/hubserver/migrations/00007_add_issue_author.sql
@@ -1,0 +1,2 @@
+-- +goose Up
+ALTER TABLE issues ADD COLUMN author_login TEXT NOT NULL DEFAULT '';

--- a/internal/hubserver/reconcile.go
+++ b/internal/hubserver/reconcile.go
@@ -67,6 +67,7 @@ type IssueSource struct {
 	Body       string
 	URL        string
 	State      string
+	AuthorID   string
 	Labels     []string
 	Assignees  []string
 	CreatedAt  time.Time

--- a/internal/hubserver/tracker_store.go
+++ b/internal/hubserver/tracker_store.go
@@ -35,6 +35,7 @@ SELECT
   q.state,
   q.rank,
   q.priority_override,
+  i.author_login,
   i.labels_json,
   i.assignees_json,
   i.source_updated_at,
@@ -188,6 +189,7 @@ func scanWorkItemRecord(row interface{ Scan(...any) error }) (tracker.Record, er
 	var queueState sql.NullString
 	var queueRank sql.NullString
 	var priorityRank sql.NullInt64
+	var authorLogin string
 	var labelsJSON string
 	var assigneesJSON string
 	var sourceUpdatedAt string
@@ -216,6 +218,7 @@ func scanWorkItemRecord(row interface{ Scan(...any) error }) (tracker.Record, er
 		&queueState,
 		&queueRank,
 		&priorityRank,
+		&authorLogin,
 		&labelsJSON,
 		&assigneesJSON,
 		&sourceUpdatedAt,
@@ -249,6 +252,7 @@ func scanWorkItemRecord(row interface{ Scan(...any) error }) (tracker.Record, er
 			record.Queue.PriorityRank = &priority
 		}
 	}
+	record.AuthorID = authorLogin
 	if err := json.Unmarshal([]byte(labelsJSON), &record.Labels); err != nil {
 		return tracker.Record{}, fmt.Errorf("decode hub work item labels: %w", err)
 	}

--- a/internal/hubserver/tracker_store_test.go
+++ b/internal/hubserver/tracker_store_test.go
@@ -31,7 +31,7 @@ func TestTrackerReadsNormalizedWorkItems(t *testing.T) {
 	if _, err := service.database.db.ExecContext(t.Context(), "INSERT INTO queue_entries (issue_id, workflow_state_id, scope, state, rank, priority_override, created_at, updated_at) SELECT ?, workflow_state_id, ?, ?, ?, ?, ?, ? FROM issues WHERE id = ?", issueID, "fleet", "Todo", "a0", 2, testTimestamp, testTimestamp, issueID); err != nil {
 		t.Fatalf("insert queue entry: %v", err)
 	}
-	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE issues SET body = ?, labels_json = ?, assignees_json = ?, github_database_id = ? WHERE id = ?", " Work item body ", `["hub"," Feature ","hub"]`, `["detent-bot"]`, 2068, issueID); err != nil {
+	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE issues SET body = ?, author_login = ?, labels_json = ?, assignees_json = ?, github_database_id = ? WHERE id = ?", " Work item body ", "octocat", `["hub"," Feature ","hub"]`, `["detent-bot"]`, 2068, issueID); err != nil {
 		t.Fatalf("update issue projection: %v", err)
 	}
 	if _, err := service.database.db.ExecContext(t.Context(), "UPDATE pull_requests SET checks_summary_json = ?, reviews_summary_json = ?, mergeable_state = ?, merge_ready = 1, merge_readiness_refreshed_at = ? WHERE issue_id = ?", `{"status":"completed","passed":3,"total":3}`, `{"decision":"approved","approvals":1}`, "clean", testTimestamp, issueID); err != nil {
@@ -59,8 +59,8 @@ func TestTrackerReadsNormalizedWorkItems(t *testing.T) {
 	if item.Repository.ID != tracker.RepositoryID(repositoryID) || item.Repository.Owner != "digitaldrywood" || item.GitHub.NodeID != "I_issue" || item.GitHub.Number != 1 || item.GitHub.DatabaseID == nil || *item.GitHub.DatabaseID != 2068 {
 		t.Errorf("source identity = repository %#v GitHub %#v", item.Repository, item.GitHub)
 	}
-	if item.BodyExcerpt != "Work item body" || strings.Join(item.Labels, ",") != "hub,Feature" || strings.Join(item.Assignees, ",") != "detent-bot" {
-		t.Errorf("normalized content = body %q labels %v assignees %v", item.BodyExcerpt, item.Labels, item.Assignees)
+	if item.BodyExcerpt != "Work item body" || item.AuthorID != "octocat" || strings.Join(item.Labels, ",") != "hub,Feature" || strings.Join(item.Assignees, ",") != "detent-bot" {
+		t.Errorf("normalized content = body %q author %q labels %v assignees %v", item.BodyExcerpt, item.AuthorID, item.Labels, item.Assignees)
 	}
 	if item.Queue == nil || item.Queue.Scope != "fleet" || item.Queue.PriorityRank == nil || *item.Queue.PriorityRank != 2 {
 		t.Errorf("Queue = %#v", item.Queue)

--- a/internal/orchestrator/claim.go
+++ b/internal/orchestrator/claim.go
@@ -14,6 +14,16 @@ const claimTimeFormat = time.RFC3339Nano
 
 func (o *Orchestrator) claimIssue(ctx context.Context, issue connector.Issue, now time.Time) (connector.Issue, Claimed, bool) {
 	issue = cloneIssue(issue)
+	if o.scheduling != nil {
+		claim, err := o.scheduling.AdoptClaim(ctx, issue, now)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("adopt Hub scheduling claim failed", "issue_id", issue.ID, "error", err)
+			}
+			return connector.Issue{}, Claimed{}, false
+		}
+		return claim.Issue, claim, true
+	}
 	claim := Claimed{
 		Issue:     issue,
 		ClaimedAt: now,

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -196,7 +196,22 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			o.logDispatchPlanDecision(ctx, state, now, decision)
 		},
 	})
+	o.releaseDeferredSchedulingClaims(ctx, state, issues)
 	o.observeProjectDispatchStatus(ctx, state, issues, decisions, outcomes, now)
+}
+
+func (o *Orchestrator) releaseDeferredSchedulingClaims(ctx context.Context, state *State, issues []connector.Issue) {
+	if o.scheduling == nil {
+		return
+	}
+	for _, issue := range issues {
+		if _, running := state.Running[issue.ID]; running {
+			continue
+		}
+		if err := o.scheduling.ReleaseClaim(ctx, issue.ID, "dispatch_deferred"); err != nil && o.logger != nil {
+			o.logger.Warn("release deferred Hub claim failed", "issue_id", issue.ID, "error", err)
+		}
+	}
 }
 
 func (o *Orchestrator) logOwnershipEligibilityStartup(planner dispatchPlanner, issues []connector.Issue) {

--- a/internal/orchestrator/heartbeat.go
+++ b/internal/orchestrator/heartbeat.go
@@ -35,6 +35,7 @@ type heartbeatManager struct {
 
 type heartbeatSettings struct {
 	connector    connector.Connector
+	scheduling   SchedulingSource
 	workAttempts store.WorkAttemptStore
 	claiming     ClaimingConfig
 	interval     time.Duration
@@ -65,6 +66,7 @@ type heartbeatResult struct {
 	workAttemptRenewed  bool
 	claimRenewed        bool
 	claimIssue          connector.Issue
+	claim               Claimed
 	claimOwnerLost      bool
 	currentClaimOwner   string
 	workerAlive         bool
@@ -76,7 +78,7 @@ type heartbeatResult struct {
 	claimError          error
 }
 
-func newHeartbeatManager(cfg Config, connectorBackend connector.Connector, workAttempts store.WorkAttemptStore, now func() time.Time, logger *slog.Logger) *heartbeatManager {
+func newHeartbeatManager(cfg Config, connectorBackend connector.Connector, workAttempts store.WorkAttemptStore, now func() time.Time, logger *slog.Logger, scheduling ...SchedulingSource) *heartbeatManager {
 	if now == nil {
 		now = time.Now
 	}
@@ -90,11 +92,11 @@ func newHeartbeatManager(cfg Config, connectorBackend connector.Connector, workA
 		now:     now,
 		logger:  logger,
 	}
-	manager.configure(cfg, connectorBackend, workAttempts)
+	manager.configure(cfg, connectorBackend, workAttempts, scheduling...)
 	return manager
 }
 
-func (m *heartbeatManager) configure(cfg Config, connectorBackend connector.Connector, workAttempts store.WorkAttemptStore) {
+func (m *heartbeatManager) configure(cfg Config, connectorBackend connector.Connector, workAttempts store.WorkAttemptStore, scheduling ...SchedulingSource) {
 	if m == nil {
 		return
 	}
@@ -104,6 +106,19 @@ func (m *heartbeatManager) configure(cfg Config, connectorBackend connector.Conn
 		claiming:     cfg.Claiming,
 		interval:     workHeartbeatInterval(cfg),
 		leaseTTL:     cfg.Claiming.LeaseTTL,
+	}
+	if len(scheduling) > 0 {
+		settings.scheduling = scheduling[0]
+	} else {
+		m.mu.Lock()
+		settings.scheduling = m.settings.scheduling
+		m.mu.Unlock()
+	}
+	if settings.scheduling != nil {
+		interval := settings.scheduling.HeartbeatInterval()
+		if interval > 0 && interval < settings.interval {
+			settings.interval = interval
+		}
 	}
 	if settings.leaseTTL <= 0 {
 		settings.leaseTTL = defaultWorkAttemptLeaseTTL
@@ -295,7 +310,15 @@ func (m *heartbeatManager) execute(ctx context.Context, target heartbeatTarget) 
 		result.workAttemptError = settings.workAttempts.RecordWorkAttemptHeartbeat(operationCtx, heartbeat)
 		result.workAttemptRenewed = result.workAttemptError == nil
 	}
-	if settings.claiming.Enabled && strings.TrimSpace(settings.claiming.LeaseField) != "" && strings.TrimSpace(target.claimOwner) != "" {
+	if settings.scheduling != nil {
+		result.claim, result.claimError = settings.scheduling.RenewClaim(operationCtx, target.issueID, now)
+		result.claimOwnerLost = errors.Is(result.claimError, ErrSchedulingClaimLost)
+		result.claimRenewed = result.claimError == nil
+		if result.claimRenewed {
+			result.claimIssue = result.claim.Issue
+			result.currentClaimOwner = result.claim.Owner
+		}
+	} else if settings.claiming.Enabled && strings.TrimSpace(settings.claiming.LeaseField) != "" && strings.TrimSpace(target.claimOwner) != "" {
 		result.claimIssue, result.currentClaimOwner, result.claimOwnerLost, result.claimError = renewTrackerClaim(operationCtx, settings, target, now)
 		result.claimRenewed = result.claimError == nil && !result.claimOwnerLost
 	}
@@ -537,10 +560,16 @@ func (o *Orchestrator) handleHeartbeatResult(state *State, result heartbeatResul
 	if !ok {
 		return
 	}
-	claimed.Owner = result.currentClaimOwner
-	claimed.LeaseRenewedAt = result.heartbeat.HeartbeatAt
-	claimed.LeaseExpiresAt = o.leaseExpiresAt(result.heartbeat.HeartbeatAt)
-	claimed.Issue = mergeIssueTrackerFields(claimed.Issue, result.claimIssue)
+	if result.claim.LeaseRenewedAt.IsZero() {
+		claimed.Owner = result.currentClaimOwner
+		claimed.LeaseRenewedAt = result.heartbeat.HeartbeatAt
+		claimed.LeaseExpiresAt = o.leaseExpiresAt(result.heartbeat.HeartbeatAt)
+		claimed.Issue = mergeIssueTrackerFields(claimed.Issue, result.claimIssue)
+	} else {
+		renewed := result.claim
+		renewed.Issue = mergeIssueTrackerFields(claimed.Issue, renewed.Issue)
+		claimed = renewed
+	}
 	state.Claimed[result.issueID] = claimed
 	running.Issue = mergeIssueTrackerFields(running.Issue, result.claimIssue)
 	state.Running[result.issueID] = running

--- a/internal/orchestrator/hub_scheduling_test.go
+++ b/internal/orchestrator/hub_scheduling_test.go
@@ -102,8 +102,11 @@ func TestHubSchedulingHeartbeatPreservesClaimedIssue(t *testing.T) {
 	issue.ID = "I_hub"
 	issue.Identifier = "acme/widgets#17"
 	issue.Title = "Hub scheduled"
-	renewedIssue := connector.NewIssue()
-	renewedIssue.ID = issue.ID
+	issue.Labels = []string{"detent:in-progress"}
+	issue.Assignees = []string{"worker-a"}
+	issue.BlockedBy = []connector.BlockedRef{{ID: "I_blocker"}}
+	issue.Fields["effort"] = "high"
+	renewedIssue := connector.Issue{ID: issue.ID}
 	renewed := Claimed{Issue: renewedIssue, Owner: "machine-a", ClaimedAt: now.Add(-time.Minute), LeaseRenewedAt: now, LeaseExpiresAt: now.Add(90 * time.Second)}
 	cfg := normalizeConfig(Config{PollInterval: 30 * time.Second, MaxConcurrentAgents: 1, Project: schedulerProjectCandidate("widgets")})
 	manager := newHeartbeatManager(cfg, nil, nil, func() time.Time { return now }, nil, &hubSchedulingSource{})
@@ -119,7 +122,9 @@ func TestHubSchedulingHeartbeatPreservesClaimedIssue(t *testing.T) {
 	orch.handleHeartbeatResult(&state, heartbeatResult{issueID: issue.ID, sequence: sequence, claimRenewed: true, claim: renewed, claimIssue: renewedIssue})
 
 	claim := state.Claimed[issue.ID]
-	if claim.Issue.Title != issue.Title || claim.Owner != "machine-a" || !claim.LeaseExpiresAt.Equal(renewed.LeaseExpiresAt) {
+	if claim.Issue.Title != issue.Title || !reflect.DeepEqual(claim.Issue.Labels, issue.Labels) ||
+		!reflect.DeepEqual(claim.Issue.Assignees, issue.Assignees) || !reflect.DeepEqual(claim.Issue.BlockedBy, issue.BlockedBy) ||
+		!reflect.DeepEqual(claim.Issue.Fields, issue.Fields) || claim.Owner != "machine-a" || !claim.LeaseExpiresAt.Equal(renewed.LeaseExpiresAt) {
 		t.Fatalf("renewed claim = %#v", claim)
 	}
 }

--- a/internal/orchestrator/hub_scheduling_test.go
+++ b/internal/orchestrator/hub_scheduling_test.go
@@ -1,0 +1,235 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestHubSchedulingCycle(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	issue := connector.NewIssue()
+	issue.ID = "I_hub"
+	issue.Identifier = "acme/widgets#17"
+	issue.Number = 17
+	issue.Title = "Hub scheduled"
+	issue.State = "Todo"
+	issue.URL = "https://github.com/acme/widgets/issues/17"
+	issue.Fields["detent_hub_work_item_id"] = "42"
+
+	tests := []struct {
+		name        string
+		fetchError  error
+		githubPause bool
+		wantRunning bool
+		wantDegrade bool
+	}{
+		{name: "Hub dispatches without connector reads", githubPause: true, wantRunning: true},
+		{name: "Hub outage degrades without spending work budgets", fetchError: errors.Join(ErrSchedulingUnavailable, errors.New("Hub unavailable")), wantDegrade: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			trackerBackend := &hubSchedulingConnector{}
+			scheduling := &hubSchedulingSource{issue: issue, fetchError: test.fetchError}
+			runner := &hubSchedulingRunner{started: make(chan struct{}, 1)}
+			cfg := normalizeConfig(Config{
+				PollInterval: 30 * time.Second, MaxConcurrentAgents: 1,
+				DispatchPriorityByState: []string{"Todo"}, TerminalStates: []string{"Done"},
+				Project: schedulerProjectCandidate("widgets"), SchedulingRepository: "acme/widgets",
+			})
+			orch, err := New(cfg, Dependencies{Connector: trackerBackend, Scheduling: scheduling, Runner: runner, Now: func() time.Time { return now }})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			state := newState(cfg)
+			if test.githubPause {
+				resetAt := now.Add(10 * time.Minute)
+				state.RateLimits = &telemetry.RateLimits{GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 0, Limit: 5000, Used: 5000, ResetAt: &resetAt}}
+			}
+			state.Retry["preserved"] = Retry{Attempt: 3, DueAt: now.Add(time.Hour)}
+			state.InstantFailures["preserved"] = InstantFailure{Count: 2}
+			state.RepeatedFailures["preserved"] = RepeatedFailure{Count: 2}
+			state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "preserved", At: now.Add(-time.Minute)}}
+			beforeRetry := state.Retry["preserved"]
+			beforeInstant := state.InstantFailures["preserved"]
+			beforeRepeated := state.RepeatedFailures["preserved"]
+			beforeBreaker := cloneProjectFailureBreaker(state.FailureBreaker)
+
+			orch.tick(t.Context(), &state, now)
+
+			if candidates, ids := trackerBackend.candidateReads.Load(), trackerBackend.idReads.Load(); candidates != 0 || ids != 0 {
+				t.Fatalf("scheduling-time connector reads = candidates %d ids %d, want zero", candidates, ids)
+			}
+			_, running := state.Running[issue.ID]
+			if running != test.wantRunning {
+				t.Fatalf("running = %t, want %t", running, test.wantRunning)
+			}
+			if test.wantRunning && (scheduling.fetches != 1 || scheduling.adoptions != 1 || scheduling.releases != 0) {
+				t.Fatalf("Hub scheduling calls = fetch %d adopt %d release %d", scheduling.fetches, scheduling.adoptions, scheduling.releases)
+			}
+			if test.githubPause && state.PollInterval != cfg.PollInterval {
+				t.Fatalf("Hub poll interval = %s, want %s despite GitHub pause", state.PollInterval, cfg.PollInterval)
+			}
+			if test.wantDegrade {
+				if !strings.Contains(state.LastRefreshError, "Hub unavailable") || !state.Snapshot(now).Refresh.Degraded() {
+					t.Fatalf("refresh = %#v", state.Snapshot(now).Refresh)
+				}
+				if !reflect.DeepEqual(state.Retry["preserved"], beforeRetry) || !reflect.DeepEqual(state.InstantFailures["preserved"], beforeInstant) || !reflect.DeepEqual(state.RepeatedFailures["preserved"], beforeRepeated) || !reflect.DeepEqual(state.FailureBreaker, beforeBreaker) {
+					t.Fatalf("outage changed work budgets: retry=%#v instant=%#v repeated=%#v breaker=%#v", state.Retry, state.InstantFailures, state.RepeatedFailures, state.FailureBreaker)
+				}
+				if state.PollInterval <= cfg.PollInterval {
+					t.Fatalf("outage poll interval = %s, want backoff above %s", state.PollInterval, cfg.PollInterval)
+				}
+			}
+			for id := range state.Running {
+				orch.cancelRunning(&state, id)
+			}
+		})
+	}
+}
+
+func TestHubSchedulingHeartbeatPreservesClaimedIssue(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	issue := connector.NewIssue()
+	issue.ID = "I_hub"
+	issue.Identifier = "acme/widgets#17"
+	issue.Title = "Hub scheduled"
+	renewedIssue := connector.NewIssue()
+	renewedIssue.ID = issue.ID
+	renewed := Claimed{Issue: renewedIssue, Owner: "machine-a", ClaimedAt: now.Add(-time.Minute), LeaseRenewedAt: now, LeaseExpiresAt: now.Add(90 * time.Second)}
+	cfg := normalizeConfig(Config{PollInterval: 30 * time.Second, MaxConcurrentAgents: 1, Project: schedulerProjectCandidate("widgets")})
+	manager := newHeartbeatManager(cfg, nil, nil, func() time.Time { return now }, nil, &hubSchedulingSource{})
+	manager.upsert(heartbeatTarget{issueID: issue.ID, claimOwner: "machine-a"})
+	manager.mu.Lock()
+	sequence := manager.targets[issue.ID].sequence
+	manager.mu.Unlock()
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{Issue: issue}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, Owner: "machine-a"}
+	orch := &Orchestrator{cfg: cfg, heartbeats: manager}
+
+	orch.handleHeartbeatResult(&state, heartbeatResult{issueID: issue.ID, sequence: sequence, claimRenewed: true, claim: renewed, claimIssue: renewedIssue})
+
+	claim := state.Claimed[issue.ID]
+	if claim.Issue.Title != issue.Title || claim.Owner != "machine-a" || !claim.LeaseExpiresAt.Equal(renewed.LeaseExpiresAt) {
+		t.Fatalf("renewed claim = %#v", claim)
+	}
+}
+
+type hubSchedulingSource struct {
+	issue      connector.Issue
+	fetchError error
+	fetches    int
+	adoptions  int
+	releases   int
+}
+
+func (s *hubSchedulingSource) HeartbeatInterval() time.Duration {
+	return 30 * time.Second
+}
+
+func (s *hubSchedulingSource) FetchCandidateIssues(_ context.Context, request SchedulingRequest) ([]connector.Issue, error) {
+	s.fetches++
+	if request.Repository != "acme/widgets" {
+		return nil, errors.New("unexpected repository")
+	}
+	if s.fetchError != nil {
+		return nil, s.fetchError
+	}
+	return []connector.Issue{s.issue}, nil
+}
+
+func (s *hubSchedulingSource) AdoptClaim(_ context.Context, issue connector.Issue, now time.Time) (Claimed, error) {
+	s.adoptions++
+	return Claimed{Issue: issue, ClaimedAt: now, LeaseRenewedAt: now, LeaseExpiresAt: now.Add(90 * time.Second), Owner: "machine-a"}, nil
+}
+
+func (s *hubSchedulingSource) RenewClaim(_ context.Context, _ string, _ time.Time) (Claimed, error) {
+	return Claimed{}, nil
+}
+
+func (s *hubSchedulingSource) ReleaseClaim(_ context.Context, _ string, _ string) error {
+	s.releases++
+	return nil
+}
+
+type hubSchedulingConnector struct {
+	reads          atomic.Int64
+	candidateReads atomic.Int64
+	stateReads     atomic.Int64
+	idReads        atomic.Int64
+	writes         atomic.Int64
+}
+
+func (c *hubSchedulingConnector) Name() string { return "github" }
+
+func (c *hubSchedulingConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.reads.Add(1)
+	c.candidateReads.Add(1)
+	return nil, nil
+}
+
+func (c *hubSchedulingConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	c.reads.Add(1)
+	c.stateReads.Add(1)
+	return nil, nil
+}
+
+func (c *hubSchedulingConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	c.reads.Add(1)
+	c.idReads.Add(1)
+	return nil, nil
+}
+
+func (c *hubSchedulingConnector) CombinedRefreshEnabled() bool { return true }
+
+func (c *hubSchedulingConnector) FetchRefreshIssues(context.Context, []string, []string, connector.IssueFilterHint) connector.RefreshIssueResult {
+	c.reads.Add(1)
+	c.candidateReads.Add(1)
+	return connector.RefreshIssueResult{}
+}
+
+func (c *hubSchedulingConnector) CreateComment(context.Context, string, string) error {
+	c.writes.Add(1)
+	return nil
+}
+
+func (c *hubSchedulingConnector) UpdateIssueState(context.Context, string, string) error {
+	c.writes.Add(1)
+	return nil
+}
+
+func (c *hubSchedulingConnector) SetAssignee(context.Context, string, string) error {
+	c.writes.Add(1)
+	return nil
+}
+
+func (c *hubSchedulingConnector) SetField(context.Context, string, string, string) error {
+	c.writes.Add(1)
+	return nil
+}
+
+type hubSchedulingRunner struct {
+	started chan struct{}
+}
+
+func (r *hubSchedulingRunner) Run(ctx context.Context, _ RunRequest) (RunResult, error) {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-ctx.Done()
+	return RunResult{}, ctx.Err()
+}
+
+func schedulerProjectCandidate(id string) scheduler.ProjectCandidate {
+	return scheduler.ProjectCandidate{ID: id, Weight: 1}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -67,8 +67,10 @@ const (
 )
 
 var (
-	ErrMissingConnector = errors.New("orchestrator connector is required")
-	ErrStopped          = errors.New("orchestrator stopped")
+	ErrMissingConnector      = errors.New("orchestrator connector is required")
+	ErrSchedulingClaimLost   = errors.New("scheduling claim lost")
+	ErrSchedulingUnavailable = errors.New("scheduling source unavailable")
+	ErrStopped               = errors.New("orchestrator stopped")
 )
 
 type Config struct {
@@ -101,6 +103,7 @@ type Config struct {
 	RateWindowPacing              workflowconfig.RateWindowPacing
 	FailureBreaker                FailureBreakerConfig
 	Project                       scheduler.ProjectCandidate
+	SchedulingRepository          string
 	Claiming                      ClaimingConfig
 	AutoPromote                   AutoPromoteConfig
 	Plan                          gate.PlanConfig
@@ -163,8 +166,24 @@ type ClaimingConfig struct {
 	HeartbeatInterval time.Duration
 }
 
+type SchedulingRequest struct {
+	ProjectID      string
+	Repository     string
+	WorkflowStates []string
+	Filter         connector.IssueFilterHint
+}
+
+type SchedulingSource interface {
+	HeartbeatInterval() time.Duration
+	FetchCandidateIssues(context.Context, SchedulingRequest) ([]connector.Issue, error)
+	AdoptClaim(context.Context, connector.Issue, time.Time) (Claimed, error)
+	RenewClaim(context.Context, string, time.Time) (Claimed, error)
+	ReleaseClaim(context.Context, string, string) error
+}
+
 type Dependencies struct {
 	Connector            connector.Connector
+	Scheduling           SchedulingSource
 	Runner               Runner
 	WorkspaceReaper      WorkspaceReaper
 	WorkflowMetrics      WorkflowMetricsRecorder
@@ -227,6 +246,7 @@ type RuntimeUpdate struct {
 type Orchestrator struct {
 	cfg                     Config
 	connector               connector.Connector
+	scheduling              SchedulingSource
 	workflowMetrics         WorkflowMetricsRecorder
 	laneMutations           store.LaneMutationStore
 	efficiency              efficiency.Recorder
@@ -592,6 +612,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	orchestrator := &Orchestrator{
 		cfg:                     cfg,
 		connector:               deps.Connector,
+		scheduling:              deps.Scheduling,
 		workflowMetrics:         deps.WorkflowMetrics,
 		laneMutations:           laneMutations,
 		efficiency:              deps.Efficiency,
@@ -663,7 +684,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		completedStops:          map[string]StopRunResult{},
 		tickWatchdog:            newTickWatchdog(cfg.Project.ID, cfg.PollInterval, logger),
 	}
-	orchestrator.heartbeats = newHeartbeatManager(cfg, deps.Connector, deps.WorkAttempts, now, logger)
+	orchestrator.heartbeats = newHeartbeatManager(cfg, deps.Connector, deps.WorkAttempts, now, logger, deps.Scheduling)
 	return orchestrator, nil
 }
 
@@ -1255,6 +1276,9 @@ func (o *Orchestrator) forceQuit(ctx context.Context, state *State, now time.Tim
 }
 
 func (o *Orchestrator) abandonClaim(ctx context.Context, issueID string) error {
+	if o.scheduling != nil {
+		return o.scheduling.ReleaseClaim(ctx, issueID, "orchestrator_release")
+	}
 	if !o.cfg.Claiming.Enabled || strings.TrimSpace(o.cfg.Claiming.LeaseField) == "" {
 		return nil
 	}

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -386,6 +386,13 @@ func (o *Orchestrator) adaptivePollInterval(state *State, now time.Time) time.Du
 	if base <= 0 {
 		base = defaultPollInterval
 	}
+	if o.scheduling != nil {
+		source := state.RefreshSources[telemetry.RefreshSourceCandidates]
+		if source.Condition == schedulingUnavailableCondition && source.FailureStreak > 0 {
+			return schedulingBackoffInterval(base, source.FailureStreak)
+		}
+		return dispatchRecoveryPollInterval(state, now, base)
+	}
 
 	if pause := o.gitHubGraphQLPause(state, now); pause > base {
 		return pause
@@ -393,7 +400,6 @@ func (o *Orchestrator) adaptivePollInterval(state *State, now time.Time) time.Du
 	if pause := o.gitHubRESTPause(state, now); pause > base {
 		return pause
 	}
-
 	bucket := gitHubGraphQLBucketFromState(state)
 	if bucket == nil || bucket.Remaining <= 0 || bucket.Remaining >= gitHubGraphQLBackoffRemaining {
 		return dispatchRecoveryPollInterval(state, now, base)
@@ -407,6 +413,22 @@ func (o *Orchestrator) adaptivePollInterval(state *State, now time.Time) time.Du
 		multiplier = 2
 	}
 	return dispatchRecoveryPollInterval(state, now, base*time.Duration(multiplier))
+}
+
+func schedulingBackoffInterval(base time.Duration, failureStreak int) time.Duration {
+	if base <= 0 || failureStreak <= 0 {
+		return base
+	}
+	shift := min(failureStreak, 4)
+	interval := base * time.Duration(1<<shift)
+	maximum := 5 * time.Minute
+	if maximum < base {
+		maximum = base
+	}
+	if interval > maximum {
+		return maximum
+	}
+	return interval
 }
 
 func (o *Orchestrator) gitHubRESTPause(state *State, now time.Time) time.Duration {

--- a/internal/orchestrator/refresh_health.go
+++ b/internal/orchestrator/refresh_health.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"sort"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ const (
 	refreshFailureDegradedThreshold = 3
 	refreshStaleIntervalMultiplier  = 2
 	defaultRefreshStaleAfter        = 2 * time.Minute
+	schedulingUnavailableCondition  = "scheduling_unavailable"
 )
 
 func recordRefreshSourceSuccess(state *State, name telemetry.RefreshSourceName, at time.Time) {
@@ -48,7 +50,10 @@ func recordRefreshSourceFailure(state *State, name telemetry.RefreshSourceName, 
 	source.FailureStreak++
 	if err != nil {
 		source.LastError = strings.TrimSpace(err.Error())
-		if availabilityErr, ok := connector.AsTrackerAvailability(err); ok {
+		if errors.Is(err, ErrSchedulingUnavailable) {
+			source.Condition = schedulingUnavailableCondition
+			source.Connector = "hub"
+		} else if availabilityErr, ok := connector.AsTrackerAvailability(err); ok {
 			source.Condition = connector.TrackerUnavailableCondition
 			source.Connector = availabilityErr.Scope.Connector
 		} else {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -79,16 +79,20 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	o.syncGitHubRESTCapacityOutage(state, now)
 	if pause := o.gitHubGraphQLPause(state, now); pause > 0 {
 		o.logger.Warn("github graphql polling paused", "remaining", gitHubGraphQLRemaining(state), "pause", pause)
-		return
+		if o.scheduling == nil {
+			return
+		}
 	}
 	if pause := o.gitHubRESTPause(state, now); pause > 0 {
 		o.logger.Warn("github rest polling paused", "remaining", gitHubRESTRemaining(state), "pause", pause)
+		if o.scheduling == nil {
+			return
+		}
+	}
+	if o.trackerAvailabilityPaused(ctx, state, now) && o.scheduling == nil {
 		return
 	}
-	if o.trackerAvailabilityPaused(ctx, state, now) {
-		return
-	}
-	if !o.retryDeferredCompletions(ctx, state, now) {
+	if !o.retryDeferredCompletions(ctx, state, now) && o.scheduling == nil {
 		return
 	}
 
@@ -345,7 +349,7 @@ func (o *Orchestrator) fetchTickIssues(
 	reserve githubBudgetReserveDecision,
 ) (tickFetchedIssues, bool) {
 	observedStates := o.observedStatusFetchStatesForTick(state)
-	if fetcher, ok := o.connector.(connector.RefreshIssueFetcher); ok && fetcher.CombinedRefreshEnabled() && !reserve.degraded {
+	if fetcher, ok := o.connector.(connector.RefreshIssueFetcher); o.scheduling == nil && ok && fetcher.CombinedRefreshEnabled() && !reserve.degraded {
 		return o.fetchCombinedTickIssues(ctx, state, now, observedStates, fetcher)
 	}
 
@@ -353,12 +357,16 @@ func (o *Orchestrator) fetchTickIssues(
 	if err != nil {
 		o.logger.Warn("fetch candidate issues failed", "error", err)
 		recordRefreshSourceFailure(state, telemetry.RefreshSourceCandidates, err, now)
-		o.observeTrackerReadFailure(state, telemetry.RefreshSourceCandidates, err, now)
+		if o.scheduling == nil {
+			o.observeTrackerReadFailure(state, telemetry.RefreshSourceCandidates, err, now)
+		}
 		markRefreshError(state, "fetch candidate issues failed: "+err.Error(), now)
 		return tickFetchedIssues{}, false
 	}
 	recordRefreshSourceSuccess(state, telemetry.RefreshSourceCandidates, now)
-	o.recordTrackerReadSuccess(state, telemetry.RefreshSourceCandidates, now)
+	if o.scheduling == nil {
+		o.recordTrackerReadSuccess(state, telemetry.RefreshSourceCandidates, now)
+	}
 
 	fetched := tickFetchedIssues{
 		candidates: cloneIssues(candidateIssues),
@@ -479,18 +487,22 @@ func (o *Orchestrator) fetchObservedIssuesByStates(ctx context.Context, states [
 }
 
 func (o *Orchestrator) fetchCandidateIssuesForTick(ctx context.Context, state *State) ([]connector.Issue, error) {
+	states := o.candidateFetchStatesForTick(state)
+	if len(states) == 0 {
+		return []connector.Issue{}, nil
+	}
+	if o.scheduling != nil {
+		return o.scheduling.FetchCandidateIssues(ctx, SchedulingRequest{
+			ProjectID:      o.cfg.Project.ID,
+			Repository:     o.cfg.SchedulingRepository,
+			WorkflowStates: states,
+			Filter:         o.authorizationFilterHint(),
+		})
+	}
 	if fetcher, ok := o.connector.(connector.CandidateIssuesFilterFetcher); ok {
-		states := o.candidateFetchStatesForTick(state)
-		if len(states) == 0 {
-			return []connector.Issue{}, nil
-		}
 		return fetcher.FetchCandidateIssuesByStatesWithFilter(ctx, states, o.authorizationFilterHint())
 	}
 	if fetcher, ok := o.connector.(connector.CandidateIssuesByStatesFetcher); ok {
-		states := o.candidateFetchStatesForTick(state)
-		if len(states) == 0 {
-			return []connector.Issue{}, nil
-		}
 		return fetcher.FetchCandidateIssuesByStates(ctx, states)
 	}
 	return o.connector.FetchCandidateIssues(ctx)

--- a/internal/project/connector_config_test.go
+++ b/internal/project/connector_config_test.go
@@ -1,14 +1,61 @@
 package project
 
 import (
+	"context"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 )
+
+type testSchedulingSource struct{}
+
+func (*testSchedulingSource) HeartbeatInterval() time.Duration { return time.Second }
+func (*testSchedulingSource) FetchCandidateIssues(context.Context, orchestrator.SchedulingRequest) ([]connector.Issue, error) {
+	return nil, nil
+}
+func (*testSchedulingSource) AdoptClaim(context.Context, connector.Issue, time.Time) (orchestrator.Claimed, error) {
+	return orchestrator.Claimed{}, nil
+}
+func (*testSchedulingSource) RenewClaim(context.Context, string, time.Time) (orchestrator.Claimed, error) {
+	return orchestrator.Claimed{}, nil
+}
+func (*testSchedulingSource) ReleaseClaim(context.Context, string, string) error { return nil }
+
+func TestProjectSchedulingSourceRequiresGitHubRepository(t *testing.T) {
+	t.Parallel()
+
+	source := &testSchedulingSource{}
+	tests := []struct {
+		name       string
+		kind       string
+		repository string
+		want       orchestrator.SchedulingSource
+	}{
+		{name: "GitHub", kind: workflowconfig.TrackerGitHub, repository: "acme/widgets", want: source},
+		{name: "GitHub missing repository", kind: workflowconfig.TrackerGitHub},
+		{name: "GitHub local", kind: workflowconfig.TrackerGitHubLocal, repository: "acme/widgets"},
+		{name: "Linear", kind: workflowconfig.TrackerLinear},
+		{name: "memory", kind: workflowconfig.TrackerMemory},
+		{name: "local SQLite", kind: workflowconfig.TrackerLocalSQLite},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workflow := workflowconfig.Default()
+			workflow.Tracker.Kind = test.kind
+			workflow.Tracker.Repository = test.repository
+			if got := projectSchedulingSource(source, workflow); got != test.want {
+				t.Fatalf("projectSchedulingSource() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
 
 func TestTrackerStateMapConvertsWorkflowMap(t *testing.T) {
 	t.Parallel()

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -411,7 +411,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	orchConfig := projectOrchestratorConfig(cfg.Project, workflow.Config)
 	orchDeps := orchestrator.Dependencies{
 		Connector:          projectConnector,
-		Scheduling:         deps.Scheduling,
+		Scheduling:         projectSchedulingSource(deps.Scheduling, workflow.Config),
 		Runner:             deps.Runner,
 		GlobalDispatchGate: deps.GlobalDispatchGate,
 		DispatchPacer:      deps.DispatchPacer,
@@ -1650,6 +1650,13 @@ func buildReleaseCoordinator(cfg workflowconfig.Config, projectConnector connect
 		RerunFlakyOnce:  cfg.Release.RerunFlakyOnce,
 		FlakyCheckNames: append([]string(nil), cfg.Release.FlakyCheckNames...),
 	}, releaseBackend)}, nil
+}
+
+func projectSchedulingSource(source orchestrator.SchedulingSource, workflow workflowconfig.Config) orchestrator.SchedulingSource {
+	if workflow.Tracker.Kind != workflowconfig.TrackerGitHub || strings.TrimSpace(workflow.Tracker.Repository) == "" {
+		return nil
+	}
+	return source
 }
 
 func projectOrchestratorConfig(project globalconfig.Project, workflow workflowconfig.Config) orchestrator.Config {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -137,6 +137,7 @@ type startOptions struct {
 
 type Dependencies struct {
 	Connector                 connector.Connector
+	Scheduling                orchestrator.SchedulingSource
 	ConnectorFactory          ConnectorFactory
 	OrchestratorFactory       OrchestratorFactory
 	WorkflowWatcherFactory    WorkflowWatcherFactory
@@ -410,6 +411,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	orchConfig := projectOrchestratorConfig(cfg.Project, workflow.Config)
 	orchDeps := orchestrator.Dependencies{
 		Connector:          projectConnector,
+		Scheduling:         deps.Scheduling,
 		Runner:             deps.Runner,
 		GlobalDispatchGate: deps.GlobalDispatchGate,
 		DispatchPacer:      deps.DispatchPacer,
@@ -1666,6 +1668,7 @@ func projectOrchestratorConfig(project globalconfig.Project, workflow workflowco
 		ActiveHours:              workflow.ActiveHours,
 		ActiveHoursOverrideUntil: overrideUntil,
 	}
+	cfg.SchedulingRepository = workflow.Tracker.Repository
 	lessonPath := strings.TrimSpace(cfg.Lessons.Path)
 	if lessonPath == "" {
 		lessonPath = lessons.DefaultPath

--- a/internal/tracker/normalize.go
+++ b/internal/tracker/normalize.go
@@ -18,6 +18,7 @@ type Record struct {
 	SourceState     string
 	WorkflowState   *WorkflowState
 	Queue           *QueueSummary
+	AuthorID        string
 	Labels          []string
 	Assignees       []string
 	CreatedAt       *time.Time
@@ -49,6 +50,7 @@ func Normalize(record Record) WorkItem {
 		SourceState:     normalizeSourceState(record.SourceState),
 		WorkflowState:   normalizeWorkflowState(record.WorkflowState),
 		Queue:           normalizeQueue(record.Queue),
+		AuthorID:        strings.TrimSpace(record.AuthorID),
 		Labels:          normalizeStrings(record.Labels),
 		Assignees:       normalizeStrings(record.Assignees),
 		CreatedAt:       cloneTime(record.CreatedAt),

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -233,6 +233,7 @@ type WorkItem struct {
 	SourceState     SourceState          `json:"source_state"`
 	WorkflowState   *WorkflowState       `json:"workflow_state,omitempty"`
 	Queue           *QueueSummary        `json:"queue,omitempty"`
+	AuthorID        string               `json:"author_id,omitempty"`
 	Labels          []string             `json:"labels"`
 	Assignees       []string             `json:"assignees"`
 	CreatedAt       *time.Time           `json:"created_at,omitempty"`


### PR DESCRIPTION
## Summary

- add authenticated Hub machine registration, capacity/capability heartbeats, repository-scoped atomic claims, and fenced lease lifecycle handling
- route orchestrator candidate scheduling through Hub while preserving GitHub for reconciliation, write-back, and irreversible-action safety reads
- surface Hub outages as degraded scheduling infrastructure with exponential backoff and no issue retry, no-progress, or work-failure budget consumption
- document and validate the new host-level `client` configuration

Fixes #2075

## UI Surface Contract

- [x] N/A; this PR does not change an operator UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make generate`
- [x] `make check` (Go 1.26.6 and golangci-lint 2.9.0; race green; 78.7% aggregate coverage)
