### PR TITLE
fix(github): trust Codex review summaries

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -354,6 +354,8 @@
 #             duration_seconds: 0
 #         # tracker.issues[].pull_request.codex_review_state | type: string | default: none | required: No | validation: None
 #         codex_review_state: null
+#         # tracker.issues[].pull_request.codex_review_source | type: string | default: none | required: No | validation: None
+#         codex_review_source: null
 #         # tracker.issues[].pull_request.codex_review_api_state | type: string | default: none | required: No | validation: None
 #         codex_review_api_state: null
 #         # tracker.issues[].pull_request.codex_review_body_severity | type: string | default: none | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -1019,6 +1019,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.codex_review_findings[].line` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.codex_review_findings[].path` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.codex_review_findings[].url` | `string` | `none` | No | None |
+| `tracker.issues[].pull_request.codex_review_source` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.codex_review_state` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.codex_review_submitted_at` | `mapping` | `none` | No | None |
 | `tracker.issues[].pull_request.diff_fingerprint` | `string` | `none` | No | None |

--- a/internal/cli/doctor_autopromote.go
+++ b/internal/cli/doctor_autopromote.go
@@ -30,6 +30,7 @@ type doctorAutoPromoteCandidateDiagnostic struct {
 	PRURL                        string     `json:"pr_url,omitempty"`
 	PRHeadSHA                    string     `json:"pr_head_sha,omitempty"`
 	PRMergeableState             string     `json:"pr_mergeable_state,omitempty"`
+	CodexReviewSource            string     `json:"codex_review_source,omitempty"`
 	LatestCodexReviewState       string     `json:"latest_codex_review_state,omitempty"`
 	LatestCodexReviewCommitSHA   string     `json:"latest_codex_review_commit_sha,omitempty"`
 	LatestCodexReviewSubmittedAt *time.Time `json:"latest_codex_review_submitted_at,omitempty"`
@@ -615,6 +616,7 @@ func doctorAutoPromoteCandidateDiagnosticFromIssue(
 	diagnostic.PRURL = strings.TrimSpace(pullRequest.URL)
 	diagnostic.PRHeadSHA = strings.TrimSpace(pullRequest.HeadSHA)
 	diagnostic.PRMergeableState = strings.TrimSpace(pullRequest.MergeableState)
+	diagnostic.CodexReviewSource = strings.TrimSpace(pullRequest.CodexReviewSource)
 	diagnostic.LatestCodexReviewState = doctorLatestCodexReviewState(pullRequest)
 	diagnostic.LatestCodexReviewCommitSHA = strings.TrimSpace(pullRequest.LatestCodexReviewCommitSHA)
 	diagnostic.LatestCodexReviewSubmittedAt = doctorLatestCodexReviewSubmittedAt(pullRequest)
@@ -700,6 +702,9 @@ func doctorAutoPromoteCandidateSummary(candidate doctorAutoPromoteCandidateDiagn
 	}
 	if candidate.LatestCodexReviewSubmittedAt != nil {
 		parts = append(parts, "submitted="+candidate.LatestCodexReviewSubmittedAt.UTC().Format(time.RFC3339))
+	}
+	if candidate.CodexReviewSource != "" {
+		parts = append(parts, "review_source="+candidate.CodexReviewSource)
 	}
 	if candidate.QuietRemainingSeconds > 0 {
 		parts = append(parts, "quiet_remaining="+(time.Duration(candidate.QuietRemainingSeconds)*time.Second).String())

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2453,6 +2453,7 @@ func TestCheckDoctorAutoPromoteCandidateDiagnostics(t *testing.T) {
 				HeadSHA:                      "head-ready",
 				CIStatus:                     "success",
 				CodexReviewState:             "COMMENTED",
+				CodexReviewSource:            connector.PullRequestReviewSourceSummaryComment,
 				CodexReviewSubmittedAt:       &oldReview,
 				LatestCodexReviewState:       "COMMENTED",
 				LatestCodexReviewCommitSHA:   "head-ready",
@@ -2464,6 +2465,7 @@ func TestCheckDoctorAutoPromoteCandidateDiagnostics(t *testing.T) {
 				PRNumber:                     398,
 				PRURL:                        "https://github.test/pull/398",
 				PRHeadSHA:                    "head-ready",
+				CodexReviewSource:            connector.PullRequestReviewSourceSummaryComment,
 				LatestCodexReviewState:       "COMMENTED",
 				LatestCodexReviewCommitSHA:   "head-ready",
 				LatestCodexReviewSubmittedAt: &oldReview,
@@ -2544,6 +2546,9 @@ func TestCheckDoctorAutoPromoteCandidateDiagnostics(t *testing.T) {
 			}
 			if tt.want.WorkpadBlocker != "" && !strings.Contains(got.Detail, tt.want.WorkpadBlocker) {
 				t.Fatalf("Detail = %q, want containing WorkpadBlocker %q", got.Detail, tt.want.WorkpadBlocker)
+			}
+			if tt.want.CodexReviewSource != "" && !strings.Contains(got.Detail, "review_source="+tt.want.CodexReviewSource) {
+				t.Fatalf("Detail = %q, want review source %q", got.Detail, tt.want.CodexReviewSource)
 			}
 		})
 	}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -106,6 +106,191 @@ func TestPullRequestCodexReviewFindingsUseExplicitBodySeverity(t *testing.T) {
 	}
 }
 
+func TestLatestCodexReviewRequiresExactCurrentHead(t *testing.T) {
+	t.Parallel()
+
+	headSHA := strings.Repeat("a", 40)
+	tests := []struct {
+		name     string
+		commitID string
+		want     bool
+	}{
+		{name: "exact head", commitID: headSHA, want: true},
+		{name: "missing commit"},
+		{name: "abbreviated commit", commitID: headSHA[:10]},
+		{name: "stale commit", commitID: strings.Repeat("b", 40)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, got := latestCodexReview([]restReview{{
+				State:    "COMMENTED",
+				User:     &actor{Login: "chatgpt-codex-connector[bot]", Type: "Bot"},
+				CommitID: tt.commitID,
+			}}, headSHA)
+			if got != tt.want {
+				t.Fatalf("latestCodexReview() ok = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectorFetchPullRequestReviewsUsesTrustedCurrentHeadSummary(t *testing.T) {
+	t.Parallel()
+
+	const headSHA = "79f9eb2d4ad5317af5ff46f29aba3b91f4b413a0"
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/gopherguides/gopher-ai/pulls/389/reviews?per_page=100",
+			body:   `[{"body":"[P1] Prior-head finding.","html_url":"https://github.com/gopherguides/gopher-ai/pull/389#pullrequestreview-1","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"commit_id":"f236cc46fbb1a0e6821f16001e97ce07e0d483cd","submitted_at":"2026-09-02T22:18:56Z"}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/gopherguides/gopher-ai/issues/389/comments?per_page=100",
+			body:   `[{"node_id":"IC_summary","body":"<!-- codex-pull-request-review-summary -->\n\n## Codex Review Summary\n\n| Review | Status | Commit | Review trigger |\n| --- | --- | --- | --- |\n| 📝 **Code Review** | ✅ **Completed** <relative-time datetime=\"2026-09-02T22:35:58.561318Z\">2026-09-02T22:35:58.561318Z</relative-time> | ` + "`79f9eb2`" + ` | Manual request |","html_url":"https://github.com/gopherguides/gopher-ai/pull/389#issuecomment-1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-09-02T16:27:27Z","updated_at":"2026-09-02T22:35:59Z"}]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{})
+	reviews, err := c.fetchPullRequestReviews(context.Background(), pullRequestRepo{Owner: "gopherguides", Name: "gopher-ai"}, 389, headSHA)
+	if err != nil {
+		t.Fatalf("fetchPullRequestReviews() error = %v", err)
+	}
+	if len(reviews.CurrentHead) != 1 {
+		t.Fatalf("CurrentHead = %#v, want trusted summary review", reviews.CurrentHead)
+	}
+	if got := pullRequestCodexReviewStateFromReviews(reviews.CurrentHead); got != "COMMENTED" {
+		t.Fatalf("current-head state = %q, want COMMENTED", got)
+	}
+	if got := reviews.CurrentHead[0].Source; got != connector.PullRequestReviewSourceSummaryComment {
+		t.Fatalf("current-head source = %q, want %q", got, connector.PullRequestReviewSourceSummaryComment)
+	}
+	if got := reviewBodySeverity(reviews.CurrentHead[0].Body); got != "" {
+		t.Fatalf("current-head severity = %q, want clean", got)
+	}
+	wantSubmittedAt := time.Date(2026, 9, 2, 22, 35, 58, 561318000, time.UTC)
+	if got := reviews.CurrentHead[0].SubmittedAt; got == nil || !got.Equal(wantSubmittedAt) {
+		t.Fatalf("current-head submitted at = %v, want %v", got, wantSubmittedAt)
+	}
+	if len(reviews.Latest) != 1 || reviews.Latest[0].CommitID != "f236cc46fbb1a0e6821f16001e97ce07e0d483cd" {
+		t.Fatalf("Latest = %#v, want prior-head formal review preserved", reviews.Latest)
+	}
+	if got := pullRequestCodexReviewStateFromReviews(reviews.Latest); got != "P1" {
+		t.Fatalf("latest formal state = %q, want stale P1 to remain observable", got)
+	}
+}
+
+func TestLatestCodexSummaryReviewFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	completedAt := time.Date(2026, 9, 2, 22, 35, 58, 561318000, time.UTC)
+	createdAt := completedAt.Add(-time.Hour)
+	updatedAt := completedAt.Add(time.Second)
+	headSHA := strings.Repeat("a", 40)
+	trustedAuthor := &actor{Login: "chatgpt-codex-connector[bot]", Type: "Bot"}
+	validComment := restComment{
+		ID:        1,
+		Body:      testCodexReviewSummaryBody("✅ **Completed** <relative-time datetime=\"2026-09-02T22:35:58.561318Z\">2026-09-02T22:35:58.561318Z</relative-time>", headSHA[:7]),
+		HTMLURL:   "https://github.test/pull/1#issuecomment-1",
+		User:      trustedAuthor,
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+	}
+
+	tests := []struct {
+		name          string
+		comments      []restComment
+		formalReviews []restReview
+		want          bool
+	}{
+		{name: "trusted completed current head", comments: []restComment{validComment}, want: true},
+		{
+			name: "untrusted user",
+			comments: []restComment{func() restComment {
+				comment := validComment
+				comment.User = &actor{Login: "chatgpt-codex-connector[bot]", Type: "User"}
+				return comment
+			}()},
+		},
+		{
+			name: "untrusted bot",
+			comments: []restComment{func() restComment {
+				comment := validComment
+				comment.User = &actor{Login: "codex-helper[bot]", Type: "Bot"}
+				return comment
+			}()},
+		},
+		{
+			name: "stale head",
+			comments: []restComment{func() restComment {
+				comment := validComment
+				comment.Body = testCodexReviewSummaryBody("✅ **Completed** <relative-time datetime=\"2026-09-02T22:35:58.561318Z\">2026-09-02T22:35:58.561318Z</relative-time>", strings.Repeat("b", 7))
+				return comment
+			}()},
+		},
+		{
+			name: "incomplete review",
+			comments: []restComment{func() restComment {
+				comment := validComment
+				comment.Body = testCodexReviewSummaryBody("🔄 **In progress**", headSHA[:7])
+				return comment
+			}()},
+		},
+		{
+			name: "malformed table",
+			comments: []restComment{func() restComment {
+				comment := validComment
+				comment.Body = strings.Replace(comment.Body, codexReviewSummaryTableSeparator, "| --- | --- |", 1)
+				return comment
+			}()},
+		},
+		{
+			name: "short commit prefix",
+			comments: []restComment{func() restComment {
+				comment := validComment
+				comment.Body = testCodexReviewSummaryBody("✅ **Completed** <relative-time datetime=\"2026-09-02T22:35:58.561318Z\">2026-09-02T22:35:58.561318Z</relative-time>", headSHA[:6])
+				return comment
+			}()},
+		},
+		{
+			name:     "ambiguous commit prefix",
+			comments: []restComment{validComment},
+			formalReviews: []restReview{{
+				CommitID: headSHA[:7] + strings.Repeat("b", 33),
+			}},
+		},
+		{
+			name: "newer incomplete edit supersedes completed summary",
+			comments: []restComment{validComment, func() restComment {
+				comment := validComment
+				comment.ID = 2
+				comment.UpdatedAt = new(updatedAt.Add(time.Minute))
+				comment.Body = testCodexReviewSummaryBody("🔄 **In progress**", headSHA[:7])
+				return comment
+			}()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, got := latestCodexSummaryReview(tt.comments, tt.formalReviews, headSHA)
+			if got != tt.want {
+				t.Fatalf("latestCodexSummaryReview() ok = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testCodexReviewSummaryBody(status string, commit string) string {
+	return codexReviewSummaryMarker + "\n\n" + codexReviewSummaryHeading + "\n\n" +
+		codexReviewSummaryTableHeader + "\n" + codexReviewSummaryTableSeparator + "\n" +
+		"| 📝 **Code Review** | " + status + " | `" + commit + "` | Manual request |"
+}
+
 func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	t.Parallel()
 
@@ -1616,6 +1801,7 @@ func TestConnectorFetchIssuesByStatesPrefersMergedLinkedPullRequestOverClosedUnm
 			path:   "/repos/digitaldrywood/creswoodcorners-phone/pulls/191/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("digitaldrywood/creswoodcorners-phone", 191),
 	})
 
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
@@ -1748,6 +1934,7 @@ func TestConnectorCachesPullRequestStatusByHeadSHA(t *testing.T) {
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"success"}]}`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/sha-187/statuses?per_page=100", body: `[]`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/187/reviews?per_page=100", body: `[]`},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 187),
 		{body: projectBody},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all", body: pullsBody},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/187", body: pullBody},
@@ -1769,7 +1956,7 @@ func TestConnectorCachesPullRequestStatusByHeadSHA(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 9 {
+	if len(requests) != 10 {
 		t.Fatalf("request count = %d, want second fetch to reuse PR status cache", len(requests))
 	}
 	for _, pattern := range []string{"/check-runs", "/statuses", "/reviews"} {
@@ -1868,7 +2055,7 @@ func TestConnectorAttachPullRequestsRotatesAfterRESTBudgetReservation(t *testing
 			_, _ = fmt.Fprintf(w, `{"number":%s,"html_url":"https://github.com/digitaldrywood/detent/pull/%s","state":"open","head":{"ref":"detent/issue-%s","sha":"sha-%s"}}`, number, number, number, number)
 		case strings.HasSuffix(path, "/check-runs"):
 			_, _ = w.Write([]byte(`{"check_runs":[]}`))
-		case strings.HasSuffix(path, "/statuses"), strings.HasSuffix(path, "/reviews"):
+		case strings.HasSuffix(path, "/statuses"), strings.HasSuffix(path, "/reviews"), strings.HasSuffix(path, "/comments"):
 			_, _ = w.Write([]byte(`[]`))
 		default:
 			t.Fatalf("unexpected REST path %s", r.URL.RequestURI())
@@ -1880,7 +2067,7 @@ func TestConnectorAttachPullRequestsRotatesAfterRESTBudgetReservation(t *testing
 		Endpoint:                   server.URL,
 		APIKey:                     "token",
 		HTTPClient:                 server.Client(),
-		RESTFanoutMaxRequests:      4,
+		RESTFanoutMaxRequests:      5,
 		DisableConditionalRequests: true,
 	})
 	if err != nil {
@@ -1949,7 +2136,7 @@ func TestConnectorAttachPullRequestsPrioritizesSkippedBranchCandidate(t *testing
 			_, _ = fmt.Fprintf(w, `{"number":%s,"html_url":"https://github.com/digitaldrywood/detent/pull/%s","state":"open","head":{"ref":"detent/digitaldrywood_detent_%s","sha":"sha-%s"}}`, number, number, number, number)
 		case strings.HasSuffix(path, "/check-runs"):
 			_, _ = w.Write([]byte(`{"check_runs":[]}`))
-		case strings.HasSuffix(path, "/statuses"), strings.HasSuffix(path, "/reviews"):
+		case strings.HasSuffix(path, "/statuses"), strings.HasSuffix(path, "/reviews"), strings.HasSuffix(path, "/comments"):
 			_, _ = w.Write([]byte(`[]`))
 		default:
 			t.Fatalf("unexpected REST path %s", r.URL.RequestURI())
@@ -1961,7 +2148,7 @@ func TestConnectorAttachPullRequestsPrioritizesSkippedBranchCandidate(t *testing
 		Endpoint:                   server.URL,
 		APIKey:                     "token",
 		HTTPClient:                 server.Client(),
-		RESTFanoutMaxRequests:      5,
+		RESTFanoutMaxRequests:      6,
 		DisableConditionalRequests: true,
 	})
 	if err != nil {
@@ -2105,6 +2292,7 @@ func TestConnectorFetchFreshIssuesByStatesRechecksPullRequestStatusForPromotion(
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"success"}]}`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100", body: `[]`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411/reviews?per_page=100", body: `[]`},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 411),
 		{body: projectBody},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411", body: pullBody},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"failure"}]}`},
@@ -2224,7 +2412,8 @@ func TestConnectorFreshPullRequestStatusReconcilesDeletedChecks(t *testing.T) {
 					w.Header().Set("ETag", `"checks-page-2-v2"`)
 					_, _ = w.Write([]byte(`{"check_runs":[]}`))
 				case "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100",
-					"/repos/digitaldrywood/detent/pulls/2028/reviews?per_page=100":
+					"/repos/digitaldrywood/detent/pulls/2028/reviews?per_page=100",
+					"/repos/digitaldrywood/detent/issues/2028/comments?per_page=100":
 					_, _ = w.Write([]byte(`[]`))
 				default:
 					w.WriteHeader(http.StatusNotFound)
@@ -2297,6 +2486,7 @@ func TestConnectorFetchFreshIssuesByStatesUsesCachedPullRequestStatusAfterRateLi
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"success"}]}`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100", body: `[]`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411/reviews?per_page=100", body: `[]`},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 411),
 		{body: projectBody},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411", body: pullBody},
 		{
@@ -2379,6 +2569,7 @@ func TestConnectorFetchIssuesByStatesCircuitBreaksPullRequestHydrationAfterSecon
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"success"}]}`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100", body: `[]`},
 		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411/reviews?per_page=100", body: `[]`},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 411),
 	})
 
 	c := newGitHubTestConnector(t, server, Config{
@@ -2536,7 +2727,7 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls/190/reviews?per_page=100",
-			body:   `[{"body":"[P1] Unsafe migration.","html_url":"https://github.com/digitaldrywood/detent/pull/190#pullrequestreview-2","state":"COMMENTED","user":{"login":"codex"},"commit_id":"sha-190","submitted_at":"2026-06-05T11:00:00Z"}]`,
+			body:   `[{"body":"[P1] Unsafe migration.","html_url":"https://github.com/digitaldrywood/detent/pull/190#pullrequestreview-2","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"commit_id":"sha-190","submitted_at":"2026-06-05T11:00:00Z"}]`,
 		},
 	})
 
