### PR TITLE
test(hubserver): synchronize listener startup

### DIFF
--- a/.detent/skills/macos-dyld-go-validation-fallback.md
+++ b/.detent/skills/macos-dyld-go-validation-fallback.md
@@ -18,4 +18,6 @@ Run the repository's exact validation target in a Linux container when Docker is
 
 Run the container as the workspace owner. Use workspace-owned temporary directories for `node_modules` and npm cache; anonymous Docker volumes default to root ownership. Prefer repository-pinned prebuilt tools when host file-table pressure makes large `go install` dependency trees fail.
 
+Keep test `TMPDIR` on an executable container-local tmpfs. A Docker Desktop bind mount can change fsnotify behavior and create duplicate file events that do not occur on a native Linux filesystem. When the gate creates disposable Git repositories, scope `safe.directory=*` to the ephemeral container so those repositories remain usable without changing host Git configuration.
+
 Re-run generation with Git repository detection enabled and confirm that unrelated generated files remain unchanged. Record both the native startup evidence and the successful exact containerized gate in the handoff.

--- a/internal/hubserver/config.go
+++ b/internal/hubserver/config.go
@@ -1,8 +1,10 @@
 package hubserver
 
 import (
+	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"time"
 
 	"github.com/google/uuid"
@@ -62,6 +64,7 @@ type Config struct {
 	FullRepairInterval         time.Duration
 
 	validateDatabaseFilesystem func(string) error
+	listen                     func(context.Context, string, string) (net.Listener, error)
 	now                        func() time.Time
 	jitter                     func() float64
 	newLeaseID                 func() string
@@ -114,6 +117,10 @@ func (c Config) normalized() Config {
 	}
 	if c.validateDatabaseFilesystem == nil {
 		c.validateDatabaseFilesystem = validateLocalDatabaseFilesystem
+	}
+	if c.listen == nil {
+		listenConfig := &net.ListenConfig{}
+		c.listen = listenConfig.Listen
 	}
 	if c.now == nil {
 		c.now = time.Now

--- a/internal/hubserver/service.go
+++ b/internal/hubserver/service.go
@@ -115,8 +115,7 @@ func Run(ctx context.Context, cfg Config) (resultErr error) {
 		resultErr = errors.Join(resultErr, service.Close())
 	}()
 
-	var listenConfig net.ListenConfig
-	listener, err := listenConfig.Listen(ctx, "tcp", cfg.ListenAddress)
+	listener, err := cfg.listen(ctx, "tcp", cfg.ListenAddress)
 	if err != nil {
 		return fmt.Errorf("listen for hub requests: %w", err)
 	}

--- a/internal/hubserver/service_test.go
+++ b/internal/hubserver/service_test.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -174,22 +171,29 @@ func TestRunStopsOnContextCancellationAndReleasesDatabase(t *testing.T) {
 	t.Parallel()
 
 	databasePath := filepath.Join(t.TempDir(), "hub.db")
-	serving := make(chan struct{})
-	logger := slog.New(slog.NewTextHandler(&servingSignalWriter{ready: serving}, nil))
+	listenerAccepting := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	result := make(chan error, 1)
 	go func() {
 		result <- Run(ctx, Config{
 			DatabasePath:  databasePath,
 			ListenAddress: "127.0.0.1:0",
-			Logger:        logger,
+			listen: func(ctx context.Context, network string, address string) (net.Listener, error) {
+				var listenConfig net.ListenConfig
+				listener, err := listenConfig.Listen(ctx, network, address)
+				if err != nil {
+					return nil, err
+				}
+				return &acceptSignalListener{Listener: listener, accepting: listenerAccepting}, nil
+			},
 		})
 	}()
 
 	select {
-	case <-serving:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Run() did not bind its listener")
+	case <-listenerAccepting:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run() did not start accepting listener connections")
 	}
 	cancel()
 	select {
@@ -197,7 +201,7 @@ func TestRunStopsOnContextCancellationAndReleasesDatabase(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("Run() did not stop after cancellation")
 	}
 
@@ -207,16 +211,15 @@ func TestRunStopsOnContextCancellationAndReleasesDatabase(t *testing.T) {
 	}
 }
 
-type servingSignalWriter struct {
-	ready chan struct{}
-	once  sync.Once
+type acceptSignalListener struct {
+	net.Listener
+	accepting chan struct{}
+	once      sync.Once
 }
 
-func (w *servingSignalWriter) Write(p []byte) (int, error) {
-	if strings.Contains(string(p), "hub serving") {
-		w.once.Do(func() {
-			close(w.ready)
-		})
-	}
-	return io.Discard.Write(p)
+func (l *acceptSignalListener) Accept() (net.Conn, error) {
+	l.once.Do(func() {
+		close(l.accepting)
+	})
+	return l.Listener.Accept()
 }


### PR DESCRIPTION
## Summary

- inject the hub listener factory through the existing private config seam pattern
- synchronize cancellation testing on the real listener entering `Accept` instead of parsing a log line
- retain 10-second wall-clock waits only as deadlock guards
- refine the macOS dyld fallback guidance for executable tmpfs and ephemeral Git repositories

Fixes #2122

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test -race ./internal/hubserver -run "^TestRunStopsOnContextCancellationAndReleasesDatabase$" -count=10` (Linux container, 2.832s)
- [x] `make check` (Linux container fallback; 78.8% coverage, all package/file floors pass)
- [x] generation left unrelated generated files unchanged
