### PR TITLE
fix(orchestrator): gate review on threads

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -352,6 +352,13 @@
 #             queue_seconds: 0
 #             # tracker.issues[].pull_request.transient_failed_checks[].duration_seconds | type: integer | default: 0 when configured | required: No | validation: None
 #             duration_seconds: 0
+#         # tracker.issues[].pull_request.unresolved_review_threads | type: list<object> | default: [] | required: No | validation: None
+#         unresolved_review_threads:
+#           -
+#             # tracker.issues[].pull_request.unresolved_review_threads[].path | type: string | default: none | required: No | validation: None
+#             path: null
+#             # tracker.issues[].pull_request.unresolved_review_threads[].line | type: integer | default: 0 when configured | required: No | validation: None
+#             line: 0
 #         # tracker.issues[].pull_request.codex_review_state | type: string | default: none | required: No | validation: None
 #         codex_review_state: null
 #         # tracker.issues[].pull_request.codex_review_source | type: string | default: none | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -1160,6 +1160,9 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.transient_failed_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].status` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].workflow_run_id` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unresolved_review_threads` | `list<object>` | `[]` | No | None |
+| `tracker.issues[].pull_request.unresolved_review_threads[].line` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unresolved_review_threads[].path` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unstarted_check_count` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks` | `list<object>` | `[]` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].conclusion` | `string` | `none` | No | None |

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -166,6 +166,10 @@ type PullRequestHydrator interface {
 	HydratePullRequest(context.Context, Issue) (Issue, error)
 }
 
+type PullRequestReviewThreadHydrator interface {
+	HydratePullRequestReviewThreads(context.Context, Issue) (Issue, error)
+}
+
 type PullRequestReferenceRefresher interface {
 	RefreshPullRequestReference(context.Context, Issue) (Issue, error)
 }

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -144,6 +144,7 @@ type PullRequestMerger interface {
 type PullRequestMergeQueue interface {
 	InspectPullRequestMergeQueue(context.Context, Issue) (PullRequestMergeQueueStatus, error)
 	EnqueuePullRequest(context.Context, Issue) (PullRequestMergeQueueEntry, error)
+	DequeuePullRequest(context.Context, PullRequestMergeQueueEntry) error
 }
 
 type PullRequestMergeQueueStatus struct {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -5095,6 +5095,118 @@ func TestConnectorHydratePullRequestRefreshesCurrentStatus(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchPullRequestReviewThreads(t *testing.T) {
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodPost,
+			path:   "/",
+			body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"head-sha","reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[{"isResolved":false,"path":"internal/orchestrator/autopromote.go","line":181,"originalLine":180},{"isResolved":true,"path":"internal/connector/issue.go","line":107,"originalLine":107}]}}}}}`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/",
+			body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"head-sha","reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"isOutdated":true,"path":"internal/connector/github/pull_requests.go","line":null,"originalLine":1092}]}}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{})
+
+	got, err := c.fetchPullRequestReviewThreads(t.Context(), pullRequestRepo{Owner: "example", Name: "repo"}, 42, "head-sha")
+	if err != nil {
+		t.Fatalf("fetchPullRequestReviewThreads() error = %v", err)
+	}
+	want := []connector.PullRequestReviewThread{
+		{Path: "internal/orchestrator/autopromote.go", Line: 181},
+		{Path: "internal/connector/github/pull_requests.go", Line: 1092},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fetchPullRequestReviewThreads() = %#v, want %#v", got, want)
+	}
+
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	if variables := requests[1]["variables"].(map[string]any); variables["after"] != "cursor-1" {
+		t.Fatalf("second request after = %v, want cursor-1", variables["after"])
+	}
+}
+
+func TestConnectorHydratePullRequestReviewThreadsCachesByHead(t *testing.T) {
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodPost,
+			path:   "/",
+			body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"head-one","reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"path":"internal/orchestrator/autopromote.go","line":181,"originalLine":181}]}}}}}`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/",
+			body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"head-two","reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{})
+	repo := pullRequestRepo{Owner: "example", Name: "repo"}
+	c.pullRequests.Set(repo, 42, "head-one", pullRequestStatus{ci: pullRequestCI{State: "SUCCESS"}})
+	c.pullRequests.Set(repo, 42, "head-two", pullRequestStatus{ci: pullRequestCI{State: "SUCCESS"}})
+	issue := connector.Issue{
+		Identifier:   "example/repo#41",
+		PRRepository: "example/repo",
+		PullRequest: &connector.PullRequest{
+			Number:  42,
+			State:   "OPEN",
+			HeadSHA: "head-one",
+		},
+	}
+
+	first, err := c.HydratePullRequestReviewThreads(t.Context(), issue)
+	if err != nil {
+		t.Fatalf("first HydratePullRequestReviewThreads() error = %v", err)
+	}
+	second, err := c.HydratePullRequestReviewThreads(t.Context(), issue)
+	if err != nil {
+		t.Fatalf("second HydratePullRequestReviewThreads() error = %v", err)
+	}
+	want := []connector.PullRequestReviewThread{{Path: "internal/orchestrator/autopromote.go", Line: 181}}
+	if !reflect.DeepEqual(first.PullRequest.UnresolvedReviewThreads, want) || !reflect.DeepEqual(second.PullRequest.UnresolvedReviewThreads, want) {
+		t.Fatalf("hydrated review threads = first %#v second %#v, want %#v", first.PullRequest.UnresolvedReviewThreads, second.PullRequest.UnresolvedReviewThreads, want)
+	}
+
+	changedHead := issue
+	pullRequest := *issue.PullRequest
+	pullRequest.HeadSHA = "head-two"
+	changedHead.PullRequest = &pullRequest
+	resolved, err := c.HydratePullRequestReviewThreads(t.Context(), changedHead)
+	if err != nil {
+		t.Fatalf("changed-head HydratePullRequestReviewThreads() error = %v", err)
+	}
+	if len(resolved.PullRequest.UnresolvedReviewThreads) != 0 {
+		t.Fatalf("changed-head unresolved review threads = %#v, want none", resolved.PullRequest.UnresolvedReviewThreads)
+	}
+	if got := len(server.requests()); got != 2 {
+		t.Fatalf("request count = %d, want one query per head", got)
+	}
+	for _, headSHA := range []string{"head-one", "head-two"} {
+		status, ok := c.pullRequests.Get(repo, 42, headSHA)
+		if !ok || status.ci.State != "SUCCESS" || !status.reviewThreadsHydrated {
+			t.Fatalf("cached status for %s = %#v, %t", headSHA, status, ok)
+		}
+	}
+}
+
+func TestConnectorFetchPullRequestReviewThreadsRejectsChangedHead(t *testing.T) {
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodPost,
+		path:   "/",
+		body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"new-head","reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+
+	_, err := c.fetchPullRequestReviewThreads(t.Context(), pullRequestRepo{Owner: "example", Name: "repo"}, 42, "old-head")
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Fatalf("fetchPullRequestReviewThreads() error = %v, want ErrInvalidResponse", err)
+	}
+}
+
 func TestConnectorLookupPullRequestByHeadUsesExactCurrentHead(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -5131,8 +5131,13 @@ func TestConnectorFetchPullRequestReviewThreads(t *testing.T) {
 	}
 }
 
-func TestConnectorHydratePullRequestReviewThreadsCachesByHead(t *testing.T) {
+func TestConnectorHydratePullRequestReviewThreadsRefreshesMutableState(t *testing.T) {
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodPost,
+			path:   "/",
+			body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"head-one","reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}`,
+		},
 		{
 			method: http.MethodPost,
 			path:   "/",
@@ -5166,9 +5171,12 @@ func TestConnectorHydratePullRequestReviewThreadsCachesByHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second HydratePullRequestReviewThreads() error = %v", err)
 	}
+	if len(first.PullRequest.UnresolvedReviewThreads) != 0 {
+		t.Fatalf("first unresolved review threads = %#v, want none", first.PullRequest.UnresolvedReviewThreads)
+	}
 	want := []connector.PullRequestReviewThread{{Path: "internal/orchestrator/autopromote.go", Line: 181}}
-	if !reflect.DeepEqual(first.PullRequest.UnresolvedReviewThreads, want) || !reflect.DeepEqual(second.PullRequest.UnresolvedReviewThreads, want) {
-		t.Fatalf("hydrated review threads = first %#v second %#v, want %#v", first.PullRequest.UnresolvedReviewThreads, second.PullRequest.UnresolvedReviewThreads, want)
+	if !reflect.DeepEqual(second.PullRequest.UnresolvedReviewThreads, want) {
+		t.Fatalf("second unresolved review threads = %#v, want %#v", second.PullRequest.UnresolvedReviewThreads, want)
 	}
 
 	changedHead := issue
@@ -5182,12 +5190,12 @@ func TestConnectorHydratePullRequestReviewThreadsCachesByHead(t *testing.T) {
 	if len(resolved.PullRequest.UnresolvedReviewThreads) != 0 {
 		t.Fatalf("changed-head unresolved review threads = %#v, want none", resolved.PullRequest.UnresolvedReviewThreads)
 	}
-	if got := len(server.requests()); got != 2 {
-		t.Fatalf("request count = %d, want one query per head", got)
+	if got := len(server.requests()); got != 3 {
+		t.Fatalf("request count = %d, want one fresh query per hydration", got)
 	}
 	for _, headSHA := range []string{"head-one", "head-two"} {
 		status, ok := c.pullRequests.Get(repo, 42, headSHA)
-		if !ok || status.ci.State != "SUCCESS" || !status.reviewThreadsHydrated {
+		if !ok || status.ci.State != "SUCCESS" {
 			t.Fatalf("cached status for %s = %#v, %t", headSHA, status, ok)
 		}
 	}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -69,6 +69,7 @@ const (
 	graphQLQueryAddProjectItem  = "add_project_item"
 	graphQLQueryMergeQueue      = "merge_queue"
 	graphQLQueryEnqueuePR       = "enqueue_pull_request"
+	graphQLQueryDequeuePR       = "dequeue_pull_request"
 	graphQLQueryRateLimitProbe  = "rate_limit_probe"
 )
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -54,6 +54,7 @@ const (
 	graphQLQueryEpicChildren    = "epic_children"
 	graphQLQueryIssueParents    = "issue_parents"
 	graphQLQueryPullRequests    = "pull_requests"
+	graphQLQueryReviewThreads   = "pull_request_review_threads"
 	graphQLQueryBlockedReasons  = "blocked_reasons"
 	graphQLQueryIssueLookup     = "issue_lookup"
 	graphQLQueryProjectItem     = "project_item"
@@ -472,6 +473,7 @@ var _ connector.PullRequestCommenter = (*Connector)(nil)
 var _ connector.PullRequestCommentReader = (*Connector)(nil)
 var _ connector.PullRequestDiffFingerprintReader = (*Connector)(nil)
 var _ connector.PullRequestHydrator = (*Connector)(nil)
+var _ connector.PullRequestReviewThreadHydrator = (*Connector)(nil)
 var _ connector.PullRequestMerger = (*Connector)(nil)
 var _ connector.Provisioner = (*Connector)(nil)
 var _ connector.RateLimitReporter = (*Connector)(nil)

--- a/internal/connector/github/merge_queue.go
+++ b/internal/connector/github/merge_queue.go
@@ -50,6 +50,14 @@ mutation DetentEnqueuePullRequest($pullRequestId: ID!) {
   rateLimit { limit used remaining cost resetAt }
 }`
 
+const dequeuePullRequestMutation = `
+mutation DetentDequeuePullRequest($mergeQueueEntryId: ID!) {
+  dequeuePullRequest(input: {id: $mergeQueueEntryId}) {
+    mergeQueueEntry { id }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
 type mergeQueueEntryNode struct {
 	ID                   string     `json:"id"`
 	State                string     `json:"state"`
@@ -135,6 +143,33 @@ func (c *Connector) EnqueuePullRequest(ctx context.Context, issue connector.Issu
 	}
 	entry := connectorMergeQueueEntry(response.EnqueuePullRequest.MergeQueueEntry)
 	return *entry, nil
+}
+
+func (c *Connector) DequeuePullRequest(ctx context.Context, entry connector.PullRequestMergeQueueEntry) error {
+	entryID := strings.TrimSpace(entry.ID)
+	if entryID == "" {
+		return errors.New("dequeue github pull request: missing merge queue entry id")
+	}
+	var response struct {
+		DequeuePullRequest *struct {
+			MergeQueueEntry *struct {
+				ID string `json:"id"`
+			} `json:"mergeQueueEntry"`
+		} `json:"dequeuePullRequest"`
+	}
+	if err := c.client.GraphQLWithType(ctx, graphQLQueryDequeuePR, dequeuePullRequestMutation, map[string]any{
+		"mergeQueueEntryId": entryID,
+	}, &response); err != nil {
+		return fmt.Errorf("dequeue github pull request: %w", err)
+	}
+	if response.DequeuePullRequest == nil || response.DequeuePullRequest.MergeQueueEntry == nil {
+		return errors.New("dequeue github pull request: github returned no merge queue entry")
+	}
+	dequeuedID := strings.TrimSpace(response.DequeuePullRequest.MergeQueueEntry.ID)
+	if dequeuedID != entryID {
+		return fmt.Errorf("dequeue github pull request: github returned merge queue entry %q, want %q", dequeuedID, entryID)
+	}
+	return nil
 }
 
 func connectorMergeQueueEntry(entry *mergeQueueEntryNode) *connector.PullRequestMergeQueueEntry {

--- a/internal/connector/github/merge_queue_test.go
+++ b/internal/connector/github/merge_queue_test.go
@@ -110,6 +110,88 @@ func TestConnectorEnqueuePullRequest(t *testing.T) {
 	}
 }
 
+func TestConnectorDequeuePullRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		entryID   string
+		response  string
+		wantError string
+		wantCall  bool
+	}{
+		{
+			name:     "dequeues existing entry",
+			entryID:  "MQE_42",
+			response: `{"data":{"dequeuePullRequest":{"mergeQueueEntry":{"id":"MQE_42"}}}}`,
+			wantCall: true,
+		},
+		{
+			name:      "rejects missing entry id",
+			wantError: "missing merge queue entry id",
+		},
+		{
+			name:      "rejects missing mutation result",
+			entryID:   "MQE_42",
+			response:  `{"data":{"dequeuePullRequest":null}}`,
+			wantError: "github returned no merge queue entry",
+			wantCall:  true,
+		},
+		{
+			name:      "rejects missing dequeued entry",
+			entryID:   "MQE_42",
+			response:  `{"data":{"dequeuePullRequest":{"mergeQueueEntry":null}}}`,
+			wantError: "github returned no merge queue entry",
+			wantCall:  true,
+		},
+		{
+			name:      "rejects mismatched dequeued entry",
+			entryID:   "MQE_42",
+			response:  `{"data":{"dequeuePullRequest":{"mergeQueueEntry":{"id":"MQE_99"}}}}`,
+			wantError: `github returned merge queue entry "MQE_99", want "MQE_42"`,
+			wantCall:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var responses []graphqlTestResponse
+			if tt.wantCall {
+				responses = []graphqlTestResponse{{body: tt.response}}
+			}
+			server := newGraphQLTestServer(t, responses)
+			client := newGitHubTestConnector(t, server, Config{})
+			err := client.DequeuePullRequest(context.Background(), connector.PullRequestMergeQueueEntry{ID: tt.entryID})
+			if tt.wantError == "" && err != nil {
+				t.Fatalf("DequeuePullRequest() error = %v", err)
+			}
+			if tt.wantError != "" && (err == nil || !strings.Contains(err.Error(), tt.wantError)) {
+				t.Fatalf("DequeuePullRequest() error = %v, want containing %q", err, tt.wantError)
+			}
+			requests := server.requests()
+			if !tt.wantCall {
+				if len(requests) != 0 {
+					t.Fatalf("requests = %#v, want none", requests)
+				}
+				return
+			}
+			if len(requests) != 1 {
+				t.Fatalf("requests = %#v, want one", requests)
+			}
+			request := requests[0]
+			if !strings.Contains(request["query"].(string), "dequeuePullRequest(input: {id: $mergeQueueEntryId})") {
+				t.Fatalf("query = %q, want dequeuePullRequest mutation", request["query"])
+			}
+			variables := request["variables"].(map[string]any)
+			if variables["mergeQueueEntryId"] != tt.entryID {
+				t.Fatalf("mergeQueueEntryId = %v, want %q", variables["mergeQueueEntryId"], tt.entryID)
+			}
+		})
+	}
+}
+
 func mergeQueueTestTime(value string) *time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -1243,19 +1243,12 @@ func applyPullRequestStatus(pullRequest *pullRequestNode, status pullRequestStat
 	}}}
 	pullRequest.LatestReviews = nodeConnection[pullRequestReview]{Nodes: clonePullRequestReviews(status.reviews.CurrentHead)}
 	pullRequest.CodexReviews = clonePullRequestCodexReviews(status.reviews)
-	pullRequest.UnresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), status.unresolvedReviewThreads...)
 }
 
 func (c *Connector) HydratePullRequestReviewThreads(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
 	repo, number, ok := hydratedPullRequestRef(issue)
 	if !ok || issue.PullRequest == nil || normalizeStateName(issue.PullRequest.State) != "open" {
 		return issue, nil
-	}
-	if c.pullRequests != nil {
-		status, found := c.pullRequests.Get(repo, number, issue.PullRequest.HeadSHA)
-		if found && status.reviewThreadsHydrated {
-			return issueWithPullRequestReviewThreads(issue, status.unresolvedReviewThreads), nil
-		}
 	}
 	threads, err := c.fetchPullRequestReviewThreads(ctx, repo, number, issue.PullRequest.HeadSHA)
 	if err != nil {
@@ -1268,13 +1261,6 @@ func (c *Connector) HydratePullRequestReviewThreads(ctx context.Context, issue c
 		return issue, err
 	}
 	issue = issueWithPullRequestReviewThreads(issue, threads)
-	if c.pullRequests != nil {
-		if status, found := c.pullRequests.Get(repo, number, issue.PullRequest.HeadSHA); found {
-			status.unresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), threads...)
-			status.reviewThreadsHydrated = true
-			c.pullRequests.Set(repo, number, issue.PullRequest.HeadSHA, status)
-		}
-	}
 	return issue, nil
 }
 

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -55,6 +55,20 @@ const (
 	minimumCodexReviewCommitPrefixLength      = 7
 )
 
+const pullRequestReviewThreadsQuery = `
+query DetentGitHubPullRequestReviewThreads($owner: String!, $name: String!, $number: Int!, $after: String) {
+	repository(owner: $owner, name: $name) {
+		pullRequest(number: $number) {
+			headRefOid
+			reviewThreads(first: 100, after: $after) {
+				pageInfo { hasNextPage endCursor }
+				nodes { isResolved isOutdated path line originalLine }
+			}
+		}
+	}
+	rateLimit { limit used remaining cost resetAt }
+}`
+
 var (
 	codexReviewSummaryStatusPattern = regexp.MustCompile(`^✅\s+\*\*Completed\*\*\s+<relative-time datetime="([^"]+)">([^<]+)</relative-time>$`)
 	codexReviewSummaryCommitPattern = regexp.MustCompile("^`([0-9a-fA-F]{7,40})`$")
@@ -915,6 +929,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		StaleSuccessfulChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.StaleSuccessfulChecks...),
 		RequiredCheckFailures:        append([]connector.PullRequestCheck(nil), pullRequest.CI.RequiredFailures...),
 		TransientFailedChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.TransientFailures...),