@@ -2558,6 +2749,9 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	pr := got[0].PullRequest
 	if pr == nil || pr.Number != 190 || pr.CIStatus != "pending" || pr.CodexReviewState != "P1" {
 		t.Fatalf("PullRequest = %#v, want PR 190 with pending CI and P1 review", pr)
+	}
+	if pr.CodexReviewSource != connector.PullRequestReviewSourceFormal {
+		t.Fatalf("CodexReviewSource = %q, want formal review", pr.CodexReviewSource)
 	}
 	if pr.MergeableState != "dirty" {
 		t.Fatalf("MergeableState = %q, want dirty from hydrated PR", pr.MergeableState)
@@ -3163,6 +3357,77 @@ func TestConnectorPullRequestStatusCacheDebugLog(t *testing.T) {
 	}
 }
 
+func TestConnectorPullRequestStatusCacheRefreshesEditedCodexSummary(t *testing.T) {
+	t.Parallel()
+
+	const headSHA = "79f9eb2d4ad5317af5ff46f29aba3b91f4b413a0"
+	completedBody := testCodexReviewSummaryBody(
+		"✅ **Completed** <relative-time datetime=\"2026-09-02T22:35:58.561318Z\">2026-09-02T22:35:58.561318Z</relative-time>",
+		headSHA[:7],
+	)
+	incompleteBody := testCodexReviewSummaryBody("🔄 **In progress**", headSHA[:7])
+	commentResponse := func(body string, updatedAt string) string {
+		return fmt.Sprintf(`[{"id":1,"body":%q,"html_url":"https://github.test/pull/389#issuecomment-1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-09-02T16:27:27Z","updated_at":%q}]`, body, updatedAt)
+	}
+	statusResponses := func(commentBody string, commentETag string) []graphqlTestResponse {
+		return []graphqlTestResponse{
+			{method: http.MethodGet, path: "/repos/gopherguides/gopher-ai/commits/" + headSHA + "/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"success"}]}`},
+			{method: http.MethodGet, path: "/repos/gopherguides/gopher-ai/commits/" + headSHA + "/statuses?per_page=100", body: `[]`},
+			{method: http.MethodGet, path: "/repos/gopherguides/gopher-ai/pulls/389/reviews?per_page=100", body: `[]`},
+			{method: http.MethodGet, path: "/repos/gopherguides/gopher-ai/issues/389/comments?per_page=100", headers: map[string]string{"ETag": commentETag}, body: commentBody},
+		}
+	}
+	responses := statusResponses(commentResponse(completedBody, "2026-09-02T22:35:59Z"), `"summary-v1"`)
+	responses = append(responses, statusResponses(commentResponse(incompleteBody, "2026-09-02T22:40:00Z"), `"summary-v2"`)...)
+	server := newGraphQLTestServer(t, responses)
+
+	now := time.Date(2026, 9, 2, 22, 36, 0, 0, time.UTC)
+	c := newGitHubTestConnector(t, server, Config{Now: func() time.Time { return now }})
+	repo := pullRequestRepo{Owner: "gopherguides", Name: "gopher-ai"}
+
+	first := pullRequestNode{Number: 389, HeadSHA: headSHA}
+	if err := c.populatePullRequestStatus(context.Background(), repo, &first, true); err != nil {
+		t.Fatalf("first populatePullRequestStatus() error = %v", err)
+	}
+	if got := pullRequestCodexReviewSource(first); got != connector.PullRequestReviewSourceSummaryComment {
+		t.Fatalf("first review source = %q, want summary comment", got)
+	}
+
+	cached := pullRequestNode{Number: 389, HeadSHA: headSHA}
+	if err := c.populatePullRequestStatus(context.Background(), repo, &cached, true); err != nil {
+		t.Fatalf("cached populatePullRequestStatus() error = %v", err)
+	}
+	if got := pullRequestCodexReviewState(cached); got != "COMMENTED" {
+		t.Fatalf("cached review state = %q, want COMMENTED", got)
+	}
+
+	now = now.Add(githubCacheTTL + time.Second)
+	refreshed := pullRequestNode{Number: 389, HeadSHA: headSHA}
+	if err := c.populatePullRequestStatus(context.Background(), repo, &refreshed, true); err != nil {
+		t.Fatalf("refreshed populatePullRequestStatus() error = %v", err)
+	}
+	if got := pullRequestCodexReviewState(refreshed); got != "" {
+		t.Fatalf("refreshed review state = %q, want incomplete edit to invalidate evidence", got)
+	}
+
+	commentRequests := 0
+	secondCommentETag := ""
+	for _, request := range server.requests() {
+		if request["path"] == "/repos/gopherguides/gopher-ai/issues/389/comments?per_page=100" {
+			commentRequests++
+			if commentRequests == 2 {
+				secondCommentETag, _ = request["if_none_match"].(string)
+			}
+		}
+	}
+	if commentRequests != 2 {
+		t.Fatalf("comment requests = %d, want one initial request and one post-expiry refresh", commentRequests)
+	}
+	if secondCommentETag != `"summary-v1"` {
+		t.Fatalf("second comment If-None-Match = %q, want cached summary ETag", secondCommentETag)
+	}
+}
+
 func TestConnectorFetchIssuesByStatesSurfacesStaleCodexReview(t *testing.T) {
 	t.Parallel()
 
@@ -3190,6 +3455,7 @@ func TestConnectorFetchIssuesByStatesSurfacesStaleCodexReview(t *testing.T) {
 			path:   "/repos/digitaldrywood/detent/pulls/411/reviews?per_page=100",
 			body:   `[{"body":"No blocking findings on an older head.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"head-previous","submitted_at":"2026-06-12T11:40:00Z"}]`,
 		},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 411),
 	})
 
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
@@ -3254,6 +3520,7 @@ func TestConnectorFetchIssuesByStatesLimitExhaustsProjectItemsBeforeSampling(t *
 			path:   "/repos/digitaldrywood/detent/pulls/371/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 371),
 	})
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
 
