### PR TITLE
Reap orphaned workspace processes on cancel

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -73,6 +73,7 @@ type sessionWorkerProcessReaper interface {
 }
 
 type workerProcessReapFunc func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error)
+type workspaceProcessReapFunc func(context.Context, string, time.Duration) (int, error)
 
 type sessionResumeStore interface {
 	UpdateSessionResumeState(context.Context, int64, store.SessionResumeState) error
@@ -105,30 +106,31 @@ func (f AgentBackendFactoryFunc) NewAgentBackend(cfg config.AgentBackend) (Agent
 type durationLimitContextFactory func(context.Context, time.Duration, error) (context.Context, context.CancelFunc)
 
 type Dependencies struct {
-	ProjectID           string
-	Workflow            config.Workflow
-	Workspace           workspace.Backend
-	AgentBackend        AgentBackend
-	AgentBackends       map[string]AgentBackend
-	AgentBackendFactory AgentBackendFactory
-	Store               SessionStore
-	Pricing             budget.PricingTable
-	BudgetChecker       BudgetChecker
-	DispatchEstimator   DispatchEstimator
-	BudgetGuardBuilder  BudgetGuardBuilder
-	Now                 func() time.Time
-	Logger              *slog.Logger
-	SecurityAuditRoot   string
-	AfterRunTimeout     time.Duration
-	MaxAgentRSSBytes    uint64
-	RSSPollInterval     time.Duration
-	ProcessRSS          func(context.Context, procgroup.Identity) (uint64, error)
-	WorkerReapGrace     time.Duration
-	ReapWorkerProcess   workerProcessReapFunc
-	sessionLimit        durationLimitContextFactory
-	turnLimit           durationLimitContextFactory
-	progressTicker      sessionProgressTickerFactory
-	lookupEnv           func(string) string
+	ProjectID              string
+	Workflow               config.Workflow
+	Workspace              workspace.Backend
+	AgentBackend           AgentBackend
+	AgentBackends          map[string]AgentBackend
+	AgentBackendFactory    AgentBackendFactory
+	Store                  SessionStore
+	Pricing                budget.PricingTable
+	BudgetChecker          BudgetChecker
+	DispatchEstimator      DispatchEstimator
+	BudgetGuardBuilder     BudgetGuardBuilder
+	Now                    func() time.Time
+	Logger                 *slog.Logger
+	SecurityAuditRoot      string
+	AfterRunTimeout        time.Duration
+	MaxAgentRSSBytes       uint64
+	RSSPollInterval        time.Duration
+	ProcessRSS             func(context.Context, procgroup.Identity) (uint64, error)
+	WorkerReapGrace        time.Duration
+	ReapWorkerProcess      workerProcessReapFunc
+	ReapWorkspaceProcesses workspaceProcessReapFunc
+	sessionLimit           durationLimitContextFactory
+	turnLimit              durationLimitContextFactory
+	progressTicker         sessionProgressTickerFactory
+	lookupEnv              func(string) string
 }
 
 type Runner struct {
@@ -154,6 +156,7 @@ type Runner struct {
 	processRSS                func(context.Context, procgroup.Identity) (uint64, error)
 	workerReapGrace           time.Duration
 	reapWorkerProcess         workerProcessReapFunc
+	reapWorkspaceProcesses    workspaceProcessReapFunc
 	cleanupWorkerArtifacts    func(string, string) error
 	waitWorkerArtifactCleanup func(context.Context, time.Duration) error
 	sessionLimit              durationLimitContextFactory
@@ -190,6 +193,9 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	}
 	if deps.ReapWorkerProcess == nil {
 		deps.ReapWorkerProcess = procgroup.Terminate
+	}
+	if deps.ReapWorkspaceProcesses == nil {
+		deps.ReapWorkspaceProcesses = workspace.ReapProcesses
 	}
 	if deps.sessionLimit == nil {
 		deps.sessionLimit = withAgentDurationLimit
@@ -251,6 +257,7 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		processRSS:                deps.ProcessRSS,
 		workerReapGrace:           deps.WorkerReapGrace,
 		reapWorkerProcess:         deps.ReapWorkerProcess,
+		reapWorkspaceProcesses:    deps.ReapWorkspaceProcesses,
 		cleanupWorkerArtifacts:    workspace.CleanupOwnedPath,
 		waitWorkerArtifactCleanup: waitForPathRemovalRetry,
 		sessionLimit:              deps.sessionLimit,
@@ -1127,13 +1134,22 @@ func (r *Runner) runAgentTurn(
 		runRequest.Issue,
 		workerProcessReapReason(ctx, turnErr),
 	)
-	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, processReapErr)
-	if processReapErr != nil {
-		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+	workspaceReapErr := r.reapCancelledWorkspaceProcesses(
+		ctx,
+		info.Path,
+		detentSessionID,
+		runRequest.WorkAttemptID,
+		runRequest.Issue,
+		turnErr,
+	)
+	workerReapErr := errors.Join(processReapErr, workspaceReapErr)
+	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, workerReapErr)
+	if workerReapErr != nil {
+		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 	}
 	if cause := context.Cause(ctx); cooperativeStopError(cause) || durationLimitError(cause) {
-		if processReapErr != nil {
-			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+		if workerReapErr != nil {
+			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 		} else {
 			turnErr = cause
 		}
@@ -2855,13 +2871,22 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		req.Issue,
 		workerProcessReapReason(sessionCtx, turnErr),
 	)
-	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, processReapErr)
-	if processReapErr != nil {
-		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+	workspaceReapErr := r.reapCancelledWorkspaceProcesses(
+		sessionCtx,
+		info.Path,
+		sessionID,
+		runReq.WorkAttemptID,
+		req.Issue,
+		turnErr,
+	)
+	workerReapErr := errors.Join(processReapErr, workspaceReapErr)
+	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, workerReapErr)
+	if workerReapErr != nil {
+		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 	}
 	if cause := context.Cause(sessionCtx); cooperativeStopError(cause) || durationLimitError(cause) {
-		if processReapErr != nil {
-			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, processReapErr))
+		if workerReapErr != nil {
+			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 		} else {
 			turnErr = cause
 		}
@@ -3281,6 +3306,51 @@ func (r *Runner) reapSessionWorkerProcess(ctx context.Context, sessionID int64, 
 	return nil
 }
 
+func (r *Runner) reapCancelledWorkspaceProcesses(
+	ctx context.Context,
+	workspacePath string,
+	sessionID int64,
+	workAttemptID int64,
+	issue connector.Issue,
+	turnErr error,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	combined := errors.Join(context.Cause(ctx), turnErr)
+	if !workerSessionCanceled(combined) {
+		return nil
+	}
+
+	reap := r.reapWorkspaceProcesses
+	if reap == nil {
+		reap = workspace.ReapProcesses
+	}
+	reaped, err := reap(context.WithoutCancel(ctx), workspacePath, r.workerReapGrace)
+	attrs := []any{
+		telemetry.WorkAttemptIDKey, workAttemptID,
+		telemetry.DetentSessionIDKey, sessionID,
+		"workspace_path", strings.TrimSpace(workspacePath),
+		"reason", workerProcessReapReason(ctx, turnErr),
+		"count", reaped,
+	}
+	if err != nil {
+		attrs = append(attrs, "error", err)
+	}
+	r.logWorkerEventLevel(slog.LevelInfo, issue, "worker_orphan_processes_reaped", attrs...)
+	if err != nil {
+		return fmt.Errorf("reap orphaned workspace processes: %w", err)
+	}
+	return nil
+}
+
+func workerSessionCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		durationLimitError(err) ||
+		errors.Is(err, ErrSessionMemoryCeilingExceeded)
+}
+
 func (r *Runner) cleanupSessionWorkerArtifacts(ctx context.Context, root string, path string) (int, error) {
 	cleanup := r.cleanupWorkerArtifacts
 	if cleanup == nil {
@@ -3301,6 +3371,8 @@ func workerProcessReapReason(ctx context.Context, turnErr error) string {
 	switch {
 	case errors.Is(combined, ErrSessionDurationExceeded), errors.Is(combined, ErrMergeFallbackBudgetExceeded):
 		return "maximum_session_lifetime_exceeded"
+	case errors.Is(combined, ErrSessionNoProgress):
+		return SessionBrakeReasonNoProgress
 	case errors.Is(combined, ErrTurnDurationExceeded):
 		return "maximum_turn_lifetime_exceeded"
 	case errors.Is(combined, context.Canceled):

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -1,8 +1,10 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -115,6 +117,7 @@ func TestRunnerSessionLifetimeReapsWorkerAndRecordsCause(t *testing.T) {
 
 	startedAt := time.Date(2026, 8, 18, 14, 0, 0, 0, time.UTC)
 	identity := procgroup.Identity{PID: 1885, GroupID: 1885, StartedAt: startedAt}
+	workspacePath := t.TempDir()
 	durationLimit := &controlledDurationLimit{}
 	processStore := &durationReapSessionStore{
 		fakeSessionStore: &fakeSessionStore{sessionID: 1885},
@@ -129,15 +132,22 @@ func TestRunnerSessionLifetimeReapsWorkerAndRecordsCause(t *testing.T) {
 	}
 	backend := &durationWorkerAgentBackend{identity: identity, expireSession: durationLimit.Expire}
 	var reaped procgroup.Identity
+	var workspaceReaped string
+	var logs bytes.Buffer
 	runner, err := NewRunner(Dependencies{
 		Workflow:     config.Workflow{Config: config.Config{Agent: config.Agent{MaxSessionDurationMS: 25}}, Prompt: "Work"},
-		Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Key: "issue-session-lifetime"}},
+		Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: workspacePath, Key: "issue-session-lifetime"}},
 		AgentBackend: backend,
 		Store:        processStore,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
 		sessionLimit: durationLimit.Context,
 		ReapWorkerProcess: func(_ context.Context, got procgroup.Identity, _ time.Duration) (procgroup.TerminationOutcome, error) {
 			reaped = got
 			return procgroup.TerminationOutcomeKilled, nil
+		},
+		ReapWorkspaceProcesses: func(_ context.Context, path string, _ time.Duration) (int, error) {
+			workspaceReaped = path
+			return 2, nil
 		},
 	})
 	if err != nil {
@@ -151,6 +161,18 @@ func TestRunnerSessionLifetimeReapsWorkerAndRecordsCause(t *testing.T) {
 	if reaped != identity {
 		t.Fatalf("reaped identity = %#v, want %#v", reaped, identity)
 	}
+	if workspaceReaped != workspacePath {
+		t.Fatalf("reaped workspace = %q, want %q", workspaceReaped, workspacePath)
+	}
+	for _, want := range []string{
+		"event=worker_orphan_processes_reaped",
+		"issue_identifier=digitaldrywood/detent#1885",
+		"count=2",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs missing %q:\n%s", want, logs.String())
+		}
+	}
 	if len(processStore.reaps) != 1 {
 		t.Fatalf("reap records = %#v, want one", processStore.reaps)
 	}
@@ -159,6 +181,36 @@ func TestRunnerSessionLifetimeReapsWorkerAndRecordsCause(t *testing.T) {
 	}
 	if processStore.finished.FinalState != FinalStateSessionDurationExceeded {
 		t.Fatalf("final state = %q, want %q", processStore.finished.FinalState, FinalStateSessionDurationExceeded)
+	}
+}
+
+func TestWorkerSessionCanceled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "context canceled", err: context.Canceled, want: true},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: true},
+		{name: "turn duration", err: ErrTurnDurationExceeded, want: true},
+		{name: "session duration", err: ErrSessionDurationExceeded, want: true},
+		{name: "merge fallback budget", err: ErrMergeFallbackBudgetExceeded, want: true},
+		{name: "session turn limit", err: ErrSessionTurnLimitExceeded, want: true},
+		{name: "session no progress", err: ErrSessionNoProgress, want: true},
+		{name: "session memory ceiling", err: ErrSessionMemoryCeilingExceeded, want: true},
+		{name: "ordinary failure", err: errors.New("provider failed")},
+		{name: "success"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := workerSessionCanceled(tt.err); got != tt.want {
+				t.Fatalf("workerSessionCanceled(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -173,6 +225,7 @@ func TestRunnerReapsWorkerAfterTerminalTurn(t *testing.T) {
 		{name: "completed", wantReason: "turn_completed"},
 		{name: "failed", turnErr: errors.New("provider failed"), wantReason: "turn_failed"},
 		{name: "cancelled", turnErr: context.Canceled, wantReason: "session_cancelled"},
+		{name: "no progress", turnErr: ErrSessionNoProgress, wantReason: SessionBrakeReasonNoProgress},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/runner/duration_limit_unix_test.go
+++ b/internal/runner/duration_limit_unix_test.go
@@ -1,0 +1,171 @@
+//go:build unix
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestRunnerSessionCancellationReapsEscapedWorkspaceProcess(t *testing.T) {
+	workspacePath := t.TempDir()
+	lockPath := filepath.Join(workspacePath, "gate.lock")
+	durationLimit := &controlledDurationLimit{}
+	command, readyReader, readyWriter := workspaceLockCommand(t, workspacePath, lockPath)
+	backend := &orphanLockAgentBackend{
+		command:       command,
+		readyReader:   readyReader,
+		readyWriter:   readyWriter,
+		expireSession: durationLimit.Expire,
+	}
+	t.Cleanup(func() {
+		if backend.command.Process != nil {
+			_ = backend.command.Process.Kill()
+		}
+		if backend.waitDone != nil {
+			<-backend.waitDone
+		}
+	})
+	var reaped int
+	var reapErr error
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{Agent: config.Agent{MaxSessionDurationMS: 25}},
+			Prompt: "Work",
+		},
+		Workspace: &fakeWorkspaceBackend{
+			info: workspace.Info{Path: workspacePath, Key: "issue-orphan-lock"},
+		},
+		AgentBackend:    backend,
+		sessionLimit:    durationLimit.Context,
+		WorkerReapGrace: 5 * time.Second,
+		ReapWorkspaceProcesses: func(ctx context.Context, path string, grace time.Duration) (int, error) {
+			reaped, reapErr = workspace.ReapProcesses(ctx, path, grace)
+			return reaped, reapErr
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, runErr := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-orphan-lock",
+			Identifier: "digitaldrywood/detent#2081",
+		},
+	})
+	if !errors.Is(runErr, ErrSessionDurationExceeded) {
+		t.Fatalf("Run() error = %v, want ErrSessionDurationExceeded", runErr)
+	}
+	if reapErr != nil || reaped != 1 {
+		t.Fatalf("workspace reap = (%d, %v), want (1, nil)", reaped, reapErr)
+	}
+
+	select {
+	case <-backend.waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workspace lock holder survived session cancellation")
+	}
+	assertLockAvailable(t, lockPath)
+}
+
+func TestWorkspaceLockProcess(t *testing.T) {
+	if os.Getenv("DETENT_WORKSPACE_LOCK_HELPER") != "1" {
+		return
+	}
+
+	lockFile, err := os.OpenFile(os.Getenv("DETENT_WORKSPACE_LOCK_PATH"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("lock file: %v", err)
+	}
+	ready := os.NewFile(3, "ready")
+	if _, err := ready.Write([]byte{1}); err != nil {
+		t.Fatalf("signal readiness: %v", err)
+	}
+	if err := ready.Close(); err != nil {
+		t.Fatalf("close readiness pipe: %v", err)
+	}
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+type orphanLockAgentBackend struct {
+	command       *exec.Cmd
+	readyReader   *os.File
+	readyWriter   *os.File
+	expireSession func()
+	waitDone      chan struct{}
+}
+
+func (b *orphanLockAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+	if err := b.command.Start(); err != nil {
+		return AgentTurnResult{}, err
+	}
+	if err := b.readyWriter.Close(); err != nil {
+		return AgentTurnResult{}, err
+	}
+	b.waitDone = make(chan struct{})
+	go func() {
+		_ = b.command.Wait()
+		close(b.waitDone)
+	}()
+	if _, err := io.ReadFull(b.readyReader, make([]byte, 1)); err != nil {
+		return AgentTurnResult{}, err
+	}
+	b.expireSession()
+	<-ctx.Done()
+	return AgentTurnResult{}, ctx.Err()
+}
+
+func workspaceLockCommand(t *testing.T, workspacePath string, lockPath string) (*exec.Cmd, *os.File, *os.File) {
+	t.Helper()
+	readyReader, readyWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create readiness pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = readyReader.Close()
+		_ = readyWriter.Close()
+	})
+	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestWorkspaceLockProcess$")
+	cmd.Dir = workspacePath
+	cmd.Env = append(os.Environ(),
+		"DETENT_WORKSPACE_LOCK_HELPER=1",
+		"DETENT_WORKSPACE_LOCK_PATH="+lockPath,
+	)
+	cmd.ExtraFiles = []*os.File{readyWriter}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd, readyReader, readyWriter
+}
+
+func assertLockAvailable(t *testing.T, path string) {
+	t.Helper()
+	lockFile, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open gate lock: %v", err)
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("gate lock is unavailable after cancellation: %v", err)
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("unlock gate file: %v", err)
+	}
+}

--- a/internal/workspace/process_other.go
+++ b/internal/workspace/process_other.go
@@ -5,8 +5,13 @@ package workspace
 import (
 	"context"
 	"log/slog"
+	"time"
 )
 
 func reapWorkspaceProcesses(context.Context, string, *slog.Logger) int {
 	return 0
+}
+
+func ReapProcesses(context.Context, string, time.Duration) (int, error) {
+	return 0, nil
 }

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -5,6 +5,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -13,32 +14,162 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
 
+const defaultProcessTerminationGrace = 250 * time.Millisecond
+
 func reapWorkspaceProcesses(ctx context.Context, path string, logger *slog.Logger) int {
-	pids, err := workspaceProcessIDs(ctx, path)
+	reaped, err := ReapProcesses(ctx, path, defaultProcessTerminationGrace)
 	if err != nil {
 		if logger != nil {
-			logger.Warn("workspace process scan failed", slog.String("path", path), slog.Any("error", err))
+			logger.Warn("workspace process reap failed", slog.String("path", path), slog.Any("error", err))
 		}
-		return 0
+	}
+	return reaped
+}
+
+func ReapProcesses(ctx context.Context, path string, grace time.Duration) (int, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return 0, errors.New("workspace path is required")
+	}
+	if !filepath.IsAbs(path) {
+		return 0, fmt.Errorf("workspace path must be absolute: %q", path)
+	}
+	path = filepath.Clean(path)
+	if filepath.Dir(path) == path {
+		return 0, fmt.Errorf("workspace path must not be a filesystem root: %q", path)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if grace <= 0 {
+		grace = defaultProcessTerminationGrace
+	}
+	return reapProcesses(ctx, path, grace, workspaceProcessIDs, syscall.Kill)
+}
+
+type workspaceProcessScanner func(context.Context, string) ([]int, error)
+type workspaceProcessSignaler func(int, syscall.Signal) error
+type workspaceProcessWaiter func(context.Context, string, time.Duration, workspaceProcessScanner) ([]int, error)
+
+func reapProcesses(
+	ctx context.Context,
+	path string,
+	grace time.Duration,
+	scan workspaceProcessScanner,
+	signal workspaceProcessSignaler,
+) (int, error) {
+	return reapProcessesWithWait(ctx, path, grace, scan, signal, waitForWorkspaceProcesses)
+}
+
+func reapProcessesWithWait(
+	ctx context.Context,
+	path string,
+	grace time.Duration,
+	scan workspaceProcessScanner,
+	signal workspaceProcessSignaler,
+	wait workspaceProcessWaiter,
+) (int, error) {
+	pids, err := scanOwnedWorkspaceProcessIDs(ctx, path, scan)
+	if err != nil {
+		return 0, fmt.Errorf("scan workspace processes: %w", err)
+	}
+	if len(pids) == 0 {
+		return 0, nil
 	}
 
-	killed := 0
+	reaped := make(map[int]struct{}, len(pids))
+	termErr := signalWorkspaceProcesses(pids, syscall.SIGTERM, signal, reaped)
+	survivors, err := wait(ctx, path, grace, scan)
+	if err != nil {
+		return len(reaped), errors.Join(termErr, err)
+	}
+	if len(survivors) == 0 {
+		return len(reaped), termErr
+	}
+
+	killErr := signalWorkspaceProcesses(survivors, syscall.SIGKILL, signal, reaped)
+	survivors, waitErr := wait(ctx, path, grace, scan)
+	if waitErr != nil {
+		return len(reaped), errors.Join(termErr, killErr, waitErr)
+	}
+	if len(survivors) > 0 {
+		return len(reaped), errors.Join(
+			termErr,
+			killErr,
+			fmt.Errorf("workspace processes remained after SIGKILL: pids=%v", survivors),
+		)
+	}
+	return len(reaped), errors.Join(termErr, killErr)
+}
+
+func scanOwnedWorkspaceProcessIDs(ctx context.Context, path string, scan workspaceProcessScanner) ([]int, error) {
+	pids, err := scan(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	owned := make([]int, 0, len(pids))
+	seen := make(map[int]struct{}, len(pids))
 	for _, pid := range pids {
 		if pid <= 0 || pid == os.Getpid() {
 			continue
 		}
-		err := syscall.Kill(pid, syscall.SIGKILL)
-		if err == nil {
-			killed++
+		if _, ok := seen[pid]; ok {
 			continue
 		}
-		if !errors.Is(err, syscall.ESRCH) && logger != nil {
-			logger.Warn("workspace process kill failed", slog.String("path", path), slog.Int("pid", pid), slog.Any("error", err))
+		seen[pid] = struct{}{}
+		owned = append(owned, pid)
+	}
+	return owned, nil
+}
+
+func signalWorkspaceProcesses(
+	pids []int,
+	sig syscall.Signal,
+	signal workspaceProcessSignaler,
+	reaped map[int]struct{},
+) error {
+	var result error
+	for _, pid := range pids {
+		if err := signal(pid, sig); errors.Is(err, syscall.ESRCH) {
+			continue
+		} else if err != nil {
+			result = errors.Join(result, fmt.Errorf("signal workspace process %d with %s: %w", pid, sig, err))
+			continue
+		}
+		reaped[pid] = struct{}{}
+	}
+	return result
+}
+
+func waitForWorkspaceProcesses(
+	ctx context.Context,
+	path string,
+	grace time.Duration,
+	scan workspaceProcessScanner,
+) ([]int, error) {
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		pids, err := scanOwnedWorkspaceProcessIDs(ctx, path, scan)
+		if err != nil {
+			return nil, fmt.Errorf("verify workspace processes: %w", err)
+		}
+		if len(pids) == 0 {
+			return nil, nil
+		}
+		select {
+		case <-ctx.Done():
+			return pids, ctx.Err()
+		case <-timer.C:
+			return pids, nil
+		case <-ticker.C:
 		}
 	}
-	return killed
 }
 
 func workspaceProcessIDs(ctx context.Context, path string) ([]int, error) {

--- a/internal/workspace/process_unix_test.go
+++ b/internal/workspace/process_unix_test.go
@@ -1,0 +1,150 @@
+//go:build unix
+
+package workspace
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestReapProcesses(t *testing.T) {
+	const processID = 2081001
+
+	scanErr := errors.New("scan failed")
+	waitErr := errors.New("wait failed")
+	tests := []struct {
+		name          string
+		initial       []int
+		scanErr       error
+		waits         [][]int
+		waitErr       error
+		signalErr     error
+		wantSignals   []syscall.Signal
+		wantReaped    int
+		wantErr       error
+		wantSubstring string
+	}{
+		{name: "empty workspace"},
+		{
+			name:        "term clears workspace",
+			initial:     []int{processID},
+			waits:       [][]int{nil},
+			wantSignals: []syscall.Signal{syscall.SIGTERM},
+			wantReaped:  1,
+		},
+		{
+			name:        "kill clears term survivor",
+			initial:     []int{processID},
+			waits:       [][]int{{processID}, nil},
+			wantSignals: []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL},
+			wantReaped:  1,
+		},
+		{
+			name:       "initial scan fails",
+			scanErr:    scanErr,
+			wantErr:    scanErr,
+			wantReaped: 0,
+		},
+		{
+			name:        "wait fails",
+			initial:     []int{processID},
+			waitErr:     waitErr,
+			wantSignals: []syscall.Signal{syscall.SIGTERM},
+			wantReaped:  1,
+			wantErr:     waitErr,
+		},
+		{
+			name:          "kill leaves survivor",
+			initial:       []int{processID},
+			waits:         [][]int{{processID}, {processID}},
+			wantSignals:   []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL},
+			wantReaped:    1,
+			wantSubstring: "remained after SIGKILL",
+		},
+		{
+			name:        "signal failure is preserved",
+			initial:     []int{processID},
+			waits:       [][]int{nil},
+			signalErr:   syscall.EPERM,
+			wantSignals: []syscall.Signal{syscall.SIGTERM},
+			wantErr:     syscall.EPERM,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var signals []syscall.Signal
+			scan := func(context.Context, string) ([]int, error) {
+				return append([]int(nil), tt.initial...), tt.scanErr
+			}
+			signal := func(pid int, sig syscall.Signal) error {
+				if pid != processID {
+					t.Fatalf("signal pid = %d, want %d", pid, processID)
+				}
+				signals = append(signals, sig)
+				return tt.signalErr
+			}
+			waitCall := 0
+			wait := func(context.Context, string, time.Duration, workspaceProcessScanner) ([]int, error) {
+				if tt.waitErr != nil {
+					return nil, tt.waitErr
+				}
+				if waitCall >= len(tt.waits) {
+					t.Fatalf("wait call %d exceeds configured results", waitCall+1)
+				}
+				result := append([]int(nil), tt.waits[waitCall]...)
+				waitCall++
+				return result, nil
+			}
+
+			reaped, err := reapProcessesWithWait(t.Context(), "/workspace", time.Second, scan, signal, wait)
+			if reaped != tt.wantReaped {
+				t.Fatalf("reaped = %d, want %d", reaped, tt.wantReaped)
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && tt.wantSubstring == "" && err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+			if tt.wantSubstring != "" && (err == nil || !strings.Contains(err.Error(), tt.wantSubstring)) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantSubstring)
+			}
+			if len(signals) != len(tt.wantSignals) {
+				t.Fatalf("signals = %v, want %v", signals, tt.wantSignals)
+			}
+			for index := range signals {
+				if signals[index] != tt.wantSignals[index] {
+					t.Fatalf("signals = %v, want %v", signals, tt.wantSignals)
+				}
+			}
+		})
+	}
+}
+
+func TestReapProcessesRejectsUnsafePaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "empty", path: ""},
+		{name: "whitespace", path: "  "},
+		{name: "relative", path: "workspace"},
+		{name: "filesystem root", path: string(filepath.Separator)},
+		{name: "cleaned filesystem root", path: filepath.Join(string(filepath.Separator), "tmp", "..")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ReapProcesses(t.Context(), tt.path, time.Second)
+			if err == nil {
+				t.Fatal("ReapProcesses() error = nil, want non-nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- reap workspace processes after cancelled worker sessions with TERM, bounded grace, KILL escalation, and survivor verification
- emit the worker_orphan_processes_reaped lifecycle event and cover escaped lock holders with deterministic and integration tests

Fixes #2081

## UI Surface Contract

- [x] N/A; this change has no UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes.

## Test Plan

- [x] Focused Linux tests for internal/workspace and internal/runner
- [x] make check (exact wrapper in an ephemeral Linux clone under Detent TMPDIR)