+		UnresolvedReviewThreads:      append([]connector.PullRequestReviewThread(nil), pullRequest.UnresolvedReviewThreads...),
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
 		CodexReviewSource:            pullRequestCodexReviewSource(pullRequest),
 		CodexReviewAPIState:          pullRequestCodexReviewAPIState(pullRequest),
@@ -1228,6 +1243,109 @@ func applyPullRequestStatus(pullRequest *pullRequestNode, status pullRequestStat
 	}}}
 	pullRequest.LatestReviews = nodeConnection[pullRequestReview]{Nodes: clonePullRequestReviews(status.reviews.CurrentHead)}
 	pullRequest.CodexReviews = clonePullRequestCodexReviews(status.reviews)
+	pullRequest.UnresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), status.unresolvedReviewThreads...)
+}
+
+func (c *Connector) HydratePullRequestReviewThreads(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
+	repo, number, ok := hydratedPullRequestRef(issue)
+	if !ok || issue.PullRequest == nil || normalizeStateName(issue.PullRequest.State) != "open" {
+		return issue, nil
+	}
+	if c.pullRequests != nil {
+		status, found := c.pullRequests.Get(repo, number, issue.PullRequest.HeadSHA)
+		if found && status.reviewThreadsHydrated {
+			return issueWithPullRequestReviewThreads(issue, status.unresolvedReviewThreads), nil
+		}
+	}
+	threads, err := c.fetchPullRequestReviewThreads(ctx, repo, number, issue.PullRequest.HeadSHA)
+	if err != nil {
+		if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
+			issue = issueWithPullRequestReviewThreads(issue, nil)
+			issue.PullRequest.HydrationUnavailableReason = state.Reason
+			issue.PullRequest.HydrationNextRetryAt = cloneGitHubTime(state.NextRetryAt)
+			return issue, nil
+		}
+		return issue, err
+	}
+	issue = issueWithPullRequestReviewThreads(issue, threads)
+	if c.pullRequests != nil {
+		if status, found := c.pullRequests.Get(repo, number, issue.PullRequest.HeadSHA); found {
+			status.unresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), threads...)
+			status.reviewThreadsHydrated = true
+			c.pullRequests.Set(repo, number, issue.PullRequest.HeadSHA, status)
+		}
+	}
+	return issue, nil
+}
+
+func issueWithPullRequestReviewThreads(issue connector.Issue, threads []connector.PullRequestReviewThread) connector.Issue {
+	if issue.PullRequest == nil {
+		return issue
+	}
+	pullRequest := *issue.PullRequest
+	pullRequest.UnresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), threads...)
+	issue.PullRequest = &pullRequest
+	return issue
+}
+
+func (c *Connector) fetchPullRequestReviewThreads(
+	ctx context.Context,
+	repo pullRequestRepo,
+	number int,
+	headSHA string,
+) ([]connector.PullRequestReviewThread, error) {
+	headSHA = strings.TrimSpace(headSHA)
+	if !validPullRequestRepo(repo) || number <= 0 || headSHA == "" {
+		return nil, ErrInvalidResponse
+	}
+	var after *string
+	threads := []connector.PullRequestReviewThread{}
+	for {
+		var response struct {
+			Repository *struct {
+				PullRequest *struct {
+					HeadSHA       string                                  `json:"headRefOid"`
+					ReviewThreads nodeConnection[pullRequestReviewThread] `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		}
+		if err := c.client.GraphQLWithType(ctx, graphQLQueryReviewThreads, pullRequestReviewThreadsQuery, map[string]any{
+			"owner":  repo.Owner,
+			"name":   repo.Name,
+			"number": number,
+			"after":  after,
+		}, &response); err != nil {
+			return nil, fmt.Errorf("fetch github pull request review threads: %w", err)
+		}
+		if response.Repository == nil || response.Repository.PullRequest == nil {
+			return nil, ErrInvalidResponse
+		}
+		if strings.TrimSpace(response.Repository.PullRequest.HeadSHA) != headSHA {
+			return nil, fmt.Errorf("%w: pull request head changed while fetching review threads", ErrInvalidResponse)
+		}
+		connection := response.Repository.PullRequest.ReviewThreads
+		for _, thread := range connection.Nodes {
+			if thread.IsResolved {
+				continue
+			}
+			line := thread.Line
+			if line <= 0 {
+				line = thread.OriginalLine
+			}
+			threads = append(threads, connector.PullRequestReviewThread{
+				Path: strings.TrimSpace(thread.Path),
+				Line: line,
+			})
+		}
+		if !connection.PageInfo.HasNextPage {
+			return threads, nil
+		}
+		cursor := strings.TrimSpace(connection.PageInfo.EndCursor)
+		if cursor == "" {
+			return nil, ErrInvalidResponse
+		}
+		after = &cursor
+	}
 }
 
 func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int, headSHA string) (pullRequestCodexReviews, error) {

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -33,10 +33,8 @@ type pullRequestStatusCacheEntry struct {
 }
 
 type pullRequestStatus struct {
-	ci                      pullRequestCI
-	reviews                 pullRequestCodexReviews
-	unresolvedReviewThreads []connector.PullRequestReviewThread
-	reviewThreadsHydrated   bool
+	ci      pullRequestCI
+	reviews pullRequestCodexReviews
 }
 
 type pullRequestHydrationState struct {
@@ -235,10 +233,8 @@ func newPullRequestStatusCacheKey(repo pullRequestRepo, number int, headSHA stri
 
 func clonePullRequestStatus(status pullRequestStatus) pullRequestStatus {
 	return pullRequestStatus{
-		ci:                      clonePullRequestCI(status.ci),
-		reviews:                 clonePullRequestCodexReviews(status.reviews),
-		unresolvedReviewThreads: append([]connector.PullRequestReviewThread(nil), status.unresolvedReviewThreads...),
-		reviewThreadsHydrated:   status.reviewThreadsHydrated,
+		ci:      clonePullRequestCI(status.ci),
+		reviews: clonePullRequestCodexReviews(status.reviews),
 	}
 }
 

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -33,8 +33,10 @@ type pullRequestStatusCacheEntry struct {
 }
 
 type pullRequestStatus struct {
-	ci      pullRequestCI
-	reviews pullRequestCodexReviews
+	ci                      pullRequestCI
+	reviews                 pullRequestCodexReviews
+	unresolvedReviewThreads []connector.PullRequestReviewThread
+	reviewThreadsHydrated   bool
 }
 
 type pullRequestHydrationState struct {
@@ -233,8 +235,10 @@ func newPullRequestStatusCacheKey(repo pullRequestRepo, number int, headSHA stri
 
 func clonePullRequestStatus(status pullRequestStatus) pullRequestStatus {
 	return pullRequestStatus{
-		ci:      clonePullRequestCI(status.ci),
-		reviews: clonePullRequestCodexReviews(status.reviews),
+		ci:                      clonePullRequestCI(status.ci),
+		reviews:                 clonePullRequestCodexReviews(status.reviews),
+		unresolvedReviewThreads: append([]connector.PullRequestReviewThread(nil), status.unresolvedReviewThreads...),
+		reviewThreadsHydrated:   status.reviewThreadsHydrated,
 	}
 }
 

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -149,25 +149,26 @@ type pullRequest struct {
 }
 
 type pullRequestNode struct {
-	NodeID                     string                            `json:"id"`
-	Number                     int                               `json:"number"`
-	URL                        string                            `json:"url"`
-	State                      string                            `json:"state"`
-	MergeableState             string                            `json:"mergeableState"`
-	Draft                      bool                              `json:"draft"`
-	Labels                     []string                          `json:"labels"`
-	ActivityAt                 *time.Time                        `json:"activityAt"`
-	HeadRefName                string                            `json:"headRefName"`
-	BaseRefName                string                            `json:"baseRefName"`
-	HeadSHA                    string                            `json:"headSHA"`
-	BaseSHA                    string                            `json:"baseRefOid"`
-	HydrationUnavailableReason string                            `json:"-"`
-	HydrationDegradedReason    string                            `json:"-"`
-	HydrationNextRetryAt       *time.Time                        `json:"-"`
-	Commits                    nodeConnection[pullRequestCommit] `json:"commits"`
-	LatestReviews              nodeConnection[pullRequestReview] `json:"latestReviews"`
-	CodexReviews               pullRequestCodexReviews           `json:"-"`
-	CI                         pullRequestCI                     `json:"-"`
+	NodeID                     string                              `json:"id"`
+	Number                     int                                 `json:"number"`
+	URL                        string                              `json:"url"`
+	State                      string                              `json:"state"`
+	MergeableState             string                              `json:"mergeableState"`
+	Draft                      bool                                `json:"draft"`
+	Labels                     []string                            `json:"labels"`
+	ActivityAt                 *time.Time                          `json:"activityAt"`
+	HeadRefName                string                              `json:"headRefName"`
+	BaseRefName                string                              `json:"baseRefName"`
+	HeadSHA                    string                              `json:"headSHA"`
+	BaseSHA                    string                              `json:"baseRefOid"`
+	HydrationUnavailableReason string                              `json:"-"`
+	HydrationDegradedReason    string                              `json:"-"`
+	HydrationNextRetryAt       *time.Time                          `json:"-"`
+	Commits                    nodeConnection[pullRequestCommit]   `json:"commits"`
+	LatestReviews              nodeConnection[pullRequestReview]   `json:"latestReviews"`
+	UnresolvedReviewThreads    []connector.PullRequestReviewThread `json:"-"`
+	CodexReviews               pullRequestCodexReviews             `json:"-"`
+	CI                         pullRequestCI                       `json:"-"`
 }
 
 type pullRequestCommit struct {
@@ -190,6 +191,14 @@ type pullRequestReview struct {
 	Author      *actor     `json:"author"`
 	CommitID    string     `json:"commitId"`
 	SubmittedAt *time.Time `json:"submittedAt"`
+}
+
+type pullRequestReviewThread struct {
+	IsResolved   bool   `json:"isResolved"`
+	IsOutdated   bool   `json:"isOutdated"`
+	Path         string `json:"path"`
+	Line         int    `json:"line"`
+	OriginalLine int    `json:"originalLine"`
 }
 
 type pullRequestCodexReviews struct {

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -591,6 +591,10 @@ func (c *Connector) EnqueuePullRequest(ctx context.Context, issue connector.Issu
 	return c.github.EnqueuePullRequest(ctx, issue)
 }
 
+func (c *Connector) DequeuePullRequest(ctx context.Context, entry connector.PullRequestMergeQueueEntry) error {
+	return c.github.DequeuePullRequest(ctx, entry)
+}
+
 func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
 	return c.github.HydratePullRequest(ctx, issue)
 }

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -60,6 +60,7 @@ type githubBackend interface {
 	connector.PullRequestCommentReader
 	connector.PullRequestHeadLookup
 	connector.PullRequestHydrator
+	connector.PullRequestReviewThreadHydrator
 	connector.PullRequestMergeQueue
 	connector.PullRequestMerger
 	connector.RateLimitReporter
@@ -133,6 +134,7 @@ var _ connector.PullRequestCommentReader = (*Connector)(nil)
 var _ connector.PullRequestDiffFingerprintReader = (*Connector)(nil)
 var _ connector.PullRequestHeadLookup = (*Connector)(nil)
 var _ connector.PullRequestHydrator = (*Connector)(nil)
+var _ connector.PullRequestReviewThreadHydrator = (*Connector)(nil)
 var _ connector.PullRequestLabelReapplier = (*Connector)(nil)
 var _ connector.PullRequestMergeQueue = (*Connector)(nil)
 var _ connector.PullRequestMerger = (*Connector)(nil)
@@ -591,6 +593,10 @@ func (c *Connector) EnqueuePullRequest(ctx context.Context, issue connector.Issu
 
 func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
 	return c.github.HydratePullRequest(ctx, issue)
+}
+
+func (c *Connector) HydratePullRequestReviewThreads(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
+	return c.github.HydratePullRequestReviewThreads(ctx, issue)
 }
 
 func (c *Connector) LookupPullRequestByHead(ctx context.Context, repository string, branch string, headSHA string) (connector.PullRequest, bool, error) {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -798,6 +798,10 @@ func (b *recordingGitHubBackend) HydratePullRequest(context.Context, connector.I
 	panic("unexpected github HydratePullRequest")
 }
 
+func (b *recordingGitHubBackend) HydratePullRequestReviewThreads(context.Context, connector.Issue) (connector.Issue, error) {
+	panic("unexpected github HydratePullRequestReviewThreads")
+}
+
 func (b *recordingGitHubBackend) LookupPullRequestByHead(context.Context, string, string, string) (connector.PullRequest, bool, error) {
 	panic("unexpected github LookupPullRequestByHead")
 }

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -794,6 +794,10 @@ func (b *recordingGitHubBackend) EnqueuePullRequest(context.Context, connector.I
 	panic("unexpected github EnqueuePullRequest")
 }
 
+func (b *recordingGitHubBackend) DequeuePullRequest(context.Context, connector.PullRequestMergeQueueEntry) error {
+	panic("unexpected github DequeuePullRequest")
+}
+
 func (b *recordingGitHubBackend) HydratePullRequest(context.Context, connector.Issue) (connector.Issue, error) {
 	panic("unexpected github HydratePullRequest")
 }

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -134,6 +134,7 @@ type PullRequest struct {
 	StaleSuccessfulChecks        []PullRequestCheck          `json:"stale_successful_checks,omitempty" yaml:"stale_successful_checks,omitempty"`
 	RequiredCheckFailures        []PullRequestCheck          `json:"required_check_failures,omitempty" yaml:"required_check_failures,omitempty"`
 	TransientFailedChecks        []PullRequestCheck          `json:"transient_failed_checks,omitempty" yaml:"transient_failed_checks,omitempty"`
+	UnresolvedReviewThreads      []PullRequestReviewThread   `json:"unresolved_review_threads,omitempty" yaml:"unresolved_review_threads,omitempty"`
 	CodexReviewState             string                      `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
 	CodexReviewSource            string                      `json:"codex_review_source,omitempty" yaml:"codex_review_source,omitempty"`
 	CodexReviewAPIState          string                      `json:"codex_review_api_state,omitempty" yaml:"codex_review_api_state,omitempty"`
@@ -175,6 +176,11 @@ type PullRequestCheck struct {
 type PullRequestFinding struct {
 	Body string `json:"body,omitempty" yaml:"body,omitempty"`
 	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	Line int    `json:"line,omitempty" yaml:"line,omitempty"`
+}
+
+type PullRequestReviewThread struct {
 	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 	Line int    `json:"line,omitempty" yaml:"line,omitempty"`
 }

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -402,6 +402,7 @@ func (c *Connector) LookupPullRequestByHead(_ context.Context, repository string
 			continue
 		}
 		pullRequest := *issue.PullRequest
+		pullRequest.UnresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), issue.PullRequest.UnresolvedReviewThreads...)
 		return pullRequest, true, nil
 	}
 	return connector.PullRequest{}, false, nil
@@ -703,6 +704,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		pullRequest.StaleSuccessfulChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.StaleSuccessfulChecks...)
 		pullRequest.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), issue.PullRequest.RequiredCheckFailures...)
 		pullRequest.TransientFailedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.TransientFailedChecks...)