@@ -3273,7 +3540,7 @@ func TestConnectorFetchIssuesByStatesLimitExhaustsProjectItemsBeforeSampling(t *
 	}
 
 	requests := server.requests()
-	if len(requests) != 6 {
+	if len(requests) != 7 {
 		t.Fatalf("request count = %d, want two project pages and linked PR status requests", len(requests))
 	}
 	if requests[0]["variables"].(map[string]any)["after"] != nil {
@@ -3890,6 +4157,7 @@ func TestConnectorFetchIssuesByStatesAttachesBlockedPullRequest(t *testing.T) {
 			path:   "/repos/digitaldrywood/detent/pulls/426/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 426),
 	})
 
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
@@ -4794,6 +5062,7 @@ func TestConnectorHydratePullRequestRefreshesCurrentStatus(t *testing.T) {
 			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 42),
 	})
 	c := newGitHubTestConnector(t, server, Config{})
 	prNumber := 42
@@ -5048,6 +5317,7 @@ func TestConnectorHydratePullRequestNormalizesStaleSuccessfulWorkflowCheckRun(t 
 			path:   "/repos/example/repo/pulls/970/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 970),
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
@@ -5118,6 +5388,7 @@ func TestConnectorHydratePullRequestUsesEffectiveCheckRunsForWorkflowTelemetry(t
 			path:   "/repos/example/repo/pulls/971/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 971),
 	})
 	c := newGitHubTestConnector(t, server, Config{})
 	prNumber := 971
