### PR TITLE
fix(worker): retry GitHub token resolution

### DIFF
--- a/.detent/skills/macos-dyld-go-validation-fallback.md
+++ b/.detent/skills/macos-dyld-go-validation-fallback.md
@@ -1,0 +1,21 @@
+---
+name: macos-dyld-go-validation-fallback
+description: Diagnose Go validation commands that compile successfully on macOS but hang before the Go runtime starts, then run the exact gate in an isolated Linux container.
+when_to_use: Use when fresh Go test or generator binaries produce no test output, time out across unrelated packages, and process samples remain in _dyld_start while macOS security services are saturated.
+---
+
+# macOS dyld Go validation fallback
+
+Confirm that the failure precedes application startup before changing code:
+
+- Compile a focused test binary with `go test -c`.
+- Run the binary directly with a short test timeout.
+- Sample the stalled process into the Detent-provided temporary directory.
+- Treat a sample dominated by `_dyld_start`, together with a saturated macOS security service, as a host execution failure rather than a Go test failure.
+- Verify the binary's code signature before choosing a fallback.
+
+Run the repository's exact validation target in a Linux container when Docker is healthy. Mount the worktree, the worktree's shared Git metadata at its original absolute path, and Detent-scoped module, build, and tool caches. Pass `safe.directory` through `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_0`, and `GIT_CONFIG_VALUE_0` so generators can resolve repository-relative paths without changing global Git configuration.
+
+Run the container as the workspace owner. Use workspace-owned temporary directories for `node_modules` and npm cache; anonymous Docker volumes default to root ownership. Prefer repository-pinned prebuilt tools when host file-table pressure makes large `go install` dependency trees fail.
+
+Re-run generation with Git repository detection enabled and confirm that unrelated generated files remain unchanged. Record both the native startup evidence and the successful exact containerized gate in the handoff.

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -550,6 +550,8 @@
 #   max_concurrent_agents_per_host: null
 #   # worker.github_token | type: string | default: none | required: No | validation: None
 #   github_token: null
+#   # worker.github_token_resolution_timeout_ms | type: integer | default: 15000 | required: No | validation: must be greater than 0
+#   github_token_resolution_timeout_ms: 15000
 #   # worker.github_rest_min_remaining_reserve | type: integer | default: 1250 | required: No | validation: must be greater than 0
 #   github_rest_min_remaining_reserve: 1250
 #   # worker.github_rest_poll_interval_ms | type: integer | default: 60000 | required: No | validation: must be greater than or equal to 60000

--- a/docs/config.md
+++ b/docs/config.md
@@ -241,9 +241,16 @@ reference remains available when permission or revocation isolation is useful:
 ```yaml
 worker:
   github_token: gh
+  github_token_resolution_timeout_ms: 15000
   github_rest_min_remaining_reserve: 1250
   github_rest_poll_interval_ms: 60000
 ```
+
+The token-resolution timeout applies to each `gh auth token` invocation. Detent
+tries the command up to three times with short backoff before recording a
+same-attempt infrastructure wait; these failures do not consume issue attempt
+or failure-breaker budgets. Increase the timeout when the host credential store
+can legitimately take longer than 15 seconds.
 
 After resolving `gh`, Detent classifies an exact orchestrator token or any token
 that resolves to the same GitHub user as `shared_budget`: GitHub's primary REST
@@ -1121,6 +1128,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `worker.github_rest_min_remaining_reserve` | `integer` | `1250` | No | must be greater than 0 |
 | `worker.github_rest_poll_interval_ms` | `integer` | `60000` | No | must be greater than or equal to 60000 |
 | `worker.github_token` | `string` | `none` | No | None |