+		pullRequest.UnresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), issue.PullRequest.UnresolvedReviewThreads...)
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		if issue.PullRequest.Labels != nil {
 			pullRequest.Labels = append([]string{}, issue.PullRequest.Labels...)

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -37,6 +37,7 @@ type AutoPromoteSummary struct {
 	CIStatus                              string
 	ReviewState                           string
 	FailedChecks                          []string
+	UnresolvedReviewThreads               []connector.PullRequestReviewThread
 	P1Findings                            []AutoPromoteFinding
 	Validator                             gate.ValidatorResult
 	SecurityAudit                         securityaudit.Evaluation
@@ -79,6 +80,7 @@ const (
 	AutoPromoteReasonPullRequestHydrationUnavailable AutoPromoteReason = "pull_request_hydration_unavailable"
 	AutoPromoteReasonMergeConflicts                  AutoPromoteReason = "merge_conflicts"
 	AutoPromoteReasonCINotGreen                      AutoPromoteReason = "ci_not_green"
+	AutoPromoteReasonUnresolvedReviewThreads         AutoPromoteReason = "unresolved_review_threads"
 	AutoPromoteReasonCodexReviewMissing              AutoPromoteReason = "automated_review_missing"
 	AutoPromoteReasonP1Findings                      AutoPromoteReason = "p1_findings"
 	AutoPromoteReasonCodexReviewNotQuiet             AutoPromoteReason = "codex_review_not_quiet"
@@ -183,6 +185,9 @@ func EvaluateAutoPromote(
 		if strings.TrimSpace(summary.PullRequestHydrationUnavailableReason) != "" ||
 			strings.TrimSpace(summary.PullRequestHydrationDegradedReason) != "" {
 			return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable)
+		}
+		if len(summary.UnresolvedReviewThreads) > 0 {
+			return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonUnresolvedReviewThreads)
 		}
 	}
 	if status, ok := artifactStatusFieldFromIssue(issue, cfg.Gate.Artifact.StatusField); ok {

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -123,6 +123,22 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
+			name:  "unresolved review threads rework before other gates",
+			issue: autoPromoteTestIssue("issue-unresolved-review-threads", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				UnresolvedReviewThreads: []connector.PullRequestReviewThread{{
+					Path: "internal/orchestrator/autopromote.go",
+					Line: 181,
+				}},
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionRework,
+				Reason: AutoPromoteReasonUnresolvedReviewThreads,
+			},
+		},
+		{
 			name:  "red ci skips when configured",
 			issue: autoPromoteTestIssue("issue-red-ci-skip", nil),
 			cfg: AutoPromoteConfig{

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -117,6 +117,13 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 				continue
 			}
 		}
+		if gateRequiresPullRequest(cfg.Gate) {
+			var hydrated bool
+			issue, hydrated = o.hydrateAutoPromoteReviewThreads(ctx, issue)
+			if !hydrated {
+				continue
+			}
+		}
 
 		issue, securityAudit := o.liveSecurityAuditEvaluation(ctx, issue)
 		summary := AutoPromoteSummaryFromIssue(issue)
@@ -961,6 +968,13 @@ func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
 
 		if normalizeState(issue.State) != "todo" {
 			continue
+		}
+		if gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
+			var hydrated bool
+			issue, hydrated = o.hydrateAutoPromoteReviewThreads(ctx, issue)
+			if !hydrated {
+				continue
+			}
 		}
 		summary := AutoPromoteSummaryFromIssue(issue)
 		if !summary.PullRequestPresent {
@@ -1908,6 +1922,9 @@ func staleTodoPullRequestDecision(
 		return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonMergeConflicts)
 	}
 	cfg = normalizeAutoPromoteConfig(cfg)
+	if gateRequiresPullRequest(cfg.Gate) && len(summary.UnresolvedReviewThreads) > 0 {
+		return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonUnresolvedReviewThreads)
+	}
 	if !cfg.Enabled {
 		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonDisabled)
 	}
@@ -2768,8 +2785,38 @@ func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	summary.CIStatus = pullRequest.CIStatus
 	summary.ReviewState = pullRequest.CodexReviewState
 	summary.FailedChecks = autoPromoteFailedChecksFromPullRequest(pullRequest)
+	summary.UnresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), pullRequest.UnresolvedReviewThreads...)
 	summary.P1Findings = autoPromoteFindingsFromPullRequest(pullRequest)
 	return summary
+}
+
+func (o *Orchestrator) hydrateAutoPromoteReviewThreads(ctx context.Context, issue connector.Issue) (connector.Issue, bool) {
+	hydrator, ok := o.connector.(connector.PullRequestReviewThreadHydrator)
+	if !ok || issue.PullRequest == nil || normalizePullRequestState(issue.PullRequest.State) != "open" {
+		return issue, true
+	}
+	hydrated, err := hydrator.HydratePullRequestReviewThreads(ctx, issue)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"pull request review thread hydration failed",
+				"issue_id", strings.TrimSpace(issue.ID),
+				"identifier", issue.Identifier,
+				"pull_request", pullRequestNumber(issue),
+				"error", err,
+			)
+		}
+		return issue, false
+	}
+	if hydrated.PullRequest != nil && pullRequestHydrationUnavailableReason(hydrated.PullRequest) != "" {
+		o.logAutoPromoteDecision(
+			hydrated,
+			autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable),
+			"",
+		)
+		return hydrated, false
+	}
+	return hydrated, true
 }
 
 func pullRequestHydrationUnavailableReason(pullRequest *connector.PullRequest) string {
@@ -3365,6 +3412,13 @@ func autoPromoteComment(
 			b.WriteString(": current-head CI is failing")
 		case AutoPromoteReasonMergeConflicts:
 			b.WriteString(": linked PR has merge conflicts")
+		case AutoPromoteReasonUnresolvedReviewThreads:
+			b.WriteString(": linked PR has ")
+			b.WriteString(strconv.Itoa(len(summary.UnresolvedReviewThreads)))
+			b.WriteString(" unresolved review thread")
+			if len(summary.UnresolvedReviewThreads) != 1 {
+				b.WriteString("s")
+			}
 		case AutoPromoteReasonWorkpadStatusInvalid:
 			b.WriteString(": workpad status is invalid")
 		}
@@ -3398,6 +3452,14 @@ func autoPromoteComment(
 		b.WriteString("\n- failed_checks: ")
 		b.WriteString(failedChecks)
 	}
+	if len(summary.UnresolvedReviewThreads) > 0 {
+		b.WriteString("\n- unresolved_review_threads: ")
+		b.WriteString(strconv.Itoa(len(summary.UnresolvedReviewThreads)))
+		if location := pullRequestReviewThreadLocation(summary.UnresolvedReviewThreads[0]); location != "" {
+			b.WriteString("\n- first_unresolved_review_thread: ")
+			b.WriteString(location)
+		}
+	}
 	if evidence := strings.TrimSpace(decision.OperationalEvidence); evidence != "" {
 		b.WriteString("\n- completion_kind: ")
 		b.WriteString(workpad.CompletionOperational)
@@ -3415,6 +3477,17 @@ func autoPromoteComment(
 	}
 
 	return b.String()
+}
+
+func pullRequestReviewThreadLocation(thread connector.PullRequestReviewThread) string {
+	path := strings.TrimSpace(thread.Path)
+	if path == "" {
+		return ""
+	}
+	if thread.Line > 0 {
+		return fmt.Sprintf("%s:%d", path, thread.Line)
+	}
+	return path
 }
 
 func appendAutoPromoteWorkpadCommentFields(b *strings.Builder, decision AutoPromoteDecision) {
@@ -3474,6 +3547,14 @@ func autoPromoteReworkLimitComment(
 	if failedChecks := strings.Join(summary.FailedChecks, ", "); failedChecks != "" {
 		b.WriteString("\n- failed_checks: ")
 		b.WriteString(failedChecks)
+	}
+	if len(summary.UnresolvedReviewThreads) > 0 {
+		b.WriteString("\n- unresolved_review_threads: ")
+		b.WriteString(strconv.Itoa(len(summary.UnresolvedReviewThreads)))
+		if location := pullRequestReviewThreadLocation(summary.UnresolvedReviewThreads[0]); location != "" {
+			b.WriteString("\n- first_unresolved_review_thread: ")
+			b.WriteString(location)
+		}
 	}
 
 	if len(decision.Findings) > 0 {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1025,6 +1025,9 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 		if issueID == "" {
 			continue
 		}
+		if _, deferred := state.nativeMergeQueueDeferred[issueID]; deferred {
+			continue
+		}
 		repository := mergeWorkerRepositoryKey(issue)
 		if mergeWorkerRepositoryConsumed(consumedRepositories, repository) {
 			continue
@@ -2989,8 +2992,21 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 	targetState string,
 	now time.Time,
 ) bool {
+	_, applied := o.applyAutoPromoteDecisionWithTarget(ctx, state, issue, summary, decision, targetState, now)
+	return applied
+}
+
+func (o *Orchestrator) applyAutoPromoteDecisionWithTarget(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	summary AutoPromoteSummary,
+	decision AutoPromoteDecision,
+	targetState string,
+	now time.Time,
+) (string, bool) {
 	if normalizeState(issue.State) == normalizeState(targetState) {
-		return false
+		return "", false
 	}
 
 	issueID := strings.TrimSpace(issue.ID)
@@ -3012,7 +3028,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 					"error", err,
 				)
 			}
-			return false
+			return "", false
 		}
 		if limit.Exceeded() {
 			disposition = laneMutationRevokeWorker
@@ -3045,7 +3061,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 				"error", err,
 			)
 		}
-		return false
+		return "", false
 	}
 
 	if strings.TrimSpace(body) != "" {
@@ -3072,7 +3088,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 		Event:   "auto_promote_transition",
 		Message: "auto-promoted " + issueLabel(issue) + " from " + sourceState + " to " + targetState,
 	})
-	return true
+	return targetState, true
 }
 
 func (s autoPromoteReworkLimitSummary) Exceeded() bool {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -203,6 +203,37 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			},
 		},
 		{
+			name: "routes unresolved review threads to rework",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-unresolved-review-threads", []string{"bug"}, &connector.PullRequest{
+				Number:   2103,
+				URL:      "https://github.test/digitaldrywood/detent/pull/2104",
+				State:    "OPEN",
+				CIStatus: "pass",
+				UnresolvedReviewThreads: []connector.PullRequestReviewThread{
+					{Path: "internal/orchestrator/autopromote.go", Line: 181},
+					{Path: "internal/connector/github/pull_requests.go", Line: 1092},
+				},
+			}),
+			wantUpdates: []autoPromoteTickUpdate{{
+				issueID: "issue-unresolved-review-threads",
+				state:   "Rework",
+			}},
+			wantCommentFragments: []string{
+				"Auto-promote routed this issue from Human Review to Rework: linked PR has 2 unresolved review threads.",
+				"reason: unresolved_review_threads",
+				"unresolved_review_threads: 2",
+				"first_unresolved_review_thread: internal/orchestrator/autopromote.go:181",
+			},
+			wantLogFragments: []string{
+				"reason=unresolved_review_threads",
+				"target_state=Rework",
+			},
+		},
+		{
 			name: "routes conflicting pull request to rework",
 			cfg: AutoPromoteConfig{
 				Enabled:       true,
@@ -2581,7 +2612,22 @@ func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 	})
 	conflicting.State = "Todo"
 	conflicting.Identifier = "digitaldrywood/creswoodcorners-phone#32"
-	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{ready, conflicting}}
+	unresolved := autoPromoteTickIssue("issue-unresolved-todo", []string{"bug"}, &connector.PullRequest{
+		Number:                 39,
+		URL:                    "https://github.test/digitaldrywood/creswoodcorners-phone/pull/39",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+		UnresolvedReviewThreads: []connector.PullRequestReviewThread{{
+			Path: "internal/orchestrator/autopromote_tick.go",
+			Line: 976,
+		}},
+	})
+	unresolved.State = "Todo"
+	unresolved.Identifier = "digitaldrywood/creswoodcorners-phone#34"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{ready, conflicting, unresolved}}
 	var logs strings.Builder
 	orch := &Orchestrator{
 		cfg:       cfg,
@@ -2595,11 +2641,15 @@ func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 	wantUpdates := []autoPromoteTickUpdate{
 		{issueID: "issue-ready-todo", state: "Merging"},
 		{issueID: "issue-conflicting-todo", state: "Rework"},
+		{issueID: "issue-unresolved-todo", state: "Rework"},
 	}
 	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
 		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
 	}
-	if len(tracker.comments) != 2 {
+	if want := []string{"issue-ready-todo", "issue-conflicting-todo", "issue-unresolved-todo"}; !reflect.DeepEqual(tracker.reviewThreadHydrations, want) {
+		t.Fatalf("review thread hydrations = %#v, want %#v", tracker.reviewThreadHydrations, want)
+	}
+	if len(tracker.comments) != 3 {
 		t.Fatalf("comments = %#v, want stale todo reconciliation comments", tracker.comments)
 	}
 	wantComments := map[string][]string{
@@ -2614,6 +2664,13 @@ func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 			"mergeable_state: dirty",
 			"https://github.test/digitaldrywood/creswoodcorners-phone/pull/38",
 		},
+		"issue-unresolved-todo": {
+			"Auto-promote routed this issue from Todo to Rework: linked PR has 1 unresolved review thread.",
+			"reason: unresolved_review_threads",
+			"unresolved_review_threads: 1",
+			"first_unresolved_review_thread: internal/orchestrator/autopromote_tick.go:976",
+			"https://github.test/digitaldrywood/creswoodcorners-phone/pull/39",
+		},
 	}
 	for _, comment := range tracker.comments {
 		for _, fragment := range wantComments[comment.issueID] {
@@ -2626,10 +2683,25 @@ func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 		"stale_todo_pr_reconciled",
 		"reason=ready",
 		"reason=merge_conflicts",
+		"reason=unresolved_review_threads",
 	} {
 		if !strings.Contains(logs.String(), fragment) {
 			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
 		}
+	}
+}
+
+func TestStaleTodoPullRequestDecisionRoutesUnresolvedThreadsWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	decision := staleTodoPullRequestDecision(
+		connector.Issue{},
+		AutoPromoteSummary{UnresolvedReviewThreads: []connector.PullRequestReviewThread{{Path: "main.go", Line: 10}}},
+		AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
+		time.Time{},
+	)
+	if decision.Action != AutoPromoteActionRework || decision.Reason != AutoPromoteReasonUnresolvedReviewThreads {
+		t.Fatalf("decision = %#v, want unresolved review thread rework", decision)
 	}
 }
 
@@ -6396,21 +6468,22 @@ func (r *autoPromoteWorkflowMetricsRecorder) snapshot() []store.WorkflowPhaseEve
 }
 
 type autoPromoteTickConnector struct {
-	stateIssues           []connector.Issue
-	candidateIssues       []connector.Issue
-	candidateIssuesSet    bool
-	candidateByStates     [][]string
-	fetchByStatesRequests [][]string
-	fetchComments         []string
-	fetchIdentifiers      [][]string
-	issueComments         map[string][]connector.IssueComment
-	resolvedIssues        []connector.Issue
-	updates               []autoPromoteTickUpdate
-	comments              []autoPromoteTickComment
-	prComments            []autoPromoteTickComment
-	setFields             []autoPromoteTickSetField
-	reruns                []autoPromoteTickRerun
-	updateErr             error
+	stateIssues            []connector.Issue
+	candidateIssues        []connector.Issue
+	candidateIssuesSet     bool
+	candidateByStates      [][]string
+	fetchByStatesRequests  [][]string
+	fetchComments          []string
+	fetchIdentifiers       [][]string
+	issueComments          map[string][]connector.IssueComment
+	resolvedIssues         []connector.Issue
+	updates                []autoPromoteTickUpdate
+	comments               []autoPromoteTickComment
+	prComments             []autoPromoteTickComment
+	setFields              []autoPromoteTickSetField
+	reruns                 []autoPromoteTickRerun
+	updateErr              error
+	reviewThreadHydrations []string
 }
 
 type autoPromoteTickMergeConnector struct {
@@ -6488,6 +6561,11 @@ func (c *autoPromoteTickConnector) FetchIssueStatesByIdentifiers(_ context.Conte
 		}
 	}
 	return issues, nil
