### PR TITLE
fix(board): isolate project refresh failures

### DIFF
--- a/internal/boardsnapshot/store.go
+++ b/internal/boardsnapshot/store.go
@@ -197,7 +197,7 @@ func Eligible(snapshot telemetry.Snapshot) bool {
 		return true
 	}
 	status := snapshot.Refresh.ReadinessStatus()
-	if status == telemetry.RefreshStatusReady || status == telemetry.RefreshStatusBehind {
+	if status == telemetry.RefreshStatusReady || status == telemetry.RefreshStatusBehind || status == telemetry.RefreshStatusPartial {
 		return true
 	}
 	return status == telemetry.RefreshStatusDegraded && carriesTrackerData(snapshot)

--- a/internal/boardsnapshot/store_test.go
+++ b/internal/boardsnapshot/store_test.go
@@ -112,6 +112,7 @@ func TestEligible(t *testing.T) {
 	}{
 		{name: "ready", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusReady}}, want: true},
 		{name: "loop behind", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusBehind}}, want: true},
+		{name: "partial fleet", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusPartial}}, want: true},
 		{name: "live snapshot without refresh signal", snapshot: telemetry.Snapshot{GeneratedAt: now, Projects: []telemetry.ProjectSnapshot{{Project: telemetry.Project{ID: "paused"}}}}, want: true},
 		{name: "degraded with prior data", snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusDegraded}, BoardIssues: []telemetry.Issue{{ID: "issue"}}}, want: true},
 		{name: "composite with cached tracker", snapshot: telemetry.Snapshot{GeneratedAt: now, Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceMixed}, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusDegraded}, Projects: []telemetry.ProjectSnapshot{{Project: telemetry.Project{ID: "alpha"}, Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceCached}}, {Project: telemetry.Project{ID: "bravo"}, Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive}}}, BoardIssues: []telemetry.Issue{{ID: "issue"}}}},

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -1796,6 +1796,8 @@ func mergeInstanceValue(current, next string, mixed string) string {
 func mergeRefresh(current, next telemetry.Refresh) telemetry.Refresh {
 	currentHadSignal := refreshHasSignal(current)
 	nextHadSignal := refreshHasSignal(next)
+	currentStatus := current.ReadinessStatus()
+	nextStatus := next.ReadinessStatus()
 	if current.PollIntervalSeconds == 0 ||
 		(next.PollIntervalSeconds > 0 && next.PollIntervalSeconds < current.PollIntervalSeconds) {
 		current.PollIntervalSeconds = next.PollIntervalSeconds
@@ -1831,14 +1833,18 @@ func mergeRefresh(current, next telemetry.Refresh) telemetry.Refresh {
 	current.Manual = mergeRefreshAttempt(current.Manual, next.Manual)
 	switch {
 	case !currentHadSignal && nextHadSignal:
-		current.Status = next.ReadinessStatus()
+		current.Status = nextStatus
 	case currentHadSignal && !nextHadSignal:
-		current.Status = current.ReadinessStatus()
-	case current.ReadinessStatus() == telemetry.RefreshStatusDegraded || next.ReadinessStatus() == telemetry.RefreshStatusDegraded:
+		current.Status = currentStatus
+	case currentStatus == telemetry.RefreshStatusPartial || nextStatus == telemetry.RefreshStatusPartial:
+		current.Status = telemetry.RefreshStatusPartial
+	case currentStatus == telemetry.RefreshStatusDegraded && nextStatus == telemetry.RefreshStatusDegraded:
 		current.Status = telemetry.RefreshStatusDegraded
-	case current.ReadinessStatus() == telemetry.RefreshStatusInitializing || next.ReadinessStatus() == telemetry.RefreshStatusInitializing:
+	case currentStatus == telemetry.RefreshStatusDegraded || nextStatus == telemetry.RefreshStatusDegraded:
+		current.Status = telemetry.RefreshStatusPartial
+	case currentStatus == telemetry.RefreshStatusInitializing || nextStatus == telemetry.RefreshStatusInitializing:
 		current.Status = telemetry.RefreshStatusInitializing
-	case current.ReadinessStatus() == telemetry.RefreshStatusBehind || next.ReadinessStatus() == telemetry.RefreshStatusBehind:
+	case currentStatus == telemetry.RefreshStatusBehind || nextStatus == telemetry.RefreshStatusBehind:
 		current.Status = telemetry.RefreshStatusBehind
 	case currentHadSignal || nextHadSignal:
 		current.Status = telemetry.RefreshStatusReady

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1181,6 +1181,138 @@ func TestPublishSnapshotOnceSurfacesPendingConnectorRetry(t *testing.T) {
 	}
 }
 
+func TestPublishSnapshotOnceIsolatesInvalidWorkflowProject(t *testing.T) {
+	t.Parallel()
+
+	const validationError = "create project pyroapex: validate project workflow: schedule_ownership.enabled must be true when scheduled work is configured"
+	now := time.Date(2026, 9, 3, 14, 0, 0, 0, time.UTC)
+	registry := projectpkg.NewRegistry()
+	healthy := startRefreshProject(t, "detent")
+	mustSetProject(t, registry, healthy)
+	waitForProjectDataSeq(t, healthy, 1)
+	if err := registry.SetPending(globalconfig.Project{ID: "pyroapex"}, projectpkg.RuntimeError{
+		Message:  validationError,
+		At:       now.Add(-time.Minute),
+		Terminal: true,
+	}); err != nil {
+		t.Fatalf("Registry.SetPending() error = %v", err)
+	}
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	var seq atomic.Uint64
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101", nil); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+
+	snapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("snapshotHub.Latest() ok = false, want published snapshot")
+	}
+	if got := snapshot.Refresh.ReadinessStatus(); got != telemetry.RefreshStatusPartial {
+		t.Fatalf("fleet Refresh status = %q, want partial", got)
+	}
+	if !snapshot.Tracker.Available() || snapshot.Tracker.Complete {
+		t.Fatalf("fleet Tracker = %#v, want available partial data", snapshot.Tracker)
+	}
+	projects := make(map[string]telemetry.ProjectSnapshot, len(snapshot.Projects))
+	for _, projectSnapshot := range snapshot.Projects {
+		projects[projectSnapshot.Project.ID] = projectSnapshot
+	}
+	if got := projects["detent"]; !got.Refresh.Ready() || !got.Tracker.Available() || !got.Tracker.Complete {
+		t.Fatalf("healthy project snapshot = %#v, want current tracker data", got)
+	}
+	if got := projects["pyroapex"]; !got.Refresh.Degraded() || got.Refresh.LastError != validationError || got.Tracker.Available() {
+		t.Fatalf("invalid project snapshot = %#v, want unavailable validation failure", got)
+	}
+	failures := snapshot.RefreshFailures()
+	if len(failures) != 1 || failures[0].ProjectID != "pyroapex" || failures[0].LastError != validationError {
+		t.Fatalf("RefreshFailures() = %#v, want pyroapex validation failure", failures)
+	}
+
+	recovered := startRefreshProject(t, "pyroapex")
+	waitForProjectDataSeq(t, recovered, 1)
+	mustSetProject(t, registry, recovered)
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now.Add(time.Minute), nil, nil, "http://localhost:4101", nil); err != nil {
+		t.Fatalf("publishSnapshotOnce(recovered) error = %v", err)
+	}
+	recoveredSnapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("snapshotHub.Latest() after recovery ok = false, want published snapshot")
+	}
+	if got := recoveredSnapshot.Refresh.ReadinessStatus(); got != telemetry.RefreshStatusReady {
+		t.Fatalf("recovered fleet Refresh status = %q, want ready", got)
+	}
+	if failures := recoveredSnapshot.RefreshFailures(); len(failures) != 0 {
+		t.Fatalf("recovered RefreshFailures() = %#v, want none", failures)
+	}
+	if !recoveredSnapshot.Tracker.Available() || !recoveredSnapshot.Tracker.Complete {
+		t.Fatalf("recovered fleet Tracker = %#v, want complete live data", recoveredSnapshot.Tracker)
+	}
+}
+
+func TestMergeRefreshAggregatesProjectReadiness(t *testing.T) {
+	t.Parallel()
+
+	ready := telemetry.Refresh{Status: telemetry.RefreshStatusReady}
+	degraded := telemetry.Refresh{Status: telemetry.RefreshStatusDegraded, LastError: "workflow invalid"}
+	partial := telemetry.Refresh{Status: telemetry.RefreshStatusPartial, LastError: "workflow invalid"}
+	tests := []struct {
+		name  string
+		left  telemetry.Refresh
+		right telemetry.Refresh
+		want  telemetry.RefreshStatus
+	}{
+		{name: "healthy projects stay ready", left: ready, right: ready, want: telemetry.RefreshStatusReady},
+		{name: "healthy then degraded is partial", left: ready, right: degraded, want: telemetry.RefreshStatusPartial},
+		{name: "degraded then healthy is partial", left: degraded, right: ready, want: telemetry.RefreshStatusPartial},
+		{name: "partial remains partial", left: partial, right: ready, want: telemetry.RefreshStatusPartial},
+		{name: "all projects degraded stays fail closed", left: degraded, right: degraded, want: telemetry.RefreshStatusDegraded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mergeRefresh(tt.left, tt.right).ReadinessStatus(); got != tt.want {
+				t.Fatalf("mergeRefresh() status = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPublishSnapshotOnceFailsClosedWhenEveryProjectIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 15, 0, 0, 0, time.UTC)
+	registry := projectpkg.NewRegistry()
+	for _, id := range []string{"detent", "pyroapex"} {
+		if err := registry.SetPending(globalconfig.Project{ID: id}, projectpkg.RuntimeError{
+			Message:  "create project " + id + ": validate project workflow: workflow invalid",
+			At:       now,
+			Terminal: true,
+		}); err != nil {
+			t.Fatalf("Registry.SetPending(%q) error = %v", id, err)
+		}
+	}
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	var seq atomic.Uint64
+	if err := publishSnapshotOnce(context.Background(), registry, nil, snapshotHub, &seq, nil, now, nil, nil, "http://localhost:4101", nil); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+	snapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("snapshotHub.Latest() ok = false, want published snapshot")
+	}
+	if got := snapshot.Refresh.ReadinessStatus(); got != telemetry.RefreshStatusDegraded {
+		t.Fatalf("fleet Refresh status = %q, want degraded", got)
+	}
+	if snapshot.Tracker.Available() || snapshot.Runtime.Available() {
+		t.Fatalf("fleet sections = tracker %#v runtime %#v, want unavailable", snapshot.Tracker, snapshot.Runtime)
+	}
+	if failures := snapshot.RefreshFailures(); len(failures) != 2 {
+		t.Fatalf("RefreshFailures() = %#v, want both invalid projects", failures)
+	}
+}
+
 type agentPoolSnapshotSourceStub []scheduler.PoolSnapshot
 
 func (s agentPoolSnapshotSourceStub) PoolSnapshots() []scheduler.PoolSnapshot {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -593,6 +593,7 @@ const (
 	RefreshStatusInitializing RefreshStatus = "initializing"
 	RefreshStatusReady        RefreshStatus = "ready"
 	RefreshStatusBehind       RefreshStatus = "behind"
+	RefreshStatusPartial      RefreshStatus = "partial"
 	RefreshStatusDegraded     RefreshStatus = "degraded"
 )
 
@@ -712,6 +713,9 @@ func (a RefreshAttempt) IsZero() bool {
 }
 
 func (r Refresh) ReadinessStatus() RefreshStatus {
+	if RefreshStatus(strings.TrimSpace(string(r.Status))) == RefreshStatusPartial {
+		return RefreshStatusPartial
+	}
 	if strings.TrimSpace(r.LastError) != "" || r.LastErrorAt != nil {
 		return RefreshStatusDegraded
 	}
@@ -773,6 +777,10 @@ func (r Refresh) WithFreshness(now time.Time) Refresh {
 			readinessStatus = RefreshStatusReady
 		}
 	}
+	if readinessStatus == RefreshStatusPartial {
+		r.Status = RefreshStatusPartial
+		return r
+	}
 	if r.NextRefreshOverdue {
 		r.Status = RefreshStatusBehind
 		return r
@@ -826,6 +834,10 @@ func (r Refresh) Initializing() bool {
 
 func (r Refresh) Degraded() bool {
 	return r.ReadinessStatus() == RefreshStatusDegraded
+}
+
+func (r Refresh) Partial() bool {
+	return r.ReadinessStatus() == RefreshStatusPartial
 }
 
 func (r Refresh) Behind() bool {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -117,6 +117,9 @@ func (s Snapshot) WithFreshness(now time.Time) Snapshot {
 		return s
 	}
 	s.Projects = append([]ProjectSnapshot(nil), s.Projects...)
+	partial := s.Refresh.Partial()
+	partialLastError := s.Refresh.LastError
+	partialLastErrorAt := copyTimePointer(s.Refresh.LastErrorAt)
 	staleAfterSeconds, observedSweepSeconds := refreshFleetStaleAfter(s.Refresh, s.Projects)
 	if staleAfterSeconds > s.Refresh.StaleAfterSeconds {
 		s.Refresh.StaleAfterSeconds = staleAfterSeconds
@@ -129,7 +132,22 @@ func (s Snapshot) WithFreshness(now time.Time) Snapshot {
 		}
 		s.Projects[index].Refresh = s.Projects[index].Refresh.WithFreshness(now)
 	}
+	if partial && hasReadyProjectRefresh(s.Projects) {
+		s.Refresh.Status = RefreshStatusPartial
+		s.Refresh.StalenessWindowExceeded = false
+		s.Refresh.LastError = partialLastError
+		s.Refresh.LastErrorAt = partialLastErrorAt
+	}
 	return s
+}
+
+func hasReadyProjectRefresh(projects []ProjectSnapshot) bool {
+	for _, project := range projects {
+		if project.Refresh.Ready() {
+			return true
+		}
+	}
+	return false
 }
 
 func refreshFleetStaleAfter(fleet Refresh, projects []ProjectSnapshot) (int64, int64) {

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -790,30 +790,52 @@ func TestRefreshReadinessStatusAt(t *testing.T) {
 	}
 }
 
-func TestPartialRefreshWithFreshness(t *testing.T) {
+func TestSnapshotPartialRefreshWithFreshness(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 3, 15, 0, 0, 0, time.UTC)
+	invalidLastRefreshAt := now.Add(-10 * time.Minute)
+	invalidErrorAt := now.Add(-time.Minute)
 	tests := []struct {
 		name       string
-		lastAge    time.Duration
+		healthyAge time.Duration
 		wantStatus telemetry.RefreshStatus
 	}{
-		{name: "healthy project remains current", lastAge: time.Minute, wantStatus: telemetry.RefreshStatusPartial},
-		{name: "last healthy project becomes stale", lastAge: 3 * time.Minute, wantStatus: telemetry.RefreshStatusDegraded},
+		{name: "invalid project source does not stale healthy fleet", healthyAge: time.Minute, wantStatus: telemetry.RefreshStatusPartial},
+		{name: "last healthy project becomes stale", healthyAge: 3 * time.Minute, wantStatus: telemetry.RefreshStatusDegraded},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			lastRefreshAt := now.Add(-tt.lastAge)
-			refresh := (telemetry.Refresh{
-				Status:            telemetry.RefreshStatusPartial,
-				StaleAfterSeconds: 120,
-				LastRefreshAt:     &lastRefreshAt,
-				LastError:         "one project unavailable",
+			healthyLastRefreshAt := now.Add(-tt.healthyAge)
+			snapshot := (telemetry.Snapshot{
+				Refresh: telemetry.Refresh{
+					Status:            telemetry.RefreshStatusPartial,
+					StaleAfterSeconds: 120,
+					LastRefreshAt:     &healthyLastRefreshAt,
+					LastError:         "pyroapex workflow invalid",
+					LastErrorAt:       &invalidErrorAt,
+					Sources: []telemetry.RefreshSource{
+						{ProjectID: "detent", Name: telemetry.RefreshSourceProject, LastSuccessAt: &healthyLastRefreshAt},
+						{ProjectID: "pyroapex", Name: telemetry.RefreshSourceProject, LastSuccessAt: &invalidLastRefreshAt, Degraded: true, LastError: "pyroapex workflow invalid", LastErrorAt: &invalidErrorAt},
+					},
+				},
+				Projects: []telemetry.ProjectSnapshot{
+					{
+						Project: telemetry.Project{ID: "detent"},
+						Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusReady, StaleAfterSeconds: 120, LastRefreshAt: &healthyLastRefreshAt},
+					},
+					{
+						Project: telemetry.Project{ID: "pyroapex"},
+						Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusDegraded, StaleAfterSeconds: 120, LastRefreshAt: &invalidLastRefreshAt, LastError: "pyroapex workflow invalid", LastErrorAt: &invalidErrorAt},
+					},
+				},
 			}).WithFreshness(now)
-			if got := refresh.ReadinessStatus(); got != tt.wantStatus {
+			if got := snapshot.Refresh.ReadinessStatus(); got != tt.wantStatus {
 				t.Fatalf("ReadinessStatus() = %q, want %q", got, tt.wantStatus)
+			}
+			if tt.wantStatus == telemetry.RefreshStatusPartial && snapshot.Refresh.LastError != "pyroapex workflow invalid" {
+				t.Fatalf("LastError = %q, want invalid project error", snapshot.Refresh.LastError)
 			}
 		})
 	}

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -699,6 +699,14 @@ func TestRefreshReadinessStatus(t *testing.T) {
 			want: telemetry.RefreshStatusDegraded,
 		},
 		{
+			name: "partial fleet preserves project error",
+			value: telemetry.Refresh{
+				Status:    telemetry.RefreshStatusPartial,
+				LastError: "one project unavailable",
+			},
+			want: telemetry.RefreshStatusPartial,
+		},
+		{
 			name: "loop behind remains operational",
 			value: telemetry.Refresh{
 				Status: telemetry.RefreshStatusBehind,
@@ -777,6 +785,35 @@ func TestRefreshReadinessStatusAt(t *testing.T) {
 			}
 			if refresh.NextRefreshOverdue != tt.wantOverdue {
 				t.Fatalf("NextRefreshOverdue = %v, want %v", refresh.NextRefreshOverdue, tt.wantOverdue)
+			}
+		})
+	}
+}
+
+func TestPartialRefreshWithFreshness(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 15, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		lastAge    time.Duration
+		wantStatus telemetry.RefreshStatus
+	}{
+		{name: "healthy project remains current", lastAge: time.Minute, wantStatus: telemetry.RefreshStatusPartial},
+		{name: "last healthy project becomes stale", lastAge: 3 * time.Minute, wantStatus: telemetry.RefreshStatusDegraded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			lastRefreshAt := now.Add(-tt.lastAge)
+			refresh := (telemetry.Refresh{
+				Status:            telemetry.RefreshStatusPartial,
+				StaleAfterSeconds: 120,
+				LastRefreshAt:     &lastRefreshAt,
+				LastError:         "one project unavailable",
+			}).WithFreshness(now)
+			if got := refresh.ReadinessStatus(); got != tt.wantStatus {
+				t.Fatalf("ReadinessStatus() = %q, want %q", got, tt.wantStatus)
 			}
 		})
 	}

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -37,6 +37,7 @@ type boardAlertKind string
 
 const (
 	boardAlertKindLastKnown              boardAlertKind = "board-last-known"
+	boardAlertKindPartialRefresh         boardAlertKind = "project-refresh-degraded"
 	boardAlertKindFailureBreaker         boardAlertKind = "project-failure-breaker"
 	boardAlertKindDispatchStall          boardAlertKind = "dispatch-stall"
 	boardAlertKindTrackerUnavailable     boardAlertKind = "tracker-unavailable"
@@ -59,6 +60,7 @@ const (
 	boardAlertSeverityDispatchStall                     = 575
 	boardAlertSeverityLastKnown                         = 600
 	boardAlertSeverityStrandedActive                    = 580
+	boardAlertSeverityPartialRefresh                    = 570
 )
 
 type boardAlert struct {
@@ -101,6 +103,9 @@ type boardStalenessDismissal struct {
 func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
 	alerts := make([]boardAlert, 0, len(snapshot.StalenessWarnings)+8)
 	if alert, ok := boardLastKnownAlert(snapshot); ok {
+		alerts = append(alerts, alert)
+	}
+	if alert, ok := boardPartialRefreshAlert(snapshot); ok {
 		alerts = append(alerts, alert)
 	}
 	if alert, ok := boardFailureBreakerAlert(snapshot); ok {
@@ -492,7 +497,40 @@ func boardLastKnownAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
 }
 
 func refreshSnapshotFailed(snapshot telemetry.Snapshot) bool {
-	return len(snapshot.RefreshFailures()) > 0
+	return !refreshSnapshotPartiallyFailed(snapshot) && len(snapshot.RefreshFailures()) > 0
+}
+
+func refreshSnapshotPartiallyFailed(snapshot telemetry.Snapshot) bool {
+	return snapshot.Refresh.Partial() && len(snapshot.RefreshFailures()) > 0
+}
+
+func boardPartialRefreshAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
+	if !refreshSnapshotPartiallyFailed(snapshot) {
+		return boardAlert{}, false
+	}
+	failures := snapshot.RefreshFailures()
+	rows := make([]boardAlertDetailRow, 0, len(failures))
+	for index, failure := range failures {
+		projectID := diagnosticsConditionProject(failure.ProjectID)
+		rows = append(rows, boardAlertDetailRow{
+			ID:      "board-alert-partial-refresh-" + boardAlertRowSlug(projectID, index),
+			Label:   projectID,
+			Summary: "Project unavailable",
+			Detail:  refreshFailureDetail(failure),
+		})
+	}
+	rows, overflow := capBoardAlertRows(rows)
+	return boardAlert{
+		ID:            "board-alert-partial-refresh",
+		Kind:          boardAlertKindPartialRefresh,
+		Severity:      boardAlertSeverityPartialRefresh,
+		Tone:          primitives.KindWarn,
+		TerseSummary:  refreshPartialFailureSummary(snapshot),
+		DetailSummary: "Healthy project data remains live while affected projects are unavailable.",
+		DetailRows:    rows,
+		Overflow:      overflow,
+		DeepLink:      "/health/ui",
+	}, true
 }
 
 func boardFailureBreakerAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
@@ -1090,6 +1128,9 @@ func boardFigures(snapshot telemetry.Snapshot) []primitives.Figure {
 func boardWorkloadCountLabel(snapshot telemetry.Snapshot, count int) string {
 	if telemetry.BoardWorkloadComplete(snapshot) {
 		return formatCount(count)
+	}
+	if refreshSnapshotPartiallyFailed(snapshot) {
+		return formatCount(count) + "+"
 	}
 	if count == 0 {
 		return "unknown"

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1638,6 +1638,128 @@ func TestBoardFiguresExposeIncompleteWorkloadProjection(t *testing.T) {
 	}
 }
 
+func TestPartialProjectRefreshPresentation(t *testing.T) {
+	t.Parallel()
+
+	const validationError = "create project pyroapex: validate project workflow: schedule_ownership.enabled must be true when scheduled work is configured"
+	now := time.Date(2026, 9, 3, 14, 0, 0, 0, time.UTC)
+	lastErrorAt := now.Add(-time.Minute)
+	liveSection := telemetry.SnapshotSection{Source: telemetry.SnapshotSourceLive, ObservedAt: now, Complete: true}
+	partialSnapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Tracker:     telemetry.SnapshotSection{Source: telemetry.SnapshotSourceMixed, ObservedAt: now},
+		Runtime:     telemetry.SnapshotSection{Source: telemetry.SnapshotSourceMixed, ObservedAt: now},
+		Refresh: telemetry.Refresh{
+			Status:        telemetry.RefreshStatusPartial,
+			LastRefreshAt: &now,
+			LastError:     validationError,
+			LastErrorAt:   &lastErrorAt,
+		},
+		Projects: []telemetry.ProjectSnapshot{
+			{
+				Project: telemetry.Project{ID: "detent"},
+				Tracker: liveSection,
+				Runtime: liveSection,
+				Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusReady, LastRefreshAt: &now},
+			},
+			{
+				Project: telemetry.Project{ID: "pyroapex"},
+				Tracker: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceUnknown},
+				Runtime: telemetry.SnapshotSection{Source: telemetry.SnapshotSourceUnknown},
+				Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusDegraded, LastError: validationError, LastErrorAt: &lastErrorAt},
+			},
+		},
+	}
+	recoveredSnapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Tracker:     liveSection,
+		Runtime:     liveSection,
+		Refresh:     telemetry.Refresh{Status: telemetry.RefreshStatusReady, LastRefreshAt: &now},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent"}, Tracker: liveSection, Runtime: liveSection, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusReady, LastRefreshAt: &now}},
+			{Project: telemetry.Project{ID: "pyroapex"}, Tracker: liveSection, Runtime: liveSection, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusReady, LastRefreshAt: &now}},
+		},
+	}
+	tests := []struct {
+		name          string
+		snapshot      telemetry.Snapshot
+		wantKind      primitives.Kind
+		wantLabel     string
+		wantLiveLabel string
+		wantHealth    string
+		wantAlerts    int
+		wantCount     string
+	}{
+		{
+			name:          "invalid project leaves healthy data visible",
+			snapshot:      partialSnapshot,
+			wantKind:      primitives.KindWarn,
+			wantLabel:     "1 project degraded · pyroapex",
+			wantLiveLabel: "Live · 1 project degraded · pyroapex",
+			wantHealth:    "Tracker refresh is partially degraded.",
+			wantAlerts:    1,
+			wantCount:     "0+",
+		},
+		{
+			name:          "successful refresh clears degradation",
+			snapshot:      recoveredSnapshot,
+			wantKind:      primitives.KindOK,
+			wantLabel:     "Data current",
+			wantLiveLabel: "Live · data current",
+			wantHealth:    "All systems nominal.",
+			wantCount:     "0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := refreshFreshnessKind(tt.snapshot); got != tt.wantKind {
+				t.Fatalf("refreshFreshnessKind() = %q, want %q", got, tt.wantKind)
+			}
+			if got := refreshFreshnessLabel(tt.snapshot); got != tt.wantLabel {
+				t.Fatalf("refreshFreshnessLabel() = %q, want %q", got, tt.wantLabel)
+			}
+			data := DashboardShellData{Snapshot: tt.snapshot}
+			if got := appLiveStatusLabel(data); got != tt.wantLiveLabel {
+				t.Fatalf("appLiveStatusLabel() = %q, want %q", got, tt.wantLiveLabel)
+			}
+			if got := appShellHealthKind(data); got != tt.wantKind {
+				t.Fatalf("appShellHealthKind() = %q, want %q", got, tt.wantKind)
+			}
+			view := healthViewFromDashboard(DashboardData{Snapshot: tt.snapshot})
+			if view.Verdict != tt.wantHealth {
+				t.Fatalf("health verdict = %q, want %q", view.Verdict, tt.wantHealth)
+			}
+			alerts := boardAlerts(tt.snapshot)
+			if len(alerts) != tt.wantAlerts {
+				t.Fatalf("boardAlerts() = %#v, want %d", alerts, tt.wantAlerts)
+			}
+			for _, figure := range boardFigures(tt.snapshot) {
+				if figure.ID != "fig-completed" && figure.Value != tt.wantCount {
+					t.Fatalf("%s value = %q, want %q", figure.ID, figure.Value, tt.wantCount)
+				}
+			}
+			if tt.wantAlerts == 0 {
+				return
+			}
+			alert := alerts[0]
+			if alert.Kind != boardAlertKindPartialRefresh || alert.DeepLink != "/health/ui" || len(alert.DetailRows) != 1 {
+				t.Fatalf("partial refresh alert = %#v", alert)
+			}
+			if row := alert.DetailRows[0]; row.Label != "pyroapex" || !strings.Contains(row.Detail, validationError) {
+				t.Fatalf("partial refresh alert row = %#v", row)
+			}
+			if !strings.Contains(view.Detail, "pyroapex") {
+				t.Fatalf("health detail = %q, want affected project", view.Detail)
+			}
+			rows := healthRefreshFailureRows(tt.snapshot.RefreshFailures())
+			if len(rows) != 1 || !strings.Contains(rows[0].Component, "pyroapex") || !strings.Contains(rows[0].Detail, validationError) {
+				t.Fatalf("health refresh rows = %#v, want matching pyroapex failure", rows)
+			}
+		})
+	}
+}
+
 func TestBoardExceptionsRequireOptIn(t *testing.T) {
 	data := boardTestData()
 	if got := boardExceptions(data, true); len(got) != 0 {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1758,7 +1758,9 @@ func snapshotReady(snapshot telemetry.Snapshot) bool {
 		return false
 	}
 	status := snapshotReadinessStatus(snapshot)
-	return status == telemetry.RefreshStatusReady || status == telemetry.RefreshStatusBehind
+	return status == telemetry.RefreshStatusReady ||
+		status == telemetry.RefreshStatusBehind ||
+		status == telemetry.RefreshStatusPartial
 }
 
 func snapshotUsesStartupCache(snapshot telemetry.Snapshot) bool {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1156,6 +1156,9 @@ func runningCountLabel(snapshot telemetry.Snapshot) string {
 		return formatCount(count)
 	}
 	if !snapshot.Runtime.Available() || !snapshot.Runtime.Complete && count == 0 {
+		if refreshSnapshotPartiallyFailed(snapshot) && snapshot.Runtime.Available() {
+			return formatCount(count) + "+"
+		}
 		return "unknown"
 	}
 	if !snapshot.Runtime.Complete {

--- a/internal/web/templates/fleet_data_test.go
+++ b/internal/web/templates/fleet_data_test.go
@@ -650,6 +650,26 @@ func TestFleetSnapshotKeepsBodyDuringDegradedRefresh(t *testing.T) {
 	}
 }
 
+func TestFleetSnapshotRendersPartialRefreshData(t *testing.T) {
+	t.Parallel()
+
+	data := DashboardData{
+		Projects: []ProjectSmallMultiple{{ID: "detent"}},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: time.Date(2026, 9, 3, 16, 0, 0, 0, time.UTC),
+			Refresh:     telemetry.Refresh{Status: telemetry.RefreshStatusPartial, LastError: "pyroapex workflow invalid"},
+			BoardIssues: []telemetry.Issue{
+				{ID: "i1", Identifier: "digitaldrywood/detent#7", ProjectID: "detent", Title: "Healthy project card", State: "Backlog"},
+			},
+		},
+		Kanban: KanbanData{States: []string{"Backlog"}},
+	}
+	html := renderBoardComponent(t, FleetSnapshot(data))
+	if !strings.Contains(html, "agent-activity") {
+		t.Fatalf("partial fleet refresh should render healthy fleet data:\n%s", html)
+	}
+}
+
 func TestSheetSessionForScopesToProject(t *testing.T) {
 	// Non-GitHub identifiers can repeat across projects; the session lookup
 	// must not surface another project's running session.

--- a/internal/web/templates/freshness_data.go
+++ b/internal/web/templates/freshness_data.go
@@ -13,6 +13,9 @@ func refreshFreshnessKind(snapshot telemetry.Snapshot) primitives.Kind {
 	if refreshSnapshotFailed(snapshot) {
 		return primitives.KindErr
 	}
+	if refreshSnapshotPartiallyFailed(snapshot) {
+		return primitives.KindWarn
+	}
 	if snapshot.Refresh.Status == telemetry.RefreshStatusInitializing {
 		return primitives.KindNeutral
 	}
@@ -41,6 +44,9 @@ func refreshFreshnessLabel(snapshot telemetry.Snapshot) string {
 	if refreshSnapshotFailed(snapshot) {
 		return "Refresh failed"
 	}
+	if refreshSnapshotPartiallyFailed(snapshot) {
+		return refreshPartialFailureSummary(snapshot)
+	}
 	if snapshot.LastKnown {
 		return "Last-known data"
 	}
@@ -55,6 +61,22 @@ func refreshFreshnessLabel(snapshot telemetry.Snapshot) string {
 	default:
 		return "Waiting for data"
 	}
+}
+
+func refreshPartialFailureSummary(snapshot telemetry.Snapshot) string {
+	failures := snapshot.RefreshFailures()
+	projectIDs := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		if projectID := strings.TrimSpace(failure.ProjectID); projectID != "" {
+			projectIDs = append(projectIDs, projectID)
+		}
+	}
+	sort.Strings(projectIDs)
+	label := boardCountLabel(len(failures), "project degraded", "projects degraded")
+	if len(projectIDs) > 0 {
+		label += " · " + strings.Join(projectIDs, ", ")
+	}
+	return label
 }
 
 func refreshFreshnessSummary(snapshot telemetry.Snapshot) string {

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -98,6 +98,12 @@ func healthViewFromDashboard(data DashboardData) healthView {
 		view.Detail, view.DetailAt, view.DetailRelative = backendCapacityOutageDetailParts(backendFaults[0], snapshot.GeneratedAt)
 		return view
 	}
+	if refreshSnapshotPartiallyFailed(snapshot) {
+		view.Kind = primitives.KindWarn
+		view.Verdict = "Tracker refresh is partially degraded."
+		view.Detail = refreshPartialFailureSummary(snapshot) + ". Healthy project data remains live."
+		return view
+	}
 	if refreshSnapshotFailed(snapshot) {
 		view.Kind = primitives.KindErr
 		view.Verdict = "Tracker refresh failed."

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -142,6 +142,14 @@ func appShellHealthKind(data DashboardShellData) primitives.Kind {
 	if refreshSnapshotFailed(data.Snapshot) {
 		return primitives.KindErr
 	}
+	if refreshSnapshotPartiallyFailed(data.Snapshot) {
+		for _, alert := range boardAlerts(data.Snapshot) {
+			if alert.Kind != boardAlertKindPartialRefresh {
+				return primitives.KindErr
+			}
+		}
+		return primitives.KindWarn
+	}
 	if len(boardAlerts(data.Snapshot)) > 0 {
 		return primitives.KindErr
 	}
@@ -162,6 +170,9 @@ func appLiveStatusKind(data DashboardShellData) primitives.Kind {
 func appLiveStatusLabel(data DashboardShellData) string {
 	if refreshSnapshotFailed(data.Snapshot) {
 		return "Live · refresh failed"
+	}
+	if refreshSnapshotPartiallyFailed(data.Snapshot) {
+		return "Live · " + refreshPartialFailureSummary(data.Snapshot)
 	}
 	if data.Snapshot.LastKnown {
 		return "Live · last-known data"


### PR DESCRIPTION
## Summary

- classify mixed healthy and degraded project refreshes as partial instead of a fleet-wide failure
- preserve healthy project snapshots and counters while naming invalid projects and their actionable errors on Board and Health
- clear partial degradation after recovery while retaining fail-closed behavior when every project refresh fails

Fixes #2106

## UI Surface Contract

- [x] The linked issue explicitly authorizes this Board and Health status presentation change.
- [x] The issue explicitly requires the fleet header and invalid-project warning; browser verification is recorded below.
- [x] Verified an isolated seeded snapshot in Chrome: Board retained healthy cards and `1+` counters, named `pyroapex`, showed its exact validation error and Health link; Health named the same project and error.

## Test Plan

- [x] `go test ./internal/telemetry ./internal/boardsnapshot ./internal/cli ./internal/web/templates ./internal/web -count=1`
- [x] `make generate`
- [x] `make check` with the repository-pinned Go 1.26.6 toolchain and golangci-lint 2.9.0
- [x] isolated browser preview on a random test-server port