+| `worker.github_token_resolution_timeout_ms` | `integer` | `15000` | No | must be greater than 0 |
 | `worker.max_concurrent_agents_per_host` | `integer` | `none` | No | must be greater than 0 |
 | `worker.ssh_hosts` | `list<string>` | `[]` | No | None |
 | `workpad` | `object` | `see child fields` | No | None |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -303,11 +303,12 @@ type DeliverableElicitationRule struct {
 }
 
 type Worker struct {
-	SSHHosts                   []string `yaml:"ssh_hosts"`
-	MaxConcurrentAgentsPerHost *int     `yaml:"max_concurrent_agents_per_host"`
-	GitHubToken                string   `yaml:"github_token,omitempty"`
-	GitHubRESTMinReserve       int      `yaml:"github_rest_min_remaining_reserve"`
-	GitHubRESTPollIntervalMS   int      `yaml:"github_rest_poll_interval_ms"`
+	SSHHosts                       []string `yaml:"ssh_hosts"`
+	MaxConcurrentAgentsPerHost     *int     `yaml:"max_concurrent_agents_per_host"`
+	GitHubToken                    string   `yaml:"github_token,omitempty"`
+	GitHubTokenResolutionTimeoutMS int      `yaml:"github_token_resolution_timeout_ms"`
+	GitHubRESTMinReserve           int      `yaml:"github_rest_min_remaining_reserve"`
+	GitHubRESTPollIntervalMS       int      `yaml:"github_rest_poll_interval_ms"`
 }
 
 type Agent struct {
@@ -1391,9 +1392,10 @@ func Default() Config {
 			Source: DependencySourceMerged,
 		},
 		Worker: Worker{
-			SSHHosts:                 []string{},
-			GitHubRESTMinReserve:     1250,
-			GitHubRESTPollIntervalMS: 60000,
+			SSHHosts:                       []string{},
+			GitHubTokenResolutionTimeoutMS: 15000,
+			GitHubRESTMinReserve:           1250,
+			GitHubRESTPollIntervalMS:       60000,
 		},
 		Agent: Agent{
 			MaxConcurrentAgents:          10,
@@ -1557,6 +1559,7 @@ func (c *Config) Validate() error {
 	if c.Worker.MaxConcurrentAgentsPerHost != nil {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
 	}
+	validatePositive("worker.github_token_resolution_timeout_ms", c.Worker.GitHubTokenResolutionTimeoutMS, &problems)
 	validatePositive("worker.github_rest_min_remaining_reserve", c.Worker.GitHubRESTMinReserve, &problems)
 	if c.Worker.GitHubRESTPollIntervalMS < 60000 {
 		problems = append(problems, "worker.github_rest_poll_interval_ms must be greater than or equal to 60000")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,12 +122,15 @@ func TestParseWorkflowOverlayPrecedence(t *testing.T) {
 func TestWorkerGitHubPolicyConfiguration(t *testing.T) {
 	t.Parallel()
 
-	workflow, err := ParseWorkflow([]byte("---\ntracker:\n  kind: memory\nworker:\n  github_token: $DETENT_WORKER_GITHUB_TOKEN\n  github_rest_min_remaining_reserve: 1250\n  github_rest_poll_interval_ms: 90000\n---\nPrompt\n"))
+	workflow, err := ParseWorkflow([]byte("---\ntracker:\n  kind: memory\nworker:\n  github_token: $DETENT_WORKER_GITHUB_TOKEN\n  github_token_resolution_timeout_ms: 30000\n  github_rest_min_remaining_reserve: 1250\n  github_rest_poll_interval_ms: 90000\n---\nPrompt\n"))
 	if err != nil {
 		t.Fatalf("ParseWorkflow() error = %v", err)
 	}
 	if workflow.Config.Worker.GitHubToken != "$DETENT_WORKER_GITHUB_TOKEN" {
 		t.Fatalf("Worker.GitHubToken = %q, want environment reference", workflow.Config.Worker.GitHubToken)
+	}
+	if workflow.Config.Worker.GitHubTokenResolutionTimeoutMS != 30000 {
+		t.Fatalf("Worker.GitHubTokenResolutionTimeoutMS = %d, want 30000", workflow.Config.Worker.GitHubTokenResolutionTimeoutMS)
 	}
 	if workflow.Config.Worker.GitHubRESTMinReserve != 1250 {
 		t.Fatalf("Worker.GitHubRESTMinReserve = %d, want 1250", workflow.Config.Worker.GitHubRESTMinReserve)
@@ -166,6 +169,9 @@ func TestWorkerGitHubDefaultReserveBrakesBeforeOrchestrator(t *testing.T) {
 	t.Parallel()
 
 	cfg := Default()
+	if cfg.Worker.GitHubTokenResolutionTimeoutMS != 15000 {
+		t.Fatalf("Worker.GitHubTokenResolutionTimeoutMS = %d, want 15000", cfg.Worker.GitHubTokenResolutionTimeoutMS)
+	}
 	if cfg.Worker.GitHubRESTMinReserve <= cfg.Tracker.GitHubRESTMinReserve {
 		t.Fatalf("worker reserve = %d, want above orchestrator floor %d", cfg.Worker.GitHubRESTMinReserve, cfg.Tracker.GitHubRESTMinReserve)
 	}
@@ -179,6 +185,13 @@ func TestWorkerGitHubPolicyValidation(t *testing.T) {
 		mutate      func(*Config)
 		wantProblem string
 	}{
+		{
+			name: "token resolution timeout must be positive",
+			mutate: func(cfg *Config) {
+				cfg.Worker.GitHubTokenResolutionTimeoutMS = 0
+			},
+			wantProblem: "worker.github_token_resolution_timeout_ms must be greater than 0",
+		},
 		{
 			name: "reserve must be positive",
 			mutate: func(cfg *Config) {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -143,7 +143,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		beforeRefresh := running
 		refreshed, err := o.refreshCompletionLane(ctx, running)
 		if err != nil {
-			if !errors.Is(event.Err, runpkg.ErrWorkerGitHubBudgetMonitor) {
+			if !errors.Is(event.Err, runpkg.ErrWorkerGitHubBudgetMonitor) && !errors.Is(event.Err, runpkg.ErrWorkerGitHubTokenResolution) {
 				availabilityErr, unavailable := connector.AsTrackerAvailability(err)
 				if unavailable && availabilityErr != nil {
 					o.deferTrackerUnavailableCompletion(ctx, state, event, running, availabilityErr)
@@ -240,6 +240,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
 	}
 	delete(state.Running, event.IssueID)
+	if o.handleWorkerGitHubTokenResolutionCompletion(ctx, state, event, running) {
+		return
+	}
 	if o.handleGitHubMonitorCompletion(ctx, state, event, running) {
 		return
 	}

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -478,7 +478,7 @@ func workAttemptCompletedAfter(left telemetry.WorkAttempt, right telemetry.WorkA
 
 func terminalAttemptRetryableFailure(attempt telemetry.WorkAttempt) bool {
 	errorClass := strings.TrimSpace(attempt.ErrorClass)
-	if errorClass == forgeUnavailableErrorClass || errorClass == workspaceBranchHoldErrorClass || errorClass == workerGitHubMonitorErrorClass {
+	if errorClass == forgeUnavailableErrorClass || errorClass == workspaceBranchHoldErrorClass || errorClass == workerGitHubMonitorErrorClass || errorClass == workerGitHubTokenResolutionErrorClass {
 		return false
 	}
 	if errorClass == githubRESTCapacityError {

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -98,6 +98,7 @@ func (o *Orchestrator) recoverDurableWorkAttempts(ctx context.Context, state *St
 		o.recoverForgeAvailabilityWaits(ctx, state, recent, now)
 		o.recoverGitHubRESTCapacityWaits(ctx, state, recent, now)
 		o.recoverWorkerGitHubMonitorWaits(ctx, state, recent, now)
+		o.recoverWorkerGitHubTokenResolutionWaits(ctx, state, recent, now)
 	}
 	decisions, err := o.workAttempts.ListRecentSchedulerDecisions(ctx, store.SchedulerDecisionQuery{
 		ProjectID: projectID,

--- a/internal/orchestrator/worker_github_token_resolution.go
+++ b/internal/orchestrator/worker_github_token_resolution.go
@@ -1,0 +1,175 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	workerGitHubTokenResolutionErrorClass = "worker_github_token_resolution_unavailable"
+	workerGitHubTokenResolutionWaitKind   = "worker_github_token_resolution"
+)
+
+type workerGitHubTokenResolutionWaitMetadata struct {
+	Attempts    int       `json:"attempts"`
+	TimeoutMS   int64     `json:"timeout_ms"`
+	DetectedAt  time.Time `json:"detected_at"`
+	NextRetryAt time.Time `json:"next_retry_at"`
+}
+
+func (o *Orchestrator) handleWorkerGitHubTokenResolutionCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	resolutionErr, unavailable := runpkg.AsWorkerGitHubTokenResolutionError(event.Err)
+	if !unavailable {
+		return false
+	}
+	detectedAt := event.CompletedAt.UTC()
+	delay := o.cfg.OverloadRetryDelay
+	if delay <= 0 {
+		delay = defaultOverloadRetryDelay
+	}
+	nextRetryAt := detectedAt.Add(delay)
+	o.finishForgeAvailabilityProbe(state, event, running)
+	o.deferBackendCapacityProbe(state, running, detectedAt, event.Err)
+	releaseWorkerGitHubMonitorProbe(state, event.IssueID, "deferred", errorString(event.Err), detectedAt)
+	o.releaseTerminalAttemptClaim(ctx, state, running.Issue, detectedAt)
+	releaseDispatchRecoveryAdmission(state, event.IssueID)
+	metadata := workerGitHubTokenResolutionWaitMetadata{
+		Attempts:    resolutionErr.Attempts,
+		TimeoutMS:   resolutionErr.Timeout.Milliseconds(),
+		DetectedAt:  detectedAt,
+		NextRetryAt: nextRetryAt,
+	}
+	o.completeDurableWorkAttemptWithMetadata(
+		ctx,
+		state,
+		running,
+		detectedAt,
+		store.WorkAttemptTerminalCapacity,
+		workerGitHubTokenResolutionErrorClass,
+		errorString(event.Err),
+		"waiting",
+		"waiting for worker GitHub token resolution",
+		map[string]any{"worker_github_token_resolution_wait": metadata},
+	)
+	if !workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		state.Retry[running.Issue.ID] = Retry{
+			Issue:      cloneIssue(running.Issue),
+			Attempt:    running.Attempt,
+			DueAt:      nextRetryAt,
+			Error:      errorString(event.Err),
+			WorkerHost: running.WorkerHost,
+			Wait: RetryWait{
+				Kind:      workerGitHubTokenResolutionWaitKind,
+				StartedAt: detectedAt,
+			},
+		}
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      detectedAt,
+		Event:   workerGitHubTokenResolutionErrorClass,
+		Message: "worker GitHub token resolution unavailable; host credential store may be slow; retrying " + issueLabel(running.Issue) + " at " + nextRetryAt.Format(time.RFC3339),
+	})
+	telemetry.LogLifecycleMessage(o.logger, slog.LevelWarn, telemetry.LifecycleSafetyControl, workerGitHubTokenResolutionErrorClass, "worker GitHub token resolution unavailable; host credential store may be slow", o.runningLifecycleCorrelation(running.Issue, running),
+		"resolution_attempts", resolutionErr.Attempts,
+		"resolution_timeout_ms", resolutionErr.Timeout.Milliseconds(),
+		"next_retry_at", nextRetryAt,
+		"error", event.Err,
+	)
+	return true
+}
+
+func (o *Orchestrator) recoverWorkerGitHubTokenResolutionWaits(ctx context.Context, state *State, attempts []store.WorkAttempt, now time.Time) {
+	if state == nil || len(attempts) == 0 {
+		return
+	}
+	latest := latestStoreTerminalAttemptsByIssue(attempts)
+	waits := make(map[string]workerGitHubTokenResolutionWaitMetadata, len(latest))
+	issueIDs := make([]string, 0, len(latest))
+	for issueID, attempt := range latest {
+		metadata, ok := workerGitHubTokenResolutionWaitMetadataFromAttempt(attempt)
+		if !ok {
+			continue
+		}
+		waits[issueID] = metadata
+		issueIDs = append(issueIDs, issueID)
+	}
+	if len(waits) == 0 {
+		return
+	}
+	issuesByID, validated := o.validateGitHubRESTWaitIssues(ctx, issueIDs)
+	for issueID, metadata := range waits {
+		attempt := latest[issueID]
+		issue := workerGitHubTokenResolutionIssueFromAttempt(attempt)
+		if validated {
+			var ok bool
+			issue, ok = issuesByID[issueID]
+			if !ok || !stateIn(issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+				continue
+			}
+		}
+		nextRetryAt := metadata.NextRetryAt.UTC()
+		if nextRetryAt.Before(now) {
+			nextRetryAt = now.UTC()
+		}
+		state.Retry[issue.ID] = Retry{
+			Issue:      cloneIssue(issue),
+			Attempt:    attempt.AttemptNumber,
+			DueAt:      nextRetryAt,
+			Error:      strings.TrimSpace(attempt.ErrorMessage),
+			WorkerHost: strings.TrimSpace(attempt.WorkerHost),
+			Wait: RetryWait{
+				Kind:      workerGitHubTokenResolutionWaitKind,
+				StartedAt: metadata.DetectedAt.UTC(),
+			},
+		}
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now.UTC(),
+			Event:   "worker_github_token_resolution_wait_restored",
+			Message: "restored durable worker GitHub token resolution wait for " + issueLabel(issue),
+		})
+	}
+}
+
+func workerGitHubTokenResolutionWaitMetadataFromAttempt(attempt store.WorkAttempt) (workerGitHubTokenResolutionWaitMetadata, bool) {
+	if attempt.TerminalState != store.WorkAttemptTerminalCapacity || strings.TrimSpace(attempt.ErrorClass) != workerGitHubTokenResolutionErrorClass {
+		return workerGitHubTokenResolutionWaitMetadata{}, false
+	}
+	var metadata struct {
+		Wait workerGitHubTokenResolutionWaitMetadata `json:"worker_github_token_resolution_wait"`
+	}
+	if json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata) != nil {
+		return workerGitHubTokenResolutionWaitMetadata{}, false
+	}
+	wait := metadata.Wait
+	if wait.Attempts <= 0 || wait.TimeoutMS <= 0 || wait.DetectedAt.IsZero() || wait.NextRetryAt.IsZero() {
+		return workerGitHubTokenResolutionWaitMetadata{}, false
+	}
+	return wait, true
+}
+
+func workerGitHubTokenResolutionIssueFromAttempt(attempt store.WorkAttempt) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = strings.TrimSpace(attempt.IssueID)
+	issue.Identifier = strings.TrimSpace(attempt.Identifier)
+	issue.URL = strings.TrimSpace(attempt.IssueURL)
+	issue.State = strings.TrimSpace(attempt.Lane)
+	issue.PRRepository = strings.TrimSpace(attempt.Repo)
+	if attempt.PRNumber != nil && *attempt.PRNumber > 0 {
+		number := int(*attempt.PRNumber)
+		issue.PRNumber = &number
+	}
+	return issue
+}

--- a/internal/orchestrator/worker_github_token_resolution.go
+++ b/internal/orchestrator/worker_github_token_resolution.go
@@ -77,6 +77,9 @@ func (o *Orchestrator) handleWorkerGitHubTokenResolutionCompletion(
 			},
 		}
 	}
+	if state.FailureBreaker.Active() && state.FailureBreaker.CanaryIssueID == running.Issue.ID {
+		o.deferProjectFailureBreakerCanary(state, running.Issue.ID, detectedAt, nextRetryAt.Sub(detectedAt))
+	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      detectedAt,
 		Event:   workerGitHubTokenResolutionErrorClass,

--- a/internal/orchestrator/worker_github_token_resolution_test.go
+++ b/internal/orchestrator/worker_github_token_resolution_test.go
@@ -1,0 +1,189 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestWorkerGitHubTokenResolutionCompletionPreservesAttemptBudget(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	issue := implementProgressIssueWithoutPR()
+	issue.ID = "issue-worker-github-token"
+	issue.Identifier = "digitaldrywood/detent#2055"
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+		OverloadRetryDelay:  45 * time.Second,
+	})
+	attempts := &implementProgressAttemptStore{}
+	var logs bytes.Buffer
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    &implementProgressConnector{},
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue: issue, Attempt: 4, WorkAttemptID: 2055, Mode: runpkg.RunModeImplement,
+		StartedAt: now.Add(-time.Minute), DiffStats: DiffStats{Status: "clean"},
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+	state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "other", At: now.Add(-time.Minute)}}
+	instantFailures := map[string]InstantFailure{issue.ID: state.InstantFailures[issue.ID]}
+	repeatedFailures := map[string]RepeatedFailure{issue.ID: state.RepeatedFailures[issue.ID]}
+	failureBreaker := cloneProjectFailureBreaker(state.FailureBreaker)
+
+	resolutionErr := &runpkg.WorkerGitHubTokenResolutionError{
+		Attempts: 3,
+		Timeout:  15 * time.Second,
+		Err:      context.DeadlineExceeded,
+	}
+	supervisor, err := runpkg.NewSupervisor(staticWorkerGitHubTokenResolutionBackend{err: resolutionErr}, runpkg.SupervisorConfig{
+		Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	completion := supervisor.Run(t.Context(), runpkg.RunRequest{Issue: issue, Attempt: 4, Mode: runpkg.RunModeImplement})
+	if completion.Retryable || completion.RetryAttempt != 0 || completion.RetryDelay != 0 {
+		t.Fatalf("runner completion = %#v, want infrastructure-owned retry", completion)
+	}
+	orch.handleRunResult(t.Context(), &state, completion)
+
+	if len(attempts.completions) != 1 {
+		t.Fatalf("completions = %#v, want one durable infrastructure wait", attempts.completions)
+	}
+	completed := attempts.completions[0]
+	if completed.TerminalState != store.WorkAttemptTerminalCapacity || completed.ErrorClass != workerGitHubTokenResolutionErrorClass {
+		t.Fatalf("completion = %#v, want token-resolution capacity classification", completed)
+	}
+	var persisted struct {
+		Wait workerGitHubTokenResolutionWaitMetadata `json:"worker_github_token_resolution_wait"`
+	}
+	if err := json.Unmarshal([]byte(completed.WorkerMetadataJSON), &persisted); err != nil {
+		t.Fatalf("decode worker metadata: %v", err)
+	}
+	if persisted.Wait.Attempts != 3 || persisted.Wait.TimeoutMS != 15000 || !persisted.Wait.NextRetryAt.Equal(now.Add(45*time.Second)) {
+		t.Fatalf("resolution wait = %#v, want attempts, timeout, and retry deadline", persisted.Wait)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 4 || !retry.DueAt.Equal(now.Add(45*time.Second)) || retry.Wait.Kind != workerGitHubTokenResolutionWaitKind {
+		t.Fatalf("retry = %#v, want same-attempt token-resolution wait", retry)
+	}
+	if !reflect.DeepEqual(state.InstantFailures, instantFailures) || !reflect.DeepEqual(state.RepeatedFailures, repeatedFailures) || !reflect.DeepEqual(state.FailureBreaker, failureBreaker) {
+		t.Fatalf("failure budgets changed: instant=%#v repeated=%#v project=%#v", state.InstantFailures, state.RepeatedFailures, state.FailureBreaker)
+	}
+	if _, blocked := state.Blocked[issue.ID]; blocked {
+		t.Fatalf("issue %q was blocked by machine-recoverable token resolution", issue.ID)
+	}
+	if strings.Contains(completed.WorkerMetadataJSON, "completion_progress") {
+		t.Fatalf("worker metadata = %s, infrastructure failure reached progress processing", completed.WorkerMetadataJSON)
+	}
+	if !strings.Contains(logs.String(), workerGitHubTokenResolutionErrorClass) || !strings.Contains(logs.String(), "host credential store may be slow") {
+		t.Fatalf("logs = %q, want distinct token-resolution infrastructure event", logs.String())
+	}
+}
+
+func TestRecoverDurableWorkerGitHubTokenResolutionWait(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 12, 10, 0, 0, time.UTC)
+	nextRetryAt := now.Add(30 * time.Second)
+	issue := connector.Issue{
+		ID: "issue-worker-github-token", Identifier: "digitaldrywood/detent#2055", State: "In Progress",
+	}
+	wait := workerGitHubTokenResolutionWaitMetadata{
+		Attempts: 3, TimeoutMS: 15000, DetectedAt: now.Add(-time.Minute), NextRetryAt: nextRetryAt,
+	}
+	attempts := &recordingWorkAttemptStore{recent: []store.WorkAttempt{{
+		ID: 2055, ProjectID: "detent", IssueID: issue.ID, Identifier: issue.Identifier, Lane: issue.State,
+		AttemptNumber: 4, WorkerHost: "worker-a", Status: store.WorkAttemptStatusTerminal, CompletedAt: now.Add(-time.Minute),
+		TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workerGitHubTokenResolutionErrorClass,
+		ErrorMessage: "credential store timed out", WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{"worker_github_token_resolution_wait": wait}),
+	}}}
+	cfg := normalizeConfig(Config{
+		Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done", "Cancelled"}, MaxConcurrentAgents: 1,
+	})
+	orch := &Orchestrator{
+		cfg: cfg, connector: &rateLimitConnector{issuesByID: []connector.Issue{issue}}, workAttempts: attempts,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return now },
+	}
+	state := newState(cfg)
+
+	orch.recoverDurableWorkAttempts(t.Context(), &state, now)
+
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 4 || !retry.DueAt.Equal(nextRetryAt) || retry.WorkerHost != "worker-a" || retry.Wait.Kind != workerGitHubTokenResolutionWaitKind || !retry.Wait.StartedAt.Equal(wait.DetectedAt) {
+		t.Fatalf("retry = %#v, want restored same-attempt token-resolution wait", retry)
+	}
+	if terminalAttemptRetryableFailure(telemetryWorkAttempt(attempts.recent[0], now)) {
+		t.Fatal("durable token-resolution wait treated as a generic terminal retry")
+	}
+}
+
+func TestWorkerGitHubTokenResolutionWaitMetadataValidation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 12, 20, 0, 0, time.UTC)
+	valid := workerGitHubTokenResolutionWaitMetadata{
+		Attempts: 3, TimeoutMS: 15000, DetectedAt: now, NextRetryAt: now.Add(time.Minute),
+	}
+	attempt := func(wait workerGitHubTokenResolutionWaitMetadata) store.WorkAttempt {
+		return store.WorkAttempt{
+			TerminalState: store.WorkAttemptTerminalCapacity,
+			ErrorClass:    workerGitHubTokenResolutionErrorClass,
+			WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+				"worker_github_token_resolution_wait": wait,
+			}),
+		}
+	}
+	tests := []struct {
+		name    string
+		attempt store.WorkAttempt
+		want    bool
+	}{
+		{name: "valid", attempt: attempt(valid), want: true},
+		{name: "malformed", attempt: store.WorkAttempt{TerminalState: store.WorkAttemptTerminalCapacity, ErrorClass: workerGitHubTokenResolutionErrorClass, WorkerMetadataJSON: `{`}},
+		{name: "ordinary failure", attempt: store.WorkAttempt{TerminalState: store.WorkAttemptTerminalFailure, ErrorClass: workerGitHubTokenResolutionErrorClass, WorkerMetadataJSON: attempt(valid).WorkerMetadataJSON}},
+		{name: "missing attempts", attempt: attempt(workerGitHubTokenResolutionWaitMetadata{TimeoutMS: valid.TimeoutMS, DetectedAt: valid.DetectedAt, NextRetryAt: valid.NextRetryAt})},
+		{name: "missing timeout", attempt: attempt(workerGitHubTokenResolutionWaitMetadata{Attempts: valid.Attempts, DetectedAt: valid.DetectedAt, NextRetryAt: valid.NextRetryAt})},
+		{name: "missing retry deadline", attempt: attempt(workerGitHubTokenResolutionWaitMetadata{Attempts: valid.Attempts, TimeoutMS: valid.TimeoutMS, DetectedAt: valid.DetectedAt})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, got := workerGitHubTokenResolutionWaitMetadataFromAttempt(tt.attempt)
+			if got != tt.want {
+				t.Fatalf("workerGitHubTokenResolutionWaitMetadataFromAttempt() valid = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type staticWorkerGitHubTokenResolutionBackend struct {
+	err error
+}
+
+func (b staticWorkerGitHubTokenResolutionBackend) Run(context.Context, runpkg.RunRequest) (runpkg.RunResult, error) {
+	return runpkg.RunResult{}, b.err
+}

--- a/internal/orchestrator/worker_github_token_resolution_test.go
+++ b/internal/orchestrator/worker_github_token_resolution_test.go
@@ -47,6 +47,10 @@ func TestWorkerGitHubTokenResolutionCompletionPreservesAttemptBudget(t *testing.
 	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
 	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
 	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+	state.FailureBreaker.Class = "runner_error:systemic"
+	state.FailureBreaker.Count = 2
+	state.FailureBreaker.CanaryIssueID = issue.ID
+	state.FailureBreaker.ResumeAt = now
 	state.FailureBreaker.Failures["existing"] = []ProjectFailure{{IssueID: "other", At: now.Add(-time.Minute)}}
 	instantFailures := map[string]InstantFailure{issue.ID: state.InstantFailures[issue.ID]}
 	repeatedFailures := map[string]RepeatedFailure{issue.ID: state.RepeatedFailures[issue.ID]}
@@ -89,8 +93,17 @@ func TestWorkerGitHubTokenResolutionCompletionPreservesAttemptBudget(t *testing.
 	if !ok || retry.Attempt != 4 || !retry.DueAt.Equal(now.Add(45*time.Second)) || retry.Wait.Kind != workerGitHubTokenResolutionWaitKind {
 		t.Fatalf("retry = %#v, want same-attempt token-resolution wait", retry)
 	}
-	if !reflect.DeepEqual(state.InstantFailures, instantFailures) || !reflect.DeepEqual(state.RepeatedFailures, repeatedFailures) || !reflect.DeepEqual(state.FailureBreaker, failureBreaker) {
+	if !reflect.DeepEqual(state.InstantFailures, instantFailures) || !reflect.DeepEqual(state.RepeatedFailures, repeatedFailures) || !reflect.DeepEqual(state.FailureBreaker.Failures, failureBreaker.Failures) || state.FailureBreaker.Class != failureBreaker.Class || state.FailureBreaker.Count != failureBreaker.Count {
 		t.Fatalf("failure budgets changed: instant=%#v repeated=%#v project=%#v", state.InstantFailures, state.RepeatedFailures, state.FailureBreaker)
+	}
+	if !state.FailureBreaker.Active() || state.FailureBreaker.CanaryIssueID != "" || !state.FailureBreaker.ResumeAt.Equal(now.Add(45*time.Second)) {
+		t.Fatalf("failure breaker = %#v, want active breaker with bounded canary backoff", state.FailureBreaker)
+	}
+	if projectFailureBreakerAllowsDispatch(&state, now.Add(44*time.Second)) {
+		t.Fatal("failure breaker admitted another canary before token-resolution backoff elapsed")
+	}
+	if !projectFailureBreakerAllowsDispatch(&state, now.Add(45*time.Second)) {
+		t.Fatal("failure breaker did not admit a new canary after token-resolution backoff")
 	}
 	if _, blocked := state.Blocked[issue.ID]; blocked {
 		t.Fatalf("issue %q was blocked by machine-recoverable token resolution", issue.ID)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1341,7 +1341,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	workerGitHub, err := r.workerGitHubPolicy(ctx, workflow.Config, req.Issue.Identifier)
 	if err != nil {
-		r.logWorkerEvent(req.Issue, "worker_github_credential_refused", "error", err)
+		r.logWorkerGitHubPolicyError(req.Issue, err, telemetry.WorkAttemptIDKey, req.WorkAttemptID)
 		return RunResult{}, err
 	}
 	req.workerGitHubActor = workerGitHub.Principal
@@ -2685,7 +2685,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	workflow, agentRuntime, _, _ := r.runtimeSnapshot()
 	workerGitHub, err := r.workerGitHubPolicy(ctx, workflow.Config, req.Issue.Identifier)
 	if err != nil {
-		r.logWorkerEvent(req.Issue, "worker_github_credential_refused", "error", err)
+		r.logWorkerGitHubPolicyError(req.Issue, err)
 		return gate.ValidatorResult{}, err
 	}
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -258,6 +258,7 @@ func cooperativeStopError(err error) bool {
 		errors.Is(err, ErrSessionMemoryCeilingExceeded) ||
 		errors.Is(err, ErrSessionTurnLimitExceeded) ||
 		errors.Is(err, ErrSessionNoProgress) ||
+		errors.Is(err, ErrWorkerGitHubTokenResolution) ||
 		errors.Is(err, ErrWorkerGitHubBudgetMonitor) ||
 		IsDeliverableConfigurationError(err)
 }

--- a/internal/runner/worker_github.go
+++ b/internal/runner/worker_github.go
@@ -26,16 +26,19 @@ import (
 )
 
 const (
-	workerGitHubRateLimitBodyMaxBytes = 64 * 1024
-	workerGitHubProbeTimeout          = 10 * time.Second
-	workerGitHubAuthTokenTimeout      = 5 * time.Second
+	workerGitHubRateLimitBodyMaxBytes            = 64 * 1024
+	workerGitHubProbeTimeout                     = 10 * time.Second
+	workerGitHubTokenResolutionDefaultTimeout    = 15 * time.Second
+	workerGitHubTokenResolutionDefaultAttempts   = 3
+	workerGitHubTokenResolutionDefaultRetryDelay = 250 * time.Millisecond
 )
 
 var (
-	ErrWorkerGitHubSharedReserve = errors.New("worker github shared-budget reserve must be above the orchestrator dispatch floor")
-	ErrWorkerGitHubRESTReserved  = errors.New("worker github REST budget reached reserved headroom")
-	ErrWorkerGitHubBudgetMonitor = errors.New("worker github REST budget monitor failed")
-	workerGitHubEnvNamePattern   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	ErrWorkerGitHubSharedReserve   = errors.New("worker github shared-budget reserve must be above the orchestrator dispatch floor")
+	ErrWorkerGitHubRESTReserved    = errors.New("worker github REST budget reached reserved headroom")
+	ErrWorkerGitHubBudgetMonitor   = errors.New("worker github REST budget monitor failed")
+	ErrWorkerGitHubTokenResolution = errors.New("worker github token resolution unavailable")
+	workerGitHubEnvNamePattern     = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )
 
 type workerGitHubCredentialMode string
@@ -54,6 +57,50 @@ type workerGitHubHTTPClient interface {
 type workerGitHubProbeContextFactory func(context.Context) (context.Context, context.CancelFunc)
 
 type workerGitHubTokenResolver func(context.Context) (string, error)
+
+type workerGitHubTokenResolutionSleeper func(context.Context, time.Duration) error
+
+type workerGitHubTokenResolutionOptions struct {
+	Timeout      time.Duration
+	MaxAttempts  int
+	RetryBackoff time.Duration
+	Sleep        workerGitHubTokenResolutionSleeper
+}
+
+type WorkerGitHubTokenResolutionError struct {
+	Attempts int
+	Timeout  time.Duration
+	Err      error
+}
+
+func (e *WorkerGitHubTokenResolutionError) Error() string {
+	if e == nil {
+		return ErrWorkerGitHubTokenResolution.Error()
+	}
+	message := fmt.Sprintf("resolve worker.github_token via gh auth token after %d attempts", e.Attempts)
+	if e.Timeout > 0 {
+		message += fmt.Sprintf(" with %s per-attempt timeout", e.Timeout)
+	}
+	if e.Err != nil {
+		message += ": " + e.Err.Error()
+	}
+	return message
+}
+
+func (e *WorkerGitHubTokenResolutionError) Unwrap() []error {
+	if e == nil || e.Err == nil {
+		return []error{ErrWorkerGitHubTokenResolution}
+	}
+	return []error{ErrWorkerGitHubTokenResolution, e.Err}
+}
+
+func AsWorkerGitHubTokenResolutionError(err error) (*WorkerGitHubTokenResolutionError, bool) {
+	var resolutionErr *WorkerGitHubTokenResolutionError
+	if !errors.As(err, &resolutionErr) || resolutionErr == nil {
+		return nil, false
+	}
+	return resolutionErr, true
+}
 
 type workerGitHubPolicy struct {
 	Enabled              bool
@@ -133,6 +180,20 @@ func (r *Runner) workerGitHubPolicy(ctx context.Context, cfg config.Config, issu
 		return workerGitHubPolicy{}, err
 	}
 	return policy.classifyCredential(ctx)
+}
+
+func (r *Runner) logWorkerGitHubPolicyError(issue connector.Issue, err error, attrs ...any) {
+	resolutionErr, ok := AsWorkerGitHubTokenResolutionError(err)
+	if !ok {
+		r.logWorkerEvent(issue, "worker_github_credential_refused", append(attrs, "error", err)...)
+		return
+	}
+	attrs = append(attrs,
+		"attempts", resolutionErr.Attempts,
+		"timeout_ms", resolutionErr.Timeout.Milliseconds(),
+		"error", err,
+	)
+	r.logWorkerEventLevel(slog.LevelWarn, issue, "worker_github_token_resolution_unavailable", attrs...)
 }
 
 func (r *Runner) ProbeGitHubRESTBudget(ctx context.Context, issue connector.Issue) (telemetry.RESTBudget, bool, error) {
@@ -261,7 +322,9 @@ func newWorkerGitHubPolicy(ctx context.Context, cfg config.Config, projectID str
 		}, nil
 	}
 
-	workerToken, err := resolveWorkerGitHubSecret(ctx, rawWorkerToken, lookupEnv, resolveGHAuthToken)
+	workerToken, err := resolveWorkerGitHubSecret(ctx, rawWorkerToken, lookupEnv, resolveGHAuthToken, workerGitHubTokenResolutionOptions{
+		Timeout: time.Duration(cfg.Worker.GitHubTokenResolutionTimeoutMS) * time.Millisecond,
+	})
 	if err != nil {
 		return workerGitHubPolicy{}, err
 	}
@@ -309,23 +372,86 @@ func withWorkerGitHubProbeTimeout(ctx context.Context) (context.Context, context
 	return context.WithTimeout(ctx, workerGitHubProbeTimeout)
 }
 
-func resolveWorkerGitHubSecret(ctx context.Context, value string, lookupEnv func(string) string, resolveGHAuthToken workerGitHubTokenResolver) (string, error) {
+func resolveWorkerGitHubSecret(
+	ctx context.Context,
+	value string,
+	lookupEnv func(string) string,
+	resolveGHAuthToken workerGitHubTokenResolver,
+	options workerGitHubTokenResolutionOptions,
+) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return "", nil
 	}
 	if config.IsGitHubTokenSentinel(value) {
-		resolved, err := resolveGHAuthToken(ctx)
-		if err != nil {
-			return "", fmt.Errorf("resolve worker.github_token via gh auth token: %w", err)
-		}
-		resolved = strings.TrimSpace(resolved)
-		if resolved == "" {
-			return "", errors.New("resolve worker.github_token via gh auth token: empty token")
-		}
-		return resolved, nil
+		return resolveWorkerGitHubToken(ctx, resolveGHAuthToken, options)
 	}
 	return resolveWorkerGitHubSecretReference(value, lookupEnv)
+}
+
+func resolveWorkerGitHubToken(
+	ctx context.Context,
+	resolve workerGitHubTokenResolver,
+	options workerGitHubTokenResolutionOptions,
+) (string, error) {
+	if options.Timeout <= 0 {
+		options.Timeout = workerGitHubTokenResolutionDefaultTimeout
+	}
+	if options.MaxAttempts <= 0 {
+		options.MaxAttempts = workerGitHubTokenResolutionDefaultAttempts
+	}
+	if options.RetryBackoff <= 0 {
+		options.RetryBackoff = workerGitHubTokenResolutionDefaultRetryDelay
+	}
+	if options.Sleep == nil {
+		options.Sleep = sleepWorkerGitHubTokenResolution
+	}
+	var lastErr error
+	for attempt := 1; attempt <= options.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		attemptCtx, cancel := context.WithTimeout(ctx, options.Timeout)
+		resolved, err := resolve(attemptCtx)
+		attemptErr := attemptCtx.Err()
+		cancel()
+		if err == nil {
+			resolved = strings.TrimSpace(resolved)
+			if resolved != "" {
+				return resolved, nil
+			}
+			err = errors.New("gh auth token returned an empty token")
+		} else if attemptErr != nil && ctx.Err() == nil {
+			err = attemptErr
+		}
+		lastErr = err
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if attempt == options.MaxAttempts {
+			break
+		}
+		delay := options.RetryBackoff * time.Duration(attempt)
+		if err := options.Sleep(ctx, delay); err != nil {
+			return "", err
+		}
+	}
+	return "", &WorkerGitHubTokenResolutionError{
+		Attempts: options.MaxAttempts,
+		Timeout:  options.Timeout,
+		Err:      lastErr,
+	}
+}
+
+func sleepWorkerGitHubTokenResolution(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func resolveWorkerGitHubSecretReference(value string, lookupEnv func(string) string) (string, error) {
@@ -349,12 +475,10 @@ func defaultWorkerGitHubToken(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", errors.New("gh was not found on PATH")
 	}
-	commandCtx, cancel := context.WithTimeout(ctx, workerGitHubAuthTokenTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(commandCtx, path, "auth", "token") // #nosec G204 -- gh path is PATH-resolved and arguments are fixed.
+	cmd := exec.CommandContext(ctx, path, "auth", "token") // #nosec G204 -- gh path is PATH-resolved and arguments are fixed.
 	output, err := cmd.CombinedOutput()
-	if commandCtx.Err() != nil {
-		return "", commandCtx.Err()
+	if ctx.Err() != nil {
+		return "", ctx.Err()
 	}
 	if err != nil {
 		if detail := strings.TrimSpace(string(output)); detail != "" {

--- a/internal/runner/worker_github_test.go
+++ b/internal/runner/worker_github_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -44,7 +45,7 @@ func TestNewWorkerGitHubPolicy(t *testing.T) {
 		{name: "gh sentinel resolves", workerToken: "gh", orchestratorToken: "ambient-token", resolveGH: func(context.Context) (string, error) { return " ambient-token\n", nil }, wantEnabled: true, wantMode: workerGitHubCredentialShared, wantToken: "ambient-token"},
 		{name: "gh sentinel without orchestrator user token is distinct", workerToken: "gh", resolveGH: func(context.Context) (string, error) { return "ambient-token", nil }, wantEnabled: true, wantMode: workerGitHubCredentialDistinct, wantToken: "ambient-token"},
 		{name: "gh sentinel with different orchestrator token needs principal classification", workerToken: "gh", orchestratorToken: "orchestrator-token", resolveGH: func(context.Context) (string, error) { return "ambient-token", nil }, wantEnabled: true, wantMode: workerGitHubCredentialUnclassified, wantToken: "ambient-token"},
-		{name: "gh sentinel resolution failure", workerToken: "gh", resolveGH: func(context.Context) (string, error) { return "", errors.New("not logged in") }, wantErrText: "resolve worker.github_token via gh auth token: not logged in"},
+		{name: "gh sentinel resolution failure", workerToken: "gh", resolveGH: func(context.Context) (string, error) { return "", errors.New("not logged in") }, wantErrText: "resolve worker.github_token via gh auth token after 3 attempts"},
 		{name: "missing referenced credential", workerToken: "$WORKER_TOKEN", orchestratorToken: "orchestrator-token", wantErrText: "WORKER_TOKEN is empty"},
 	}
 
@@ -99,6 +100,132 @@ func TestNewWorkerGitHubPolicy(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveWorkerGitHubSecretRetries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resolve      workerGitHubTokenResolver
+		wantToken    string
+		wantCalls    int
+		wantSleeps   []time.Duration
+		wantErr      bool
+		wantDeadline bool
+	}{
+		{
+			name: "transient failures recover",
+			resolve: func() workerGitHubTokenResolver {
+				calls := 0
+				return func(context.Context) (string, error) {
+					calls++
+					if calls < 3 {
+						return "", errors.New("keychain busy")
+					}
+					return "resolved-token", nil
+				}
+			}(),
+			wantToken:  "resolved-token",
+			wantCalls:  3,
+			wantSleeps: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+		},
+		{
+			name: "per-attempt deadlines exhaust",
+			resolve: func(ctx context.Context) (string, error) {
+				<-ctx.Done()
+				return "", ctx.Err()
+			},
+			wantCalls:    3,
+			wantSleeps:   []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+			wantErr:      true,
+			wantDeadline: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			calls := 0
+			var sleeps []time.Duration
+			resolver := func(ctx context.Context) (string, error) {
+				calls++
+				return tt.resolve(ctx)
+			}
+			token, err := resolveWorkerGitHubSecret(t.Context(), "gh", nil, resolver, workerGitHubTokenResolutionOptions{
+				Timeout:      5 * time.Millisecond,
+				MaxAttempts:  3,
+				RetryBackoff: 10 * time.Millisecond,
+				Sleep: func(_ context.Context, delay time.Duration) error {
+					sleeps = append(sleeps, delay)
+					return nil
+				},
+			})
+			if token != tt.wantToken || (err != nil) != tt.wantErr {
+				t.Fatalf("resolveWorkerGitHubSecret() = %q, %v; want %q, error %t", token, err, tt.wantToken, tt.wantErr)
+			}
+			if calls != tt.wantCalls {
+				t.Fatalf("resolver calls = %d, want %d", calls, tt.wantCalls)
+			}
+			if !slices.Equal(sleeps, tt.wantSleeps) {
+				t.Fatalf("retry sleeps = %v, want %v", sleeps, tt.wantSleeps)
+			}
+			if !tt.wantErr {
+				return
+			}
+			resolutionErr, ok := AsWorkerGitHubTokenResolutionError(err)
+			if !ok || resolutionErr.Attempts != 3 || resolutionErr.Timeout != 5*time.Millisecond {
+				t.Fatalf("error = %#v, want typed resolution error with retry evidence", err)
+			}
+			if tt.wantDeadline && !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("error = %v, want context deadline exceeded", err)
+			}
+		})
+	}
+}
+
+func TestResolveWorkerGitHubSecretHonorsParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	calls := 0
+	_, err := resolveWorkerGitHubSecret(ctx, "gh", nil, func(context.Context) (string, error) {
+		calls++
+		return "", errors.New("unexpected call")
+	}, workerGitHubTokenResolutionOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("resolveWorkerGitHubSecret() error = %v, want context canceled", err)
+	}
+	if errors.Is(err, ErrWorkerGitHubTokenResolution) {
+		t.Fatalf("resolveWorkerGitHubSecret() error = %v, parent cancellation classified as infrastructure", err)
+	}
+	if calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", calls)
+	}
+}
+
+func TestLogWorkerGitHubPolicyErrorUsesResolutionEvent(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	runner := &Runner{
+		projectID: "detent",
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	runner.logWorkerGitHubPolicyError(connector.Issue{
+		ID: "issue-worker-github-token", Identifier: "digitaldrywood/detent#2055",
+	}, &WorkerGitHubTokenResolutionError{
+		Attempts: 3,
+		Timeout:  15 * time.Second,
+		Err:      context.DeadlineExceeded,
+	}, telemetry.WorkAttemptIDKey, int64(2055))
+
+	if !strings.Contains(logs.String(), "worker_github_token_resolution_unavailable") || !strings.Contains(logs.String(), "attempts=3") || !strings.Contains(logs.String(), "timeout_ms=15000") {
+		t.Fatalf("logs = %q, want token-resolution event with retry evidence", logs.String())
+	}
+	if strings.Contains(logs.String(), "worker_github_credential_refused") {
+		t.Fatalf("logs = %q, resolution failure used generic credential-refused event", logs.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a configurable 15-second per-attempt timeout for `worker.github_token: gh`
- retry `gh auth token` three times with bounded backoff and distinct operator logging
- persist exhausted resolution as a same-attempt infrastructure wait that survives restart without consuming failure budgets
- refresh generated configuration references and add deterministic runner/orchestrator regression tests

Fixes #2055

## UI Surface Contract

- [x] N/A; this change has no UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes.

## Test Plan

- [x] `make generate`
- [x] `make check` in Linux arm64 with bounded package concurrency; 78.8% total coverage and all package/file floors passed
- [x] focused config, runner, and orchestrator tests in Linux arm64
- [x] compile-only checks and `go vet` for changed packages on macOS
- [x] initial full-gate runs exposed the unrelated hubserver timing issue tracked in #2118
- [x] current-head CI run 33827159012 at `4e74cb26`: all 11 jobs passed