+}
+
+func (c *autoPromoteTickConnector) HydratePullRequestReviewThreads(_ context.Context, issue connector.Issue) (connector.Issue, error) {
+	c.reviewThreadHydrations = append(c.reviewThreadHydrations, strings.TrimSpace(issue.ID))
+	return cloneIssue(issue), nil
 }
 
 func (c *autoPromoteTickConnector) CreateComment(_ context.Context, issueID string, body string) error {

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -39,6 +39,7 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			var hydrated bool
 			issue, hydrated = o.hydrateAutoPromoteReviewThreads(ctx, issue)
 			if !hydrated {
+				result.transitioned[issueID] = struct{}{}
 				continue
 			}
 		}

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -69,6 +69,9 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 
 		result.transitioned[issueID] = struct{}{}
 		if direct, promoted := o.tryDirectCompletedActiveAutoPromote(ctx, state, issue, targetState, completed.FinalState, cfg, now); direct {
+			if completedActiveReviewThreadsKeepParked(issue, promoted.State, cfg) {
+				continue
+			}
 			if normalizeState(issue.State) == normalizeState(promoted.State) {
 				result.dispatchCandidates = append(result.dispatchCandidates, promoted)
 			} else if mergeWorkerIssue(promoted) {
@@ -114,6 +117,13 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		return autoPromoteTickResult{}
 	}
 	return result
+}
+
+func completedActiveReviewThreadsKeepParked(issue connector.Issue, targetState string, cfg AutoPromoteConfig) bool {
+	return gateRequiresPullRequest(cfg.Gate) &&
+		normalizeState(issue.State) == normalizeState(targetState) &&
+		issue.PullRequest != nil &&
+		len(issue.PullRequest.UnresolvedReviewThreads) > 0
 }
 
 func (o *Orchestrator) transitionActiveArtifactGateWaitIssuesToReview(

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -35,6 +35,13 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		if !ok {
 			continue
 		}
+		if gateRequiresPullRequest(cfg.Gate) {
+			var hydrated bool
+			issue, hydrated = o.hydrateAutoPromoteReviewThreads(ctx, issue)
+			if !hydrated {
+				continue
+			}
+		}
 		if normalizeState(issue.State) == normalizeState(cfg.ReworkState) &&
 			normalizeState(completed.Issue.State) != normalizeState(issue.State) {
 			continue
@@ -189,14 +196,21 @@ func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 	cfg AutoPromoteConfig,
 	now time.Time,
 ) (bool, connector.Issue) {
-	if !cfg.Enabled || cfg.QuietDuration != 0 || normalizeState(reviewState) != normalizeState(cfg.SourceState) {
+	if normalizeState(reviewState) != normalizeState(cfg.SourceState) {
 		return false, connector.Issue{}
 	}
 
 	summary := AutoPromoteSummaryFromIssue(issue)
 	summary.CompletedFinalState = completedFinalState
 	summary.OperationalCompletionAccepted = autoPromoteOperationalCompletionAccepted(state, issue.ID)
-	decision := EvaluateAutoPromote(issue, summary, cfg, now)
+	unresolvedReviewThreads := gateRequiresPullRequest(cfg.Gate) && len(summary.UnresolvedReviewThreads) > 0
+	if !unresolvedReviewThreads && (!cfg.Enabled || cfg.QuietDuration != 0) {
+		return false, connector.Issue{}
+	}
+	decision := autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonUnresolvedReviewThreads)
+	if !unresolvedReviewThreads {
+		decision = EvaluateAutoPromote(issue, summary, cfg, now)
+	}
 	if autoPromoteDecisionNeedsWorkpadHydration(decision) {
 		issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, cfg, now)
 	}
@@ -291,13 +305,16 @@ func completedActiveReviewTargetState(
 	if !completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(cfg.Gate), operationalCompletionAccepted) {
 		return ""
 	}
+	if !completedActiveFinalStateReviewEligible(finalState, reviewState) {
+		return ""
+	}
+	if !operationalCompletionAccepted && gateRequiresPullRequest(cfg.Gate) && len(issue.PullRequest.UnresolvedReviewThreads) > 0 {
+		return reviewState
+	}
 	if !completedActiveShouldEnterReview(issue, cfg, operationalCompletionAccepted) {
 		return ""
 	}
-	if completedActiveFinalStateReviewEligible(finalState, reviewState) {
-		return reviewState
-	}
-	return ""
+	return reviewState
 }
 
 func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConfig, operationalCompletionAccepted bool) bool {

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -230,16 +230,17 @@ func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 		o.logAutoPromoteDecision(issue, decision, "")
 		return false, connector.Issue{}
 	}
-	promoted := promotedIssue(issue, targetState, now)
 	if normalizeState(issue.State) == normalizeState(targetState) {
+		promoted := promotedIssue(issue, targetState, now)
 		o.logAutoPromoteDecision(issue, decision, targetState)
 		o.logCompletedActiveAutoPromoteSameState(issue, decision, cfg)
 		return true, promoted
 	}
-	if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
+	effectiveTargetState, applied := o.applyAutoPromoteDecisionWithTarget(ctx, state, issue, summary, decision, targetState, now)
+	if !applied {
 		return false, connector.Issue{}
 	}
-	return true, promoted
+	return true, promotedIssue(issue, effectiveTargetState, now)
 }
 
 func (o *Orchestrator) finishCompletedActiveReviewTransition(
@@ -427,15 +428,16 @@ func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
 			o.logAutoPromoteDecision(issue, decision, "")
 			return false, connector.Issue{}
 		}
-		if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
+		effectiveTargetState, applied := o.applyAutoPromoteDecisionWithTarget(ctx, state, issue, summary, decision, targetState, now)
+		if !applied {
 			return false, connector.Issue{}
 		}
-		promoted := promotedIssue(issue, targetState, now)
-		o.finishCompletedActiveReviewTransition(ctx, state, issue, completed, targetState)
+		promoted := promotedIssue(issue, effectiveTargetState, now)
+		o.finishCompletedActiveReviewTransition(ctx, state, issue, completed, effectiveTargetState)
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      now,
 			Event:   "completed_active_gate_wait_timeout",
-			Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState + " after auto-promote gate wait timeout",
+			Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + effectiveTargetState + " after auto-promote gate wait timeout",
 		})
 		return true, promoted
 	}

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -150,6 +150,20 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			},
 		},
 		{
+			name: "unresolved review threads bypass command gate wait",
+			issue: func() connector.Issue {
+				issue := completionTransitionIssue("In Progress", "OPEN")
+				issue.PullRequest.UnresolvedReviewThreads = []connector.PullRequestReviewThread{{Path: "internal/orchestrator/state.go", Line: 42}}
+				return issue
+			}(),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindCommand},
+			},
+			want: autoPromoteSourceState,
+		},
+		{
 			name:       "zero quiet command gate with review wait advances to human review",
 			issue:      completionTransitionIssue("In Progress", "OPEN"),
 			finalState: FinalStateCompleted,
@@ -447,6 +461,134 @@ func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.
 	}
 	if len(state.RecentEvents) != 0 {
 		t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)
+	}
+}
+
+func TestTransitionCompletedActiveIssuesRoutesUnresolvedReviewThreadsToRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 15, 0, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.PullRequest = &connector.PullRequest{
+		Number:   2104,
+		URL:      "https://github.test/digitaldrywood/detent/pull/2104",
+		State:    "OPEN",
+		CIStatus: "pass",
+		UnresolvedReviewThreads: []connector.PullRequestReviewThread{{
+			Path: "internal/orchestrator/autopromote.go",
+			Line: 181,
+		}},
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one rework comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Auto-promote routed this issue from In Progress to Rework: linked PR has 1 unresolved review thread.",
+		"reason: unresolved_review_threads",
+		"unresolved_review_threads: 1",
+		"first_unresolved_review_thread: internal/orchestrator/autopromote.go:181",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+}
+
+func TestTransitionCompletedActiveIssuesWaitsWhenReviewThreadsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 15, 2, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.PullRequest.HydrationUnavailableReason = connector.PullRequestHydrationReasonRateLimited
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate:    gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if len(result.transitioned) != 0 || len(tracker.updates) != 0 || len(tracker.comments) != 0 {
+		t.Fatalf("result = %#v updates = %#v comments = %#v, want no transition", result, tracker.updates, tracker.comments)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "In Progress" {
+		t.Fatalf("Completed issue state = %q, want In Progress", got)
+	}
+}
+
+func TestTransitionCompletedReworkIssueReturnsToHumanReviewAfterThreadsResolve(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 15, 5, 0, 0, time.UTC)
+	issue := completionTransitionIssue("Rework", "OPEN")
+	issue.PullRequest.Number = 2104
+	issue.PullRequest.URL = "https://github.test/digitaldrywood/detent/pull/2104"
+	issue.PullRequest.CIStatus = "pass"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Human Review"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want no rework comment after threads resolve", tracker.comments)
 	}
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
@@ -518,6 +519,77 @@ func TestTransitionCompletedActiveIssuesRoutesUnresolvedReviewThreadsToRework(t 
 		if !strings.Contains(tracker.comments[0].body, fragment) {
 			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
 		}
+	}
+}
+
+func TestTransitionCompletedActiveIssuesPreservesReworkBreakerTarget(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 16, 0, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.Identifier = "digitaldrywood/detent#2103"
+	issue.URL = "https://github.test/digitaldrywood/detent/issues/2103"
+	issue.PullRequest = &connector.PullRequest{
+		Number:   2124,
+		URL:      "https://github.test/digitaldrywood/detent/pull/2124",
+		State:    "OPEN",
+		CIStatus: "pass",
+		HeadSHA:  "head-with-open-thread",
+		UnresolvedReviewThreads: []connector.PullRequestReviewThread{{
+			Path: "internal/orchestrator/completion_transition.go",
+			Line: 223,
+		}},
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Rework",
+		Reason:       string(AutoPromoteReasonUnresolvedReviewThreads),
+		Status:       "entered",
+		StartedAt:    now.Add(-time.Hour),
+		MetadataJSON: workflowLaneMetadataJSON(issue, workflowLaneMetadata{}),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			ReworkLimit:   1,
+			Gate:          gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker, workflowMetrics: metrics}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Blocked"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Blocked" {
+		t.Fatalf("Completed issue state = %q, want Blocked", got)
+	}
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatchCandidates = %#v, want none", result.dispatchCandidates)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "Rework limit was reached") {
+		t.Fatalf("comments = %#v, want one rework-limit handoff", tracker.comments)
 	}
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -521,6 +521,59 @@ func TestTransitionCompletedActiveIssuesRoutesUnresolvedReviewThreadsToRework(t 
 	}
 }
 
+func TestTransitionCompletedReworkIssueParksWhileReviewThreadsRemainUnresolved(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 14, 0, 0, 0, time.UTC)
+	issue := completionTransitionIssue("Rework", "OPEN")
+	issue.PullRequest = &connector.PullRequest{
+		Number:   2104,
+		URL:      "https://github.test/digitaldrywood/detent/pull/2104",
+		State:    "OPEN",
+		CIStatus: "pass",
+		UnresolvedReviewThreads: []connector.PullRequestReviewThread{{
+			Path: "internal/orchestrator/completion_transition.go",
+			Line: 211,
+		}},
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+
+	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if len(result.dispatchCandidates) != 0 || len(tracker.updates) != 0 || len(tracker.comments) != 0 {
+		t.Fatalf("result = %#v updates = %#v comments = %#v, want parked without redispatch", result, tracker.updates, tracker.comments)
+	}
+	if _, ok := state.Completed[issue.ID]; !ok {
+		t.Fatalf("Completed[%q] missing while review threads remain unresolved", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing while review threads remain unresolved", issue.ID)
+	}
+	if got := tracker.reviewThreadHydrations; !reflect.DeepEqual(got, []string{issue.ID}) {
+		t.Fatalf("review thread hydrations = %#v, want one for %s", got, issue.ID)
+	}
+}
+
 func TestTransitionCompletedActiveIssuesWaitsWhenReviewThreadsUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
@@ -545,11 +546,65 @@ func TestTransitionCompletedActiveIssuesWaitsWhenReviewThreadsUnavailable(t *tes
 
 	result := orch.transitionCompletedActiveIssuesToReview(t.Context(), &state, []connector.Issue{issue}, now)
 
-	if len(result.transitioned) != 0 || len(tracker.updates) != 0 || len(tracker.comments) != 0 {
-		t.Fatalf("result = %#v updates = %#v comments = %#v, want no transition", result, tracker.updates, tracker.comments)
+	if _, ok := result.transitioned[issue.ID]; !ok || len(tracker.updates) != 0 || len(tracker.comments) != 0 {
+		t.Fatalf("result = %#v updates = %#v comments = %#v, want parked without backend transition", result, tracker.updates, tracker.comments)
 	}
 	if got := state.Completed[issue.ID].Issue.State; got != "In Progress" {
 		t.Fatalf("Completed issue state = %q, want In Progress", got)
+	}
+}
+
+func TestHandleRunResultParksCompletedRunWhenReviewThreadsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 15, 3, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.PullRequest.Number = 2104
+	issue.PullRequest.HeadSHA = "head-sha"
+	issue.PullRequest.CIStatus = "pass"
+	issue.PullRequest.HydrationUnavailableReason = connector.PullRequestHydrationReasonRateLimited
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate:    gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		ContinuationRetryDelay: time.Minute,
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:     issue,
+		Attempt:   1,
+		StartedAt: now.Add(-time.Minute),
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result: runpkg.RunResult{
+			FinalState:         FinalStateCompleted,
+			PullRequestUpdated: true,
+		},
+	})
+
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present while review-thread hydration is pending", issue.ID)
+	}
+	if _, ok := state.Completed[issue.ID]; !ok {
+		t.Fatalf("Completed[%q] missing while review-thread hydration is pending", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing while review-thread hydration is pending", issue.ID)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no backend transition", tracker.updates)
+	}
+	if got := tracker.reviewThreadHydrations; !reflect.DeepEqual(got, []string{issue.ID}) {
+		t.Fatalf("review thread hydrations = %#v, want one for %s", got, issue.ID)
 	}
 }
 

--- a/internal/orchestrator/lesson_capture.go
+++ b/internal/orchestrator/lesson_capture.go
@@ -72,7 +72,7 @@ func reworkFailureKind(reason string, pullRequest *connector.PullRequest, failed
 		return "ci_failure"
 	case mergeWorkerRequiredChecksMissingReason, mergeWorkerFastPathNotReadyReason:
 		return "ci_signal_missing"
-	case string(AutoPromoteReasonP1Findings), "plan_review_decision":
+	case string(AutoPromoteReasonP1Findings), string(AutoPromoteReasonUnresolvedReviewThreads), "plan_review_decision":
 		return "changes_requested"
 	case string(AutoPromoteReasonValidatorRework), string(AutoPromoteReasonValidatorScoreBelowThreshold), string(AutoPromoteReasonValidatorBlockedSeverity):
 		return "validator_rework"

--- a/internal/orchestrator/merge_fast_path_test.go
+++ b/internal/orchestrator/merge_fast_path_test.go
@@ -220,6 +220,58 @@ func TestMergingFastPathMissingRequiredChecksRoutesToRework(t *testing.T) {
 	}
 }
 
+func TestMergingFastPathUnresolvedReviewThreadsRouteToRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 13, 5, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-unresolved-review-threads", []string{"bug"}, &connector.PullRequest{
+		Number:         2124,
+		URL:            "https://github.test/digitaldrywood/detent/pull/2124",
+		BranchName:     "detent/unresolved-review-threads",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		HeadSHA:        "head-unresolved-review-threads",
+		UnresolvedReviewThreads: []connector.PullRequestReviewThread{
+			{Path: "internal/orchestrator/autopromote_tick.go", Line: 126},
+			{Path: "internal/orchestrator/run_completion.go", Line: 1582},
+		},
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/detent#2103"
+	issue.PRRepository = "digitaldrywood/detent"
+
+	tracker, state := completeMergeFastPathTestRun(t, issue, now, 1, gate.Config{})
+
+	if len(tracker.merges) != 0 {
+		t.Fatalf("merges = %#v, want none with unresolved review threads", tracker.merges)
+	}
+	if got, want := tracker.reviewThreadHydrations, []string{issue.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("review thread hydrations = %#v, want %#v", got, want)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one Rework routing comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"reason: unresolved_review_threads",
+		"unresolved_review_threads: 2",
+		"first_unresolved_review_thread: internal/orchestrator/autopromote_tick.go:126",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment = %q, want fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after Rework handoff", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after Rework handoff", issue.ID)
+	}
+}
+
 func TestMergingFastPathChangedHeadReappliesCITriggerBeforeMerge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -36,12 +36,12 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 	if state == nil {
 		return out
 	}
