### PR TITLE
test(hubserver): relax listener ready guard

### DIFF
--- a/internal/hubserver/service_test.go
+++ b/internal/hubserver/service_test.go
@@ -170,6 +170,7 @@ func TestServeRequiresListener(t *testing.T) {
 func TestRunStopsOnContextCancellationAndReleasesDatabase(t *testing.T) {
 	t.Parallel()
 
+	const listenerReadyDeadlockGuard = 30 * time.Second
 	databasePath := filepath.Join(t.TempDir(), "hub.db")
 	listenerAccepting := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -192,7 +193,7 @@ func TestRunStopsOnContextCancellationAndReleasesDatabase(t *testing.T) {
 
 	select {
 	case <-listenerAccepting:
-	case <-time.After(10 * time.Second):
+	case <-time.After(listenerReadyDeadlockGuard):
 		t.Fatal("Run() did not start accepting listener connections")
 	}
 	cancel()


### PR DESCRIPTION
## Summary

- Wait for the explicit hub listener-ready event with a 30-second OS deadlock guard so scheduler pressure does not become a behavioral failure.
- Preserve the context-cancellation and database-release assertions unchanged.

Fixes #2118

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/hubserver -run ^TestRunStopsOnContextCancellationAndReleasesDatabase$ -count=10 -timeout=10m`
- [x] `go test -race ./internal/hubserver -count=10 -timeout=10m`
- [x] `make check`