### PR TITLE
fix: back off GitHub lookups during outages

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -263,6 +263,7 @@ type options struct {
 	shutdown          *ShutdownController
 	restart           *RestartRequest
 	service           ServiceFactory
+	serviceInjected   bool
 	startupRecovery   StartupRecoveryFactory
 }
 
@@ -338,6 +339,7 @@ func WithServiceFactory(factory ServiceFactory) Option {
 	return func(opts *options) {
 		if factory != nil {
 			opts.service = factory
+			opts.serviceInjected = true
 		}
 	}
 }

--- a/internal/cli/dashboard_client.go
+++ b/internal/cli/dashboard_client.go
@@ -121,10 +121,7 @@ func newDashboardReadClient(
 	if err != nil {
 		return nil, fmt.Errorf("resolve dashboard API URL: %w", err)
 	}
-	credential := strings.TrimSpace(opts.lookupEnv("DETENT_API_TOKEN"))
-	if credential == "" {
-		credential = strings.TrimSpace(boot.Global.APIToken)
-	}
+	credential := dashboardAPICredential(boot.Global.APIToken, opts.lookupEnv)
 	if opts.httpDo == nil {
 		return nil, errors.New("dashboard API HTTP client is not configured")
 	}
@@ -135,6 +132,17 @@ func newDashboardReadClient(
 		http:       dashboardHTTPClientFunc(opts.httpDo),
 		timeout:    dashboardReadTimeout,
 	}, nil
+}
+
+func dashboardAPICredential(configured string, lookupEnv func(string) string) string {
+	credential := ""
+	if lookupEnv != nil {
+		credential = strings.TrimSpace(lookupEnv("DETENT_API_TOKEN"))
+	}
+	if credential == "" {
+		credential = strings.TrimSpace(configured)
+	}
+	return credential
 }
 
 func (c *DashboardReadClient) ExplainIssue(ctx context.Context, projectID string, reference string) (explain.IssueExplanation, error) {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -39,6 +39,7 @@ type ServiceFactory func(servicepkg.Config) (ServiceRunner, error)
 type statusServiceRunner struct {
 	ServiceRunner
 	fallbackURL string
+	credential  string
 	httpDo      func(*http.Request) (*http.Response, error)
 }
 
@@ -183,6 +184,7 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 	}
 	factory := opts.service
 	statusHTTPDo := opts.httpDo
+	statusCredential := dashboardAPICredential(cfg.APIToken, opts.lookupEnv)
 	if factory == nil {
 		factory = defaultServiceFactory
 	} else {
@@ -204,7 +206,7 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 		return nil, err
 	}
 	if cmd.Name() == "status" {
-		return statusServiceRunner{ServiceRunner: runner, fallbackURL: dashboardURL, httpDo: statusHTTPDo}, nil
+		return statusServiceRunner{ServiceRunner: runner, fallbackURL: dashboardURL, credential: statusCredential, httpDo: statusHTTPDo}, nil
 	}
 	return runner, nil
 }