-	if gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
+	if nativeMergeQueueCleanupRequired(o.cfg) {
 		return out
 	}
 	state.nativeMergeQueueDeferred = map[string]struct{}{}
 	queue, ok := o.connector.(connector.PullRequestMergeQueue)
-	if !ok || !o.cfg.MergeFastPathEnabled {
+	if !ok {
 		return out
 	}
 	pruneNativeMergeQueueEntries(state, out)
@@ -116,7 +116,7 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 	return out
 }
 
-func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueueIssues(
+func (o *Orchestrator) reconcileUnsafeNativeMergeQueueIssues(
 	ctx context.Context,
 	state *State,
 	issues []connector.Issue,
@@ -129,8 +129,11 @@ func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueueIssues(
 	}
 	previousDeferred := state.nativeMergeQueueDeferred
 	state.nativeMergeQueueDeferred = map[string]struct{}{}
-	if !gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
+	if !nativeMergeQueueCleanupRequired(o.cfg) {
 		return out
+	}
+	if state.nativeMergeQueueChecks == nil {
+		state.nativeMergeQueueChecks = map[string]time.Time{}
 	}
 	queue, ok := o.connector.(connector.PullRequestMergeQueue)
 	if !ok {
@@ -143,20 +146,28 @@ func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueueIssues(
 		}
 	}
 	for _, issue := range out {
-		if !reviewThreadGatedNativeMergeQueueCleanupCandidate(issue, state, previousMerging, previousDeferred) {
+		if !nativeMergeQueueCleanupCandidate(issue, state, previousMerging, previousDeferred, now) {
 			continue
 		}
-		o.reconcileReviewThreadGatedNativeMergeQueue(ctx, state, out, issue, queue, now)
+		o.reconcileUnsafeNativeMergeQueue(ctx, state, out, issue, queue, now)
 	}
 	pruneNativeMergeQueueEntries(state, out)
+	pruneNativeMergeQueueInspections(state, out)
 	return out
 }
 
-func reviewThreadGatedNativeMergeQueueCleanupCandidate(
+func nativeMergeQueueCleanupRequired(cfg Config) bool {
+	return !cfg.MergeFastPathEnabled ||
+		gateRequiresPullRequest(cfg.AutoPromote.Gate) ||
+		gate.Effective(cfg.AutoPromote.Gate).SecurityAudit.Enabled
+}
+
+func nativeMergeQueueCleanupCandidate(
 	issue connector.Issue,
 	state *State,
 	previousMerging map[string]struct{},
 	previousDeferred map[string]struct{},
+	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
 	if issueID == "" {
@@ -174,10 +185,24 @@ func reviewThreadGatedNativeMergeQueueCleanupCandidate(
 	if _, ok := previousDeferred[issueID]; ok {
 		return true
 	}
-	return issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil
+	if issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil {
+		return true
+	}
+	if !nativeMergeQueueRecoveryCandidate(issue) {
+		return false
+	}
+	checkedAt, checked := state.nativeMergeQueueChecks[issueID]
+	return !checked || now.Sub(checkedAt) >= nativeMergeQueueEntryRefresh
 }
 
-func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueue(
+func nativeMergeQueueRecoveryCandidate(issue connector.Issue) bool {
+	if issue.PullRequest == nil || normalizePullRequestState(issue.PullRequest.State) != "open" {
+		return false
+	}
+	return pullRequestRepository(issue) != "" && pullRequestNumber(issue) > 0
+}
+
+func (o *Orchestrator) reconcileUnsafeNativeMergeQueue(
 	ctx context.Context,
 	state *State,
 	issues []connector.Issue,
@@ -192,6 +217,7 @@ func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueue(
 		o.logNativeMergeQueueFailure(issue, "inspection_failed", err)
 		return
 	}
+	state.nativeMergeQueueChecks[issueID] = now
 	if status.Entry == nil {
 		delete(state.nativeMergeQueueEntries, issueID)
 		clearNativeMergeQueueEntry(issues, issueID)
@@ -263,6 +289,23 @@ func pruneNativeMergeQueueEntries(state *State, issues []connector.Issue) {
 		}
 		if _, ok := active[issueID]; !ok {
 			delete(state.nativeMergeQueueEntries, issueID)
+		}
+	}
+}
+
+func pruneNativeMergeQueueInspections(state *State, issues []connector.Issue) {
+	active := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+			active[issueID] = struct{}{}
+		}
+	}
+	for issueID := range state.nativeMergeQueueChecks {
+		if _, deferred := state.nativeMergeQueueDeferred[issueID]; deferred {
+			continue
+		}
+		if _, ok := active[issueID]; !ok {
+			delete(state.nativeMergeQueueChecks, issueID)
 		}
 	}
 }

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -124,21 +125,17 @@ func (o *Orchestrator) reconcileUnsafeNativeMergeQueueIssues(
 	now time.Time,
 ) []connector.Issue {
 	out := mergeIssueSlices(issues, previous)
-	if state == nil {
+	if state == nil || !nativeMergeQueueCleanupRequired(o.cfg) {
 		return out
-	}
-	previousDeferred := state.nativeMergeQueueDeferred
-	state.nativeMergeQueueDeferred = map[string]struct{}{}
-	if !nativeMergeQueueCleanupRequired(o.cfg) {
-		return out
-	}
-	if state.nativeMergeQueueChecks == nil {
-		state.nativeMergeQueueChecks = map[string]time.Time{}
 	}
 	queue, ok := o.connector.(connector.PullRequestMergeQueue)
 	if !ok {
 		return out
 	}
+	out = mergeIssueSlices(out, nativeMergeQueueRetryIssues(state.nativeQueueRetries))
+	previousDeferred := state.nativeMergeQueueDeferred
+	state.nativeMergeQueueDeferred = map[string]struct{}{}
+	state.nativeQueueRetries = map[string]connector.Issue{}
 	previousMerging := make(map[string]struct{}, len(previous))
 	for _, issue := range previous {
 		if mergeWorkerIssue(issue) {
@@ -146,13 +143,12 @@ func (o *Orchestrator) reconcileUnsafeNativeMergeQueueIssues(
 		}
 	}
 	for _, issue := range out {
-		if !nativeMergeQueueCleanupCandidate(issue, state, previousMerging, previousDeferred, now) {
+		if !nativeMergeQueueCleanupCandidate(issue, state, previousMerging, previousDeferred) {
 			continue
 		}
 		o.reconcileUnsafeNativeMergeQueue(ctx, state, out, issue, queue, now)
 	}
 	pruneNativeMergeQueueEntries(state, out)
-	pruneNativeMergeQueueInspections(state, out)
 	return out
 }
 
@@ -162,12 +158,44 @@ func nativeMergeQueueCleanupRequired(cfg Config) bool {
 		gate.Effective(cfg.AutoPromote.Gate).SecurityAudit.Enabled
 }
 
+func (o *Orchestrator) fetchUnsafeNativeMergeQueueTerminalIssues(
+	ctx context.Context,
+	state *State,
+	now time.Time,
+	reserve githubBudgetReserveDecision,
+) []connector.Issue {
+	if state == nil || !state.nativeQueueSweepPending || !nativeMergeQueueCleanupRequired(o.cfg) {
+		return nil
+	}
+	if _, ok := o.connector.(connector.PullRequestMergeQueue); !ok {
+		state.nativeQueueSweepPending = false
+		return nil
+	}
+	if reserve.degraded {
+		return nil
+	}
+	states := displayStateNames(o.cfg.TerminalStates)
+	if len(states) == 0 {
+		state.nativeQueueSweepPending = false
+		return nil
+	}
+	issues, err := o.fetchObservedIssuesByStates(ctx, states)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("fetch unsafe native merge queue terminal issues failed", "error", err)
+		}
+		markRefreshError(state, "fetch unsafe native merge queue terminal issues failed: "+err.Error(), now)
+		return nil
+	}
+	state.nativeQueueSweepPending = false
+	return terminalIssues(issues, o.cfg.TerminalStates)
+}
+
 func nativeMergeQueueCleanupCandidate(
 	issue connector.Issue,
 	state *State,
 	previousMerging map[string]struct{},
 	previousDeferred map[string]struct{},
-	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
 	if issueID == "" {
@@ -188,11 +216,7 @@ func nativeMergeQueueCleanupCandidate(
 	if issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil {
 		return true
 	}
-	if !nativeMergeQueueRecoveryCandidate(issue) {
-		return false
-	}
-	checkedAt, checked := state.nativeMergeQueueChecks[issueID]
-	return !checked || now.Sub(checkedAt) >= nativeMergeQueueEntryRefresh
+	return nativeMergeQueueRecoveryCandidate(issue)
 }
 
 func nativeMergeQueueRecoveryCandidate(issue connector.Issue) bool {
@@ -214,10 +238,10 @@ func (o *Orchestrator) reconcileUnsafeNativeMergeQueue(
 	status, err := queue.InspectPullRequestMergeQueue(ctx, issue)
 	if err != nil {
 		state.nativeMergeQueueDeferred[issueID] = struct{}{}
+		state.nativeQueueRetries[issueID] = cloneIssue(issue)
 		o.logNativeMergeQueueFailure(issue, "inspection_failed", err)
 		return
 	}
-	state.nativeMergeQueueChecks[issueID] = now
 	if status.Entry == nil {
 		delete(state.nativeMergeQueueEntries, issueID)
 		clearNativeMergeQueueEntry(issues, issueID)
@@ -226,6 +250,7 @@ func (o *Orchestrator) reconcileUnsafeNativeMergeQueue(
 	entry := *status.Entry
 	if err := queue.DequeuePullRequest(ctx, entry); err != nil {
 		state.nativeMergeQueueDeferred[issueID] = struct{}{}
+		state.nativeQueueRetries[issueID] = cloneIssue(issue)
 		cacheNativeMergeQueueEntry(state, issueID, entry, now)
 		applyNativeMergeQueueEntry(issues, issueID, entry)
 		o.logNativeMergeQueueFailure(issue, "dequeue_failed", err)
@@ -239,6 +264,19 @@ func (o *Orchestrator) reconcileUnsafeNativeMergeQueue(
 		Event:   "merge_worker_native_queue_dequeued",
 		Message: "dequeued " + issueLabel(issue) + " from the native merge queue",
 	})
+}
+
+func nativeMergeQueueRetryIssues(retries map[string]connector.Issue) []connector.Issue {
+	issueIDs := make([]string, 0, len(retries))
+	for issueID := range retries {
+		issueIDs = append(issueIDs, issueID)
+	}
+	sort.Strings(issueIDs)
+	issues := make([]connector.Issue, 0, len(issueIDs))
+	for _, issueID := range issueIDs {
+		issues = append(issues, cloneIssue(retries[issueID]))
+	}
+	return issues
 }
 
 func nativeMergeQueueCandidate(issue connector.Issue, cfg Config) bool {
@@ -289,23 +327,6 @@ func pruneNativeMergeQueueEntries(state *State, issues []connector.Issue) {
 		}
 		if _, ok := active[issueID]; !ok {
 			delete(state.nativeMergeQueueEntries, issueID)
-		}
-	}
-}
-
-func pruneNativeMergeQueueInspections(state *State, issues []connector.Issue) {
-	active := make(map[string]struct{}, len(issues))
-	for _, issue := range issues {
-		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
-			active[issueID] = struct{}{}
-		}
-	}
-	for issueID := range state.nativeMergeQueueChecks {
-		if _, deferred := state.nativeMergeQueueDeferred[issueID]; deferred {
-			continue
-		}
-		if _, ok := active[issueID]; !ok {
-			delete(state.nativeMergeQueueChecks, issueID)
 		}
 	}
 }

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -117,6 +117,9 @@ func nativeMergeQueueCandidate(issue connector.Issue, cfg Config) bool {
 	if strings.TrimSpace(issue.ID) == "" || issue.PullRequest == nil {
 		return false
 	}
+	if gateRequiresPullRequest(cfg.AutoPromote.Gate) {
+		return false
+	}
 	if gate.Effective(cfg.AutoPromote.Gate).SecurityAudit.Enabled {
 		return false
 	}

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -36,6 +36,9 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 	if state == nil {
 		return out
 	}
+	if gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
+		return out
+	}
 	state.nativeMergeQueueDeferred = map[string]struct{}{}
 	queue, ok := o.connector.(connector.PullRequestMergeQueue)
 	if !ok || !o.cfg.MergeFastPathEnabled {
@@ -46,10 +49,6 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 
 	for _, candidate := range staleMergingQueueIssues(out, o.cfg, state, now) {
 		issueID := strings.TrimSpace(candidate.ID)
-		if gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
-			o.reconcileReviewThreadGatedNativeMergeQueue(ctx, state, out, candidate, queue, now)
-			continue
-		}
 		if !nativeMergeQueueCandidate(candidate, o.cfg) || staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
@@ -113,6 +112,31 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			Event:   "merge_worker_native_queue_enqueued",
 			Message: "enqueued " + issueLabel(candidate) + " in the native merge queue",
 		})
+	}
+	return out
+}
+
+func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueueIssues(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) []connector.Issue {
+	out := cloneIssues(issues)
+	if state == nil {
+		return out
+	}
+	state.nativeMergeQueueDeferred = map[string]struct{}{}
+	if !gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
+		return out
+	}
+	queue, ok := o.connector.(connector.PullRequestMergeQueue)
+	if !ok {
+		return out
+	}
+	pruneNativeMergeQueueEntries(state, out)
+	for _, issue := range staleMergingQueueIssues(out, o.cfg, state, now) {
+		o.reconcileReviewThreadGatedNativeMergeQueue(ctx, state, out, issue, queue, now)
 	}
 	return out
 }

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -46,6 +46,10 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 
 	for _, candidate := range staleMergingQueueIssues(out, o.cfg, state, now) {
 		issueID := strings.TrimSpace(candidate.ID)
+		if gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
+			o.reconcileReviewThreadGatedNativeMergeQueue(ctx, state, out, candidate, queue, now)
+			continue
+		}
 		if !nativeMergeQueueCandidate(candidate, o.cfg) || staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
@@ -111,6 +115,44 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 		})
 	}
 	return out
+}
+
+func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueue(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	issue connector.Issue,
+	queue connector.PullRequestMergeQueue,
+	now time.Time,
+) {
+	issueID := strings.TrimSpace(issue.ID)
+	status, err := queue.InspectPullRequestMergeQueue(ctx, issue)
+	if err != nil {
+		state.nativeMergeQueueDeferred[issueID] = struct{}{}
+		o.logNativeMergeQueueFailure(issue, "inspection_failed", err)
+		return
+	}
+	if status.Entry == nil {
+		delete(state.nativeMergeQueueEntries, issueID)
+		clearNativeMergeQueueEntry(issues, issueID)
+		return
+	}
+	entry := *status.Entry
+	if err := queue.DequeuePullRequest(ctx, entry); err != nil {
+		state.nativeMergeQueueDeferred[issueID] = struct{}{}
+		cacheNativeMergeQueueEntry(state, issueID, entry, now)
+		applyNativeMergeQueueEntry(issues, issueID, entry)
+		o.logNativeMergeQueueFailure(issue, "dequeue_failed", err)
+		return
+	}
+	delete(state.nativeMergeQueueEntries, issueID)
+	clearNativeMergeQueueEntry(issues, issueID)
+	o.logNativeMergeQueueDequeued(issue, entry)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "merge_worker_native_queue_dequeued",
+		Message: "dequeued " + issueLabel(issue) + " from the native merge queue",
+	})
 }
 
 func nativeMergeQueueCandidate(issue connector.Issue, cfg Config) bool {
@@ -236,6 +278,16 @@ func (o *Orchestrator) logNativeMergeQueueDelegated(issue connector.Issue, entry
 		"queue_position", entry.Position,
 		"queue_depth", entry.Depth,
 		"estimated_time_to_merge_seconds", entry.EstimatedTimeToMergeSeconds,
+	)...)
+}
+
+func (o *Orchestrator) logNativeMergeQueueDequeued(issue connector.Issue, entry connector.PullRequestMergeQueueEntry) {
+	if o.logger == nil {
+		return
+	}
+	o.logger.Info("merge_worker_native_queue_dequeued", mergeWorkerLogAttrs(issue,
+		"queue_entry_id", entry.ID,
+		"queue_state", entry.State,
 	)...)
 }
 

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -15,6 +15,7 @@ import (
 const (
 	nativeMergeQueueEntryRefresh     = 2 * time.Minute
 	nativeMergeQueueRepositoryExpiry = 5 * time.Minute
+	nativeMergeQueueTerminalSweep    = 2 * time.Minute
 )
 
 type nativeMergeQueueEntry struct {
@@ -164,11 +165,14 @@ func (o *Orchestrator) fetchUnsafeNativeMergeQueueTerminalIssues(
 	now time.Time,
 	reserve githubBudgetReserveDecision,
 ) []connector.Issue {
-	if state == nil || !state.nativeQueueSweepPending || !nativeMergeQueueCleanupRequired(o.cfg) {
+	if state == nil || !nativeMergeQueueCleanupRequired(o.cfg) {
+		return nil
+	}
+	if !state.nativeQueueSweepAt.IsZero() && now.Sub(state.nativeQueueSweepAt) < nativeMergeQueueTerminalSweep {
 		return nil
 	}
 	if _, ok := o.connector.(connector.PullRequestMergeQueue); !ok {
-		state.nativeQueueSweepPending = false
+		state.nativeQueueSweepAt = now
 		return nil
 	}
 	if reserve.degraded {
@@ -176,7 +180,7 @@ func (o *Orchestrator) fetchUnsafeNativeMergeQueueTerminalIssues(
 	}
 	states := displayStateNames(o.cfg.TerminalStates)
 	if len(states) == 0 {
-		state.nativeQueueSweepPending = false
+		state.nativeQueueSweepAt = now
 		return nil
 	}
 	issues, err := o.fetchObservedIssuesByStates(ctx, states)
@@ -187,7 +191,7 @@ func (o *Orchestrator) fetchUnsafeNativeMergeQueueTerminalIssues(
 		markRefreshError(state, "fetch unsafe native merge queue terminal issues failed: "+err.Error(), now)
 		return nil
 	}
-	state.nativeQueueSweepPending = false
+	state.nativeQueueSweepAt = now
 	return terminalIssues(issues, o.cfg.TerminalStates)
 }
 

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -120,12 +120,14 @@ func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueueIssues(
 	ctx context.Context,
 	state *State,
 	issues []connector.Issue,
+	previous []connector.Issue,
 	now time.Time,
 ) []connector.Issue {
-	out := cloneIssues(issues)
+	out := mergeIssueSlices(issues, previous)
 	if state == nil {
 		return out
 	}
+	previousDeferred := state.nativeMergeQueueDeferred
 	state.nativeMergeQueueDeferred = map[string]struct{}{}
 	if !gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
 		return out
@@ -134,11 +136,45 @@ func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueueIssues(
 	if !ok {
 		return out
 	}
-	pruneNativeMergeQueueEntries(state, out)
-	for _, issue := range staleMergingQueueIssues(out, o.cfg, state, now) {
+	previousMerging := make(map[string]struct{}, len(previous))
+	for _, issue := range previous {
+		if mergeWorkerIssue(issue) {
+			previousMerging[strings.TrimSpace(issue.ID)] = struct{}{}
+		}
+	}
+	for _, issue := range out {
+		if !reviewThreadGatedNativeMergeQueueCleanupCandidate(issue, state, previousMerging, previousDeferred) {
+			continue
+		}
 		o.reconcileReviewThreadGatedNativeMergeQueue(ctx, state, out, issue, queue, now)
 	}
+	pruneNativeMergeQueueEntries(state, out)
 	return out
+}
+
+func reviewThreadGatedNativeMergeQueueCleanupCandidate(
+	issue connector.Issue,
+	state *State,
+	previousMerging map[string]struct{},
+	previousDeferred map[string]struct{},
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return false
+	}
+	if mergeWorkerIssue(issue) {
+		return true
+	}
+	if _, ok := state.nativeMergeQueueEntries[issueID]; ok {
+		return true
+	}
+	if _, ok := previousMerging[issueID]; ok {
+		return true
+	}
+	if _, ok := previousDeferred[issueID]; ok {
+		return true
+	}
+	return issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil
 }
 
 func (o *Orchestrator) reconcileReviewThreadGatedNativeMergeQueue(
@@ -222,6 +258,9 @@ func pruneNativeMergeQueueEntries(state *State, issues []connector.Issue) {
 		}
 	}
 	for issueID := range state.nativeMergeQueueEntries {
+		if _, deferred := state.nativeMergeQueueDeferred[issueID]; deferred {
+			continue
+		}
 		if _, ok := active[issueID]; !ok {
 			delete(state.nativeMergeQueueEntries, issueID)
 		}

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"reflect"
 	"testing"
 	"time"
@@ -561,6 +563,57 @@ func TestTickReconcilesReviewThreadGatedNativeQueueBeforeStaleMerging(t *testing
 	}
 }
 
+func TestTickReconcilesReviewThreadGatedNativeQueueWithoutObservedStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 17, 0, 0, 0, time.UTC)
+	issue := nativeMergeQueueTestIssue(405, "success")
+	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-405", State: "QUEUED"}
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{
+				candidateIssuesSet: true,
+			},
+		},
+		statusErr: errors.New("status unavailable"),
+		entries:   map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
+	}
+	cfg := normalizeConfig(Config{
+		PollInterval:         time.Minute,
+		MergeFastPathEnabled: false,
+		MaxConcurrentAgents:  1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate:    gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Pipeline = []connector.Issue{issue}
+
+	orch.tick(t.Context(), &state, now)
+
+	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
+	}
+	if len(tracker.enqueued) != 0 {
+		t.Fatalf("enqueued issues = %#v, want none", tracker.enqueued)
+	}
+	if len(state.Pipeline) != 1 || state.Pipeline[0].ID != issue.ID {
+		t.Fatalf("pipeline = %#v, want prior issue %q retained", state.Pipeline, issue.ID)
+	}
+}
+
 func nativeMergeQueueTestConfig(cfg Config) Config {
 	cfg.AutoPromote.Gate.Kind = gate.KindArtifact
 	return normalizeConfig(cfg)
@@ -589,10 +642,18 @@ type nativeMergeQueueConnector struct {
 	available   *bool
 	inspectErr  error
 	dequeueErr  error
+	statusErr   error
 	inspections int
 	entries     map[string]connector.PullRequestMergeQueueEntry
 	enqueued    []string
 	dequeued    []connector.PullRequestMergeQueueEntry
+}
+
+func (c *nativeMergeQueueConnector) FetchIssuesByStates(ctx context.Context, states []string) ([]connector.Issue, error) {
+	if c.statusErr != nil {
+		return nil, c.statusErr
+	}
+	return c.autoPromoteTickConnector.FetchIssuesByStates(ctx, states)
 }
 
 func (c *nativeMergeQueueConnector) InspectPullRequestMergeQueue(_ context.Context, issue connector.Issue) (connector.PullRequestMergeQueueStatus, error) {

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -471,7 +471,7 @@ func TestReconcileReviewThreadGatedNativeMergeQueueIssues(t *testing.T) {
 			orch := &Orchestrator{cfg: cfg, connector: tracker}
 			state := newState(cfg)
 
-			queued := orch.reconcileReviewThreadGatedNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			queued := orch.reconcileReviewThreadGatedNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, nil, now)
 
 			if tracker.inspections != 1 || len(tracker.enqueued) != 0 {
 				t.Fatalf("native queue activity = %d inspections and %#v enqueues, want one inspection and no enqueue", tracker.inspections, tracker.enqueued)
@@ -611,6 +611,109 @@ func TestTickReconcilesReviewThreadGatedNativeQueueWithoutObservedStatus(t *test
 	}
 	if len(state.Pipeline) != 1 || state.Pipeline[0].ID != issue.ID {
 		t.Fatalf("pipeline = %#v, want prior issue %q retained", state.Pipeline, issue.ID)
+	}
+}
+
+func TestTickReconcilesReviewThreadGatedNativeQueueAfterLeavingMerging(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 17, 15, 0, 0, time.UTC)
+	previous := nativeMergeQueueTestIssue(406, "success")
+	current := cloneIssue(previous)
+	current.State = "Human Review"
+	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-406", State: "QUEUED"}
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{
+				stateIssues:        []connector.Issue{current},
+				candidateIssuesSet: true,
+			},
+		},
+		entries: map[string]connector.PullRequestMergeQueueEntry{previous.ID: entry},
+	}
+	cfg := normalizeConfig(Config{
+		PollInterval:         time.Minute,
+		MergeFastPathEnabled: false,
+		MaxConcurrentAgents:  1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		AutoPromote: AutoPromoteConfig{
+			Gate: gate.Config{Kind: gate.KindHumanReview},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Pipeline = []connector.Issue{previous}
+	cacheNativeMergeQueueEntry(&state, previous.ID, entry, now.Add(-time.Minute))
+
+	orch.tick(t.Context(), &state, now)
+
+	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
+	}
+	if len(state.Pipeline) != 1 || state.Pipeline[0].State != current.State {
+		t.Fatalf("pipeline = %#v, want current %q state retained", state.Pipeline, current.State)
+	}
+	if _, ok := state.nativeMergeQueueEntries[previous.ID]; ok {
+		t.Fatalf("nativeMergeQueueEntries[%q] remains after dequeue", previous.ID)
+	}
+}
+
+func TestReconcileReviewThreadGatedNativeQueueRetriesAfterLeavingMerging(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 17, 30, 0, 0, time.UTC)
+	previous := nativeMergeQueueTestIssue(407, "success")
+	current := cloneIssue(previous)
+	current.State = "Human Review"
+	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-407", State: "QUEUED"}
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{},
+		},
+		inspectErr: errors.New("inspect unavailable"),
+		entries:    map[string]connector.PullRequestMergeQueueEntry{previous.ID: entry},
+	}
+	cfg := normalizeConfig(Config{
+		AutoPromote:  AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
+		ActiveStates: []string{"Merging"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	orch.reconcileReviewThreadGatedNativeMergeQueueIssues(
+		t.Context(),
+		&state,
+		[]connector.Issue{current},
+		[]connector.Issue{previous},
+		now,
+	)
+	if _, ok := state.nativeMergeQueueDeferred[previous.ID]; !ok {
+		t.Fatalf("nativeMergeQueueDeferred[%q] missing after inspection failure", previous.ID)
+	}
+
+	tracker.inspectErr = nil
+	orch.reconcileReviewThreadGatedNativeMergeQueueIssues(
+		t.Context(),
+		&state,
+		[]connector.Issue{current},
+		nil,
+		now.Add(time.Minute),
+	)
+
+	if tracker.inspections != 2 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want two inspections and one dequeue", tracker.inspections, len(tracker.dequeued))
+	}
+	if _, ok := state.nativeMergeQueueDeferred[previous.ID]; ok {
+		t.Fatalf("nativeMergeQueueDeferred[%q] remains after successful retry", previous.ID)
 	}
 }
 

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -416,31 +417,78 @@ func TestNativeMergeQueueCandidateRejectsNonAtomicSecurityAuditGate(t *testing.T
 func TestDelegateNativeMergeQueueIssuesFallsBackForReviewThreadGate(t *testing.T) {
 	t.Parallel()
 
-	issue := nativeMergeQueueTestIssue(403, "success")
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{},
-		},
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	queueEntry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-403", State: "QUEUED"}
+	tests := []struct {
+		name           string
+		gateKind       string
+		entry          *connector.PullRequestMergeQueueEntry
+		inspectErr     error
+		dequeueErr     error
+		wantCandidates int
+		wantQueued     bool
+		wantDequeued   int
+	}{
+		{name: "dispatches when no native entry exists", wantCandidates: 1},
+		{name: "dequeues existing native entry before dispatch", entry: &queueEntry, wantCandidates: 1, wantDequeued: 1},
+		{name: "dequeues existing native entry for human review gate", gateKind: gate.KindHumanReview, entry: &queueEntry, wantCandidates: 1, wantDequeued: 1},
+		{name: "defers when queue inspection fails", inspectErr: errors.New("inspect unavailable")},
+		{name: "defers when dequeue fails", entry: &queueEntry, dequeueErr: errors.New("dequeue unavailable"), wantQueued: true, wantDequeued: 1},
 	}
-	cfg := normalizeConfig(Config{
-		MergeFastPathEnabled: true,
-		MaxConcurrentAgentsByState: map[string]int{
-			"Merging": 1,
-		},
-		AutoPromote:  AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
-		ActiveStates: []string{"Merging"},
-	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
-	state := newState(cfg)
 
-	queued := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, time.Now())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if tracker.inspections != 0 || len(tracker.enqueued) != 0 {
-		t.Fatalf("native queue activity = %d inspections and %#v enqueues, want none", tracker.inspections, tracker.enqueued)
-	}
-	candidates := orch.mergeWorkerDispatchCandidates(&state, queued, time.Now())
-	if len(candidates) != 1 || candidates[0].ID != issue.ID {
-		t.Fatalf("merge worker candidates = %#v, want review-thread-gated issue %q", candidates, issue.ID)
+			issue := nativeMergeQueueTestIssue(403, "success")
+			gateKind := tt.gateKind
+			if gateKind == "" {
+				gateKind = gate.KindCommand
+			}
+			if gateKind == gate.KindHumanReview {
+				issue.Labels = append(issue.Labels, gate.DefaultApprovalLabel)
+			}
+			tracker := &nativeMergeQueueConnector{
+				autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+					autoPromoteTickConnector: &autoPromoteTickConnector{},
+				},
+				inspectErr: tt.inspectErr,
+				dequeueErr: tt.dequeueErr,
+			}
+			if tt.entry != nil {
+				tracker.entries = map[string]connector.PullRequestMergeQueueEntry{issue.ID: *tt.entry}
+			}
+			cfg := normalizeConfig(Config{
+				MergeFastPathEnabled: true,
+				MaxConcurrentAgentsByState: map[string]int{
+					"Merging": 1,
+				},
+				AutoPromote:  AutoPromoteConfig{Gate: gate.Config{Kind: gateKind}},
+				ActiveStates: []string{"Merging"},
+			})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+
+			queued := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+
+			if tracker.inspections != 1 || len(tracker.enqueued) != 0 {
+				t.Fatalf("native queue activity = %d inspections and %#v enqueues, want one inspection and no enqueue", tracker.inspections, tracker.enqueued)
+			}
+			if got := len(tracker.dequeued); got != tt.wantDequeued {
+				t.Fatalf("dequeue calls = %d, want %d", got, tt.wantDequeued)
+			}
+			queuedEntry := queued[0].PullRequest.MergeQueueEntry
+			if (queuedEntry != nil) != tt.wantQueued {
+				t.Fatalf("queued entry = %#v, want present %t", queuedEntry, tt.wantQueued)
+			}
+			candidates := orch.mergeWorkerDispatchCandidates(&state, queued, now)
+			if len(candidates) != tt.wantCandidates {
+				t.Fatalf("merge worker candidates = %#v, want %d", candidates, tt.wantCandidates)
+			}
+			if tt.wantCandidates == 1 && candidates[0].ID != issue.ID {
+				t.Fatalf("merge worker candidate = %#v, want issue %q", candidates[0], issue.ID)
+			}
+		})
 	}
 }
 