@@ -5171,6 +5442,7 @@ func TestConnectorHydratePullRequestIgnoresOptionalSkippedCheckRun(t *testing.T)
 			path:   "/repos/example/pyroapex/pulls/1648/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/pyroapex", 1648),
 	})
 	c := newGitHubTestConnector(t, server, Config{})
 	prNumber := 1648
@@ -5223,6 +5495,7 @@ func TestConnectorHydratePullRequestTreatsSkippedRequiredStatusCheckAsPending(t 
 			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 42),
 	})
 	c := newGitHubTestConnector(t, server, Config{RequiredStatusChecks: []string{"Lint", "Windows Core"}})
 	prNumber := 42
@@ -5278,6 +5551,7 @@ func TestConnectorHydratePullRequestWaitsForRunningRequiredCheckDespiteCancelled
 			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 42),
 	})
 	c := newGitHubTestConnector(t, server, Config{RequiredStatusChecks: []string{"Changed-file coverage", "Checks"}})
 	prNumber := 42
@@ -5331,6 +5605,7 @@ func TestConnectorHydratePullRequestBlocksMissingRequiredStatusCheck(t *testing.
 			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 42),
 	})
 	c := newGitHubTestConnector(t, server, Config{RequiredStatusChecks: []string{"Lint", "Windows Core"}})
 	prNumber := 42
