### PR TITLE
fix: surface dispatch faults on board

### DIFF
--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -148,6 +148,7 @@ func demoScenarioDefinitions() []demoScenario {
 		{ID: "board-scheduled-pacing", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "board-scheduled-pacing", KanbanMode: workflowconfig.KanbanModeReadOnly},
 		{ID: "diagnostics-scheduled-pacing", Route: "/diagnostics", WaitSelector: "#diagnostics-conditions", Page: "diagnostics", Variant: "board-scheduled-pacing"},
 		{ID: "board-degraded-health-banners", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "board-degraded-health-banners", KanbanMode: workflowconfig.KanbanModeReadOnly},
+		{ID: "board-dispatch-fault", Route: "/", WaitSelector: "#board-alerts", Page: "fleet-kanban", Variant: "board-dispatch-fault", KanbanMode: workflowconfig.KanbanModeReadOnly},
 		{ID: "board-alerts-heavy", Route: "/", WaitSelector: "#board-alerts", Page: "fleet-kanban", Variant: "board-alerts-heavy", KanbanMode: workflowconfig.KanbanModeReadOnly, HideFromManifest: true},
 		{ID: "board-admission-proposals-zero", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "healthy", KanbanMode: workflowconfig.KanbanModeReadOnly, HideFromManifest: true},
 		{ID: "board-admission-proposals-one", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "admission-proposals-one", KanbanMode: workflowconfig.KanbanModeReadOnly, HideFromManifest: true},

--- a/internal/web/demofixtures/fixtures.go
+++ b/internal/web/demofixtures/fixtures.go
@@ -95,6 +95,8 @@ func SnapshotForScenario(id string, variant string) telemetry.Snapshot {
 		snapshot = demoBoardScheduledPacingSnapshot()
 	case "board-degraded-health-banners":
 		snapshot = demoBoardDegradedHealthBannersSnapshot()
+	case "board-dispatch-fault":
+		snapshot = demoBoardDispatchFaultSnapshot()
 	case "board-alerts-heavy":
 		snapshot = demoBoardAlertsHeavySnapshot()
 	case "admission-proposals-one":
@@ -453,6 +455,53 @@ func demoBoardAlertsHeavySnapshot() telemetry.Snapshot {
 	return snapshot
 }
 
+func demoBoardDispatchFaultSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	now := snapshot.GeneratedAt
+	allSkippedSince := now.Add(-3 * time.Hour)
+	lastSelectedAt := now.Add(-4 * time.Hour)
+	secondsSinceLastSelected := int64(4 * time.Hour / time.Second)
+	const waitReason = "issue does not match authorization selector: missing required label `detent`"
+	stall := telemetry.DispatchStatus{
+		ProjectID:                demoPrimaryProjectID,
+		CandidateCount:           4,
+		EligibleCandidateCount:   0,
+		SkippedCount:             4,
+		WaitReason:               waitReason,
+		WaitReasonCode:           "authorization_selector_declined",
+		AllSkippedSince:          &allSkippedSince,
+		LastSelectedAt:           &lastSelectedAt,
+		SecondsSinceLastSelected: &secondsSinceLastSelected,
+		StallDurationSeconds:     int64(3 * time.Hour / time.Second),
+		ObservedAt:               now,
+		Stalled:                  true,
+		NeedsHumanAttention:      true,
+		Class:                    observability.ClassFault,
+	}
+	for index := range snapshot.Projects {
+		if snapshot.Projects[index].Project.ID == demoPrimaryProjectID {
+			snapshot.Projects[index].Dispatch = stall
+		}
+	}
+	snapshot.DispatchStalls = nil
+	snapshot.SchedulerDecisions = make([]telemetry.SchedulerDecision, 0, stall.CandidateCount)
+	for number := 5301; number <= 5304; number++ {
+		identifier := "digitaldrywood/detent-core#" + strconv.Itoa(number)
+		snapshot.SchedulerDecisions = append(snapshot.SchedulerDecisions, telemetry.SchedulerDecision{
+			ProjectID:  demoPrimaryProjectID,
+			IssueID:    "demo-dispatch-fault-" + strconv.Itoa(number),
+			Identifier: identifier,
+			IssueURL:   demoIssueURL(identifier),
+			Lane:       "Todo",
+			Result:     "skipped",
+			Reason:     "authorization_selector_declined",
+			DecisionAt: now.Add(-time.Hour),
+			WaitReason: waitReason,
+		})
+	}
+	return snapshot
+}
+
 func demoBoardStalenessWarningsSnapshot(count int) telemetry.Snapshot {
 	snapshot := demoHealthySnapshot()
 	snapshot.StalenessWarnings = make([]telemetry.StalenessWarning, 0, count)
@@ -659,6 +708,22 @@ func demoBoardRampActiveRecoveriesSnapshot() telemetry.Snapshot {
 func demoBoardScheduledPacingSnapshot() telemetry.Snapshot {
 	snapshot := demoHealthySnapshot()
 	now := snapshot.GeneratedAt
+	pacing := telemetry.DispatchStatus{
+		ProjectID:              demoPrimaryProjectID,
+		CandidateCount:         3,
+		EligibleCandidateCount: 3,
+		SkippedCount:           3,
+		WaitReason:             "provider rate window is pacing dispatch until the next reset",
+		WaitReasonCode:         "provider_rate_window_backpressure",
+		ObservedAt:             now,
+		Stalled:                true,
+		Class:                  observability.ClassDiagnostic,
+	}
+	for index := range snapshot.Projects {
+		if snapshot.Projects[index].Project.ID == demoPrimaryProjectID {
+			snapshot.Projects[index].Dispatch = pacing
+		}
+	}
 	snapshot.DispatchRecoveries = []telemetry.DispatchRecovery{
 		{ProjectID: demoPrimaryProjectID, Kind: "github_rest", Reason: "remaining 288 at or below dispatch floor", Status: "waiting", StartedAt: now.Add(-3 * time.Minute), ResumeAt: now.Add(14 * time.Minute), MaxConcurrent: 6},
 		{ProjectID: "docs-site", Kind: "github_rest", Reason: "remaining 296 at or below dispatch floor", Status: "waiting", StartedAt: now.Add(-2 * time.Minute), ResumeAt: now.Add(14 * time.Minute), MaxConcurrent: 6},

--- a/internal/web/demofixtures/fixtures_test.go
+++ b/internal/web/demofixtures/fixtures_test.go
@@ -46,6 +46,7 @@ func TestSnapshotForScenarioVariants(t *testing.T) {
 		{name: "no history", projectID: "agent-lab", variant: "no-history"},
 		{name: "one board staleness warning", variant: "board-staleness-one"},
 		{name: "twenty board staleness warnings", variant: "board-staleness-twenty"},
+		{name: "board dispatch fault", variant: "board-dispatch-fault"},
 		{name: "settings empty", variant: "settings-empty"},
 		{name: "settings long paths", variant: "settings-long-paths"},
 		{name: "settings missing", variant: "settings-missing"},
@@ -88,6 +89,28 @@ func TestSnapshotForScenarioVariants(t *testing.T) {
 			assertSnapshotProjectIDs(t, snapshot)
 			assertSnapshotIssueIDs(t, snapshot)
 		})
+	}
+}
+
+func TestBoardDispatchFaultScenarioUsesProjectDispatchPayload(t *testing.T) {
+	t.Parallel()
+
+	snapshot := SnapshotForScenario("", "board-dispatch-fault")
+	if len(snapshot.DispatchStalls) != 0 {
+		t.Fatalf("DispatchStalls = %#v, want project-only dispatch payload", snapshot.DispatchStalls)
+	}
+	var status telemetry.DispatchStatus
+	for _, project := range snapshot.Projects {
+		if project.Project.ID == demoPrimaryProjectID {
+			status = project.Dispatch
+			break
+		}
+	}
+	if status.Class != observability.ClassFault || !status.Stalled || !status.NeedsHumanAttention || status.SkippedCount != 4 {
+		t.Fatalf("project dispatch = %#v, want four-card human-attention fault", status)
+	}
+	if len(snapshot.SchedulerDecisions) != status.SkippedCount {
+		t.Fatalf("scheduler decisions = %d, want %d affected cards", len(snapshot.SchedulerDecisions), status.SkippedCount)
 	}
 }
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -143,12 +143,7 @@ func boardAlerts(snapshot telemetry.Snapshot) []boardAlert {
 }
 
 func boardDispatchStallAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
-	faults := make([]telemetry.DispatchStatus, 0, len(snapshot.DispatchStalls))
-	for _, stall := range snapshot.DispatchStalls {
-		if dispatchConditionClass(stall) == observability.ClassFault {
-			faults = append(faults, stall)
-		}
-	}
+	faults := boardFaultDispatchStalls(snapshot)
 	if len(faults) == 0 {
 		return boardAlert{}, false
 	}
@@ -162,12 +157,33 @@ func boardDispatchStallAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
 		if stall.LastSelectedAt != nil {
 			detail += " · last dispatch selected " + formatDuration(float64(valueOrZero(stall.SecondsSinceLastSelected))) + " ago"
 		}
-		rows = append(rows, boardAlertDetailRow{
-			ID:      "board-alert-dispatch-stall-" + boardAlertRowSlug(projectID, index),
-			Label:   projectID,
-			Summary: "Needs human attention",
-			Detail:  detail + " · wait reason: " + strings.TrimSpace(stall.WaitReason),
-		})
+		detail += " · wait reason: " + strings.TrimSpace(stall.WaitReason)
+		decisions := boardDispatchStallDecisions(snapshot.SchedulerDecisions, stall)
+		if len(decisions) == 0 {
+			rows = append(rows, boardAlertDetailRow{
+				ID:      "board-alert-dispatch-stall-" + boardAlertRowSlug(projectID, index),
+				Label:   projectID,
+				Summary: "Needs human attention",
+				Detail:  detail,
+			})
+			continue
+		}
+		for decisionIndex, decision := range decisions {
+			label := strings.TrimSpace(decision.Identifier)
+			if label == "" {
+				label = strings.TrimSpace(decision.IssueID)
+			}
+			if label == "" {
+				label = "Affected card"
+			}
+			rows = append(rows, boardAlertDetailRow{
+				ID:      "board-alert-dispatch-stall-" + boardAlertRowSlug(projectID+"-"+label, index+decisionIndex),
+				Label:   label,
+				Link:    strings.TrimSpace(decision.IssueURL),
+				Summary: projectID + " · needs human attention · affected card",
+				Detail:  detail,
+			})
+		}
 	}
 	rows, overflow := capBoardAlertRows(rows)
 	return boardAlert{
@@ -181,6 +197,76 @@ func boardDispatchStallAlert(snapshot telemetry.Snapshot) (boardAlert, bool) {
 		Overflow:      overflow,
 		DeepLink:      "/health/ui",
 	}, true
+}
+
+func boardFaultDispatchStalls(snapshot telemetry.Snapshot) []telemetry.DispatchStatus {
+	faults := make([]telemetry.DispatchStatus, 0, len(snapshot.DispatchStalls)+len(snapshot.Projects))
+	seen := map[string]struct{}{}
+	appendFault := func(status telemetry.DispatchStatus, fallbackProjectID string) {
+		if strings.TrimSpace(status.ProjectID) == "" {
+			status.ProjectID = strings.TrimSpace(fallbackProjectID)
+		}
+		if !status.Stalled || !status.NeedsHumanAttention || dispatchConditionClass(status) != observability.ClassFault {
+			return
+		}
+		key := strings.ToLower(strings.TrimSpace(status.ProjectID))
+		if key == "" {
+			key = "fleet"
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		faults = append(faults, status)
+	}
+	for _, stall := range snapshot.DispatchStalls {
+		appendFault(stall, snapshot.Project.ID)
+	}
+	for _, project := range snapshot.Projects {
+		appendFault(project.Dispatch, project.Project.ID)
+	}
+	if len(snapshot.Projects) == 0 {
+		appendFault(snapshot.Dispatch, snapshot.Project.ID)
+	}
+	return faults
+}
+
+func boardDispatchStallDecisions(decisions []telemetry.SchedulerDecision, stall telemetry.DispatchStatus) []telemetry.SchedulerDecision {
+	projectID := strings.TrimSpace(stall.ProjectID)
+	reason := strings.TrimSpace(stall.WaitReasonCode)
+	seen := map[string]struct{}{}
+	matched := make([]telemetry.SchedulerDecision, 0, stall.CandidateCount)
+	for _, decision := range decisions {
+		if !strings.EqualFold(strings.TrimSpace(decision.Result), "skipped") || strings.TrimSpace(decision.Reason) != reason {
+			continue
+		}
+		decisionProjectID := strings.TrimSpace(decision.ProjectID)
+		if projectID != "" && decisionProjectID != "" && !strings.EqualFold(decisionProjectID, projectID) {
+			continue
+		}
+		if stall.AllSkippedSince != nil && !decision.DecisionAt.IsZero() && decision.DecisionAt.Before(*stall.AllSkippedSince) {
+			continue
+		}
+		key := strings.TrimSpace(decision.IssueID)
+		if key == "" {
+			key = strings.TrimSpace(decision.Identifier)
+		}
+		if key == "" {
+			key = strings.TrimSpace(decision.IssueURL)
+		}
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		matched = append(matched, decision)
+		if stall.CandidateCount > 0 && len(matched) == stall.CandidateCount {
+			break
+		}
+	}
+	return matched
 }
 
 func valueOrZero(value *int64) int64 {

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -2903,7 +2903,7 @@ func TestBoardAlertsRenderOnlyFaultConditions(t *testing.T) {
 		{
 			name: "total selector exclusion",
 			snapshot: telemetry.Snapshot{GeneratedAt: now, DispatchStalls: []telemetry.DispatchStatus{{
-				ProjectID: "detent", CandidateCount: 8, SkippedCount: 8, Stalled: true, WaitReasonCode: "authorization_selector_declined", WaitReason: "authorization selector excludes every candidate",
+				ProjectID: "detent", CandidateCount: 8, SkippedCount: 8, Stalled: true, NeedsHumanAttention: true, Class: observability.ClassFault, WaitReasonCode: "authorization_selector_declined", WaitReason: "authorization selector excludes every candidate",
 			}}},
 			want: 1,
 		},
@@ -3125,25 +3125,124 @@ func TestBoardAlertsSurfaceDispatchStallAsNeedsAttention(t *testing.T) {
 	t.Parallel()
 
 	const authorizationDetail = "issue does not match authorization selector: missing required label `detent`"
+	now := time.Date(2026, 8, 17, 20, 0, 0, 0, time.UTC)
+	allSkippedSince := now.Add(-3 * time.Hour)
 	secondsSinceLastSelected := int64(14_400)
-	alerts := boardAlerts(telemetry.Snapshot{DispatchStalls: []telemetry.DispatchStatus{{
+	stall := telemetry.DispatchStatus{
 		ProjectID:                "detent",
-		CandidateCount:           8,
+		CandidateCount:           4,
+		EligibleCandidateCount:   0,
+		SkippedCount:             4,
 		WaitReason:               authorizationDetail,
 		WaitReasonCode:           "authorization_selector_declined",
+		AllSkippedSince:          &allSkippedSince,
 		SecondsSinceLastSelected: &secondsSinceLastSelected,
 		StallDurationSeconds:     10_800,
 		Stalled:                  true,
 		NeedsHumanAttention:      true,
-	}}})
+		Class:                    observability.ClassFault,
+	}
+	decisions := make([]telemetry.SchedulerDecision, 0, 4)
+	for number := 2111; number <= 2114; number++ {
+		decisions = append(decisions, telemetry.SchedulerDecision{
+			ProjectID:  "detent",
+			IssueID:    "issue-" + strconv.Itoa(number),
+			Identifier: "digitaldrywood/detent#" + strconv.Itoa(number),
+			IssueURL:   "https://github.com/digitaldrywood/detent/issues/" + strconv.Itoa(number),
+			Result:     "skipped",
+			Reason:     "authorization_selector_declined",
+			DecisionAt: now.Add(-time.Hour),
+		})
+	}
+	alerts := boardAlerts(telemetry.Snapshot{
+		Projects: []telemetry.ProjectSnapshot{{
+			Project:  telemetry.Project{ID: "detent"},
+			Dispatch: stall,
+		}},
+		SchedulerDecisions: decisions,
+	})
 	if len(alerts) != 1 || alerts[0].Kind != boardAlertKindDispatchStall || alerts[0].Tone != primitives.KindErr {
 		t.Fatalf("boardAlerts() = %#v, want one dispatch-stall error", alerts)
 	}
-	combined := alerts[0].TerseSummary + " " + alerts[0].DetailSummary + " " + alerts[0].DetailRows[0].Summary + " " + alerts[0].DetailRows[0].Detail
-	for _, want := range []string{"Dispatch stalled", "human attention", "8 candidates", "3h", authorizationDetail} {
-		if !strings.Contains(combined, want) {
-			t.Fatalf("dispatch alert = %q, want containing %q", combined, want)
+	var combined strings.Builder
+	combined.WriteString(alerts[0].TerseSummary)
+	combined.WriteString(" ")
+	combined.WriteString(alerts[0].DetailSummary)
+	for _, row := range alerts[0].DetailRows {
+		combined.WriteString(" ")
+		combined.WriteString(row.Label)
+		combined.WriteString(" ")
+		combined.WriteString(row.Summary)
+		combined.WriteString(" ")
+		combined.WriteString(row.Detail)
+		combined.WriteString(" ")
+		combined.WriteString(row.Link)
+	}
+	for _, want := range []string{"Dispatch stalled", "human attention", "4 candidates", "3h", authorizationDetail, "digitaldrywood/detent#2111", "digitaldrywood/detent#2114"} {
+		if !strings.Contains(combined.String(), want) {
+			t.Fatalf("dispatch alert = %q, want containing %q", combined.String(), want)
 		}
+	}
+}
+
+func TestBoardAlertsExcludeSelfHealingDispatchConditions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status telemetry.DispatchStatus
+	}{
+		{
+			name: "capacity wait",
+			status: telemetry.DispatchStatus{
+				Stalled: true, NeedsHumanAttention: false, Class: observability.ClassDiagnostic, WaitReasonCode: "global_capacity_full",
+			},
+		},
+		{
+			name: "rate window pacing",
+			status: telemetry.DispatchStatus{
+				Stalled: true, NeedsHumanAttention: false, Class: observability.ClassDiagnostic, WaitReasonCode: "provider_rate_window_backpressure",
+			},
+		},
+		{
+			name: "reservation wait",
+			status: telemetry.DispatchStatus{
+				Stalled: true, NeedsHumanAttention: false, Class: observability.ClassDiagnostic, WaitReasonCode: "priority_reservation",
+			},
+		},
+		{
+			name: "fault without human attention",
+			status: telemetry.DispatchStatus{
+				Stalled: true, NeedsHumanAttention: false, Class: observability.ClassFault, WaitReasonCode: "authorization_selector_declined",
+			},
+		},
+		{
+			name: "human attention without fault",
+			status: telemetry.DispatchStatus{
+				Stalled: true, NeedsHumanAttention: true, Class: observability.ClassDiagnostic, WaitReasonCode: "global_capacity_full",
+			},
+		},
+		{
+			name: "resumed fault",
+			status: telemetry.DispatchStatus{
+				Stalled: false, NeedsHumanAttention: true, Class: observability.ClassFault, WaitReasonCode: "authorization_selector_declined",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.status.ProjectID = "detent"
+			alerts := boardAlerts(telemetry.Snapshot{Projects: []telemetry.ProjectSnapshot{{
+				Project:  telemetry.Project{ID: "detent"},
+				Dispatch: tt.status,
+			}}})
+			for _, alert := range alerts {
+				if alert.Kind == boardAlertKindDispatchStall {
+					t.Fatalf("boardAlerts() = %#v, want no dispatch-stall alert", alerts)
+				}
+			}
+		})
 	}
 }
 

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -574,6 +574,78 @@ test("board shows only health states needing attention", async ({
   await capturePageAndAttach(page, "board-alerts-expanded.png", testInfo);
 });
 
+test("board surfaces dispatch faults with affected cards and clears by morph", async ({
+  page,
+  context,
+}) => {
+  await openScenario(page, {
+    runtime: screenshotsRuntime,
+    scenario: "board-dispatch-fault",
+    route: "/",
+    waitSelector: "#board-alerts",
+    viewport: desktopViewport,
+  });
+
+  const snapshot = page.locator("#snapshot");
+  const bar = page.locator("#board-alerts");
+  await expect(bar).toContainText("Dispatch stalled (1 project)");
+  await expect(bar).toHaveAttribute("data-board-alert-tone", "err");
+  await page.locator("#board-alerts-toggle").click();
+
+  const overlay = page.locator("body > #board-alerts-overlay");
+  const fault = overlay.locator('[data-board-alert="dispatch-stall"]');
+  await expect(fault).toContainText(
+    "issue does not match authorization selector: missing required label `detent`",
+  );
+  await expect(fault).toContainText("4 candidates skipped for 3h");
+  for (let number = 5301; number <= 5304; number += 1) {
+    const identifier = `digitaldrywood/detent-core#${number}`;
+    await expect(fault.getByRole("link", { name: identifier })).toHaveAttribute(
+      "href",
+      `https://github.test/digitaldrywood/detent-core/issues/${number}`,
+    );
+  }
+
+  const healthyPage = await context.newPage();
+  await healthyPage.setExtraHTTPHeaders({
+    "X-Detent-Demo-Scenario": "fleet-healthy-parallel-work",
+  });
+  await healthyPage.goto(`${screenshotsRuntime.url}/`, {
+    waitUntil: "domcontentloaded",
+  });
+  const healthySnapshot = await healthyPage.locator("#snapshot").innerHTML();
+  await healthyPage.close();
+
+  await snapshot.evaluate((element) => {
+    window.__detentDispatchFaultSnapshot = element;
+  });
+  await sseMorphSnapshot(page, healthySnapshot);
+  await expect(page.locator("#board-alerts")).toHaveCount(0);
+  expect(
+    await snapshot.evaluate(
+      (element) => window.__detentDispatchFaultSnapshot === element,
+    ),
+  ).toBe(true);
+  await expect(overlay).toBeHidden();
+});
+
+test("board keeps self-healing dispatch waits out of fault alerts", async ({
+  page,
+}) => {
+  await openScenario(page, {
+    runtime: screenshotsRuntime,
+    scenario: "board-scheduled-pacing",
+    route: "/",
+    waitSelector: "#board-lanes",
+    viewport: desktopViewport,
+  });
+
+  await expect(
+    page.locator('[data-board-alert="dispatch-stall"]'),
+  ).toHaveCount(0);
+  await expect(page.locator("#snapshot")).not.toContainText("Dispatch stalled");
+});
+
 test("board lane picker hides and restores lanes", async ({ page }) => {
   await openScenario(page, {
     runtime: screenshotsRuntime,


### PR DESCRIPTION
## Summary

- surface stalled, human-attention dispatch faults from canonical project snapshots on the board
- identify affected cards from matching scheduler decisions and show the readable wait reason
- keep self-healing waits under Health and clear the fault alert through the existing snapshot morph

Fixes #2115

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

The linked issue explicitly requires fault-class dispatch stalls on the board. An isolated desktop Playwright preview verified the alert bar, expanded wait reason, four affected-card links, and morph clearing behavior. Existing desktop baseline files are unchanged.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/web/... -count=1`
- [x] focused Playwright dispatch fault present/absent specs
- [x] isolated desktop semantic snapshot and viewport inspection