@@ -470,13 +518,19 @@ func nativeMergeQueueTestIssue(number int, ciStatus string) connector.Issue {
 type nativeMergeQueueConnector struct {
 	*autoPromoteTickMergeConnector
 	available   *bool
+	inspectErr  error
+	dequeueErr  error
 	inspections int
 	entries     map[string]connector.PullRequestMergeQueueEntry
 	enqueued    []string
+	dequeued    []connector.PullRequestMergeQueueEntry
 }
 
 func (c *nativeMergeQueueConnector) InspectPullRequestMergeQueue(_ context.Context, issue connector.Issue) (connector.PullRequestMergeQueueStatus, error) {
 	c.inspections++
+	if c.inspectErr != nil {
+		return connector.PullRequestMergeQueueStatus{}, c.inspectErr
+	}
 	available := true
 	if c.available != nil {
 		available = *c.available
@@ -499,4 +553,9 @@ func (c *nativeMergeQueueConnector) EnqueuePullRequest(_ context.Context, issue 
 		EnqueuedAt:                  timePointer(time.Now()),
 		URL:                         "https://github.test/digitaldrywood/detent/queue/main",
 	}, nil
+}
+
+func (c *nativeMergeQueueConnector) DequeuePullRequest(_ context.Context, entry connector.PullRequestMergeQueueEntry) error {
+	c.dequeued = append(c.dequeued, entry)
+	return c.dequeueErr
 }

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -40,7 +40,7 @@ func TestDelegateNativeMergeQueueIssuesEnqueuesGreenTrainWithoutWorkerDispatch(t
 			autoPromoteTickConnector: &autoPromoteTickConnector{},
 		},
 	}
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		MergeFastPathEnabled: true,
 		MaxConcurrentAgents:  1,
 		MaxConcurrentAgentsByState: map[string]int{
@@ -88,7 +88,7 @@ func TestDelegateNativeMergeQueueIssuesHonorsAgedHeadReservation(t *testing.T) {
 	recent.PullRequest.URL = "https://github.test/digitaldrywood/pyroapex/pull/1749"
 	recentAt := now.Add(-time.Minute)
 	recent.StageUpdatedAt = &recentAt
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		MergeFastPathEnabled: true,
 		MaxConcurrentAgents:  1,
 		MaxConcurrentAgentsByState: map[string]int{
@@ -160,7 +160,7 @@ func TestTickDelegatesNativeMergeQueueTrainWithoutAgentDispatch(t *testing.T) {
 			},
 		},
 	}
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		PollInterval:         time.Minute,
 		MergeFastPathEnabled: true,
 		MaxConcurrentAgents:  1,
@@ -215,7 +215,7 @@ func TestDelegateNativeMergeQueueIssuesCachesQueueEntries(t *testing.T) {
 			autoPromoteTickConnector: &autoPromoteTickConnector{},
 		},
 	}
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		MergeFastPathEnabled: true,
 		ActiveStates:         []string{"Merging"},
 		TerminalStates:       []string{"Done"},
@@ -244,7 +244,7 @@ func TestDelegateNativeMergeQueueIssuesReenqueuesMissingCachedEntry(t *testing.T
 			autoPromoteTickConnector: &autoPromoteTickConnector{},
 		},
 	}
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		MergeFastPathEnabled: true,
 		ActiveStates:         []string{"Merging"},
 		TerminalStates:       []string{"Done"},
