### PR TITLE
test(hubserver): stabilize Run cancellation

### DIFF
--- a/internal/hubserver/service_test.go
+++ b/internal/hubserver/service_test.go
@@ -170,14 +170,16 @@ func TestServeRequiresListener(t *testing.T) {
 func TestRunStopsOnContextCancellationAndReleasesDatabase(t *testing.T) {
 	t.Parallel()
 
-	const listenerReadyDeadlockGuard = 30 * time.Second
+	const runDeadlockGuard = time.Minute
+
 	databasePath := filepath.Join(t.TempDir(), "hub.db")
 	listenerAccepting := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	result := make(chan error, 1)
+	runDone := make(chan struct{})
+	runResult := make(chan error, 1)
 	go func() {
-		result <- Run(ctx, Config{
+		defer close(runDone)
+		runResult <- Run(ctx, Config{
 			DatabasePath:  databasePath,
 			ListenAddress: "127.0.0.1:0",
 			listen: func(ctx context.Context, network string, address string) (net.Listener, error) {
@@ -190,20 +192,32 @@ func TestRunStopsOnContextCancellationAndReleasesDatabase(t *testing.T) {
 			},
 		})
 	}()
+	cancelAndJoin := func() bool {
+		cancel()
+		select {
+		case <-runDone:
+			return true
+		case <-time.After(runDeadlockGuard):
+			t.Error("Run() did not stop after cancellation")
+			return false
+		}
+	}
+	t.Cleanup(func() {
+		cancelAndJoin()
+	})
 
 	select {
 	case <-listenerAccepting:
-	case <-time.After(listenerReadyDeadlockGuard):
+	case <-runDone:
+		t.Fatalf("Run() returned before accepting listener connections: %v", <-runResult)
+	case <-time.After(runDeadlockGuard):
 		t.Fatal("Run() did not start accepting listener connections")
 	}
-	cancel()
-	select {
-	case err := <-result:
-		if err != nil {
-			t.Fatalf("Run() error = %v", err)
-		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("Run() did not stop after cancellation")
+	if !cancelAndJoin() {
+		return
+	}
+	if err := <-runResult; err != nil {
+		t.Fatalf("Run() error = %v", err)
 	}
 
 	service := openTestService(t, Config{DatabasePath: databasePath})


### PR DESCRIPTION
## Summary

- Always cancel and join the background hub run before temporary database cleanup, including startup failure paths.
- Synchronize startup with the listener Accept signal and observe Run completion through an explicit channel.
- Reserve a one-minute wall-clock bound for deadlock detection.

Fixes #2110
Fixes #2123

## UI Surface Contract

- [x] N/A; this test-only change has no UI surface impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] Go 1.26.6: `go test -race ./internal/hubserver -run '^TestRunStopsOnContextCancellationAndReleasesDatabase$' -count=50 -parallel=8 -timeout=10m`
- [x] `PATH="$TMPDIR/detent-tools/bin:$PATH" GOTOOLCHAIN=go1.26.6 make check` with golangci-lint v2.9.0 built using Go 1.26.6; 78.9% coverage, all package/file floors passed
- [x] Current-head CI run 33922377090 at 39e29e02: all 11 checks passed, including Windows bounded-concurrency portability (10m34s), Ubuntu verification/race (10m15s), and GoReleaser (8m33s)

Recovery validation for #2123: retained commit `3530d117` has the exact same `service_test.go` blob as merged main (`004fba1881f96d335b5449645bfe01d67ca1e019`). Rebase onto `1601bca2` dropped the duplicate patch. Native focused race stress passed 50 one-CPU iterations (10.164s); hubserver package race stress passed 10 iterations (81.139s); fresh `make check` passed with 79.8% coverage and all configured package/file floors satisfied. No additional source changes were required.