@@ -5397,6 +5672,7 @@ func TestConnectorHydratePullRequestDetectsTransientKilledCheck(t *testing.T) {
 			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 42),
 	})
 	c := newGitHubTestConnector(t, server, Config{})
 	prNumber := 42
@@ -5456,6 +5732,7 @@ func TestConnectorHydratePullRequestIncludesWorkflowAndAnnotationsInRESTFanoutCa
 			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("example/repo", 42),
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		RESTFanoutMaxRequests:      4,
@@ -5488,6 +5765,14 @@ func TestConnectorHydratePullRequestIncludesWorkflowAndAnnotationsInRESTFanoutCa
 	}
 	if got := restEndpointUsageCount(usage.Requests, "check run annotations"); got != 1 {
 		t.Fatalf("check run annotations usage count = %d, want throttled synthetic request; usage = %#v", got, usage.Requests)
+	}
+}
+
+func emptyPullRequestCommentsResponse(repository string, number int) graphqlTestResponse {
+	return graphqlTestResponse{
+		method: http.MethodGet,
+		path:   fmt.Sprintf("/repos/%s/issues/%d/comments?per_page=100", repository, number),
+		body:   `[]`,
 	}
 }
 
@@ -6319,6 +6604,9 @@ func (s *graphqlTestServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	payload := map[string]any{
 		"method": r.Method,
 		"path":   r.URL.RequestURI(),
+	}
+	if ifNoneMatch := r.Header.Get("If-None-Match"); ifNoneMatch != "" {
+		payload["if_none_match"] = ifNoneMatch
 	}
 	if r.Method == http.MethodPost && r.URL.Path == "/" {
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -46,7 +47,17 @@ type pullRequestRepo struct {
 
 const (
 	linkedPullRequestHydrationConcurrency     = 8
-	linkedPullRequestHydrationRequestEstimate = 5
+	linkedPullRequestHydrationRequestEstimate = 6
+	codexReviewSummaryMarker                  = "<!-- codex-pull-request-review-summary -->"
+	codexReviewSummaryHeading                 = "## Codex Review Summary"
+	codexReviewSummaryTableHeader             = "| Review | Status | Commit | Review trigger |"
+	codexReviewSummaryTableSeparator          = "| --- | --- | --- | --- |"
+	minimumCodexReviewCommitPrefixLength      = 7
+)
+
+var (
+	codexReviewSummaryStatusPattern = regexp.MustCompile(`^✅\s+\*\*Completed\*\*\s+<relative-time datetime="([^"]+)">([^<]+)</relative-time>$`)
+	codexReviewSummaryCommitPattern = regexp.MustCompile("^`([0-9a-fA-F]{7,40})`$")
 )
 
 type linkedPullRequestHydration struct {
@@ -905,6 +916,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		RequiredCheckFailures:        append([]connector.PullRequestCheck(nil), pullRequest.CI.RequiredFailures...),
 		TransientFailedChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.TransientFailures...),
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
+		CodexReviewSource:            pullRequestCodexReviewSource(pullRequest),
 		CodexReviewAPIState:          pullRequestCodexReviewAPIState(pullRequest),
 		CodexReviewBodySeverity:      pullRequestCodexReviewBodySeverity(pullRequest),
 		CodexReviewSubmittedAt:       pullRequestCodexReviewSubmittedAt(pullRequest),
@@ -1220,6 +1232,23 @@ func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullReques
 	if review, ok := latestCodexReview(response, ""); ok {
 		reviews.Latest = []pullRequestReview{review}
 	}
+	if len(reviews.CurrentHead) > 0 {
+		return reviews, nil
+	}
+	comments, err := fetchRESTList[restComment](ctx, c.client, restIssueCommentsListPath(issueRef{
+		Owner:  repo.Owner,
+		Name:   repo.Name,
+		Number: number,
+	}))
+	if err != nil {
+		return pullRequestCodexReviews{}, fmt.Errorf("fetch github pull request review summary comments: %w", err)
+	}
+	if review, ok := latestCodexSummaryReview(comments, response, headSHA); ok {
+		reviews.CurrentHead = []pullRequestReview{review}
+		if len(reviews.Latest) == 0 {
+			reviews.Latest = []pullRequestReview{review}
+		}
+	}
 	return reviews, nil
 }
 
@@ -1330,13 +1359,14 @@ func latestCodexReview(reviews []restReview, headSHA string) (pullRequestReview,
 		if !codexReviewAuthor(review.User) || strings.EqualFold(strings.TrimSpace(review.State), "DISMISSED") {
 			continue
 		}
-		if headSHA != "" && strings.TrimSpace(review.CommitID) != "" && review.CommitID != headSHA {
+		if headSHA != "" && !strings.EqualFold(strings.TrimSpace(review.CommitID), headSHA) {
 			continue
 		}
 		candidate := pullRequestReview{
 			Body:        review.Body,
 			URL:         review.HTMLURL,
 			State:       review.State,
+			Source:      connector.PullRequestReviewSourceFormal,
 			Author:      review.User,
 			CommitID:    review.CommitID,
 			SubmittedAt: review.SubmittedAt,
@@ -1347,6 +1377,188 @@ func latestCodexReview(reviews []restReview, headSHA string) (pullRequestReview,
 		}
 	}
 	return latest, found
+}
+
+type codexReviewSummary struct {
+	commitPrefix string
+	completedAt  time.Time
+}
+
+func latestCodexSummaryReview(comments []restComment, formalReviews []restReview, headSHA string) (pullRequestReview, bool) {
+	comment, ok := latestTrustedCodexSummaryComment(comments)
+	if !ok {
+		return pullRequestReview{}, false
+	}
+	summary, ok := parseCodexReviewSummary(comment.Body)
+	if !ok || !codexReviewSummaryMatchesHead(summary.commitPrefix, headSHA, formalReviews) {
+		return pullRequestReview{}, false
+	}
+	if comment.CreatedAt != nil && summary.completedAt.Before(*comment.CreatedAt) {
+		return pullRequestReview{}, false
+	}
+	if comment.UpdatedAt == nil || summary.completedAt.After(comment.UpdatedAt.Add(time.Second)) {
+		return pullRequestReview{}, false
+	}
+	completedAt := summary.completedAt
+	return pullRequestReview{
+		Body:        comment.Body,
+		URL:         comment.HTMLURL,
+		State:       "COMMENTED",
+		Source:      connector.PullRequestReviewSourceSummaryComment,
+		Author:      comment.User,
+		CommitID:    strings.ToLower(strings.TrimSpace(headSHA)),
+		SubmittedAt: &completedAt,
+	}, true
+}
+
+func latestTrustedCodexSummaryComment(comments []restComment) (restComment, bool) {
+	var latest restComment
+	found := false
+	for _, comment := range comments {
+		if !trustedCodexSummaryAuthor(comment.User) || !strings.Contains(comment.Body, codexReviewSummaryMarker) {
+			continue
+		}
+		if !found || restCommentAfter(comment, latest) {
+			latest = comment
+			found = true
+		}
+	}
+	return latest, found
+}
+
+func trustedCodexSummaryAuthor(author *actor) bool {
+	if author == nil || !strings.EqualFold(strings.TrimSpace(actorType(author)), "Bot") {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(author.Login)) {
+	case "chatgpt-codex-connector", "chatgpt-codex-connector[bot]":
+		return true
+	default:
+		return false
+	}
+}
+
+func restCommentAfter(left restComment, right restComment) bool {
+	leftAt := firstNonNilTime(left.UpdatedAt, left.CreatedAt)
+	rightAt := firstNonNilTime(right.UpdatedAt, right.CreatedAt)
+	if leftAt == nil {
+		return rightAt == nil && left.ID > right.ID
+	}
+	if rightAt == nil {
+		return true
+	}
+	if leftAt.Equal(*rightAt) {
+		return left.ID > right.ID
+	}
+	return leftAt.After(*rightAt)
+}
+
+func firstNonNilTime(values ...*time.Time) *time.Time {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func parseCodexReviewSummary(body string) (codexReviewSummary, bool) {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != codexReviewSummaryMarker || strings.Count(body, codexReviewSummaryMarker) != 1 {
+		return codexReviewSummary{}, false
+	}
+	headingIndex := -1
+	headerIndex := -1
+	for index, line := range lines {
+		switch strings.TrimSpace(line) {
+		case codexReviewSummaryHeading:
+			if headingIndex >= 0 {
+				return codexReviewSummary{}, false
+			}
+			headingIndex = index
+		case codexReviewSummaryTableHeader:
+			if headerIndex >= 0 {
+				return codexReviewSummary{}, false
+			}
+			headerIndex = index
+		}
+	}
+	if headingIndex <= 0 || headerIndex <= headingIndex || headerIndex+2 >= len(lines) || strings.TrimSpace(lines[headerIndex+1]) != codexReviewSummaryTableSeparator {
+		return codexReviewSummary{}, false
+	}
+
+	var summary codexReviewSummary
+	found := false
+	for _, line := range lines[headerIndex+2:] {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			if found {
+				break
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") {
+			break
+		}
+		cells := strings.Split(strings.Trim(line, "|"), "|")
+		if len(cells) != 4 {
+			return codexReviewSummary{}, false
+		}
+		if strings.TrimSpace(cells[0]) != "📝 **Code Review**" {
+			continue
+		}
+		if found {
+			return codexReviewSummary{}, false
+		}
+		statusMatches := codexReviewSummaryStatusPattern.FindStringSubmatch(strings.TrimSpace(cells[1]))
+		commitMatches := codexReviewSummaryCommitPattern.FindStringSubmatch(strings.TrimSpace(cells[2]))
+		if len(statusMatches) != 3 || len(commitMatches) != 2 {
+			return codexReviewSummary{}, false
+		}
+		completedAt, err := time.Parse(time.RFC3339Nano, statusMatches[1])
+		if err != nil {
+			return codexReviewSummary{}, false
+		}
+		displayedAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(statusMatches[2]))
+		if err != nil || !displayedAt.Equal(completedAt) {
+			return codexReviewSummary{}, false
+		}
+		summary = codexReviewSummary{
+			commitPrefix: strings.ToLower(commitMatches[1]),
+			completedAt:  completedAt,
+		}
+		found = true
+	}
+	return summary, found
+}
+
+func codexReviewSummaryMatchesHead(prefix string, headSHA string, formalReviews []restReview) bool {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	headSHA = strings.ToLower(strings.TrimSpace(headSHA))
+	if len(prefix) < minimumCodexReviewCommitPrefixLength || !validFullGitSHA(headSHA) || !strings.HasPrefix(headSHA, prefix) {
+		return false
+	}
+	matches := map[string]struct{}{headSHA: {}}
+	for _, review := range formalReviews {
+		commitID := strings.ToLower(strings.TrimSpace(review.CommitID))
+		if validFullGitSHA(commitID) && strings.HasPrefix(commitID, prefix) {
+			matches[commitID] = struct{}{}
+		}
+	}
+	return len(matches) == 1
+}
+
+func validFullGitSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, character := range value {
+		if !strings.ContainsRune("0123456789abcdef", character) {
+			return false
+		}
+	}
+	return true
 }
 
 func codexReviewAuthor(author *actor) bool {
@@ -1368,6 +1580,15 @@ func pullRequestReviewAfter(left pullRequestReview, right pullRequestReview) boo
 
 func pullRequestCodexReviewState(pullRequest pullRequestNode) string {
 	return pullRequestCodexReviewStateFromReviews(pullRequest.LatestReviews.Nodes)
+}
+
+func pullRequestCodexReviewSource(pullRequest pullRequestNode) string {
+	for _, review := range pullRequest.LatestReviews.Nodes {
+		if source := strings.TrimSpace(review.Source); source != "" {
+			return source
+		}
+	}
+	return ""
 }
 
 func pullRequestLatestCodexReviewState(pullRequest pullRequestNode) string {

--- a/internal/connector/github/pull_requests_concurrency_test.go
+++ b/internal/connector/github/pull_requests_concurrency_test.go
@@ -339,6 +339,8 @@ func writePullRequestStatusResponse(w http.ResponseWriter, path string) {
 		_, _ = w.Write([]byte(`[]`))
 	case strings.HasSuffix(path, "/reviews") || strings.Contains(path, "/reviews?"):
 		_, _ = w.Write([]byte(`[]`))
+	case strings.HasSuffix(path, "/comments") || strings.Contains(path, "/comments?"):
+		_, _ = w.Write([]byte(`[]`))
 	default:
 		http.Error(w, "unexpected path "+path, http.StatusNotFound)
 	}

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -576,6 +576,7 @@ func TestConnectorFetchLabelIssuesByStatesAttachesCurrentAgentBranchPullRequest(
 			path:   "/repos/digitaldrywood/digitaldrywood/pulls/434/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("digitaldrywood/digitaldrywood", 434),
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		GitHubStatusSource: GitHubStatusSourceLabel,
@@ -674,6 +675,7 @@ func TestConnectorFetchIssuesByStatesScopesPullRequestHydrationByIssueState(t *t
 			path:   "/repos/digitaldrywood/detent/pulls/120/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 120),
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		GitHubStatusSource: GitHubStatusSourceLabel,
@@ -1014,6 +1016,7 @@ func TestConnectorFetchCandidateIssuesSurfacesStatusLabelConflict(t *testing.T) 
 			path:   "/repos/digitaldrywood/detent/pulls/609/reviews?per_page=100",
 			body:   `[]`,
 		},
+		emptyPullRequestCommentsResponse("digitaldrywood/detent", 609),
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		GitHubStatusSource: GitHubStatusSourceLabel,

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -186,6 +186,7 @@ type pullRequestReview struct {
 	Body        string     `json:"body"`
 	URL         string     `json:"url"`
 	State       string     `json:"state"`
+	Source      string     `json:"-"`
 	Author      *actor     `json:"author"`
 	CommitID    string     `json:"commitId"`
 	SubmittedAt *time.Time `json:"submittedAt"`

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -135,6 +135,7 @@ type PullRequest struct {
 	RequiredCheckFailures        []PullRequestCheck          `json:"required_check_failures,omitempty" yaml:"required_check_failures,omitempty"`
 	TransientFailedChecks        []PullRequestCheck          `json:"transient_failed_checks,omitempty" yaml:"transient_failed_checks,omitempty"`
 	CodexReviewState             string                      `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
+	CodexReviewSource            string                      `json:"codex_review_source,omitempty" yaml:"codex_review_source,omitempty"`
 	CodexReviewAPIState          string                      `json:"codex_review_api_state,omitempty" yaml:"codex_review_api_state,omitempty"`
 	CodexReviewBodySeverity      string                      `json:"codex_review_body_severity,omitempty" yaml:"codex_review_body_severity,omitempty"`
 	CodexReviewSubmittedAt       *time.Time                  `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`
@@ -144,6 +145,11 @@ type PullRequest struct {
 	LatestCodexReviewSubmittedAt *time.Time                  `json:"latest_codex_review_submitted_at,omitempty" yaml:"latest_codex_review_submitted_at,omitempty"`
 	MergeQueueEntry              *PullRequestMergeQueueEntry `json:"merge_queue_entry,omitempty" yaml:"merge_queue_entry,omitempty"`
 }
+
+const (
+	PullRequestReviewSourceFormal         = "pull_request_review"
+	PullRequestReviewSourceSummaryComment = "summary_comment"
+)
 
 const (
 	PullRequestHydrationReasonRateLimited         = "rate_limited"

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -694,6 +694,71 @@ func TestEvaluateAutoPromote(t *testing.T) {
 	}
 }
 
+func TestAutoPromoteUsesCurrentHeadSummaryOverStaleFormalReview(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 2, 23, 0, 0, 0, time.UTC)
+	reviewedAt := now.Add(-20 * time.Minute)
+	issue := autoPromoteTestIssue("issue-summary-review", nil)
+	issue.PullRequest = &connector.PullRequest{
+		Number:                       389,
+		URL:                          "https://github.com/gopherguides/gopher-ai/pull/389",
+		State:                        "OPEN",
+		MergeableState:               "clean",
+		HeadSHA:                      "79f9eb2d4ad5317af5ff46f29aba3b91f4b413a0",
+		CIStatus:                     "success",
+		CodexReviewState:             "COMMENTED",
+		CodexReviewSource:            connector.PullRequestReviewSourceSummaryComment,
+		CodexReviewSubmittedAt:       &reviewedAt,
+		LatestCodexReviewState:       "P1",
+		LatestCodexReviewCommitSHA:   "f236cc46fbb1a0e6821f16001e97ce07e0d483cd",
+		LatestCodexReviewSubmittedAt: new(reviewedAt.Add(-time.Minute)),
+	}
+
+	tests := []struct {
+		name       string
+		mutate     func(*connector.PullRequest)
+		wantAction AutoPromoteAction
+		wantReason AutoPromoteReason
+	}{
+		{
+			name:       "trusted clean summary promotes",
+			wantAction: AutoPromoteActionPromote,
+			wantReason: AutoPromoteReasonReady,
+		},
+		{
+			name: "current head p1 reworks",
+			mutate: func(pullRequest *connector.PullRequest) {
+				pullRequest.CodexReviewState = "P1"
+				pullRequest.CodexReviewSource = connector.PullRequestReviewSourceFormal
+				pullRequest.CodexReviewFindings = []connector.PullRequestFinding{{Body: "[P1] Current-head defect."}}
+			},
+			wantAction: AutoPromoteActionRework,
+			wantReason: AutoPromoteReasonP1Findings,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			candidate := issue
+			pullRequest := *issue.PullRequest
+			candidate.PullRequest = &pullRequest
+			if tt.mutate != nil {
+				tt.mutate(candidate.PullRequest)
+			}
+			decision := EvaluateAutoPromote(candidate, AutoPromoteSummaryFromIssue(candidate), AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			}, now)
+			if decision.Action != tt.wantAction || decision.Reason != tt.wantReason {
+				t.Fatalf("decision = %s/%s, want %s/%s", decision.Action, decision.Reason, tt.wantAction, tt.wantReason)
+			}
+		})
+	}
+}
+
 func TestEvaluateAutoPromoteOperationalCompletion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -450,6 +450,7 @@ func pullRequestDiagnosticAttrs(issue connector.Issue, now time.Time) []any {
 		"pr_unstarted_check_count", len(pr.UnstartedChecks),
 		"pr_slow_check_count", len(pr.SlowChecks),
 		"pr_codex_review_state", strings.TrimSpace(pr.CodexReviewState),
+		"pr_codex_review_source", strings.TrimSpace(pr.CodexReviewSource),
 		"pr_latest_codex_review_state", strings.TrimSpace(pr.LatestCodexReviewState),
 		"pr_hydration_unavailable_reason", strings.TrimSpace(pr.HydrationUnavailableReason),
 		"pr_hydration_degraded_reason", strings.TrimSpace(pr.HydrationDegradedReason),

--- a/internal/orchestrator/diagnostics_test.go
+++ b/internal/orchestrator/diagnostics_test.go
@@ -1,0 +1,27 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestPullRequestDiagnosticAttrsIncludeReviewEvidenceSource(t *testing.T) {
+	t.Parallel()
+
+	attrs := pullRequestDiagnosticAttrs(connector.Issue{PullRequest: &connector.PullRequest{
+		CodexReviewState:  "COMMENTED",
+		CodexReviewSource: connector.PullRequestReviewSourceSummaryComment,
+	}}, time.Time{})
+	values := make(map[string]any, len(attrs)/2)
+	for index := 0; index+1 < len(attrs); index += 2 {
+		key, ok := attrs[index].(string)
+		if ok {
+			values[key] = attrs[index+1]
+		}
+	}
+	if got := values["pr_codex_review_source"]; got != connector.PullRequestReviewSourceSummaryComment {
+		t.Fatalf("pr_codex_review_source = %v, want %q", got, connector.PullRequestReviewSourceSummaryComment)
+	}
+}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -1264,6 +1264,7 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		UnstartedChecks:            telemetryPullRequestChecks(pullRequest.UnstartedChecks),
 		RequiredCheckFailures:      telemetryPullRequestChecks(pullRequest.RequiredCheckFailures),
 		CodexReviewState:           pullRequest.CodexReviewState,
+		CodexReviewSource:          pullRequest.CodexReviewSource,
 	}
 	if pullRequest.MergeQueueEntry != nil {
 		out.MergeQueueEntry = &telemetry.PullRequestMergeQueueEntry{

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1143,6 +1143,7 @@ type PullRequest struct {
 	UnstartedChecks            []PullRequestCheck          `json:"unstarted_checks,omitempty"`
 	RequiredCheckFailures      []PullRequestCheck          `json:"required_check_failures,omitempty"`
 	CodexReviewState           string                      `json:"codex_review_state,omitempty"`
+	CodexReviewSource          string                      `json:"codex_review_source,omitempty"`
 	MergeQueueEntry            *PullRequestMergeQueueEntry `json:"merge_queue_entry,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- Recognize completed Codex review-summary comments from the trusted integration when no exact-head formal review exists.
- Bind abbreviated summary evidence uniquely to the full current head while retaining stale formal severity for diagnostics.
- Expose review evidence provenance and refresh edited summaries through the existing status/ETag cache.

Fixes #2104

## UI Surface Contract

- [x] N/A; this PR does not change UI surface, layout, density, first-viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`
- [x] Reproduced the PR #389 stale-formal/current-summary response shape and verified it promotes when otherwise ready.
- [x] Covered stale, incomplete, malformed, ambiguous, and untrusted summaries; current-head P1 routing; edited-comment cache refresh; and evidence-source diagnostics.