@@ -275,7 +275,7 @@ func TestDelegateNativeMergeQueueIssuesFallsBackWhenCachedQueueDisappears(t *tes
 		},
 		available: &available,
 	}
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		MergeFastPathEnabled: true,
 		MaxConcurrentAgentsByState: map[string]int{
 			"Merging": 1,
@@ -318,7 +318,7 @@ func TestDelegateNativeMergeQueueIssuesRecoversExistingEntriesAfterRestart(t *te
 			"issue-212": {ID: "MQE_212", State: "QUEUED", Position: 2, Depth: 2},
 		},
 	}
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		MergeFastPathEnabled: true,
 		ActiveStates:         []string{"Merging"},
 		TerminalStates:       []string{"Done"},
@@ -347,7 +347,7 @@ func TestDelegateNativeMergeQueueIssuesFallsBackWithoutNativeQueue(t *testing.T)
 		},
 		available: &available,
 	}
-	cfg := normalizeConfig(Config{
+	cfg := nativeMergeQueueTestConfig(Config{
 		MergeFastPathEnabled: true,
 		MaxConcurrentAgentsByState: map[string]int{
 			"Merging": 1,
@@ -393,7 +393,7 @@ func TestNativeMergeQueueCandidate(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(&issue)
 			}
-			if got := nativeMergeQueueCandidate(issue, normalizeConfig(Config{})); got != tt.want {
+			if got := nativeMergeQueueCandidate(issue, nativeMergeQueueTestConfig(Config{})); got != tt.want {
 				t.Fatalf("nativeMergeQueueCandidate() = %t, want %t", got, tt.want)
 			}
 		})
@@ -405,11 +405,48 @@ func TestNativeMergeQueueCandidateRejectsNonAtomicSecurityAuditGate(t *testing.T
 
 	issue := nativeMergeQueueTestIssue(402, "success")
 	cfg := normalizeConfig(Config{AutoPromote: AutoPromoteConfig{Gate: gate.Config{
+		Kind:          gate.KindArtifact,
 		SecurityAudit: gate.SecurityAuditConfig{Enabled: true},
 	}}})
 	if nativeMergeQueueCandidate(issue, cfg) {
 		t.Fatal("nativeMergeQueueCandidate() = true, want programmatic exact-head merge")
 	}
+}
+
+func TestDelegateNativeMergeQueueIssuesFallsBackForReviewThreadGate(t *testing.T) {
+	t.Parallel()
+
+	issue := nativeMergeQueueTestIssue(403, "success")
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{},
+		},
+	}
+	cfg := normalizeConfig(Config{
+		MergeFastPathEnabled: true,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		AutoPromote:  AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
+		ActiveStates: []string{"Merging"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	queued := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, time.Now())
+
+	if tracker.inspections != 0 || len(tracker.enqueued) != 0 {
+		t.Fatalf("native queue activity = %d inspections and %#v enqueues, want none", tracker.inspections, tracker.enqueued)
+	}
+	candidates := orch.mergeWorkerDispatchCandidates(&state, queued, time.Now())
+	if len(candidates) != 1 || candidates[0].ID != issue.ID {
+		t.Fatalf("merge worker candidates = %#v, want review-thread-gated issue %q", candidates, issue.ID)
+	}
+}
+
+func nativeMergeQueueTestConfig(cfg Config) Config {
+	cfg.AutoPromote.Gate.Kind = gate.KindArtifact
+	return normalizeConfig(cfg)
 }
 
 func nativeMergeQueueTestIssue(number int, ciStatus string) connector.Issue {

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -787,7 +787,7 @@ func TestReconcileNativeMergeQueueRecoversDepartedIssueAfterRestart(t *testing.T
 	}
 }
 
-func TestReconcileNativeMergeQueueCachesEmptyRecoveryInspection(t *testing.T) {
+func TestReconcileNativeMergeQueueRechecksEmptyRecoveryInspection(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 4, 18, 15, 0, 0, time.UTC)
@@ -816,11 +816,91 @@ func TestReconcileNativeMergeQueueCachesEmptyRecoveryInspection(t *testing.T) {
 		)
 	}
 
-	if tracker.inspections != 2 {
-		t.Fatalf("native queue inspections = %d, want 2", tracker.inspections)
+	if tracker.inspections != 3 {
+		t.Fatalf("native queue inspections = %d, want 3", tracker.inspections)
 	}
 	if len(tracker.dequeued) != 0 {
 		t.Fatalf("dequeued entries = %#v, want none", tracker.dequeued)
+	}
+}
+
+func TestTickReconcilesUnsafeNativeQueueTerminalIssueAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 18, 30, 0, 0, time.UTC)
+	issue := nativeMergeQueueTestIssue(411, "success")
+	issue.State = "Cancelled"
+	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-411", State: "QUEUED"}
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{
+				stateIssues:        []connector.Issue{issue},
+				candidateIssuesSet: true,
+			},
+		},
+		entries: map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
+	}
+	cfg := normalizeConfig(Config{
+		PollInterval:         time.Minute,
+		MergeFastPathEnabled: true,
+		MaxConcurrentAgents:  1,
+		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
+		ActiveStates:         []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:       []string{"Merging"},
+		TerminalStates:       []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+
+	orch.tick(t.Context(), &state, now)
+
+	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
+	}
+	if state.nativeQueueSweepPending {
+		t.Fatal("nativeQueueSweepPending = true after successful terminal sweep")
+	}
+}
+
+func TestReconcileUnsafeNativeQueueRetriesTerminalIssueWithoutRefetch(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 18, 45, 0, 0, time.UTC)
+	issue := nativeMergeQueueTestIssue(412, "success")
+	issue.State = "Cancelled"
+	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-412", State: "QUEUED"}
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{},
+		},
+		inspectErr: errors.New("inspect unavailable"),
+		entries:    map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
+	}
+	cfg := normalizeConfig(Config{
+		MergeFastPathEnabled: true,
+		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
+		TerminalStates:       []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	orch.reconcileUnsafeNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, nil, now)
+	if _, ok := state.nativeQueueRetries[issue.ID]; !ok {
+		t.Fatalf("nativeQueueRetries[%q] missing after inspection failure", issue.ID)
+	}
+
+	tracker.inspectErr = nil
+	orch.reconcileUnsafeNativeMergeQueueIssues(t.Context(), &state, nil, nil, now.Add(time.Minute))
+
+	if tracker.inspections != 2 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want two inspections and one dequeue", tracker.inspections, len(tracker.dequeued))
+	}
+	if _, ok := state.nativeQueueRetries[issue.ID]; ok {
+		t.Fatalf("nativeQueueRetries[%q] remains after successful retry", issue.ID)
 	}
 }
 

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -414,7 +414,7 @@ func TestNativeMergeQueueCandidateRejectsNonAtomicSecurityAuditGate(t *testing.T
 	}
 }
 
-func TestDelegateNativeMergeQueueIssuesFallsBackForReviewThreadGate(t *testing.T) {
+func TestReconcileReviewThreadGatedNativeMergeQueueIssues(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
@@ -459,7 +459,7 @@ func TestDelegateNativeMergeQueueIssuesFallsBackForReviewThreadGate(t *testing.T
 				tracker.entries = map[string]connector.PullRequestMergeQueueEntry{issue.ID: *tt.entry}
 			}
 			cfg := normalizeConfig(Config{
-				MergeFastPathEnabled: true,
+				MergeFastPathEnabled: false,
 				MaxConcurrentAgentsByState: map[string]int{
 					"Merging": 1,
 				},
@@ -469,7 +469,7 @@ func TestDelegateNativeMergeQueueIssuesFallsBackForReviewThreadGate(t *testing.T
 			orch := &Orchestrator{cfg: cfg, connector: tracker}
 			state := newState(cfg)
 
-			queued := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			queued := orch.reconcileReviewThreadGatedNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
 
 			if tracker.inspections != 1 || len(tracker.enqueued) != 0 {
 				t.Fatalf("native queue activity = %d inspections and %#v enqueues, want one inspection and no enqueue", tracker.inspections, tracker.enqueued)
@@ -487,6 +487,75 @@ func TestDelegateNativeMergeQueueIssuesFallsBackForReviewThreadGate(t *testing.T
 			}
 			if tt.wantCandidates == 1 && candidates[0].ID != issue.ID {
 				t.Fatalf("merge worker candidate = %#v, want issue %q", candidates[0], issue.ID)
+			}
+		})
+	}
+}
+
+func TestTickReconcilesReviewThreadGatedNativeQueueBeforeStaleMerging(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 16, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		dequeueErr  error
+		wantUpdates []autoPromoteTickUpdate
+	}{
+		{
+			name:        "dequeues before approval revocation transition",
+			wantUpdates: []autoPromoteTickUpdate{{issueID: "issue-404", state: "Human Review"}},
+		},
+		{
+			name:       "defers approval revocation when dequeue fails",
+			dequeueErr: errors.New("dequeue unavailable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := nativeMergeQueueTestIssue(404, "success")
+			entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-404", State: "QUEUED"}
+			tracker := &nativeMergeQueueConnector{
+				autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+					autoPromoteTickConnector: &autoPromoteTickConnector{
+						stateIssues:        []connector.Issue{issue},
+						candidateIssuesSet: true,
+					},
+				},
+				dequeueErr: tt.dequeueErr,
+				entries:    map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
+			}
+			cfg := normalizeConfig(Config{
+				PollInterval:         time.Minute,
+				MergeFastPathEnabled: false,
+				MaxConcurrentAgents:  1,
+				MaxConcurrentAgentsByState: map[string]int{
+					"Merging": 1,
+				},
+				AutoPromote: AutoPromoteConfig{
+					Enabled: true,
+					Gate:    gate.Config{Kind: gate.KindHumanReview},
+				},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates: []string{"Merging"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+
+			orch.tick(t.Context(), &state, now)
+
+			if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
+				t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
+			}
+			if !reflect.DeepEqual(tracker.updates, tt.wantUpdates) {
+				t.Fatalf("updates = %#v, want %#v", tracker.updates, tt.wantUpdates)
+			}
+			_, deferred := state.nativeMergeQueueDeferred[issue.ID]
+			if deferred != (tt.dequeueErr != nil) {
+				t.Fatalf("nativeMergeQueueDeferred[%q] present = %t, want %t", issue.ID, deferred, tt.dequeueErr != nil)
 			}
 		})
 	}

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -861,8 +861,53 @@ func TestTickReconcilesUnsafeNativeQueueTerminalIssueAfterRestart(t *testing.T) 
 	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
 		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
 	}
-	if state.nativeQueueSweepPending {
-		t.Fatal("nativeQueueSweepPending = true after successful terminal sweep")
+	if state.nativeQueueSweepAt != now {
+		t.Fatalf("nativeQueueSweepAt = %s, want %s", state.nativeQueueSweepAt, now)
+	}
+}
+
+func TestTickPeriodicallyReconcilesUnsafeNativeQueueTerminalIssues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 18, 40, 0, 0, time.UTC)
+	issue := nativeMergeQueueTestIssue(413, "success")
+	issue.State = "Done"
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{
+				stateIssues:        []connector.Issue{issue},
+				candidateIssuesSet: true,
+			},
+		},
+	}
+	cfg := normalizeConfig(Config{
+		PollInterval:         time.Minute,
+		MergeFastPathEnabled: true,
+		MaxConcurrentAgents:  1,
+		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
+		ActiveStates:         []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:       []string{"Merging"},
+		TerminalStates:       []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+
+	orch.tick(t.Context(), &state, now)
+	tracker.entries = map[string]connector.PullRequestMergeQueueEntry{
+		issue.ID: {ID: "MQE_issue-413", State: "QUEUED"},
+	}
+	orch.tick(t.Context(), &state, now.Add(time.Minute))
+	orch.tick(t.Context(), &state, now.Add(nativeMergeQueueTerminalSweep))
+
+	if tracker.inspections != 2 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want two inspections and one dequeue", tracker.inspections, len(tracker.dequeued))
+	}
+	if state.nativeQueueSweepAt != now.Add(nativeMergeQueueTerminalSweep) {
+		t.Fatalf("nativeQueueSweepAt = %s, want %s", state.nativeQueueSweepAt, now.Add(nativeMergeQueueTerminalSweep))
 	}
 }
 

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -416,7 +416,7 @@ func TestNativeMergeQueueCandidateRejectsNonAtomicSecurityAuditGate(t *testing.T
 	}
 }
 