@@ -233,9 +235,10 @@ func (r statusServiceRunner) backendOutages(ctx context.Context, dashboardURL st
 		return nil
 	}
 	client := &DashboardReadClient{
-		baseURL: baseURL,
-		http:    dashboardHTTPClientFunc(r.httpDo),
-		timeout: serviceStatusSnapshotTimeout,
+		baseURL:    baseURL,
+		credential: r.credential,
+		http:       dashboardHTTPClientFunc(r.httpDo),
+		timeout:    serviceStatusSnapshotTimeout,
 	}
 	state, err := client.State(ctx, "")
 	if err != nil {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -187,7 +187,8 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 	statusCredential := dashboardAPICredential(cfg.APIToken, opts.lookupEnv)
 	if factory == nil {
 		factory = defaultServiceFactory
-	} else {
+	}
+	if opts.serviceInjected {
 		statusHTTPDo = nil
 	}
 	dashboardURL := "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(dashboardPort.Value))
@@ -217,8 +218,8 @@ func (r statusServiceRunner) Status(ctx context.Context) (servicepkg.Status, err
 		return servicepkg.Status{}, err
 	}
 	status.DashboardURL = r.fallbackURL
-	if port, ok := installedServicePort(status.ServiceManager, status.DefinitionPath); ok {
-		status.DashboardURL = "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(port))
+	if dashboardURL, ok := installedServiceDashboardURL(status.ServiceManager, status.DefinitionPath, status.DashboardURL); ok {
+		status.DashboardURL = dashboardURL
 	}
 	if status.Running() {
 		status.BackendOutages = r.backendOutages(ctx, status.DashboardURL)
@@ -255,13 +256,13 @@ func (r statusServiceRunner) backendOutages(ctx context.Context, dashboardURL st
 	return outages
 }
 
-func installedServicePort(manager servicepkg.ManagerName, path string) (int, bool) {
+func installedServiceDashboardURL(manager servicepkg.ManagerName, path string, fallbackURL string) (string, bool) {
 	if strings.TrimSpace(path) == "" {
-		return 0, false
+		return "", false
 	}
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return 0, false
+		return "", false
 	}
 	var arguments []string
 	switch manager {
@@ -270,17 +271,31 @@ func installedServicePort(manager servicepkg.ManagerName, path string) (int, boo
 	case servicepkg.ManagerLaunchd:
 		arguments = launchdDefinitionArguments(content)
 	default:
-		return 0, false
+		return "", false
 	}
-	for index, argument := range arguments {
-		if argument == "--port" && index+1 < len(arguments) {
-			return validServicePort(arguments[index+1])
-		}
-		if raw, ok := strings.CutPrefix(argument, "--port="); ok {
-			return validServicePort(raw)
-		}
+	parsed, err := url.Parse(strings.TrimSpace(fallbackURL))
+	if err != nil || parsed.Hostname() == "" {
+		return "", false
 	}
-	return 0, false
+	port, ok := validServicePort(parsed.Port())
+	if !ok {
+		return "", false
+	}
+	host := parsed.Hostname()
+	hostSet := false
+	if installedHost, ok := serviceStringFlag(arguments, "--host"); ok {
+		host = installedHost
+		hostSet = true
+	}
+	portSet := false
+	if installedPort, ok := serviceIntFlag(arguments, "--port"); ok {
+		port = installedPort
+		portSet = true
+	}
+	if !hostSet && !portSet {
+		return "", false
+	}
+	return "http://" + dashboardServerAddr(BootConfig{Host: host, Port: &port}), true
 }
 
 func runningServiceArguments(ctx context.Context, configPath string, opts options) []string {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -4,11 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,8 +23,11 @@ import (
 	"github.com/spf13/cobra"
 
 	servicepkg "github.com/digitaldrywood/detent/internal/service"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/update"
 )
+
+const serviceStatusSnapshotTimeout = 2 * time.Second
 
 type ServiceRunner interface {
 	Start(context.Context, servicepkg.StartOptions) (servicepkg.StartResult, error)
@@ -33,6 +39,7 @@ type ServiceFactory func(servicepkg.Config) (ServiceRunner, error)
 type statusServiceRunner struct {
 	ServiceRunner
 	fallbackURL string
+	httpDo      func(*http.Request) (*http.Response, error)
 }
 
 func defaultServiceFactory(cfg servicepkg.Config) (ServiceRunner, error) {
@@ -175,8 +182,11 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 		arguments = append(arguments[:len(arguments)-1], "--port", strconv.Itoa(resolvedPort.Value), "--headless")
 	}
 	factory := opts.service
+	statusHTTPDo := opts.httpDo
 	if factory == nil {
 		factory = defaultServiceFactory
+	} else {
+		statusHTTPDo = nil
 	}
 	dashboardURL := "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(dashboardPort.Value))
 	runner, err := factory(servicepkg.Config{
@@ -194,7 +204,7 @@ func serviceRunnerForCommand(cmd *cobra.Command, configPath *string, host *strin
 		return nil, err
 	}
 	if cmd.Name() == "status" {
-		return statusServiceRunner{ServiceRunner: runner, fallbackURL: dashboardURL}, nil
+		return statusServiceRunner{ServiceRunner: runner, fallbackURL: dashboardURL, httpDo: statusHTTPDo}, nil
 	}
 	return runner, nil
 }
@@ -208,7 +218,38 @@ func (r statusServiceRunner) Status(ctx context.Context) (servicepkg.Status, err
 	if port, ok := installedServicePort(status.ServiceManager, status.DefinitionPath); ok {
 		status.DashboardURL = "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(port))
 	}
+	if status.Running() {
+		status.BackendOutages = r.backendOutages(ctx, status.DashboardURL)
+	}
 	return status, nil
+}
+
+func (r statusServiceRunner) backendOutages(ctx context.Context, dashboardURL string) []telemetry.BackendOutage {
+	if r.httpDo == nil {
+		return nil
+	}
+	baseURL, err := url.Parse(strings.TrimSpace(dashboardURL))
+	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" {
+		return nil
+	}
+	client := &DashboardReadClient{
+		baseURL: baseURL,
+		http:    dashboardHTTPClientFunc(r.httpDo),
+		timeout: serviceStatusSnapshotTimeout,
+	}
+	state, err := client.State(ctx, "")
+	if err != nil {
+		return nil
+	}
+	raw, err := json.Marshal(state.field("backend_outages"))
+	if err != nil {
+		return nil
+	}
+	var outages []telemetry.BackendOutage
+	if err := json.Unmarshal(raw, &outages); err != nil {
+		return nil
+	}
+	return outages
 }
 
 func installedServicePort(manager servicepkg.ManagerName, path string) (int, bool) {
@@ -491,6 +532,22 @@ func writeServiceStatusText(out io.Writer, status servicepkg.Status) error {
 		"Dashboard: "+status.DashboardURL,
 		"Config: "+status.ConfigPath,
 	)
+	for _, outage := range status.BackendOutages {
+		if outage.Kind != "github_lookup_backoff" {
+			continue
+		}
+		nextProbeAt := outage.ResumeAt
+		if outage.NextProbeAt != nil {
+			nextProbeAt = *outage.NextProbeAt
+		}
+		lines = append(lines, fmt.Sprintf(
+			"GitHub lookup backoff: trigger=%s step=%d next probe=%s reason=%s",
+			outage.Trigger,
+			outage.ProbeAttempts,
+			nextProbeAt.Format(time.RFC3339),
+			outage.Reason,
+		))
+	}
 	if status.DefinitionPath != "" {
 		lines = append(lines, "Definition: "+status.DefinitionPath)
 	}

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -233,6 +233,9 @@ func TestStatusServiceRunnerReportsGitHubLookupBackoff(t *testing.T) {
 		if r.URL.Path != "/api/v1/state" {
 			t.Fatalf("request path = %q, want /api/v1/state", r.URL.Path)
 		}
+		if got := r.Header.Get("Authorization"); got != "Bearer operator-token" {
+			t.Fatalf("Authorization = %q, want bearer credential", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"backend_outages": []telemetry.BackendOutage{{
@@ -251,6 +254,7 @@ func TestStatusServiceRunnerReportsGitHubLookupBackoff(t *testing.T) {
 	runner := statusServiceRunner{
 		ServiceRunner: &serviceRunnerStub{status: servicepkg.Status{State: servicepkg.StateRunning}},
 		fallbackURL:   server.URL,
+		credential:    "operator-token",
 		httpDo:        server.Client().Do,
 	}
 	status, err := runner.Status(t.Context())

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -5,15 +5,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	servicepkg "github.com/digitaldrywood/detent/internal/service"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/update"
 )
 
@@ -218,6 +222,58 @@ func TestStatusCommandManualStoppedIsSuccessful(t *testing.T) {
 	}
 	if status.ServiceManager != servicepkg.ManagerManual || status.Expected {
 		t.Fatalf("status = %#v", status)
+	}
+}
+
+func TestStatusServiceRunnerReportsGitHubLookupBackoff(t *testing.T) {
+	t.Parallel()
+
+	nextProbeAt := time.Date(2026, 9, 3, 18, 30, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/state" {
+			t.Fatalf("request path = %q, want /api/v1/state", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"backend_outages": []telemetry.BackendOutage{{
+				BackendID:     "github-lookups",
+				Kind:          "github_lookup_backoff",
+				Trigger:       "github_graphql_rate_limit",
+				Reason:        "GitHub GraphQL returned a rate-limit response",
+				ResumeAt:      nextProbeAt,
+				NextProbeAt:   &nextProbeAt,
+				ProbeAttempts: 3,
+			}},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	runner := statusServiceRunner{
+		ServiceRunner: &serviceRunnerStub{status: servicepkg.Status{State: servicepkg.StateRunning}},
+		fallbackURL:   server.URL,
+		httpDo:        server.Client().Do,
+	}
+	status, err := runner.Status(t.Context())
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if len(status.BackendOutages) != 1 || status.BackendOutages[0].ProbeAttempts != 3 {
+		t.Fatalf("BackendOutages = %#v, want active lookup backoff", status.BackendOutages)
+	}
+
+	var output bytes.Buffer
+	if err := writeServiceStatusText(&output, status); err != nil {
+		t.Fatalf("writeServiceStatusText() error = %v", err)
+	}
+	for _, want := range []string{
+		"GitHub lookup backoff:",
+		"trigger=github_graphql_rate_limit",
+		"step=3",
+		"next probe=2026-09-03T18:30:00Z",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, output.String())
+		}
 	}
 }
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -281,6 +281,64 @@ func TestStatusServiceRunnerReportsGitHubLookupBackoff(t *testing.T) {
 	}
 }
 
+func TestServiceRunnerForCommandConfiguresStatusSnapshotHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		configure func(*options)
+		wantHTTP  bool
+	}{
+		{
+			name:     "built-in service factory",
+			wantHTTP: true,
+		},
+		{
+			name: "explicitly injected service factory",
+			configure: func(opts *options) {
+				WithServiceFactory(serviceFactoryFor(&serviceRunnerStub{}))(opts)
+			},
+			wantHTTP: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "global.yaml")
+			cfg, err := globalconfig.DefaultAt(path)
+			if err != nil {
+				t.Fatalf("DefaultAt() error = %v", err)
+			}
+			if err := globalconfig.Write(path, cfg); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+
+			opts := defaultOptions()
+			opts.lookupEnv = func(string) string { return "" }
+			if tt.configure != nil {
+				tt.configure(&opts)
+			}
+			host := ""
+			port := -1
+			cmd := newStatusCommand(&path, &host, &port, opts)
+			cmd.SetContext(t.Context())
+			runner, err := serviceRunnerForCommand(cmd, &path, &host, &port, opts)
+			if err != nil {
+				t.Fatalf("serviceRunnerForCommand() error = %v", err)
+			}
+			statusRunner, ok := runner.(statusServiceRunner)
+			if !ok {
+				t.Fatalf("runner type = %T, want statusServiceRunner", runner)
+			}
+			if got := statusRunner.httpDo != nil; got != tt.wantHTTP {
+				t.Fatalf("status HTTP configured = %t, want %t", got, tt.wantHTTP)
+			}
+		})
+	}
+}
+
 func TestStoppedManagedServiceUsesNonzeroExitCode(t *testing.T) {
 	t.Parallel()
 
@@ -414,7 +472,7 @@ func TestServiceCommandsLoadLegacyWorkflowPort(t *testing.T) {
 	}
 }
 
-func TestStatusCommandResolvesDashboardPort(t *testing.T) {
+func TestStatusCommandResolvesDashboardAddress(t *testing.T) {
 	t.Setenv("PORT", "4200")
 
 	tests := []struct {
@@ -435,16 +493,16 @@ func TestStatusCommandResolvesDashboardPort(t *testing.T) {
 			wantFactoryURL:   "http://localhost:4100",
 		},
 		{
-			name:             "installed unit port",
+			name:             "installed unit concrete host and port",
 			configPort:       4100,
 			writeConfig:      true,
-			definition:       "[Service]\nExecStart=\"/usr/bin/detent\" \"--config\" \"/tmp/global.yaml\" \"--port\" \"4300\" \"--headless\"\n",
+			definition:       "[Service]\nExecStart=\"/usr/bin/detent\" \"--config\" \"/tmp/global.yaml\" \"--host\" \"100.109.187.102\" \"--port\" \"4300\" \"--headless\"\n",
 			manager:          servicepkg.ManagerSystemd,
-			wantDashboardURL: "http://localhost:4300",
+			wantDashboardURL: "http://100.109.187.102:4300",
 			wantFactoryURL:   "http://localhost:4100",
 		},
 		{
-			name:        "installed launchd port",
+			name:        "installed launchd wildcard host and port",
 			configPort:  4100,
 			writeConfig: true,
 			definition: `<?xml version="1.0" encoding="UTF-8"?>
@@ -457,6 +515,8 @@ func TestStatusCommandResolvesDashboardPort(t *testing.T) {
     <string>/usr/local/bin/detent</string>
     <string>--config</string>
     <string>/tmp/global.yaml</string>
+    <string>--host</string>
+    <string>0.0.0.0</string>
     <string>--port</string>
     <string>4400</string>
     <string>--headless</string>
@@ -464,7 +524,7 @@ func TestStatusCommandResolvesDashboardPort(t *testing.T) {
 </dict>
 </plist>`,
 			manager:          servicepkg.ManagerLaunchd,
-			wantDashboardURL: "http://localhost:4400",
+			wantDashboardURL: "http://127.0.0.1:4400",
 			wantFactoryURL:   "http://localhost:4100",
 		},
 		{

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -32,6 +32,7 @@ type Config struct {
 	HTTPMaxIdleConnsPerHost     int
 	HTTPIdleConnTimeoutMS       int
 	GitHubRESTMinReserve        int
+	GitHubGraphQLMinReserve     int
 	GitHubRESTFanoutMaxRequests int
 	GitHubRESTDebugLogging      bool
 	GitHubUnstartedSeconds      int
@@ -86,6 +87,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 				IdleConnTimeout:     time.Duration(cfg.HTTPIdleConnTimeoutMS) * time.Millisecond,
 			},
 			RESTMinRemainingReserve:    cfg.GitHubRESTMinReserve,
+			GraphQLMinRemainingReserve: cfg.GitHubGraphQLMinReserve,
 			RESTFanoutMaxRequests:      cfg.GitHubRESTFanoutMaxRequests,
 			RESTDebugLogging:           cfg.GitHubRESTDebugLogging,
 			UnstartedThreshold:         time.Duration(cfg.GitHubUnstartedSeconds) * time.Second,
@@ -135,6 +137,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 					IdleConnTimeout:     time.Duration(cfg.HTTPIdleConnTimeoutMS) * time.Millisecond,
 				},
 				RESTMinRemainingReserve:    cfg.GitHubRESTMinReserve,
+				GraphQLMinRemainingReserve: cfg.GitHubGraphQLMinReserve,
 				RESTFanoutMaxRequests:      cfg.GitHubRESTFanoutMaxRequests,
 				RESTDebugLogging:           cfg.GitHubRESTDebugLogging,
 				UnstartedThreshold:         time.Duration(cfg.GitHubUnstartedSeconds) * time.Second,

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -149,8 +149,9 @@ func (c *Client) GraphQLWithType(ctx context.Context, queryType string, query st
 
 func (c *Client) graphQLWithType(ctx context.Context, queryType string, query string, variables map[string]any, out any, allowTokenRefresh bool) error {
 	queryType = graphQLQueryType(queryType, query)
+	lookup := graphQLLookup(query)
 	trackerRead := graphQLTrackerRead(queryType, query)
-	if err := c.graphQLLookupBackoffError(queryType, trackerRead, time.Now()); err != nil {
+	if err := c.graphQLLookupBackoffError(queryType, lookup, time.Now()); err != nil {
 		return err
 	}
 	token, err := c.tokenSource.Token(ctx)
@@ -246,7 +247,9 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 		c.recordGraphQLRateLimitFailure(err, headerRateLimit)
 		return err
 	}
-	c.clearGraphQLRateLimitStatus()
+	if queryType != graphQLQueryRateLimitProbe {
+		c.clearGraphQLRateLimitStatus()
+	}
 	if out == nil {
 		return nil
 	}
@@ -334,7 +337,7 @@ func (c *Client) restTextWithTokenRefresh(ctx context.Context, path, accept stri
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, http.MethodGet, path, resp.StatusCode, resp.Header, receivedAt, false)
+	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, http.MethodGet, path, resp.StatusCode, resp.Header, raw, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest text response", http.MethodGet, path, family, resp.StatusCode)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		responseErr := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
@@ -414,7 +417,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, receivedAt, false)
+	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest probe response", method, path, family, resp.StatusCode)
 	result := restProbeResult{
 		StatusCode: resp.StatusCode,
@@ -521,7 +524,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, receivedAt, conditional)
+	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, conditional)
 	if resp.StatusCode == http.StatusNotModified {
 		if !conditional {
 			return nil, ErrInvalidResponse
@@ -677,8 +680,8 @@ func (c *Client) clearGraphQLRateLimitStatus() {
 	c.mu.Unlock()
 }
 
-func (c *Client) graphQLLookupBackoffError(queryType string, trackerRead bool, now time.Time) error {
-	if !trackerRead || queryType == graphQLQueryRateLimitProbe {
+func (c *Client) graphQLLookupBackoffError(queryType string, lookup bool, now time.Time) error {
+	if !lookup || queryType == graphQLQueryRateLimitProbe {
 		return nil
 	}
 	c.mu.RLock()
@@ -975,17 +978,18 @@ func (c *Client) rememberRESTBackoffKey(backoffKey string) {
 	c.mu.Unlock()
 }
 
-func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, credentialIdentity string, method string, path string, status int, headers http.Header, now time.Time, conditional bool) {
+func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, credentialIdentity string, method string, path string, status int, headers http.Header, body []byte, now time.Time, conditional bool) {
 	limit, hasLimit := int64Header(headers, "X-RateLimit-Limit")
 	used, hasUsed := int64Header(headers, "X-RateLimit-Used")
 	remaining, hasRemaining := int64Header(headers, "X-RateLimit-Remaining")
 	reset, hasReset := int64Header(headers, "X-RateLimit-Reset")
 	retryAfter, hasRetryAfter := parseRetryAfter(headers.Get("Retry-After"), now)
-	rateLimited := restStatusRateLimited(status, headers)
+	headerRateLimited := restStatusRateLimited(status, headers, nil)
+	rateLimited := restStatusRateLimited(status, headers, body)
 	family := restEndpointFamily(method, path)
 	resourceHeader := strings.TrimSpace(headers.Get("X-RateLimit-Resource"))
 	resource := restRateLimitResourceName(resourceHeader, family)
-	sharedBackoff := rateLimited && restShouldApplySharedBackoff(family, remaining, hasRemaining)
+	sharedBackoff := rateLimited && (restShouldApplySharedBackoff(family, remaining, hasRemaining) || !headerRateLimited)
 
 	var resetAt time.Time
 	if hasReset {
@@ -1125,7 +1129,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, credentialIde
 			"path", path,
 			"endpoint_family", family,
 			"request_purpose", restRequestPurpose(method, path),
-			"backoff_reason", restRateLimitKindFromHeaders(status, headers),
+			"backoff_reason", restRateLimitKind(status, headers, body),
 			"retry_after_seconds", int64(backoffUntil.Sub(now)/time.Second),
 			"remaining", remaining,
 		)
@@ -1524,7 +1528,7 @@ func classifyStatusAt(status int, headers http.Header, body []byte, now time.Tim
 	case status == http.StatusForbidden && githubCommentingDisabled(body):
 		base = ErrResourceExhausted
 	case status == http.StatusForbidden:
-		if strings.TrimSpace(headers.Get("Retry-After")) != "" || headers.Get("X-RateLimit-Remaining") == "0" {
+		if restStatusRateLimited(status, headers, body) {
 			base = ErrRateLimited
 		} else {
 			base = ErrAuthenticationFailed
@@ -1543,7 +1547,7 @@ func classifyStatusAt(status int, headers http.Header, body []byte, now time.Tim
 		Err:        base,
 	}
 	if errors.Is(base, ErrRateLimited) {
-		statusErr.RateLimitKind = restRateLimitKindFromHeaders(status, headers)
+		statusErr.RateLimitKind = restRateLimitKind(status, headers, body)
 		statusErr.RetryAfter, _ = parseRetryAfter(headers.Get("Retry-After"), now)
 		if reset, ok := int64Header(headers, "X-RateLimit-Reset"); ok {
 			statusErr.ResetAt = time.Unix(reset, 0).UTC()
@@ -1559,19 +1563,31 @@ func githubCommentingDisabled(body []byte) bool {
 	)
 }
 
-func restStatusRateLimited(status int, headers http.Header) bool {
+func githubRateLimitExceeded(body []byte) bool {
+	var response struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(strings.TrimSpace(response.Message)), "rate limit")
+}
+
+func restStatusRateLimited(status int, headers http.Header, body []byte) bool {
 	switch status {
 	case http.StatusTooManyRequests:
 		return true
 	case http.StatusForbidden:
-		return strings.TrimSpace(headers.Get("Retry-After")) != "" || headers.Get("X-RateLimit-Remaining") == "0"
+		return strings.TrimSpace(headers.Get("Retry-After")) != "" ||
+			headers.Get("X-RateLimit-Remaining") == "0" ||
+			githubRateLimitExceeded(body)
 	default:
 		return false
 	}
 }
 
-func restRateLimitKindFromHeaders(status int, headers http.Header) string {
-	if !restStatusRateLimited(status, headers) {
+func restRateLimitKind(status int, headers http.Header, body []byte) string {
+	if !restStatusRateLimited(status, headers, body) {
 		return ""
 	}
 	if remaining, ok := int64Header(headers, "X-RateLimit-Remaining"); ok && remaining <= 0 {
@@ -1714,8 +1730,12 @@ func graphQLQueryType(queryType string, query string) string {
 	return "graphql"
 }
 
+func graphQLLookup(query string) bool {
+	return !strings.HasPrefix(strings.ToLower(strings.TrimSpace(query)), "mutation")
+}
+
 func graphQLTrackerRead(queryType string, query string) bool {
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(query)), "mutation") {
+	if !graphQLLookup(query) {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(queryType)) {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -47,6 +47,7 @@ type ClientConfig struct {
 	Endpoint                   string
 	TokenSource                TokenSource
 	HTTPClient                 HTTPClient
+	GraphQLMinRemainingReserve int64
 	RESTPolicy                 RESTBudgetPolicy
 	DisableConditionalRequests bool
 	RESTDebugLogging           bool
@@ -63,6 +64,7 @@ type Client struct {
 	restEndpoint           string
 	tokenSource            TokenSource
 	httpClient             HTTPClient
+	graphQLMinReserve      int64
 	restPolicy             RESTBudgetPolicy
 	restDebugLogging       bool
 	logger                 *slog.Logger
@@ -83,6 +85,7 @@ type Client struct {
 	restBackoffUntil       time.Time
 	restBackoffKey         string
 	restBackoffs           *restBackoffRegistry
+	restRateLimitStatus    bool
 	hasRestRateLimit       bool
 	authHealth             connector.AuthHealth
 	hasAuthHealth          bool
@@ -126,6 +129,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		restEndpoint:        restEndpoint,
 		tokenSource:         cfg.TokenSource,
 		httpClient:          httpClient,
+		graphQLMinReserve:   max(cfg.GraphQLMinRemainingReserve, 0),
 		restPolicy:          normalizeRESTBudgetPolicy(cfg.RESTPolicy),
 		restDebugLogging:    cfg.RESTDebugLogging,
 		logger:              logger,
@@ -144,6 +148,11 @@ func (c *Client) GraphQLWithType(ctx context.Context, queryType string, query st
 }
 
 func (c *Client) graphQLWithType(ctx context.Context, queryType string, query string, variables map[string]any, out any, allowTokenRefresh bool) error {
+	queryType = graphQLQueryType(queryType, query)
+	trackerRead := graphQLTrackerRead(queryType, query)
+	if err := c.graphQLLookupBackoffError(queryType, trackerRead, time.Now()); err != nil {
+		return err
+	}
 	token, err := c.tokenSource.Token(ctx)
 	if err != nil {
 		return fmt.Errorf("resolve github token: %w", err)
@@ -163,8 +172,6 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 		return fmt.Errorf("encode github graphql request: %w", err)
 	}
 
-	queryType = graphQLQueryType(queryType, query)
-	trackerRead := graphQLTrackerRead(queryType, query)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, &body)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
@@ -239,6 +246,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 		c.recordGraphQLRateLimitFailure(err, headerRateLimit)
 		return err
 	}
+	c.clearGraphQLRateLimitStatus()
 	if out == nil {
 		return nil
 	}
@@ -657,6 +665,57 @@ func (c *Client) GraphQLRateLimit() (connector.GraphQLRateLimit, bool) {
 	return c.rateLimit, c.hasRateLimit
 }
 
+func (c *Client) GraphQLRateLimitStatus() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.graphQLRateLimitStatus
+}
+
+func (c *Client) clearGraphQLRateLimitStatus() {
+	c.mu.Lock()
+	c.graphQLRateLimitStatus = ""
+	c.mu.Unlock()
+}
+
+func (c *Client) graphQLLookupBackoffError(queryType string, trackerRead bool, now time.Time) error {
+	if !trackerRead || queryType == graphQLQueryRateLimitProbe {
+		return nil
+	}
+	c.mu.RLock()
+	status := c.graphQLRateLimitStatus
+	rateLimit := c.rateLimit
+	hasRateLimit := c.hasRateLimit
+	reserve := c.graphQLMinReserve
+	c.mu.RUnlock()
+
+	if status == connector.GraphQLRateLimitStatusBackoff || status == connector.GraphQLRateLimitStatusExhausted {
+		return graphQLLookupPausedError(rateLimit, now, "GitHub GraphQL rate-limit response is in backoff")
+	}
+	if reserve > 0 && hasRateLimit && rateLimit.Limit > 0 && rateLimit.Remaining <= reserve && !graphQLRateLimitSnapshotExpired(rateLimit, now) {
+		return graphQLLookupPausedError(rateLimit, now, "GitHub GraphQL remaining budget is reserved for shared work")
+	}
+	return nil
+}
+
+func graphQLLookupPausedError(rateLimit connector.GraphQLRateLimit, now time.Time, body string) error {
+	retryAfter := rateLimit.RetryAfter
+	if retryAfter <= 0 && rateLimit.ResetAt.After(now) {
+		retryAfter = rateLimit.ResetAt.Sub(now)
+	}
+	return &StatusError{
+		StatusCode:    http.StatusTooManyRequests,
+		Body:          body,
+		Err:           ErrRateLimited,
+		RateLimitKind: restRateLimitKindPrimaryExhausted,
+		RetryAfter:    retryAfter,
+		ResetAt:       rateLimit.ResetAt,
+	}
+}
+
+func graphQLRateLimitSnapshotExpired(rateLimit connector.GraphQLRateLimit, now time.Time) bool {
+	return !rateLimit.ResetAt.IsZero() && now.After(rateLimit.ResetAt.Add(restRateLimitResetSkew))
+}
+
 func (c *Client) ResetGraphQLRateLimitUsage() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -720,7 +779,44 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 	}
 	c.restRequests = nil
 	c.restFanoutUnits = 0
+	c.restRateLimitStatus = false
 	return usage
+}
+
+func (c *Client) RESTRateLimitStatus() connector.RESTRateLimitUsage {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	now := time.Now()
+	rateLimit := c.restRateLimit
+	if core, ok := c.restRateLimits["core"]; ok {
+		rateLimit = core
+	}
+	backoffUntil := c.restBackoffUntil
+	if c.restBackoffs != nil && c.restBackoffKey != "" {
+		if shared := c.restBackoffs.until(c.restBackoffKey, now); shared.After(backoffUntil) {
+			backoffUntil = shared
+		}
+	}
+	usage := connector.RESTRateLimitUsage{
+		RateLimit:    rateLimit,
+		HasRateLimit: c.hasRestRateLimit,
+		BackoffUntil: backoffUntil,
+		RateLimited:  c.restRateLimitStatus || backoffUntil.After(now),
+	}
+	return usage
+}
+
+func (c *Client) clearRESTBackoff() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	backoffKey := c.restBackoffKey
+	c.restBackoffUntil = time.Time{}
+	c.restRateLimitStatus = false
+	if c.restBackoffs != nil && backoffKey != "" {
+		c.restBackoffs.clear(backoffKey)
+	}
 }
 
 func (c *Client) restBackoffError(backoffKey string, now time.Time) error {
@@ -902,6 +998,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, credentialIde
 	if backoffKey != "" {
 		c.restBackoffKey = backoffKey
 	}
+	c.restRateLimitStatus = c.restRateLimitStatus || rateLimited
 	snapshot := c.restRateLimit
 	if resource != "" && c.restRateLimits != nil {
 		snapshot = c.restRateLimits[resource]
@@ -1800,6 +1897,15 @@ func (r *restBackoffRegistry) set(key string, until time.Time) {
 	if current := r.untils[key]; current.IsZero() || until.After(current) {
 		r.untils[key] = until
 	}
+}
+
+func (r *restBackoffRegistry) clear(key string) {
+	if r == nil || strings.TrimSpace(key) == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.untils, key)
+	r.mu.Unlock()
 }
 
 func restEndpointFamily(method string, path string) string {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -86,6 +86,176 @@ func TestClientGraphQLSendsBearerRequest(t *testing.T) {
 	}
 }
 
+func TestClientGraphQLStopsLookupsAfterRateLimitResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		headers    http.Header
+		body       string
+		reserve    int64
+	}{
+		{
+			name:       "rate limit response",
+			statusCode: http.StatusTooManyRequests,
+			headers:    http.Header{"Retry-After": []string{"30"}},
+			body:       `{"message":"API rate limit already exceeded"}`,
+		},
+		{
+			name:       "forbidden exhausted",
+			statusCode: http.StatusForbidden,
+			headers: http.Header{
+				"X-RateLimit-Limit":     []string{"5000"},
+				"X-RateLimit-Remaining": []string{"0"},
+				"X-RateLimit-Reset":     []string{"2082758400"},
+			},
+			body: `{"message":"API rate limit already exceeded"}`,
+		},
+		{
+			name:       "header remaining below reserve",
+			statusCode: http.StatusOK,
+			headers: http.Header{
+				"X-RateLimit-Limit":     []string{"5000"},
+				"X-RateLimit-Remaining": []string{"1000"},
+				"X-RateLimit-Used":      []string{"4000"},
+				"X-RateLimit-Reset":     []string{"2082758400"},
+			},
+			body:    `{"data":{"viewer":{"login":"octocat"}}}`,
+			reserve: 1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				for key, values := range tt.headers {
+					for _, value := range values {
+						w.Header().Add(key, value)
+					}
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := NewClient(ClientConfig{
+				Endpoint:                   server.URL,
+				TokenSource:                StaticTokenSource("test-token"),
+				HTTPClient:                 server.Client(),
+				GraphQLMinRemainingReserve: tt.reserve,
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			for call := range 2 {
+				err = client.GraphQL(context.Background(), "query { viewer { login } rateLimit { limit used remaining cost resetAt } }", nil, nil)
+				if call == 0 && tt.statusCode == http.StatusOK {
+					if err != nil {
+						t.Fatalf("first GraphQL() error = %v", err)
+					}
+					continue
+				}
+				if !errors.Is(err, ErrRateLimited) {
+					t.Fatalf("GraphQL() call %d error = %v, want ErrRateLimited", call+1, err)
+				}
+			}
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("GraphQL HTTP calls = %d, want 1 after rate limit signal", got)
+			}
+		})
+	}
+}
+
+func TestClientGraphQLSuccessfulMutationClearsRateLimitResponse(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "30")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"API rate limit already exceeded"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"item-1"}},"viewer":{"login":"octocat"}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if err := client.GraphQL(context.Background(), "query { viewer { login } }", nil, nil); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("first GraphQL() error = %v, want ErrRateLimited", err)
+	}
+	if err := client.GraphQLWithType(context.Background(), graphQLQueryUpdateField, "mutation { updateProjectV2ItemFieldValue { projectV2Item { id } } }", nil, nil); err != nil {
+		t.Fatalf("mutation GraphQL() error = %v", err)
+	}
+	if err := client.GraphQL(context.Background(), "query { viewer { login } }", nil, nil); err != nil {
+		t.Fatalf("GraphQL() after successful mutation error = %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("GraphQL HTTP calls = %d, want rate limit, mutation, recovered lookup", got)
+	}
+}
+
+func TestConnectorProbeRESTRateLimitClearsRecoveredBackoff(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		if call == 1 {
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"API rate limit already exceeded"}`))
+			return
+		}
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "2000")
+		w.Header().Set("X-RateLimit-Used", "3000")
+		w.Header().Set("X-RateLimit-Reset", "2082758400")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	conn, err := NewConnector(Config{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+	if err := conn.client.REST(context.Background(), http.MethodGet, "/user", nil, nil); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("REST() error = %v, want ErrRateLimited", err)
+	}
+	rateLimit, err := conn.ProbeRESTRateLimit(context.Background(), 1000)
+	if err != nil {
+		t.Fatalf("ProbeRESTRateLimit() error = %v", err)
+	}
+	if rateLimit.Remaining != 2000 {
+		t.Fatalf("ProbeRESTRateLimit().Remaining = %d, want 2000", rateLimit.Remaining)
+	}
+	if err := conn.client.REST(context.Background(), http.MethodGet, "/user", nil, nil); err != nil {
+		t.Fatalf("REST() after recovery error = %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("HTTP calls = %d, want rate limit, probe, recovered request", got)
+	}
+}
+
 func TestClientTrackerAvailabilityClassification(t *testing.T) {
 	t.Parallel()
 
@@ -700,6 +870,10 @@ func TestClientRESTAggregatesUsageAndBacksOffAfterRateLimit(t *testing.T) {
 	}
 	if calls.Load() != 2 {
 		t.Fatalf("REST calls = %d, want 2 before local backoff", calls.Load())
+	}
+	status := client.RESTRateLimitStatus()
+	if !status.RateLimited || status.RateLimit.Remaining != 0 || status.BackoffUntil.IsZero() {
+		t.Fatalf("RESTRateLimitStatus() = %#v, want active exhausted backoff", status)
 	}
 
 	usage := client.FlushRESTRateLimitUsage()
@@ -1873,7 +2047,7 @@ func TestClientGraphQLClearsRetryAfterOnHeaderRefresh(t *testing.T) {
 		t.Fatalf("GraphQLRateLimit().RetryAfter = %s, want 2m", rateLimit.RetryAfter)
 	}
 
-	err = client.GraphQL(context.Background(), "query { viewer { login } }", nil, nil)
+	err = client.GraphQLWithType(context.Background(), graphQLQueryRateLimitProbe, "query { viewer { login } }", nil, nil)
 	if err != nil {
 		t.Fatalf("GraphQL() error = %v", err)
 	}

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -90,11 +90,12 @@ func TestClientGraphQLStopsLookupsAfterRateLimitResponse(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		statusCode int
-		headers    http.Header
-		body       string
-		reserve    int64
+		name              string
+		statusCode        int
+		headers           http.Header
+		body              string
+		reserve           int64
+		followupQueryType string
 	}{
 		{
 			name:       "rate limit response",
@@ -123,6 +124,13 @@ func TestClientGraphQLStopsLookupsAfterRateLimitResponse(t *testing.T) {
 			},
 			body:    `{"data":{"viewer":{"login":"octocat"}}}`,
 			reserve: 1000,
+		},
+		{
+			name:              "merge queue lookup",
+			statusCode:        http.StatusTooManyRequests,
+			headers:           http.Header{"Retry-After": []string{"30"}},
+			body:              `{"message":"API rate limit already exceeded"}`,
+			followupQueryType: graphQLQueryMergeQueue,
 		},
 	}
 
@@ -154,7 +162,11 @@ func TestClientGraphQLStopsLookupsAfterRateLimitResponse(t *testing.T) {
 			}
 
 			for call := range 2 {
-				err = client.GraphQL(context.Background(), "query { viewer { login } rateLimit { limit used remaining cost resetAt } }", nil, nil)
+				queryType := ""
+				if call > 0 {
+					queryType = tt.followupQueryType
+				}
+				err = client.GraphQLWithType(context.Background(), queryType, "query { viewer { login } rateLimit { limit used remaining cost resetAt } }", nil, nil)
 				if call == 0 && tt.statusCode == http.StatusOK {
 					if err != nil {
 						t.Fatalf("first GraphQL() error = %v", err)
@@ -167,6 +179,142 @@ func TestClientGraphQLStopsLookupsAfterRateLimitResponse(t *testing.T) {
 			}
 			if got := calls.Load(); got != 1 {
 				t.Fatalf("GraphQL HTTP calls = %d, want 1 after rate limit signal", got)
+			}
+		})
+	}
+}
+
+func TestClientStopsLookupsAfterHeaderlessForbiddenRateLimitResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(context.Context, *Client) error
+	}{
+		{
+			name: "graphql",
+			call: func(ctx context.Context, client *Client) error {
+				return client.GraphQL(ctx, "query { viewer { login } }", nil, nil)
+			},
+		},
+		{
+			name: "rest",
+			call: func(ctx context.Context, client *Client) error {
+				return client.REST(ctx, http.MethodGet, "/repos/digitaldrywood/detent/issues/1/comments", nil, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message":"API rate limit already exceeded"}`))
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := NewClient(ClientConfig{
+				Endpoint:    server.URL,
+				TokenSource: StaticTokenSource("test-token"),
+				HTTPClient:  server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			for call := range 2 {
+				err := tt.call(context.Background(), client)
+				if !errors.Is(err, ErrRateLimited) {
+					t.Fatalf("call %d error = %v, want ErrRateLimited", call+1, err)
+				}
+			}
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("HTTP calls = %d, want 1 after rate limit signal", got)
+			}
+		})
+	}
+}
+
+func TestConnectorRateLimitProbesRequireFreshResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		seed      func(context.Context, *Connector) error
+		probe     func(context.Context, *Connector) error
+		backedOff func(*Connector) bool
+	}{
+		{
+			name: "graphql",
+			seed: func(ctx context.Context, conn *Connector) error {
+				return conn.client.GraphQL(ctx, "query { viewer { login } }", nil, nil)
+			},
+			probe: func(ctx context.Context, conn *Connector) error {
+				_, err := conn.ProbeGraphQLRateLimit(ctx)
+				return err
+			},
+			backedOff: func(conn *Connector) bool {
+				return conn.GraphQLRateLimitStatus() == connector.GraphQLRateLimitStatusBackoff
+			},
+		},
+		{
+			name: "rest",
+			seed: func(ctx context.Context, conn *Connector) error {
+				return conn.client.REST(ctx, http.MethodGet, "/user", nil, nil)
+			},
+			probe: func(ctx context.Context, conn *Connector) error {
+				_, err := conn.ProbeRESTRateLimit(ctx, 1000)
+				return err
+			},
+			backedOff: func(conn *Connector) bool {
+				return conn.RESTRateLimitStatus().RateLimited
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if calls.Add(1) == 1 {
+					w.Header().Set("Retry-After", "60")
+					w.Header().Set("X-RateLimit-Limit", "5000")
+					w.Header().Set("X-RateLimit-Remaining", "4000")
+					w.Header().Set("X-RateLimit-Used", "1000")
+					w.WriteHeader(http.StatusTooManyRequests)
+					_, _ = w.Write([]byte(`{"message":"API rate limit already exceeded"}`))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+
+			conn, err := NewConnector(Config{
+				Endpoint:    server.URL,
+				TokenSource: StaticTokenSource("test-token"),
+				HTTPClient:  server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("NewConnector() error = %v", err)
+			}
+			if err := tt.seed(context.Background(), conn); !errors.Is(err, ErrRateLimited) {
+				t.Fatalf("seed error = %v, want ErrRateLimited", err)
+			}
+			if err := tt.probe(context.Background(), conn); !errors.Is(err, ErrInvalidResponse) {
+				t.Fatalf("probe error = %v, want ErrInvalidResponse", err)
+			}
+			if !tt.backedOff(conn) {
+				t.Fatal("rate limit backoff cleared without a fresh quota response")
+			}
+			if got := calls.Load(); got != 2 {
+				t.Fatalf("HTTP calls = %d, want seed and probe", got)
 			}
 		})
 	}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -29,6 +30,11 @@ query DetentGitHubProjectURL($projectId: ID!) {
     __typename
     ... on ProjectV2 { url }
   }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
+const graphQLRateLimitProbeQuery = `
+query DetentGitHubRateLimitProbe {
   rateLimit { limit used remaining cost resetAt }
 }`
 
@@ -62,6 +68,7 @@ const (
 	graphQLQueryAddProjectItem  = "add_project_item"
 	graphQLQueryMergeQueue      = "merge_queue"
 	graphQLQueryEnqueuePR       = "enqueue_pull_request"
+	graphQLQueryRateLimitProbe  = "rate_limit_probe"
 )
 
 type Config struct {
@@ -87,6 +94,7 @@ type Config struct {
 	HTTPClient                 HTTPClient
 	HTTPTransport              HTTPTransportConfig
 	RESTMinRemainingReserve    int
+	GraphQLMinRemainingReserve int
 	RESTFanoutMaxRequests      int
 	RESTDebugLogging           bool
 	UnstartedThreshold         time.Duration
@@ -189,9 +197,10 @@ func NewConnector(cfg Config) (*Connector, error) {
 	}
 
 	client, err := NewClient(ClientConfig{
-		Endpoint:    cfg.Endpoint,
-		TokenSource: tokenSource,
-		HTTPClient:  httpClient,
+		Endpoint:                   cfg.Endpoint,
+		TokenSource:                tokenSource,
+		HTTPClient:                 httpClient,
+		GraphQLMinRemainingReserve: int64(cfg.GraphQLMinRemainingReserve),
 		RESTPolicy: RESTBudgetPolicy{
 			MinRemainingReserve: int64(cfg.RESTMinRemainingReserve),
 			FanoutMaxRequests:   int64(cfg.RESTFanoutMaxRequests),
@@ -262,6 +271,40 @@ func (c *Connector) GraphQLRateLimit() (connector.GraphQLRateLimit, bool) {
 	return c.client.GraphQLRateLimit()
 }
 
+func (c *Connector) GraphQLRateLimitStatus() string {
+	return c.client.GraphQLRateLimitStatus()
+}
+
+func (c *Connector) ProbeGraphQLRateLimit(ctx context.Context) (connector.GraphQLRateLimit, error) {
+	if err := c.client.GraphQLWithType(ctx, graphQLQueryRateLimitProbe, graphQLRateLimitProbeQuery, nil, nil); err != nil {
+		return connector.GraphQLRateLimit{}, err
+	}
+	rateLimit, ok := c.client.GraphQLRateLimit()
+	if !ok {
+		return connector.GraphQLRateLimit{}, ErrInvalidResponse
+	}
+	c.client.clearGraphQLRateLimitStatus()
+	return rateLimit, nil
+}
+
+func (c *Connector) ProbeRESTRateLimit(ctx context.Context, minimumRemaining int64) (connector.RESTRateLimit, error) {
+	result, err := c.client.restProbe(ctx, http.MethodGet, "/rate_limit", nil)
+	if err != nil {
+		return connector.RESTRateLimit{}, err
+	}
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		return connector.RESTRateLimit{}, classifyStatusAt(result.StatusCode, result.Headers, []byte(result.FullBody), c.now())
+	}
+	usage := c.client.RESTRateLimitStatus()
+	if !usage.HasRateLimit {
+		return connector.RESTRateLimit{}, ErrInvalidResponse
+	}
+	if usage.RateLimit.Remaining > minimumRemaining {
+		c.client.clearRESTBackoff()
+	}
+	return usage.RateLimit, nil
+}
+
 func (c *Connector) AuthHealth() (connector.AuthHealth, bool) {
 	if c == nil || c.client == nil {
 		return connector.AuthHealth{}, false
@@ -279,6 +322,10 @@ func (c *Connector) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage
 
 func (c *Connector) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 	return c.client.FlushRESTRateLimitUsage()
+}
+
+func (c *Connector) RESTRateLimitStatus() connector.RESTRateLimitUsage {
+	return c.client.RESTRateLimitStatus()
 }
 
 func (c *Connector) LiveConnections() int {
@@ -417,5 +464,9 @@ var _ connector.PullRequestMerger = (*Connector)(nil)
 var _ connector.Provisioner = (*Connector)(nil)
 var _ connector.RateLimitReporter = (*Connector)(nil)
 var _ connector.GraphQLRateLimitUsageReporter = (*Connector)(nil)
+var _ connector.GraphQLRateLimitStatusReporter = (*Connector)(nil)
+var _ connector.GraphQLRateLimitProber = (*Connector)(nil)
 var _ connector.RESTRateLimitUsageReporter = (*Connector)(nil)
+var _ connector.RESTRateLimitStatusReporter = (*Connector)(nil)
+var _ connector.RESTRateLimitProber = (*Connector)(nil)
 var _ connector.AuthHealthReporter = (*Connector)(nil)

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -276,8 +276,14 @@ func (c *Connector) GraphQLRateLimitStatus() string {
 }
 
 func (c *Connector) ProbeGraphQLRateLimit(ctx context.Context) (connector.GraphQLRateLimit, error) {
-	if err := c.client.GraphQLWithType(ctx, graphQLQueryRateLimitProbe, graphQLRateLimitProbeQuery, nil, nil); err != nil {
+	var response struct {
+		RateLimit *struct{} `json:"rateLimit"`
+	}
+	if err := c.client.GraphQLWithType(ctx, graphQLQueryRateLimitProbe, graphQLRateLimitProbeQuery, nil, &response); err != nil {
 		return connector.GraphQLRateLimit{}, err
+	}
+	if response.RateLimit == nil {
+		return connector.GraphQLRateLimit{}, ErrInvalidResponse
 	}
 	rateLimit, ok := c.client.GraphQLRateLimit()
 	if !ok {
@@ -294,6 +300,12 @@ func (c *Connector) ProbeRESTRateLimit(ctx context.Context, minimumRemaining int
 	}
 	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
 		return connector.RESTRateLimit{}, classifyStatusAt(result.StatusCode, result.Headers, []byte(result.FullBody), c.now())
+	}
+	if _, ok := int64Header(result.Headers, "X-RateLimit-Limit"); !ok {
+		return connector.RESTRateLimit{}, ErrInvalidResponse
+	}
+	if _, ok := int64Header(result.Headers, "X-RateLimit-Remaining"); !ok {
+		return connector.RESTRateLimit{}, ErrInvalidResponse
 	}
 	usage := c.client.RESTRateLimitStatus()
 	if !usage.HasRateLimit {

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -41,6 +41,10 @@ type githubBackend interface {
 	connector.Authenticator
 	connector.AuthHealthReporter
 	connector.GraphQLRateLimitUsageReporter
+	connector.GraphQLRateLimitStatusReporter
+	connector.GraphQLRateLimitProber
+	connector.RESTRateLimitStatusReporter
+	connector.RESTRateLimitProber
 	connector.InstanceIdentifier
 	connector.IssueChildrenResolver
 	connector.IssueCloser
@@ -104,6 +108,10 @@ var _ connector.Closer = (*Connector)(nil)
 var _ connector.ConditionalPoller = (*Connector)(nil)
 var _ connector.RateLimitReporter = (*Connector)(nil)
 var _ connector.GraphQLRateLimitUsageReporter = (*Connector)(nil)
+var _ connector.GraphQLRateLimitStatusReporter = (*Connector)(nil)
+var _ connector.GraphQLRateLimitProber = (*Connector)(nil)
+var _ connector.RESTRateLimitStatusReporter = (*Connector)(nil)
+var _ connector.RESTRateLimitProber = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
 var _ connector.ProjectURLResolver = (*Connector)(nil)
 var _ connector.IssueChildrenResolver = (*Connector)(nil)
@@ -263,6 +271,22 @@ func (c *Connector) ProjectURL(ctx context.Context) (string, error) {
 
 func (c *Connector) GraphQLRateLimit() (connector.GraphQLRateLimit, bool) {
 	return c.github.GraphQLRateLimit()
+}
+
+func (c *Connector) GraphQLRateLimitStatus() string {
+	return c.github.GraphQLRateLimitStatus()
+}
+
+func (c *Connector) ProbeGraphQLRateLimit(ctx context.Context) (connector.GraphQLRateLimit, error) {
+	return c.github.ProbeGraphQLRateLimit(ctx)
+}
+
+func (c *Connector) RESTRateLimitStatus() connector.RESTRateLimitUsage {
+	return c.github.RESTRateLimitStatus()
+}
+
+func (c *Connector) ProbeRESTRateLimit(ctx context.Context, minimumRemaining int64) (connector.RESTRateLimit, error) {
+	return c.github.ProbeRESTRateLimit(ctx, minimumRemaining)
 }
 
 func (c *Connector) AuthHealth() (connector.AuthHealth, bool) {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -724,6 +724,22 @@ func (b *recordingGitHubBackend) GraphQLRateLimit() (connector.GraphQLRateLimit,
 	return connector.GraphQLRateLimit{}, false
 }
 
+func (b *recordingGitHubBackend) GraphQLRateLimitStatus() string {
+	return ""
+}
+
+func (b *recordingGitHubBackend) ProbeGraphQLRateLimit(context.Context) (connector.GraphQLRateLimit, error) {
+	return connector.GraphQLRateLimit{}, nil
+}
+
+func (b *recordingGitHubBackend) RESTRateLimitStatus() connector.RESTRateLimitUsage {
+	return connector.RESTRateLimitUsage{}
+}
+
+func (b *recordingGitHubBackend) ProbeRESTRateLimit(context.Context, int64) (connector.RESTRateLimit, error) {
+	return connector.RESTRateLimit{}, nil
+}
+
 func (b *recordingGitHubBackend) AuthHealth() (connector.AuthHealth, bool) {
 	return connector.AuthHealth{}, false
 }

--- a/internal/connector/ratelimit.go
+++ b/internal/connector/ratelimit.go
@@ -1,6 +1,9 @@
 package connector
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const (
 	GraphQLRateLimitStatusUnknown   = "unknown"
@@ -40,6 +43,14 @@ type RateLimitReporter interface {
 type GraphQLRateLimitUsageReporter interface {
 	ResetGraphQLRateLimitUsage()
 	FlushGraphQLRateLimitUsage() GraphQLRateLimitUsage
+}
+
+type GraphQLRateLimitStatusReporter interface {
+	GraphQLRateLimitStatus() string
+}
+
+type GraphQLRateLimitProber interface {
+	ProbeGraphQLRateLimit(context.Context) (GraphQLRateLimit, error)
 }
 
 type RESTRateLimit struct {
@@ -90,4 +101,12 @@ type RESTRateLimitUsage struct {
 
 type RESTRateLimitUsageReporter interface {
 	FlushRESTRateLimitUsage() RESTRateLimitUsage
+}
+
+type RESTRateLimitStatusReporter interface {
+	RESTRateLimitStatus() RESTRateLimitUsage
+}
+
+type RESTRateLimitProber interface {
+	ProbeRESTRateLimit(context.Context, int64) (RESTRateLimit, error)
 }

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -328,6 +328,7 @@ const (
 	dispatchIssueFailureStartStateTransition  = "start_state_transition_failed"
 	dispatchIssueFailureBackendCapacityPaused = "backend_capacity_paused"
 	dispatchIssueFailureGitHubRESTPaused      = "github_rest_capacity_paused"
+	dispatchIssueFailureGitHubLookupPaused    = "github_lookup_backoff"
 	dispatchIssueFailureTrackerUnavailable    = "tracker_unavailable"
 	dispatchIssueFailureForgeUnavailable      = "forge_unavailable"
 	dispatchIssueFailureGitHubMonitor         = "worker_github_budget_monitor_unavailable"
@@ -451,6 +452,9 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	runMode := o.dispatchMode(ctx, state, issue)
 	capacityRequest := runpkg.RunRequest{Issue: issue, Mode: runMode, SelectorContext: o.selectorContext()}
 	capacityScope, capacityProbeKey, capacityPaused := o.backendCapacityDispatch(state, capacityRequest, now)
+	if o.scheduling == nil && !githubLookupBackoffAllowsDispatch(state, capacityProbeKey) {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureGitHubLookupPaused}
+	}
 	if capacityPaused {
 		return dispatchIssueOutcome{reason: dispatchIssueFailureBackendCapacityPaused}
 	}

--- a/internal/orchestrator/dispatch_recovery.go
+++ b/internal/orchestrator/dispatch_recovery.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	dispatchRecoveryGitHubREST            = "github_rest"
+	dispatchRecoveryGitHubLookup          = "github_lookup"
 	dispatchRecoveryPullRequestHydration  = "pull_request_hydration"
 	dispatchRecoveryBackendCapacity       = "backend_capacity"
 	dispatchRecoveryTrackerUnavailable    = connector.TrackerUnavailableCondition

--- a/internal/orchestrator/github_lookup_backoff.go
+++ b/internal/orchestrator/github_lookup_backoff.go
@@ -209,8 +209,9 @@ func (o *Orchestrator) observeGitHubLookupBackoff(state *State, now time.Time) b
 	if active {
 		if signal, signaled := o.currentGitHubLookupSignal(state, now); signaled && outage.Trigger == githubLookupTriggerProvider {
 			o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+			return true
 		}
-		return true
+		return outage.Trigger != githubLookupTriggerProvider || outage.LastProbeResult != githubLookupProbeResultProviderDue
 	}
 	signal, ok := o.currentGitHubLookupSignal(state, now)
 	if !ok {

--- a/internal/orchestrator/github_lookup_backoff.go
+++ b/internal/orchestrator/github_lookup_backoff.go
@@ -1,0 +1,539 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	githubLookupBackoffKind            = "github_lookup_backoff"
+	githubLookupTriggerGraphQL         = "github_graphql_rate_limit"
+	githubLookupTriggerREST            = "github_rest_rate_limit"
+	githubLookupTriggerProvider        = "provider_capacity_outage"
+	githubLookupBackoffInitial         = 30 * time.Second
+	githubLookupBackoffMaximum         = 15 * time.Minute
+	githubLookupBackoffJitterDivisor   = 5
+	githubLookupProbeResultBackingOff  = "backing_off"
+	githubLookupProbeResultProviderDue = "provider_probe_due"
+)
+
+var githubLookupBackoffScope = backendcapacity.Scope{
+	BackendID:   "github-lookups",
+	BackendKind: "tracker",
+	Provider:    "github",
+}
+
+type githubLookupSignal struct {
+	trigger string
+	reason  string
+	resetAt time.Time
+}
+
+func (o *Orchestrator) githubLookupBackoffGate(ctx context.Context, state *State, now time.Time) bool {
+	if state == nil {
+		return false
+	}
+	if now.IsZero() {
+		now = o.clockNow()
+	}
+	provider, providerActive := activeProviderCapacityOutage(state.BackendOutages)
+	key, outage, active := githubLookupBackoff(state.BackendOutages)
+	signal, signaled := o.currentGitHubLookupSignal(state, now)
+
+	if !active {
+		switch {
+		case signaled:
+			o.advanceGitHubLookupBackoff(state, BackendOutage{}, signal, now, time.Time{})
+			return true
+		case providerActive:
+			o.advanceGitHubLookupBackoff(state, BackendOutage{}, providerGitHubLookupSignal(provider), now, providerCapacityProbeAt(provider))
+			return true
+		default:
+			return false
+		}
+	}
+
+	if signaled && outage.Trigger == githubLookupTriggerProvider {
+		o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+		return true
+	}
+	if outage.Trigger == githubLookupTriggerProvider {
+		if !providerActive {
+			o.recoverGitHubLookupBackoff(state, key, outage, now, "provider capacity recovered")
+			return false
+		}
+		if now.Before(outage.NextProbeAt) {
+			return true
+		}
+		providerProbeAt := providerCapacityProbeAt(provider)
+		if strings.TrimSpace(provider.ProbeIssueID) != "" || providerProbeAt.IsZero() || now.Before(providerProbeAt) {
+			o.advanceGitHubLookupBackoff(state, outage, providerGitHubLookupSignal(provider), now, providerProbeAt)
+			return true
+		}
+		outage.LastProbeAt = now.UTC()
+		outage.LastProbeResult = githubLookupProbeResultProviderDue
+		outage.LastProbeDetail = "provider capacity canary is due"
+		state.BackendOutages[key] = outage
+		return false
+	}
+
+	if now.Before(outage.NextProbeAt) {
+		return true
+	}
+	if outage.Trigger == githubLookupTriggerREST {
+		return o.probeGitHubRESTLookupBackoff(ctx, state, key, outage, now)
+	}
+	prober, ok := o.connector.(connector.GraphQLRateLimitProber)
+	if !ok {
+		signal.reason = "GitHub GraphQL rate-limit probe is unavailable"
+		if signal.trigger == "" {
+			signal.trigger = outage.Trigger
+		}
+		o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+		return true
+	}
+
+	outage.LastProbeAt = now.UTC()
+	rateLimit, err := prober.ProbeGraphQLRateLimit(ctx)
+	if err != nil {
+		signal = githubLookupSignal{
+			trigger: outage.Trigger,
+			reason:  "GitHub GraphQL rate-limit probe failed: " + err.Error(),
+			resetAt: outage.ResetAt,
+		}
+		o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+		return true
+	}
+	o.captureGitHubLookupProbe(state, rateLimit, now)
+	if rateLimit.Limit <= 0 || rateLimit.Remaining <= o.cfg.GitHubGraphQLMinReserve {
+		signal = githubLookupSignal{
+			trigger: githubLookupTriggerGraphQL,
+			reason: fmt.Sprintf(
+				"GitHub GraphQL remaining %d is at or below lookup floor %d",
+				rateLimit.Remaining,
+				o.cfg.GitHubGraphQLMinReserve,
+			),
+			resetAt: rateLimit.ResetAt,
+		}
+		o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+		return true
+	}
+
+	outage.LastProbeResult = "capacity_available"
+	outage.LastProbeDetail = fmt.Sprintf("GitHub GraphQL probe reports %d remaining", rateLimit.Remaining)
+	if signal, active := o.currentGitHubLookupSignal(state, now); active {
+		o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+		return true
+	}
+	o.recoverGitHubLookupBackoff(state, key, outage, now, outage.LastProbeDetail)
+	return false
+}
+
+func (o *Orchestrator) probeGitHubRESTLookupBackoff(
+	ctx context.Context,
+	state *State,
+	key string,
+	outage BackendOutage,
+	now time.Time,
+) bool {
+	prober, ok := o.connector.(connector.RESTRateLimitProber)
+	if !ok {
+		o.advanceGitHubLookupBackoff(state, outage, githubLookupSignal{
+			trigger: githubLookupTriggerREST,
+			reason:  "GitHub REST rate-limit probe is unavailable",
+			resetAt: outage.ResetAt,
+		}, now, time.Time{})
+		return true
+	}
+
+	outage.LastProbeAt = now.UTC()
+	rateLimit, err := prober.ProbeRESTRateLimit(ctx, o.cfg.GitHubRESTMinReserve)
+	if err != nil {
+		o.advanceGitHubLookupBackoff(state, outage, githubLookupSignal{
+			trigger: githubLookupTriggerREST,
+			reason:  "GitHub REST rate-limit probe failed: " + err.Error(),
+			resetAt: outage.ResetAt,
+		}, now, time.Time{})
+		return true
+	}
+	o.captureGitHubRESTLookupProbe(state, rateLimit, now)
+	if rateLimit.Limit <= 0 || rateLimit.Remaining <= o.cfg.GitHubRESTMinReserve {
+		o.advanceGitHubLookupBackoff(state, outage, githubLookupSignal{
+			trigger: githubLookupTriggerREST,
+			reason: fmt.Sprintf(
+				"GitHub REST remaining %d is at or below lookup floor %d",
+				rateLimit.Remaining,
+				o.cfg.GitHubRESTMinReserve,
+			),
+			resetAt: rateLimit.ResetAt,
+		}, now, time.Time{})
+		return true
+	}
+
+	outage.LastProbeResult = "capacity_available"
+	outage.LastProbeDetail = fmt.Sprintf("GitHub REST probe reports %d remaining", rateLimit.Remaining)
+	if signal, active := o.currentGitHubLookupSignal(state, now); active {
+		o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+		return true
+	}
+	o.recoverGitHubLookupBackoff(state, key, outage, now, outage.LastProbeDetail)
+	return false
+}
+
+func (o *Orchestrator) syncGitHubLookupBackoff(state *State, now time.Time) {
+	if state == nil {
+		return
+	}
+	if _, _, active := githubLookupBackoff(state.BackendOutages); active {
+		return
+	}
+	if signal, ok := o.currentGitHubLookupSignal(state, now); ok {
+		o.advanceGitHubLookupBackoff(state, BackendOutage{}, signal, now, time.Time{})
+		return
+	}
+	if provider, ok := activeProviderCapacityOutage(state.BackendOutages); ok {
+		o.advanceGitHubLookupBackoff(state, BackendOutage{}, providerGitHubLookupSignal(provider), now, providerCapacityProbeAt(provider))
+	}
+}
+
+func (o *Orchestrator) observeGitHubLookupBackoff(state *State, now time.Time) bool {
+	_, outage, active := githubLookupBackoff(state.BackendOutages)
+	if active {
+		if signal, signaled := o.currentGitHubLookupSignal(state, now); signaled && outage.Trigger == githubLookupTriggerProvider {
+			o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
+		}
+		return true
+	}
+	signal, ok := o.currentGitHubLookupSignal(state, now)
+	if !ok {
+		return false
+	}
+	o.advanceGitHubLookupBackoff(state, BackendOutage{}, signal, now, time.Time{})
+	return true
+}
+
+func (o *Orchestrator) finalizeGitHubLookupProviderProbe(state *State, now time.Time) {
+	key, outage, active := githubLookupBackoff(state.BackendOutages)
+	if !active || outage.Trigger != githubLookupTriggerProvider || outage.LastProbeResult != githubLookupProbeResultProviderDue {
+		return
+	}
+	provider, providerActive := activeProviderCapacityOutage(state.BackendOutages)
+	if !providerActive {
+		o.recoverGitHubLookupBackoff(state, key, outage, now, "provider capacity recovered")
+		return
+	}
+	o.advanceGitHubLookupBackoff(state, outage, providerGitHubLookupSignal(provider), now, providerCapacityProbeAt(provider))
+}
+
+func (o *Orchestrator) currentGitHubLookupSignal(state *State, now time.Time) (githubLookupSignal, bool) {
+	if reporter, ok := o.connector.(connector.GraphQLRateLimitStatusReporter); ok {
+		switch reporter.GraphQLRateLimitStatus() {
+		case connector.GraphQLRateLimitStatusBackoff, connector.GraphQLRateLimitStatusExhausted:
+			return githubLookupSignal{
+				trigger: githubLookupTriggerGraphQL,
+				reason:  "GitHub GraphQL returned a rate-limit response",
+			}, true
+		}
+	}
+	if reporter, ok := o.connector.(connector.RateLimitReporter); ok {
+		if rateLimit, exists := reporter.GraphQLRateLimit(); exists {
+			if graphQLLookupReserveExceeded(rateLimit, o.cfg.GitHubGraphQLMinReserve, now) {
+				o.captureGitHubLookupProbe(state, rateLimit, now)
+				return githubLookupSignal{
+					trigger: githubLookupTriggerGraphQL,
+					reason: fmt.Sprintf(
+						"GitHub GraphQL remaining %d is at or below lookup floor %d",
+						rateLimit.Remaining,
+						o.cfg.GitHubGraphQLMinReserve,
+					),
+					resetAt: rateLimit.ResetAt,
+				}, true
+			}
+		}
+	}
+	if reporter, ok := o.connector.(connector.RESTRateLimitStatusReporter); ok {
+		usage := reporter.RESTRateLimitStatus()
+		if usage.RateLimited || usage.BackoffUntil.After(now) {
+			return githubLookupSignal{
+				trigger: githubLookupTriggerREST,
+				reason:  "GitHub REST returned a rate-limit response",
+				resetAt: usage.BackoffUntil,
+			}, true
+		}
+		if restLookupReserveExceeded(usage.RateLimit, usage.HasRateLimit, o.cfg.GitHubRESTMinReserve, now) {
+			return githubLookupSignal{
+				trigger: githubLookupTriggerREST,
+				reason: fmt.Sprintf(
+					"GitHub REST remaining %d is at or below lookup floor %d",
+					usage.RateLimit.Remaining,
+					o.cfg.GitHubRESTMinReserve,
+				),
+				resetAt: usage.RateLimit.ResetAt,
+			}, true
+		}
+	}
+	if state != nil && state.RateLimits != nil {
+		bucket := state.RateLimits.GitHubGraphQL
+		if bucket != nil && (bucket.Status == telemetry.RateLimitStatusBackoff || bucket.Status == telemetry.RateLimitStatusExhausted) {
+			return githubLookupSignal{
+				trigger: githubLookupTriggerGraphQL,
+				reason:  "GitHub GraphQL returned a rate-limit response",
+				resetAt: rateLimitBucketResetAt(bucket),
+			}, true
+		}
+		if budgetBelowReserve(bucket, o.cfg.GitHubGraphQLMinReserve, now) {
+			return githubLookupSignal{
+				trigger: githubLookupTriggerGraphQL,
+				reason: fmt.Sprintf(
+					"GitHub GraphQL remaining %d is at or below lookup floor %d",
+					bucket.Remaining,
+					o.cfg.GitHubGraphQLMinReserve,
+				),
+				resetAt: rateLimitBucketResetAt(bucket),
+			}, true
+		}
+		rest := state.RateLimits.GitHubREST
+		if budgetBelowReserve(rest, o.cfg.GitHubRESTMinReserve, now) || state.RateLimits.RESTUsage != nil && state.RateLimits.RESTUsage.RateLimited {
+			return githubLookupSignal{
+				trigger: githubLookupTriggerREST,
+				reason:  "GitHub REST returned a rate-limit response or crossed its reserve floor",
+				resetAt: rateLimitBucketResetAt(rest),
+			}, true
+		}
+	}
+	return githubLookupSignal{}, false
+}
+
+func graphQLLookupReserveExceeded(rateLimit connector.GraphQLRateLimit, floor int64, now time.Time) bool {
+	return floor > 0 &&
+		rateLimit.Limit > 0 &&
+		rateLimit.Remaining <= floor &&
+		(rateLimit.ResetAt.IsZero() || !now.After(rateLimit.ResetAt.Add(githubRateLimitResetSkew)))
+}
+
+func restLookupReserveExceeded(rateLimit connector.RESTRateLimit, hasRateLimit bool, floor int64, now time.Time) bool {
+	return floor > 0 &&
+		hasRateLimit &&
+		rateLimit.Limit > 0 &&
+		rateLimit.Remaining <= floor &&
+		(rateLimit.ResetAt.IsZero() || !now.After(rateLimit.ResetAt.Add(githubRateLimitResetSkew)))
+}
+
+func rateLimitBucketResetAt(bucket *telemetry.RateLimitBucket) time.Time {
+	if bucket == nil || bucket.ResetAt == nil {
+		return time.Time{}
+	}
+	return bucket.ResetAt.UTC()
+}
+
+func (o *Orchestrator) advanceGitHubLookupBackoff(
+	state *State,
+	existing BackendOutage,
+	signal githubLookupSignal,
+	now time.Time,
+	probeDeadline time.Time,
+) BackendOutage {
+	if state.BackendOutages == nil {
+		state.BackendOutages = map[string]BackendOutage{}
+	}
+	attempt := existing.ProbeAttempts + 1
+	delay := githubLookupBackoffDelay(attempt, o.cfg.Project.ID+"\x00"+signal.trigger)
+	nextProbeAt := now.Add(delay).UTC()
+	if probeDeadline.After(now) && probeDeadline.Before(nextProbeAt) {
+		nextProbeAt = probeDeadline.UTC()
+		delay = nextProbeAt.Sub(now)
+	}
+	detectedAt := existing.DetectedAt
+	if detectedAt.IsZero() {
+		detectedAt = now.UTC()
+	}
+	resetAt := signal.resetAt.UTC()
+	if resetAt.IsZero() {
+		resetAt = existing.ResetAt
+	}
+	outage := BackendOutage{
+		Scope:           githubLookupBackoffScope,
+		Kind:            githubLookupBackoffKind,
+		Reason:          strings.TrimSpace(signal.reason),
+		Trigger:         strings.TrimSpace(signal.trigger),
+		DetectedAt:      detectedAt,
+		LastObservedAt:  now.UTC(),
+		ResetAt:         resetAt,
+		ResumeAt:        nextProbeAt,
+		NextProbeAt:     nextProbeAt,
+		LastProbeAt:     existing.LastProbeAt,
+		LastProbeResult: githubLookupProbeResultBackingOff,
+		LastProbeDetail: strings.TrimSpace(signal.reason),
+		ProbeAttempts:   attempt,
+	}
+	state.BackendOutages[githubLookupBackoffScope.Key()] = outage
+	o.markDispatchRecoveryWait(state, dispatchRecoveryGitHubLookup, outage.Reason, nextProbeAt, now)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "github_lookup_backoff_scheduled",
+		Message: fmt.Sprintf("GitHub lookups backed off after %s for %s; next probe at %s", outage.Trigger, delay, nextProbeAt.Format(time.RFC3339)),
+	})
+	if o.logger != nil {
+		o.logger.Warn(
+			"github lookup backoff scheduled",
+			"project_id", o.cfg.Project.ID,
+			"trigger", outage.Trigger,
+			"delay", delay,
+			"next_probe_at", nextProbeAt,
+			"backoff_step", attempt,
+			"reason", outage.Reason,
+		)
+	}
+	return outage
+}
+
+func (o *Orchestrator) recoverGitHubLookupBackoff(state *State, key string, outage BackendOutage, now time.Time, detail string) {
+	delete(state.BackendOutages, key)
+	o.activateDispatchRecovery(state, dispatchRecoveryGitHubLookup, outage.Reason, now, "")
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "github_lookup_backoff_recovered",
+		Message: "GitHub lookup backoff recovered: " + strings.TrimSpace(detail),
+	})
+	if o.logger != nil {
+		o.logger.Info(
+			"github lookup backoff recovered",
+			"project_id", o.cfg.Project.ID,
+			"trigger", outage.Trigger,
+			"backoff_steps", outage.ProbeAttempts,
+			"recovered_at", now,
+			"detail", strings.TrimSpace(detail),
+		)
+	}
+}
+
+func (o *Orchestrator) captureGitHubLookupProbe(state *State, rateLimit connector.GraphQLRateLimit, now time.Time) {
+	if state.RateLimits == nil {
+		state.RateLimits = &telemetry.RateLimits{}
+	}
+	state.RateLimits.GitHubGraphQL = gitHubGraphQLBucket(rateLimit, now, "")
+}
+
+func (o *Orchestrator) captureGitHubRESTLookupProbe(state *State, rateLimit connector.RESTRateLimit, now time.Time) {
+	if state.RateLimits == nil {
+		state.RateLimits = &telemetry.RateLimits{}
+	}
+	state.RateLimits.GitHubREST = gitHubRESTBucket(connector.RESTRateLimitUsage{
+		RateLimit:    rateLimit,
+		HasRateLimit: true,
+	}, now)
+	state.RateLimits.RESTUsage = nil
+}
+
+func githubLookupBackoff(outages map[string]BackendOutage) (string, BackendOutage, bool) {
+	for key, outage := range outages {
+		if outage.Kind == githubLookupBackoffKind {
+			return key, outage, true
+		}
+	}
+	return "", BackendOutage{}, false
+}
+
+func activeProviderCapacityOutage(outages map[string]BackendOutage) (BackendOutage, bool) {
+	var selected BackendOutage
+	found := false
+	for _, key := range sortedKeys(outages) {
+		outage := outages[key]
+		if outage.Kind == githubLookupBackoffKind || strings.EqualFold(outage.Scope.BackendKind, "tracker") {
+			continue
+		}
+		if !found || earlierProviderProbe(outage, selected) {
+			selected = outage
+			found = true
+		}
+	}
+	return selected, found
+}
+
+func earlierProviderProbe(left BackendOutage, right BackendOutage) bool {
+	leftAt := providerCapacityProbeAt(left)
+	rightAt := providerCapacityProbeAt(right)
+	if leftAt.IsZero() {
+		return false
+	}
+	return rightAt.IsZero() || leftAt.Before(rightAt)
+}
+
+func providerCapacityProbeAt(outage BackendOutage) time.Time {
+	if strings.TrimSpace(outage.ProbeIssueID) != "" {
+		return time.Time{}
+	}
+	if !outage.NextProbeAt.IsZero() {
+		return outage.NextProbeAt.UTC()
+	}
+	return outage.ResumeAt.UTC()
+}
+
+func providerGitHubLookupSignal(outage BackendOutage) githubLookupSignal {
+	backend := strings.TrimSpace(outage.Scope.BackendID)
+	if backend == "" {
+		backend = strings.TrimSpace(outage.Scope.BackendKind)
+	}
+	return githubLookupSignal{
+		trigger: githubLookupTriggerProvider,
+		reason:  "provider capacity outage is active for " + backend,
+		resetAt: outage.ResetAt,
+	}
+}
+
+func githubLookupBackoffDelay(attempt int, seed string) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	delay := githubLookupBackoffInitial
+	for range attempt - 1 {
+		if delay >= githubLookupBackoffMaximum/2 {
+			delay = githubLookupBackoffMaximum
+			break
+		}
+		delay *= 2
+	}
+	window := delay / githubLookupBackoffJitterDivisor
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(seed))
+	_, _ = hash.Write([]byte("\x00" + strconv.Itoa(attempt)))
+	span := uint64(window*2 + 1)
+	offset := time.Duration(int64(hash.Sum64()%span) - int64(window))
+	delay += offset
+	if delay > githubLookupBackoffMaximum {
+		return githubLookupBackoffMaximum
+	}
+	return delay
+}
+
+func githubLookupBackoffPause(state *State, now time.Time) time.Duration {
+	if state == nil {
+		return 0
+	}
+	_, outage, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || !outage.NextProbeAt.After(now) {
+		return 0
+	}
+	return outage.NextProbeAt.Sub(now)
+}
+
+func githubLookupBackoffAllowsDispatch(state *State, capacityProbeKey string) bool {
+	if state == nil {
+		return true
+	}
+	_, outage, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok {
+		return true
+	}
+	return outage.Trigger == githubLookupTriggerProvider &&
+		outage.LastProbeResult == githubLookupProbeResultProviderDue &&
+		strings.TrimSpace(capacityProbeKey) != ""
+}

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -44,8 +45,8 @@ func TestTickPausesUntilGitHubGraphQLResetWhenRemainingLow(t *testing.T) {
 
 	orch.tick(context.Background(), &state, now)
 
-	if tracker.fetchCandidateCalls != 1 {
-		t.Fatalf("FetchCandidateIssues() calls = %d, want 1", tracker.fetchCandidateCalls)
+	if tracker.fetchCandidateCalls != 0 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want 0 during lookup backoff", tracker.fetchCandidateCalls)
 	}
 	if state.RateLimits == nil || state.RateLimits.GitHubGraphQL == nil {
 		t.Fatalf("RateLimits = %#v, want GitHub GraphQL snapshot", state.RateLimits)
@@ -53,11 +54,14 @@ func TestTickPausesUntilGitHubGraphQLResetWhenRemainingLow(t *testing.T) {
 	if state.RateLimits.GitHubGraphQL.Remaining != 25 || state.RateLimits.GitHubGraphQL.Cost != 4 {
 		t.Fatalf("GitHubGraphQL = %#v, want remaining 25 cost 4", state.RateLimits.GitHubGraphQL)
 	}
-	if state.PollInterval != 17*time.Minute {
-		t.Fatalf("PollInterval = %s, want reset pause 17m", state.PollInterval)
+	if state.PollInterval < 24*time.Second || state.PollInterval > 36*time.Second {
+		t.Fatalf("PollInterval = %s, want jittered initial backoff between 24s and 36s", state.PollInterval)
 	}
-	if !state.NextRefreshAt.Equal(resetAt) {
-		t.Fatalf("NextRefreshAt = %v, want %v", state.NextRefreshAt, resetAt)
+	if !state.NextRefreshAt.Equal(now.Add(state.PollInterval)) {
+		t.Fatalf("NextRefreshAt = %v, want %v", state.NextRefreshAt, now.Add(state.PollInterval))
+	}
+	if _, outage, ok := githubLookupBackoff(state.BackendOutages); !ok || outage.Trigger != githubLookupTriggerGraphQL || outage.ProbeAttempts != 1 {
+		t.Fatalf("BackendOutages = %#v, want first GraphQL lookup backoff", state.BackendOutages)
 	}
 }
 
@@ -92,8 +96,8 @@ func TestTickSkipsConnectorPollingDuringGitHubGraphQLPause(t *testing.T) {
 	if tracker.fetchByStatesCalls != 0 {
 		t.Fatalf("FetchIssuesByStates() calls = %d, want 0 during pause", tracker.fetchByStatesCalls)
 	}
-	if state.PollInterval != 10*time.Minute {
-		t.Fatalf("PollInterval = %s, want reset pause 10m", state.PollInterval)
+	if state.PollInterval < 24*time.Second || state.PollInterval > 36*time.Second {
+		t.Fatalf("PollInterval = %s, want jittered initial backoff between 24s and 36s", state.PollInterval)
 	}
 }
 
@@ -122,8 +126,8 @@ func TestTickPausesForGitHubGraphQLRetryAfterWithPrimaryRemaining(t *testing.T) 
 
 	orch.tick(context.Background(), &state, now)
 
-	if state.PollInterval != 2*time.Minute {
-		t.Fatalf("PollInterval = %s, want retry-after pause 2m", state.PollInterval)
+	if state.PollInterval < 24*time.Second || state.PollInterval > 36*time.Second {
+		t.Fatalf("PollInterval = %s, want jittered initial backoff between 24s and 36s", state.PollInterval)
 	}
 	if state.RateLimits == nil || state.RateLimits.GitHubGraphQL == nil {
 		t.Fatalf("RateLimits = %#v, want GitHub GraphQL retry-after snapshot", state.RateLimits)
@@ -432,8 +436,8 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 	if state.RateLimits.GitHubRESTBudgets[0].ResetAt == nil || state.RateLimits.GitHubRESTBudgets[1].ResetAt == nil || state.RateLimits.GitHubRESTBudgets[0].ResetAt.Equal(*state.RateLimits.GitHubRESTBudgets[1].ResetAt) {
 		t.Fatalf("GitHubRESTBudgets = %#v, want distinct endpoint reset windows", state.RateLimits.GitHubRESTBudgets)
 	}
-	if state.PollInterval != time.Minute {
-		t.Fatalf("PollInterval = %s, want REST retry-after pause 1m", state.PollInterval)
+	if state.PollInterval < 24*time.Second || state.PollInterval > 36*time.Second {
+		t.Fatalf("PollInterval = %s, want jittered initial lookup backoff between 24s and 36s", state.PollInterval)
 	}
 }
 
@@ -836,8 +840,8 @@ func TestTickDetectsGitHubRESTExhaustionBeforeDispatch(t *testing.T) {
 	if _, ok := activeGitHubRESTCapacityOutage(&state, now); !ok {
 		t.Fatalf("BackendOutages = %#v, want active GitHub REST outage", state.BackendOutages)
 	}
-	if state.PollInterval != 30*time.Minute || !state.NextRefreshAt.Equal(resetAt) {
-		t.Fatalf("refresh = interval %s next %v, want reset at %v", state.PollInterval, state.NextRefreshAt, resetAt)
+	if state.PollInterval < 24*time.Second || state.PollInterval > 36*time.Second || !state.NextRefreshAt.Equal(now.Add(state.PollInterval)) {
+		t.Fatalf("refresh = interval %s next %v, want jittered initial lookup backoff", state.PollInterval, state.NextRefreshAt)
 	}
 }
 
@@ -907,7 +911,7 @@ func TestRunCompletionDuringGitHubRESTCapacityOutageDoesNotStrikeBreakers(t *tes
 	}
 }
 
-func TestTickSkipsNonessentialGitHubWorkBelowRESTReserve(t *testing.T) {
+func TestTickBacksOffAllGitHubWorkBelowRESTReserve(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
@@ -932,18 +936,17 @@ func TestTickSkipsNonessentialGitHubWorkBelowRESTReserve(t *testing.T) {
 		},
 	}
 	tracker := &rateLimitConnector{}
-	var logs bytes.Buffer
 	orch := &Orchestrator{
 		cfg:       cfg,
 		connector: tracker,
 		reaper:    rateLimitWorkspaceReaper{},
-		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	orch.tick(context.Background(), &state, now)
 
-	if tracker.fetchCandidateCalls != 1 {
-		t.Fatalf("FetchCandidateIssues() calls = %d, want minimal active candidate fetch", tracker.fetchCandidateCalls)
+	if tracker.fetchCandidateCalls != 0 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want no lookups below REST reserve", tracker.fetchCandidateCalls)
 	}
 	if tracker.fetchByStatesCalls != 0 {
 		t.Fatalf("FetchIssuesByStates() calls = %d, want no cleanup or observed sweep", tracker.fetchByStatesCalls)
@@ -951,23 +954,9 @@ func TestTickSkipsNonessentialGitHubWorkBelowRESTReserve(t *testing.T) {
 	if tracker.fetchByStatesLimitCalls != 0 {
 		t.Fatalf("FetchIssuesByStatesLimit() calls = %d, want no observed probe during reserve", tracker.fetchByStatesLimitCalls)
 	}
-	if !rateLimitRecentEventContains(state.RecentEvents, "github_budget_reserved", "preserve shared budget") {
-		t.Fatalf("RecentEvents = %#v, want github budget reserve event", state.RecentEvents)
-	}
-	if !rateLimitRecentEventContains(state.RecentEvents, "github_rest_capacity_paused", "resuming at") {
-		t.Fatalf("RecentEvents = %#v, want GitHub REST dispatch pause event", state.RecentEvents)
-	}
-	logOutput := logs.String()
-	for _, want := range []string{
-		"github polling degraded to preserve shared budget",
-		"workspace cleanup skipped to preserve shared github budget",
-		"observed status polling skipped to preserve shared github budget",
-		"rest_remaining=900",
-		"rest_reserve=1000",
-	} {
-		if !strings.Contains(logOutput, want) {
-			t.Fatalf("log output missing %q:\n%s", want, logOutput)
-		}
+	_, outage, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || outage.Trigger != githubLookupTriggerREST || outage.ProbeAttempts != 1 {
+		t.Fatalf("BackendOutages = %#v, want first REST-triggered lookup backoff", state.BackendOutages)
 	}
 }
 
@@ -1029,7 +1018,7 @@ func TestGitHubBudgetReserveDecisionUsesCurrentRateLimitWindow(t *testing.T) {
 	}
 }
 
-func TestTickAllowsConditionalPollingBelowRESTReserve(t *testing.T) {
+func TestTickBacksOffConditionalPollingBelowRESTReserve(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
@@ -1061,17 +1050,15 @@ func TestTickAllowsConditionalPollingBelowRESTReserve(t *testing.T) {
 
 	orch.tick(context.Background(), &state, now)
 
-	if base.fetchCandidateCalls != 1 || base.fetchByStatesCalls != 1 {
-		t.Fatalf("fetch calls = candidates %d states %d, want one conditional cycle", base.fetchCandidateCalls, base.fetchByStatesCalls)
+	if base.fetchCandidateCalls != 0 || base.fetchByStatesCalls != 0 {
+		t.Fatalf("fetch calls = candidates %d states %d, want no conditional cycle during backoff", base.fetchCandidateCalls, base.fetchByStatesCalls)
 	}
-	for _, event := range state.RecentEvents {
-		if event.Event == "github_budget_reserved" {
-			t.Fatalf("RecentEvents = %#v, want no reserve skip for conditional polling", state.RecentEvents)
-		}
+	if _, outage, ok := githubLookupBackoff(state.BackendOutages); !ok || outage.Trigger != githubLookupTriggerREST {
+		t.Fatalf("BackendOutages = %#v, want REST-triggered lookup backoff", state.BackendOutages)
 	}
 }
 
-func TestTickClearsStaleBlockedStatusWhenCandidateResumesBelowGitHubReserve(t *testing.T) {
+func TestTickDefersStaleBlockedStatusReconciliationBelowGitHubReserve(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
@@ -1115,8 +1102,8 @@ func TestTickClearsStaleBlockedStatusWhenCandidateResumesBelowGitHubReserve(t *t
 
 	orch.tick(context.Background(), &state, now)
 
-	if tracker.fetchCandidateCalls != 1 {
-		t.Fatalf("FetchCandidateIssues() calls = %d, want minimal active candidate fetch", tracker.fetchCandidateCalls)
+	if tracker.fetchCandidateCalls != 0 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want no lookup during backoff", tracker.fetchCandidateCalls)
 	}
 	if tracker.fetchByStatesCalls != 0 {
 		t.Fatalf("FetchIssuesByStates() calls = %d, want observed polling skipped", tracker.fetchByStatesCalls)
@@ -1124,11 +1111,11 @@ func TestTickClearsStaleBlockedStatusWhenCandidateResumesBelowGitHubReserve(t *t
 	if tracker.fetchByStatesLimitCalls != 0 {
 		t.Fatalf("FetchIssuesByStatesLimit() calls = %d, want observed probe skipped", tracker.fetchByStatesLimitCalls)
 	}
-	if len(state.BoardIssues) != 1 || state.BoardIssues[0].ID != issue.ID || state.BoardIssues[0].State != "In Progress" {
-		t.Fatalf("BoardIssues = %#v, want resumed In Progress candidate", state.BoardIssues)
+	if len(state.BoardIssues) != 0 {
+		t.Fatalf("BoardIssues = %#v, want prior snapshot preserved without lookup", state.BoardIssues)
 	}
-	if _, ok := state.Blocked[issue.ID]; ok {
-		t.Fatalf("Blocked[%q] still tracked after candidate resumed In Progress during budget reserve", issue.ID)
+	if _, ok := state.Blocked[issue.ID]; !ok {
+		t.Fatalf("Blocked[%q] cleared without tracker lookup", issue.ID)
 	}
 }
 
@@ -1160,8 +1147,8 @@ func TestTickSkipsObservedPollingBelowGraphQLReserve(t *testing.T) {
 
 	orch.tick(context.Background(), &state, now)
 
-	if tracker.fetchCandidateCalls != 1 {
-		t.Fatalf("FetchCandidateIssues() calls = %d, want minimal active candidate fetch", tracker.fetchCandidateCalls)
+	if tracker.fetchCandidateCalls != 0 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want no lookup during backoff", tracker.fetchCandidateCalls)
 	}
 	if tracker.fetchByStatesCalls != 0 {
 		t.Fatalf("FetchIssuesByStates() calls = %d, want observed polling skipped", tracker.fetchByStatesCalls)
@@ -1412,6 +1399,329 @@ func TestTickPrioritizesStatusDriftBeforeBulkTrackerReads(t *testing.T) {
 	}
 }
 
+func TestTickStopsBulkTrackerReadsAfterGraphQLRateLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:               30 * time.Second,
+		ActiveStates:               []string{"Todo", "In Progress"},
+		TerminalStates:             []string{"Done"},
+		GitHubGraphQLMinReserve:    1000,
+		GitHubGraphQLWarnRemaining: 1500,
+	})
+	state := newState(cfg)
+	tracker := &orderedTickConnector{
+		rateLimitConnector: &rateLimitConnector{},
+		statusDriftErr:     errors.New("API rate limit already exceeded"),
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if tracker.fetchCandidateCalls != 0 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want 0 after status drift rate limit", tracker.fetchCandidateCalls)
+	}
+	if got := tracker.calls; len(got) != 1 || got[0] != "status_drift" {
+		t.Fatalf("tracker call order = %#v, want only status drift", got)
+	}
+}
+
+func TestTickStopsBulkTrackerReadsAfterRESTRateLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:        30 * time.Second,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 1,
+	})
+	state := newState(cfg)
+	tracker := &orderedTickConnector{
+		rateLimitConnector: &rateLimitConnector{},
+		statusDriftErr:     errors.New("API rate limit already exceeded"),
+		statusDriftREST:    true,
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if tracker.fetchCandidateCalls != 0 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want 0 after REST rate limit", tracker.fetchCandidateCalls)
+	}
+	if _, outage, ok := githubLookupBackoff(state.BackendOutages); !ok || outage.Trigger != githubLookupTriggerREST {
+		t.Fatalf("BackendOutages = %#v, want REST-triggered lookup backoff", state.BackendOutages)
+	}
+}
+
+func TestGitHubLookupBackoffDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		attempt int
+		minimum time.Duration
+		maximum time.Duration
+	}{
+		{name: "initial", attempt: 1, minimum: 24 * time.Second, maximum: 36 * time.Second},
+		{name: "second", attempt: 2, minimum: 48 * time.Second, maximum: 72 * time.Second},
+		{name: "fifth", attempt: 5, minimum: 384 * time.Second, maximum: 576 * time.Second},
+		{name: "capped", attempt: 20, minimum: 12 * time.Minute, maximum: 15 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := githubLookupBackoffDelay(tt.attempt, "detent\x00github")
+			if got < tt.minimum || got > tt.maximum {
+				t.Fatalf("githubLookupBackoffDelay(%d) = %s, want %s..%s", tt.attempt, got, tt.minimum, tt.maximum)
+			}
+			if repeated := githubLookupBackoffDelay(tt.attempt, "detent\x00github"); repeated != got {
+				t.Fatalf("repeated delay = %s, want deterministic %s", repeated, got)
+			}
+		})
+	}
+}
+
+func TestGitHubLookupBackoffAllowsDispatch(t *testing.T) {
+	t.Parallel()
+
+	providerScope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	tests := []struct {
+		name             string
+		state            *State
+		capacityProbeKey string
+		want             bool
+	}{
+		{name: "no state", want: true},
+		{name: "no outage", state: &State{}, want: true},
+		{
+			name: "provider outage without lookup state",
+			state: &State{BackendOutages: map[string]BackendOutage{
+				providerScope.Key(): {Scope: providerScope},
+			}},
+			want: true,
+		},
+		{
+			name: "rate limit blocks provider canary",
+			state: &State{BackendOutages: map[string]BackendOutage{
+				githubLookupBackoffScope.Key(): {
+					Scope:           githubLookupBackoffScope,
+					Kind:            githubLookupBackoffKind,
+					Trigger:         githubLookupTriggerGraphQL,
+					LastProbeResult: githubLookupProbeResultBackingOff,
+				},
+			}},
+			capacityProbeKey: "codex",
+		},
+		{
+			name: "provider canary due",
+			state: &State{BackendOutages: map[string]BackendOutage{
+				githubLookupBackoffScope.Key(): {
+					Scope:           githubLookupBackoffScope,
+					Kind:            githubLookupBackoffKind,
+					Trigger:         githubLookupTriggerProvider,
+					LastProbeResult: githubLookupProbeResultProviderDue,
+				},
+			}},
+			capacityProbeKey: "codex",
+			want:             true,
+		},
+		{
+			name: "ordinary attempt while provider canary due",
+			state: &State{BackendOutages: map[string]BackendOutage{
+				githubLookupBackoffScope.Key(): {
+					Scope:           githubLookupBackoffScope,
+					Kind:            githubLookupBackoffKind,
+					Trigger:         githubLookupTriggerProvider,
+					LastProbeResult: githubLookupProbeResultProviderDue,
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := githubLookupBackoffAllowsDispatch(tt.state, tt.capacityProbeKey); got != tt.want {
+				t.Fatalf("githubLookupBackoffAllowsDispatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitHubLookupBackoffProbesAndRecoversGradually(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	resetAt := now.Add(time.Hour)
+	cfg := normalizeConfig(Config{
+		Project:                 scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents:     4,
+		GitHubGraphQLMinReserve: 1000,
+	})
+	tracker := &rateLimitConnector{
+		rateLimitStatus: connector.GraphQLRateLimitStatusExhausted,
+		probeRateLimits: []connector.GraphQLRateLimit{
+			{Limit: 5000, Used: 4000, Remaining: 1000, ResetAt: resetAt},
+			{Limit: 5000, Used: 3999, Remaining: 1001, ResetAt: resetAt},
+		},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+	var logs bytes.Buffer
+	orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	state := newState(cfg)
+
+	if !orch.githubLookupBackoffGate(context.Background(), &state, now) {
+		t.Fatal("initial githubLookupBackoffGate() = false, want backoff")
+	}
+	_, first, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || first.ProbeAttempts != 1 {
+		t.Fatalf("first backoff = %#v, want attempt 1", first)
+	}
+	tracker.rateLimitStatus = ""
+	if !orch.githubLookupBackoffGate(context.Background(), &state, first.NextProbeAt.Add(-time.Nanosecond)) {
+		t.Fatal("githubLookupBackoffGate() before probe = false, want backoff")
+	}
+	if tracker.probeCalls != 0 {
+		t.Fatalf("probe calls before deadline = %d, want 0", tracker.probeCalls)
+	}
+	if !orch.githubLookupBackoffGate(context.Background(), &state, first.NextProbeAt) {
+		t.Fatal("low-capacity githubLookupBackoffGate() = false, want continued backoff")
+	}
+	_, second, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || second.ProbeAttempts != 2 || !second.NextProbeAt.After(first.NextProbeAt) {
+		t.Fatalf("second backoff = %#v, want later attempt 2", second)
+	}
+	if orch.githubLookupBackoffGate(context.Background(), &state, second.NextProbeAt) {
+		t.Fatal("healthy githubLookupBackoffGate() = true, want recovery")
+	}
+	if _, _, active := githubLookupBackoff(state.BackendOutages); active {
+		t.Fatalf("BackendOutages = %#v, want lookup backoff cleared", state.BackendOutages)
+	}
+	recovery := state.DispatchRecoveries[dispatchRecoveryGitHubLookup]
+	if recovery.Status != dispatchRecoveryStatusRamping || recovery.Limit != 1 {
+		t.Fatalf("DispatchRecoveries[%q] = %#v, want one-at-a-time ramp", dispatchRecoveryGitHubLookup, recovery)
+	}
+	for _, want := range []string{"github lookup backoff scheduled", "trigger=github_graphql_rate_limit", "delay=", "next_probe_at="} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("log output missing %q:\n%s", want, logs.String())
+		}
+	}
+}
+
+func TestGitHubRESTLookupBackoffUsesRESTProbe(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	resetAt := now.Add(time.Hour)
+	cfg := normalizeConfig(Config{
+		Project:              scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents:  4,
+		GitHubRESTMinReserve: 1000,
+	})
+	tracker := &rateLimitConnector{
+		restStatus: connector.RESTRateLimitUsage{
+			RateLimited:  true,
+			BackoffUntil: now.Add(time.Minute),
+		},
+		restProbeRateLimits: []connector.RESTRateLimit{
+			{Limit: 5000, Used: 4000, Remaining: 1000, ResetAt: resetAt},
+			{Limit: 5000, Used: 3999, Remaining: 1001, ResetAt: resetAt},
+		},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+	state := newState(cfg)
+
+	if !orch.githubLookupBackoffGate(context.Background(), &state, now) {
+		t.Fatal("initial githubLookupBackoffGate() = false, want REST backoff")
+	}
+	_, first, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || first.Trigger != githubLookupTriggerREST {
+		t.Fatalf("first backoff = %#v, want REST trigger", first)
+	}
+	if !orch.githubLookupBackoffGate(context.Background(), &state, first.NextProbeAt) {
+		t.Fatal("low-capacity REST probe recovered backoff")
+	}
+	_, second, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || second.ProbeAttempts != 2 {
+		t.Fatalf("second backoff = %#v, want attempt 2", second)
+	}
+	if orch.githubLookupBackoffGate(context.Background(), &state, second.NextProbeAt) {
+		t.Fatal("healthy REST probe kept backoff active")
+	}
+	if tracker.restProbeCalls != 2 || tracker.probeCalls != 0 {
+		t.Fatalf("probe calls = REST %d GraphQL %d, want REST 2 GraphQL 0", tracker.restProbeCalls, tracker.probeCalls)
+	}
+}
+
+func TestTickBacksOffGitHubLookupsDuringProviderOutage(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:        30 * time.Second,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 2,
+	})
+	state := newState(cfg)
+	providerScope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	state.BackendOutages[providerScope.Key()] = BackendOutage{
+		Scope:       providerScope,
+		Kind:        string(backendcapacity.ErrorTypeUsageLimit),
+		Reason:      "provider responses unavailable",
+		DetectedAt:  now.Add(-time.Minute),
+		ResumeAt:    now.Add(5 * time.Minute),
+		NextProbeAt: now.Add(5 * time.Minute),
+	}
+	tracker := &rateLimitConnector{}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if tracker.fetchCandidateCalls != 0 || tracker.fetchByStatesCalls != 0 {
+		t.Fatalf("tracker calls = candidates %d states %d, want none", tracker.fetchCandidateCalls, tracker.fetchByStatesCalls)
+	}
+	if _, outage, ok := githubLookupBackoff(state.BackendOutages); !ok || outage.Trigger != githubLookupTriggerProvider {
+		t.Fatalf("BackendOutages = %#v, want provider-triggered lookup backoff", state.BackendOutages)
+	}
+}
+
+func TestProviderLookupProbeWindowIsSingleUse(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}})
+	state := newState(cfg)
+	providerScope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	state.BackendOutages[providerScope.Key()] = BackendOutage{
+		Scope:       providerScope,
+		NextProbeAt: now,
+	}
+	state.BackendOutages[githubLookupBackoffScope.Key()] = BackendOutage{
+		Scope:           githubLookupBackoffScope,
+		Kind:            githubLookupBackoffKind,
+		Trigger:         githubLookupTriggerProvider,
+		NextProbeAt:     now,
+		ProbeAttempts:   3,
+		LastProbeResult: githubLookupProbeResultProviderDue,
+	}
+	orch := newRateLimitTestOrchestrator(cfg, &rateLimitConnector{})
+
+	orch.finalizeGitHubLookupProviderProbe(&state, now)
+
+	_, outage, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || outage.ProbeAttempts != 4 || !outage.NextProbeAt.After(now) || outage.LastProbeResult != githubLookupProbeResultBackingOff {
+		t.Fatalf("lookup backoff = %#v, want next step after one due window", outage)
+	}
+}
+
 func TestTickReconcilesRunningIssuesOnSlowerCadence(t *testing.T) {
 	t.Parallel()
 
@@ -1462,6 +1772,14 @@ type rateLimitConnector struct {
 	hasRateLimit            bool
 	usage                   connector.GraphQLRateLimitUsage
 	restUsage               connector.RESTRateLimitUsage
+	restStatus              connector.RESTRateLimitUsage
+	restProbeRateLimits     []connector.RESTRateLimit
+	restProbeErrs           []error
+	restProbeCalls          int
+	rateLimitStatus         string
+	probeRateLimits         []connector.GraphQLRateLimit
+	probeErrs               []error
+	probeCalls              int
 	resetUsageCalls         int
 	flushUsageCalls         int
 	flushRESTUsageCalls     int
@@ -1492,12 +1810,21 @@ func (c *cleanupProbeConnector) FetchIssueStateProbe(_ context.Context, states [
 
 type orderedTickConnector struct {
 	*rateLimitConnector
-	calls []string
+	calls           []string
+	statusDriftErr  error
+	statusDriftREST bool
 }
 
 func (c *orderedTickConnector) FetchStatusDrift(context.Context) (connector.StatusDrift, error) {
 	c.calls = append(c.calls, "status_drift")
-	return connector.StatusDrift{}, nil
+	if c.statusDriftErr != nil {
+		if c.statusDriftREST {
+			c.restStatus = connector.RESTRateLimitUsage{RateLimited: true}
+		} else {
+			c.rateLimitStatus = connector.GraphQLRateLimitStatusExhausted
+		}
+	}
+	return connector.StatusDrift{}, c.statusDriftErr
 }
 
 func (c *orderedTickConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
@@ -1566,6 +1893,22 @@ func (c *rateLimitConnector) GraphQLRateLimit() (connector.GraphQLRateLimit, boo
 	return c.rateLimit, c.hasRateLimit
 }
 
+func (c *rateLimitConnector) GraphQLRateLimitStatus() string {
+	return c.rateLimitStatus
+}
+
+func (c *rateLimitConnector) ProbeGraphQLRateLimit(context.Context) (connector.GraphQLRateLimit, error) {
+	index := c.probeCalls
+	c.probeCalls++
+	if index < len(c.probeErrs) && c.probeErrs[index] != nil {
+		return connector.GraphQLRateLimit{}, c.probeErrs[index]
+	}
+	if index < len(c.probeRateLimits) {
+		return c.probeRateLimits[index], nil
+	}
+	return connector.GraphQLRateLimit{}, errors.New("unexpected GraphQL rate-limit probe")
+}
+
 func (c *rateLimitConnector) ResetGraphQLRateLimitUsage() {
 	c.resetUsageCalls++
 	c.usage = connector.GraphQLRateLimitUsage{}
@@ -1579,6 +1922,26 @@ func (c *rateLimitConnector) FlushGraphQLRateLimitUsage() connector.GraphQLRateL
 func (c *rateLimitConnector) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 	c.flushRESTUsageCalls++
 	return c.restUsage
+}
+
+func (c *rateLimitConnector) RESTRateLimitStatus() connector.RESTRateLimitUsage {
+	return c.restStatus
+}
+
+func (c *rateLimitConnector) ProbeRESTRateLimit(_ context.Context, minimumRemaining int64) (connector.RESTRateLimit, error) {
+	index := c.restProbeCalls
+	c.restProbeCalls++
+	if index < len(c.restProbeErrs) && c.restProbeErrs[index] != nil {
+		return connector.RESTRateLimit{}, c.restProbeErrs[index]
+	}
+	if index < len(c.restProbeRateLimits) {
+		rateLimit := c.restProbeRateLimits[index]
+		if rateLimit.Remaining > minimumRemaining {
+			c.restStatus = connector.RESTRateLimitUsage{}
+		}
+		return rateLimit, nil
+	}
+	return connector.RESTRateLimit{}, errors.New("unexpected REST rate-limit probe")
 }
 
 type rateLimitWorkspaceReaper struct{}

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -1722,6 +1722,44 @@ func TestProviderLookupProbeWindowIsSingleUse(t *testing.T) {
 	}
 }
 
+func TestTickProviderProbeWindowReachesCandidateFetch(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:        30 * time.Second,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+		MaxConcurrentAgents: 1,
+	})
+	state := newState(cfg)
+	providerScope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	state.BackendOutages[providerScope.Key()] = BackendOutage{
+		Scope:       providerScope,
+		NextProbeAt: now,
+	}
+	state.BackendOutages[githubLookupBackoffScope.Key()] = BackendOutage{
+		Scope:         githubLookupBackoffScope,
+		Kind:          githubLookupBackoffKind,
+		Trigger:       githubLookupTriggerProvider,
+		NextProbeAt:   now,
+		ProbeAttempts: 1,
+	}
+	tracker := &rateLimitConnector{}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if tracker.fetchCandidateCalls != 1 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want provider canary window to reach candidate fetch", tracker.fetchCandidateCalls)
+	}
+	_, outage, ok := githubLookupBackoff(state.BackendOutages)
+	if !ok || outage.ProbeAttempts != 2 || outage.LastProbeResult != githubLookupProbeResultBackingOff {
+		t.Fatalf("lookup backoff = %#v, want single-use probe window followed by next step", outage)
+	}
+}
+
 func TestTickReconcilesRunningIssuesOnSlowerCadence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -386,6 +386,9 @@ func (o *Orchestrator) adaptivePollInterval(state *State, now time.Time) time.Du
 	if base <= 0 {
 		base = defaultPollInterval
 	}
+	if pause := githubLookupBackoffPause(state, now); pause > 0 {
+		return pause
+	}
 	if o.scheduling != nil {
 		source := state.RefreshSources[telemetry.RefreshSourceCandidates]
 		if source.Condition == schedulingUnavailableCondition && source.FailureStreak > 0 {

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -509,6 +509,10 @@ func (o *Orchestrator) finishRefresh(state *State, now time.Time, captureREST bo
 		o.logRESTRateLimitCycle(restCycle)
 	}
 	o.syncGitHubRESTCapacityOutage(state, now)
+	if o.scheduling == nil {
+		o.finalizeGitHubLookupProviderProbe(state, now)
+		o.syncGitHubLookupBackoff(state, now)
+	}
 
 	interval := o.adaptivePollInterval(state, now)
 	state.PollInterval = interval

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -77,6 +77,9 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	}()
 
 	o.syncGitHubRESTCapacityOutage(state, now)
+	if o.scheduling == nil && o.githubLookupBackoffGate(ctx, state, now) {
+		return
+	}
 	if pause := o.gitHubGraphQLPause(state, now); pause > 0 {
 		o.logger.Warn("github graphql polling paused", "remaining", gitHubGraphQLRemaining(state), "pause", pause)
 		if o.scheduling == nil {
@@ -107,10 +110,19 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	}
 	timing.next("status_drift")
 	o.refreshStatusDrift(ctx, state, now, reserve)
+	if o.scheduling == nil && o.observeGitHubLookupBackoff(state, now) {
+		return
+	}
 	timing.next("release")
 	o.evaluateRelease(ctx, state, now)
 	timing.next("active_runs")
 	o.refreshActiveRuns(ctx, state, now, reserve)
+	if o.scheduling == nil {
+		o.syncGitHubLookupBackoff(state, now)
+		if _, outage, active := githubLookupBackoff(state.BackendOutages); active && outage.LastProbeResult != githubLookupProbeResultProviderDue {
+			return
+		}
+	}
 	if state.Draining || o.dispatchQuiesced() {
 		return
 	}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -2190,6 +2190,7 @@ func defaultConnectorFactoryWithRefresh(cfg workflowconfig.Config, refreshGitHub
 		HTTPMaxIdleConnsPerHost:     cfg.Tracker.HTTPMaxIdleConnsPerHost,
 		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
 		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
+		GitHubGraphQLMinReserve:     cfg.Tracker.GitHubGraphQLMinReserve,
 		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
 		GitHubUnstartedSeconds:      cfg.Tracker.GitHubUnstartedSeconds,
 		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/instancelock"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/update"
 )
 
@@ -125,20 +126,21 @@ type StartResult struct {
 }
 
 type Status struct {
-	InstallMethod  update.InstallSource `json:"install_method"`
-	ServiceManager ManagerName          `json:"service_manager"`
-	ServiceScope   string               `json:"service_scope,omitempty"`
-	Service        string               `json:"service"`
-	DefinitionPath string               `json:"definition_path,omitempty"`
-	Expected       bool                 `json:"expected_running"`
-	State          State                `json:"state"`
-	PID            int                  `json:"pid,omitempty"`
-	StartedAt      time.Time            `json:"started_at,omitempty"`
-	UptimeSeconds  int64                `json:"uptime_seconds,omitempty"`
-	Version        string               `json:"version"`
-	AutoUpdate     string               `json:"auto_update"`
-	DashboardURL   string               `json:"dashboard_url"`
-	ConfigPath     string               `json:"config_path"`
+	InstallMethod  update.InstallSource      `json:"install_method"`
+	ServiceManager ManagerName               `json:"service_manager"`
+	ServiceScope   string                    `json:"service_scope,omitempty"`
+	Service        string                    `json:"service"`
+	DefinitionPath string                    `json:"definition_path,omitempty"`
+	Expected       bool                      `json:"expected_running"`
+	State          State                     `json:"state"`
+	PID            int                       `json:"pid,omitempty"`
+	StartedAt      time.Time                 `json:"started_at,omitempty"`
+	UptimeSeconds  int64                     `json:"uptime_seconds,omitempty"`
+	Version        string                    `json:"version"`
+	AutoUpdate     string                    `json:"auto_update"`
+	DashboardURL   string                    `json:"dashboard_url"`
+	ConfigPath     string                    `json:"config_path"`
+	BackendOutages []telemetry.BackendOutage `json:"backend_outages,omitempty"`
 }
 
 func (s Status) Running() bool {


### PR DESCRIPTION
## Summary

- coordinate jittered exponential backoff for GitHub lookups after provider-capacity or GitHub rate-limit signals
- resume through cheap quota/provider probes and the existing one-at-a-time dispatch recovery ramp
- expose active lookup backoff details through logs, telemetry, and `detent status`

Fixes #2112

## Test Plan

- `go test ./internal/connector ./internal/connector/factory ./internal/connector/github ./internal/connector/githublocal ./internal/orchestrator ./internal/cli ./internal/service ./internal/project -count=1`
- `make check`