-func TestReconcileReviewThreadGatedNativeMergeQueueIssues(t *testing.T) {
+func TestReconcileUnsafeNativeMergeQueueIssues(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
@@ -471,7 +471,7 @@ func TestReconcileReviewThreadGatedNativeMergeQueueIssues(t *testing.T) {
 			orch := &Orchestrator{cfg: cfg, connector: tracker}
 			state := newState(cfg)
 
-			queued := orch.reconcileReviewThreadGatedNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, nil, now)
+			queued := orch.reconcileUnsafeNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, nil, now)
 
 			if tracker.inspections != 1 || len(tracker.enqueued) != 0 {
 				t.Fatalf("native queue activity = %d inspections and %#v enqueues, want one inspection and no enqueue", tracker.inspections, tracker.enqueued)
@@ -494,7 +494,7 @@ func TestReconcileReviewThreadGatedNativeMergeQueueIssues(t *testing.T) {
 	}
 }
 
-func TestTickReconcilesReviewThreadGatedNativeQueueBeforeStaleMerging(t *testing.T) {
+func TestTickReconcilesUnsafeNativeQueueBeforeStaleMerging(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 4, 16, 0, 0, 0, time.UTC)
@@ -563,7 +563,7 @@ func TestTickReconcilesReviewThreadGatedNativeQueueBeforeStaleMerging(t *testing
 	}
 }
 
-func TestTickReconcilesReviewThreadGatedNativeQueueWithoutObservedStatus(t *testing.T) {
+func TestTickReconcilesUnsafeNativeQueueWithoutObservedStatus(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 4, 17, 0, 0, 0, time.UTC)
@@ -614,7 +614,7 @@ func TestTickReconcilesReviewThreadGatedNativeQueueWithoutObservedStatus(t *test
 	}
 }
 
-func TestTickReconcilesReviewThreadGatedNativeQueueAfterLeavingMerging(t *testing.T) {
+func TestTickReconcilesUnsafeNativeQueueAfterLeavingMerging(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 4, 17, 15, 0, 0, time.UTC)
@@ -667,7 +667,7 @@ func TestTickReconcilesReviewThreadGatedNativeQueueAfterLeavingMerging(t *testin
 	}
 }
 
-func TestReconcileReviewThreadGatedNativeQueueRetriesAfterLeavingMerging(t *testing.T) {
+func TestReconcileUnsafeNativeQueueRetriesAfterLeavingMerging(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 4, 17, 30, 0, 0, time.UTC)
@@ -689,7 +689,7 @@ func TestReconcileReviewThreadGatedNativeQueueRetriesAfterLeavingMerging(t *test
 	orch := &Orchestrator{cfg: cfg, connector: tracker}
 	state := newState(cfg)
 
-	orch.reconcileReviewThreadGatedNativeMergeQueueIssues(
+	orch.reconcileUnsafeNativeMergeQueueIssues(
 		t.Context(),
 		&state,
 		[]connector.Issue{current},
@@ -701,7 +701,7 @@ func TestReconcileReviewThreadGatedNativeQueueRetriesAfterLeavingMerging(t *test
 	}
 
 	tracker.inspectErr = nil
-	orch.reconcileReviewThreadGatedNativeMergeQueueIssues(
+	orch.reconcileUnsafeNativeMergeQueueIssues(
 		t.Context(),
 		&state,
 		[]connector.Issue{current},
@@ -714,6 +714,113 @@ func TestReconcileReviewThreadGatedNativeQueueRetriesAfterLeavingMerging(t *test
 	}
 	if _, ok := state.nativeMergeQueueDeferred[previous.ID]; ok {
 		t.Fatalf("nativeMergeQueueDeferred[%q] remains after successful retry", previous.ID)
+	}
+}
+
+func TestReconcileNativeMergeQueueAfterSecurityAuditEnabled(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 17, 45, 0, 0, time.UTC)
+	issue := nativeMergeQueueTestIssue(408, "success")
+	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-408", State: "QUEUED"}
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{},
+		},
+		entries: map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
+	}
+	cfg := normalizeConfig(Config{
+		MergeFastPathEnabled: true,
+		AutoPromote: AutoPromoteConfig{Gate: gate.Config{
+			Kind:          gate.KindArtifact,
+			SecurityAudit: gate.SecurityAuditConfig{Enabled: true},
+		}},
+		ActiveStates: []string{"Merging"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	orch.reconcileUnsafeNativeMergeQueueIssues(
+		t.Context(),
+		&state,
+		[]connector.Issue{issue},
+		nil,
+		now,
+	)
+
+	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
+	}
+}
+
+func TestReconcileNativeMergeQueueRecoversDepartedIssueAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 18, 0, 0, 0, time.UTC)
+	issue := nativeMergeQueueTestIssue(409, "success")
+	issue.State = "Rework"
+	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-409", State: "QUEUED"}
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{},
+		},
+		entries: map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
+	}
+	cfg := normalizeConfig(Config{
+		MergeFastPathEnabled: true,
+		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
+		ActiveStates:         []string{"Rework", "Merging"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	orch.reconcileUnsafeNativeMergeQueueIssues(
+		t.Context(),
+		&state,
+		[]connector.Issue{issue},
+		nil,
+		now,
+	)
+
+	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
+		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
+	}
+}
+
+func TestReconcileNativeMergeQueueCachesEmptyRecoveryInspection(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 18, 15, 0, 0, time.UTC)
+	issue := nativeMergeQueueTestIssue(410, "success")
+	issue.State = "Human Review"
+	tracker := &nativeMergeQueueConnector{
+		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
+			autoPromoteTickConnector: &autoPromoteTickConnector{},
+		},
+	}
+	cfg := normalizeConfig(Config{
+		MergeFastPathEnabled: true,
+		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindHumanReview}},
+		ActiveStates:         []string{"Merging"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	for _, checkedAt := range []time.Time{now, now.Add(time.Minute), now.Add(nativeMergeQueueEntryRefresh)} {
+		orch.reconcileUnsafeNativeMergeQueueIssues(
+			t.Context(),
+			&state,
+			[]connector.Issue{issue},
+			nil,
+			checkedAt,
+		)
+	}
+
+	if tracker.inspections != 2 {
+		t.Fatalf("native queue inspections = %d, want 2", tracker.inspections)
+	}
+	if len(tracker.dequeued) != 0 {
+		t.Fatalf("dequeued entries = %#v, want none", tracker.dequeued)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1202,6 +1202,9 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 		o.ownershipStartupLogged = false
 	}
 	o.cfg = cfg
+	if nativeMergeQueueCleanupRequired(cfg) {
+		state.nativeQueueSweepPending = true
+	}
 	now := time.Now
 	if o.now != nil {
 		now = o.now

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1203,7 +1203,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	}
 	o.cfg = cfg
 	if nativeMergeQueueCleanupRequired(cfg) {
-		state.nativeQueueSweepPending = true
+		state.nativeQueueSweepAt = time.Time{}
 	}
 	now := time.Now
 	if o.now != nil {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1632,6 +1632,27 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		o.reworkMergeWorkerResult(ctx, state, event, running, issue, reason, nil, "")
 		return true
 	}
+	if gateRequiresPullRequest(o.cfg.AutoPromote.Gate) {
+		var hydrated bool
+		issue, hydrated = o.hydrateAutoPromoteReviewThreads(ctx, issue)
+		if !hydrated {
+			o.waitForMergeWorkerPullRequestHydration(ctx, state, event, running, issue)
+			return true
+		}
+		if issue.PullRequest != nil && len(issue.PullRequest.UnresolvedReviewThreads) > 0 {
+			o.reworkMergeWorkerResult(
+				ctx,
+				state,
+				event,
+				running,
+				issue,
+				string(AutoPromoteReasonUnresolvedReviewThreads),
+				nil,
+				"",
+			)
+			return true
+		}
+	}
 	merger, ok := o.connector.(connector.PullRequestMerger)
 	if !ok {
 		return false
@@ -2369,6 +2390,14 @@ func mergeWorkerReworkComment(issue connector.Issue, reason string, missingCheck
 		b.WriteString("\n```")
 	}
 	if issue.PullRequest != nil {
+		if reason == string(AutoPromoteReasonUnresolvedReviewThreads) && len(issue.PullRequest.UnresolvedReviewThreads) > 0 {
+			b.WriteString("\n- unresolved_review_threads: ")
+			b.WriteString(strconv.Itoa(len(issue.PullRequest.UnresolvedReviewThreads)))
+			if location := pullRequestReviewThreadLocation(issue.PullRequest.UnresolvedReviewThreads[0]); location != "" {
+				b.WriteString("\n- first_unresolved_review_thread: ")
+				b.WriteString(location)
+			}
+		}
 		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
 			b.WriteString("\n- pull request: ")
 			b.WriteString(url)
@@ -2382,7 +2411,11 @@ func mergeWorkerReworkComment(issue connector.Issue, reason string, missingCheck
 			b.WriteString(mergeableState)
 		}
 	}
-	b.WriteString("\n\nRefresh or re-push the current PR head so required checks run, then complete the normal Rework gate.")
+	if reason == string(AutoPromoteReasonUnresolvedReviewThreads) {
+		b.WriteString("\n\nResolve the outstanding review threads, then complete the normal Rework gate.")
+	} else {
+		b.WriteString("\n\nRefresh or re-push the current PR head so required checks run, then complete the normal Rework gate.")
+	}
 	return b.String()
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -86,7 +86,8 @@ type State struct {
 	nativeMergeQueueEntries  map[string]nativeMergeQueueEntry
 	nativeMergeQueueRepos    map[string]nativeMergeQueueRepository
 	nativeMergeQueueDeferred map[string]struct{}
-	nativeMergeQueueChecks   map[string]time.Time
+	nativeQueueRetries       map[string]connector.Issue
+	nativeQueueSweepPending  bool
 	TransientCheckRetries    map[string]TransientCheckRetry
 	DependencyAutoUnblocks   map[string]DependencyAutoUnblockRecord
 	BudgetRefusals           map[string]BudgetRefusal
@@ -396,7 +397,8 @@ func newState(cfg Config) State {
 		nativeMergeQueueEntries:  map[string]nativeMergeQueueEntry{},
 		nativeMergeQueueRepos:    map[string]nativeMergeQueueRepository{},
 		nativeMergeQueueDeferred: map[string]struct{}{},
-		nativeMergeQueueChecks:   map[string]time.Time{},
+		nativeQueueRetries:       map[string]connector.Issue{},
+		nativeQueueSweepPending:  true,
 		TransientCheckRetries:    map[string]TransientCheckRetry{},
 		DependencyAutoUnblocks:   map[string]DependencyAutoUnblockRecord{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
@@ -485,7 +487,8 @@ func (s State) clone() State {
 		nativeMergeQueueEntries:  cloneNativeMergeQueueEntries(s.nativeMergeQueueEntries),
 		nativeMergeQueueRepos:    maps.Clone(s.nativeMergeQueueRepos),
 		nativeMergeQueueDeferred: maps.Clone(s.nativeMergeQueueDeferred),
-		nativeMergeQueueChecks:   maps.Clone(s.nativeMergeQueueChecks),
+		nativeQueueRetries:       cloneIssueMap(s.nativeQueueRetries),
+		nativeQueueSweepPending:  s.nativeQueueSweepPending,
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		DependencyAutoUnblocks:   maps.Clone(s.DependencyAutoUnblocks),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -87,7 +87,7 @@ type State struct {
 	nativeMergeQueueRepos    map[string]nativeMergeQueueRepository
 	nativeMergeQueueDeferred map[string]struct{}
 	nativeQueueRetries       map[string]connector.Issue
-	nativeQueueSweepPending  bool
+	nativeQueueSweepAt       time.Time
 	TransientCheckRetries    map[string]TransientCheckRetry
 	DependencyAutoUnblocks   map[string]DependencyAutoUnblockRecord
 	BudgetRefusals           map[string]BudgetRefusal
@@ -398,7 +398,6 @@ func newState(cfg Config) State {
 		nativeMergeQueueRepos:    map[string]nativeMergeQueueRepository{},
 		nativeMergeQueueDeferred: map[string]struct{}{},
 		nativeQueueRetries:       map[string]connector.Issue{},
-		nativeQueueSweepPending:  true,
 		TransientCheckRetries:    map[string]TransientCheckRetry{},
 		DependencyAutoUnblocks:   map[string]DependencyAutoUnblockRecord{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
@@ -488,7 +487,7 @@ func (s State) clone() State {
 		nativeMergeQueueRepos:    maps.Clone(s.nativeMergeQueueRepos),
 		nativeMergeQueueDeferred: maps.Clone(s.nativeMergeQueueDeferred),
 		nativeQueueRetries:       cloneIssueMap(s.nativeQueueRetries),
-		nativeQueueSweepPending:  s.nativeQueueSweepPending,
+		nativeQueueSweepAt:       s.nativeQueueSweepAt,
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		DependencyAutoUnblocks:   maps.Clone(s.DependencyAutoUnblocks),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -86,6 +86,7 @@ type State struct {
 	nativeMergeQueueEntries  map[string]nativeMergeQueueEntry
 	nativeMergeQueueRepos    map[string]nativeMergeQueueRepository
 	nativeMergeQueueDeferred map[string]struct{}
+	nativeMergeQueueChecks   map[string]time.Time
 	TransientCheckRetries    map[string]TransientCheckRetry
 	DependencyAutoUnblocks   map[string]DependencyAutoUnblockRecord
 	BudgetRefusals           map[string]BudgetRefusal
@@ -395,6 +396,7 @@ func newState(cfg Config) State {
 		nativeMergeQueueEntries:  map[string]nativeMergeQueueEntry{},
 		nativeMergeQueueRepos:    map[string]nativeMergeQueueRepository{},
 		nativeMergeQueueDeferred: map[string]struct{}{},
+		nativeMergeQueueChecks:   map[string]time.Time{},
 		TransientCheckRetries:    map[string]TransientCheckRetry{},
 		DependencyAutoUnblocks:   map[string]DependencyAutoUnblockRecord{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
@@ -483,6 +485,7 @@ func (s State) clone() State {
 		nativeMergeQueueEntries:  cloneNativeMergeQueueEntries(s.nativeMergeQueueEntries),
 		nativeMergeQueueRepos:    maps.Clone(s.nativeMergeQueueRepos),
 		nativeMergeQueueDeferred: maps.Clone(s.nativeMergeQueueDeferred),
+		nativeMergeQueueChecks:   maps.Clone(s.nativeMergeQueueChecks),
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		DependencyAutoUnblocks:   maps.Clone(s.DependencyAutoUnblocks),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -730,6 +730,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		pullRequest.StaleSuccessfulChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.StaleSuccessfulChecks...)
 		pullRequest.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), issue.PullRequest.RequiredCheckFailures...)
 		pullRequest.TransientFailedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.TransientFailedChecks...)
+		pullRequest.UnresolvedReviewThreads = append([]connector.PullRequestReviewThread(nil), issue.PullRequest.UnresolvedReviewThreads...)
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		pullRequest.Labels = cloneStringSlice(issue.PullRequest.Labels)
 		cloned.PullRequest = &pullRequest

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -156,7 +156,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched,
 		o.reconcileClosedCompletedIssueStatuses(ctx, state, transitions.issues, now),
 	)
-	reviewThreadQueueIssues := o.reconcileReviewThreadGatedNativeMergeQueueIssues(
+	reviewThreadQueueIssues := o.reconcileUnsafeNativeMergeQueueIssues(
 		ctx,
 		state,
 		mergeIssueSlices(fetched.status, fetched.candidates),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -188,6 +188,15 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			fetched,
 			autoPromoted.transitioned,
 		)
+		reviewThreadQueueIssues := o.reconcileReviewThreadGatedNativeMergeQueueIssues(
+			ctx,
+			state,
+			mergeIssueSlices(fetched.status, fetched.candidates),
+			now,
+		)
+		fetched.status = overlayNativeMergeQueueIssues(fetched.status, reviewThreadQueueIssues)
+		fetched.candidates = overlayNativeMergeQueueIssues(fetched.candidates, reviewThreadQueueIssues)
+		state.Pipeline = overlayNativeMergeQueueIssues(state.Pipeline, reviewThreadQueueIssues)
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -159,10 +159,8 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	reviewThreadQueueIssues := o.reconcileReviewThreadGatedNativeMergeQueueIssues(
 		ctx,
 		state,
-		mergeIssueSlices(
-			mergeIssueSlices(fetched.status, fetched.candidates),
-			previous.pipeline,
-		),
+		mergeIssueSlices(fetched.status, fetched.candidates),
+		previous.pipeline,
 		now,
 	)
 	fetched.status = overlayNativeMergeQueueIssues(fetched.status, reviewThreadQueueIssues)

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -156,6 +156,18 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched,
 		o.reconcileClosedCompletedIssueStatuses(ctx, state, transitions.issues, now),
 	)
+	reviewThreadQueueIssues := o.reconcileReviewThreadGatedNativeMergeQueueIssues(
+		ctx,
+		state,
+		mergeIssueSlices(
+			mergeIssueSlices(fetched.status, fetched.candidates),
+			previous.pipeline,
+		),
+		now,
+	)
+	fetched.status = overlayNativeMergeQueueIssues(fetched.status, reviewThreadQueueIssues)
+	fetched.candidates = overlayNativeMergeQueueIssues(fetched.candidates, reviewThreadQueueIssues)
+	state.Pipeline = overlayNativeMergeQueueIssues(state.Pipeline, reviewThreadQueueIssues)
 	if fetched.statusOK {
 		fetched = filterReconciledTickIssues(
 			state,
@@ -188,15 +200,6 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			fetched,
 			autoPromoted.transitioned,
 		)
-		reviewThreadQueueIssues := o.reconcileReviewThreadGatedNativeMergeQueueIssues(
-			ctx,
-			state,
-			mergeIssueSlices(fetched.status, fetched.candidates),
-			now,
-		)
-		fetched.status = overlayNativeMergeQueueIssues(fetched.status, reviewThreadQueueIssues)
-		fetched.candidates = overlayNativeMergeQueueIssues(fetched.candidates, reviewThreadQueueIssues)
-		state.Pipeline = overlayNativeMergeQueueIssues(state.Pipeline, reviewThreadQueueIssues)
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -131,6 +131,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	if !ok {
 		return
 	}
+	nativeQueueTerminalIssues := o.fetchUnsafeNativeMergeQueueTerminalIssues(ctx, state, now, reserve)
 	timing.next("reconciliation")
 	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
 	fetched = applyStatusPullRequestHydrationBlocksToCandidates(fetched)
@@ -159,7 +160,10 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	reviewThreadQueueIssues := o.reconcileUnsafeNativeMergeQueueIssues(
 		ctx,
 		state,
-		mergeIssueSlices(fetched.status, fetched.candidates),
+		mergeIssueSlices(
+			mergeIssueSlices(fetched.status, fetched.candidates),
+			nativeQueueTerminalIssues,
+		),
 		previous.pipeline,
 		now,
 	)


### PR DESCRIPTION
## Summary

- hydrate unresolved GitHub review threads from the exact PR head on every gate evaluation, including paginated and outdated threads
- route Human Review, completed-active, and stale Todo issues to Rework with the thread count and first path:line
- fail closed when thread hydration is unavailable, park same-state Rework completions, and recheck immediately before programmatic merge
- keep PR-review gates off the non-atomic native merge queue; clean up legacy entries before stale-Merging reconciliation even when fast-path delegation is disabled
- preserve the breaker-adjusted target in completed snapshots when Rework is redirected to Blocked

Fixes #2103

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] Linux `make check` with Go 1.26.6 and golangci-lint v2.9.0
- [x] focused review-thread, queue-recovery, and breaker-state tests
- [x] full `go test ./internal/orchestrator -count=1`
- [x] runner deadlock-guard regression passes 10/10 under `-race`; unrelated full-suite flake tracked in #2151