### PR TITLE
fix(runner): reap terminal subprocesses

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1076,6 +1076,7 @@ func (r *Runner) runAgentTurn(
 		}
 	}
 	turnStarted := false
+	workerProcessObserved := false
 	turnResult, cleanupScratch, turnErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(ctx, backend, turnRequest, runRequest.AgentTools, runRequest.AgentToolHandler, func(updateCtx context.Context, update AgentUpdate) error {
 		eventAt := r.now()
 		if update.Type == AgentUpdateTokenUsage {
@@ -1086,6 +1087,9 @@ func (r *Runner) runAgentTurn(
 		}
 		if !update.AuxiliaryTurn && (update.Type == AgentUpdateTurnStarted || strings.TrimSpace(update.TurnID) != "") {
 			turnStarted = true
+		}
+		if update.Type == AgentUpdateProcessStarted && update.WorkerProcess.PID > 0 {
+			workerProcessObserved = true
 		}
 		r.logAgentUpdate(runRequest, detentSessionID, update)
 		if err := r.persistSessionWorkerProcess(updateCtx, detentSessionID, update, info.Path, filepath.Join(info.Path, ".detent", "tmp")); err != nil {
@@ -1134,13 +1138,14 @@ func (r *Runner) runAgentTurn(
 		runRequest.Issue,
 		workerProcessReapReason(ctx, turnErr),
 	)
-	workspaceReapErr := r.reapCancelledWorkspaceProcesses(
+	workspaceReapErr := r.reapWorkspaceProcessesAfterTurn(
 		ctx,
 		info.Path,
 		detentSessionID,
 		runRequest.WorkAttemptID,
 		runRequest.Issue,
 		turnErr,
+		workerProcessObserved,
 	)
 	workerReapErr := errors.Join(processReapErr, workspaceReapErr)
 	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, workerReapErr)
@@ -2804,6 +2809,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	}
 	var output strings.Builder
 	usage := newSessionTokenUsage(false)
+	workerProcessObserved := false
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
 	turnResult, cleanupScratch, turnErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(sessionCtx, backend, AgentTurnRequest{
 		Workspace:          info.Path,
@@ -2826,6 +2832,9 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		eventAt := r.now()
 		if update.Type == AgentUpdateTokenUsage {
 			update.Tokens = usage.normalize(update.Tokens)
+		}
+		if update.Type == AgentUpdateProcessStarted && update.WorkerProcess.PID > 0 {
+			workerProcessObserved = true
 		}
 		if !update.RuntimeIdentity.IsZero() {
 			update.RuntimeIdentity = update.RuntimeIdentity.ObserveAt(eventAt)
@@ -2871,13 +2880,14 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		req.Issue,
 		workerProcessReapReason(sessionCtx, turnErr),
 	)
-	workspaceReapErr := r.reapCancelledWorkspaceProcesses(
+	workspaceReapErr := r.reapWorkspaceProcessesAfterTurn(
 		sessionCtx,
 		info.Path,
 		sessionID,
 		runReq.WorkAttemptID,
 		req.Issue,
 		turnErr,
+		workerProcessObserved,
 	)
 	workerReapErr := errors.Join(processReapErr, workspaceReapErr)
 	scratchCleanupErr := cleanupWorkerScratchAfterProcessReap(cleanupScratch, workerReapErr)
@@ -3306,19 +3316,20 @@ func (r *Runner) reapSessionWorkerProcess(ctx context.Context, sessionID int64, 
 	return nil
 }
 
-func (r *Runner) reapCancelledWorkspaceProcesses(
+func (r *Runner) reapWorkspaceProcessesAfterTurn(
 	ctx context.Context,
 	workspacePath string,
 	sessionID int64,
 	workAttemptID int64,
 	issue connector.Issue,
 	turnErr error,
+	workerProcessObserved bool,
 ) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	combined := errors.Join(context.Cause(ctx), turnErr)
-	if !workerSessionCanceled(combined) {
+	if !workerProcessObserved && !workerSessionCanceled(combined) {
 		return nil
 	}
 

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -232,19 +232,27 @@ func TestRunnerReapsWorkerAfterTerminalTurn(t *testing.T) {
 			t.Parallel()
 			startedAt := time.Date(2026, 8, 18, 14, 0, 0, 0, time.UTC)
 			identity := procgroup.Identity{PID: 1885, GroupID: 1885, StartedAt: startedAt}
+			workspacePath := t.TempDir()
+			var logs bytes.Buffer
 			processStore := &durationReapSessionStore{
 				fakeSessionStore: &fakeSessionStore{sessionID: 1885},
 				process: store.WorkerProcess{SessionID: 1885, WorkerProcessIdentity: store.WorkerProcessIdentity{
 					PID: identity.PID, GroupID: identity.GroupID, StartedAt: identity.StartedAt,
 				}},
 			}
+			workspaceReaped := ""
 			runner, err := NewRunner(Dependencies{
 				Workflow:     config.Workflow{Prompt: "Work"},
-				Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir(), Key: "issue-terminal-worker"}},
+				Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: workspacePath, Key: "issue-terminal-worker"}},
 				AgentBackend: terminalWorkerAgentBackend{identity: identity, err: tt.turnErr},
 				Store:        processStore,
+				Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
 				ReapWorkerProcess: func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
 					return procgroup.TerminationOutcomeAlreadyExited, nil
+				},
+				ReapWorkspaceProcesses: func(_ context.Context, path string, _ time.Duration) (int, error) {
+					workspaceReaped = path
+					return 0, nil
 				},
 			})
 			if err != nil {
@@ -259,6 +267,19 @@ func TestRunnerReapsWorkerAfterTerminalTurn(t *testing.T) {
 			}
 			if len(processStore.reaps) != 1 || processStore.reaps[0].Reason != tt.wantReason || processStore.reaps[0].Outcome != store.WorkerProcessOutcomeAlreadyExited {
 				t.Fatalf("reap records = %#v, want reason %q", processStore.reaps, tt.wantReason)
+			}
+			if workspaceReaped != workspacePath {
+				t.Fatalf("reaped workspace = %q, want %q", workspaceReaped, workspacePath)
+			}
+			for _, want := range []string{
+				"event=worker_orphan_processes_reaped",
+				"issue_identifier=digitaldrywood/detent#1885",
+				"reason=" + tt.wantReason,
+				"count=0",
+			} {
+				if !strings.Contains(logs.String(), want) {
+					t.Fatalf("logs missing %q:\n%s", want, logs.String())
+				}
 			}
 		})
 	}

--- a/internal/runner/duration_limit_unix_test.go
+++ b/internal/runner/duration_limit_unix_test.go
@@ -15,70 +15,85 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/procgroup"
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
-func TestRunnerSessionCancellationReapsEscapedWorkspaceProcess(t *testing.T) {
-	workspacePath := t.TempDir()
-	lockPath := filepath.Join(workspacePath, "gate.lock")
-	durationLimit := &controlledDurationLimit{}
-	command, readyReader, readyWriter := workspaceLockCommand(t, workspacePath, lockPath)
-	backend := &orphanLockAgentBackend{
-		command:       command,
-		readyReader:   readyReader,
-		readyWriter:   readyWriter,
-		expireSession: durationLimit.Expire,
-	}
-	t.Cleanup(func() {
-		if backend.command.Process != nil {
-			_ = backend.command.Process.Kill()
-		}
-		if backend.waitDone != nil {
-			<-backend.waitDone
-		}
-	})
-	var reaped int
-	var reapErr error
-
-	runner, err := NewRunner(Dependencies{
-		Workflow: config.Workflow{
-			Config: config.Config{Agent: config.Agent{MaxSessionDurationMS: 25}},
-			Prompt: "Work",
-		},
-		Workspace: &fakeWorkspaceBackend{
-			info: workspace.Info{Path: workspacePath, Key: "issue-orphan-lock"},
-		},
-		AgentBackend:    backend,
-		sessionLimit:    durationLimit.Context,
-		WorkerReapGrace: 5 * time.Second,
-		ReapWorkspaceProcesses: func(ctx context.Context, path string, grace time.Duration) (int, error) {
-			reaped, reapErr = workspace.ReapProcesses(ctx, path, grace)
-			return reaped, reapErr
-		},
-	})
-	if err != nil {
-		t.Fatalf("NewRunner() error = %v", err)
+func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
+	tests := []struct {
+		name      string
+		completed bool
+		wantErr   error
+	}{
+		{name: "completed turn abandons command", completed: true},
+		{name: "session cancellation", wantErr: ErrSessionDurationExceeded},
 	}
 
-	_, runErr := runner.Run(context.Background(), RunRequest{
-		Issue: connector.Issue{
-			ID:         "issue-orphan-lock",
-			Identifier: "digitaldrywood/detent#2081",
-		},
-	})
-	if !errors.Is(runErr, ErrSessionDurationExceeded) {
-		t.Fatalf("Run() error = %v, want ErrSessionDurationExceeded", runErr)
-	}
-	if reapErr != nil || reaped != 1 {
-		t.Fatalf("workspace reap = (%d, %v), want (1, nil)", reaped, reapErr)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspacePath := t.TempDir()
+			lockPath := filepath.Join(workspacePath, "gate.lock")
+			durationLimit := &controlledDurationLimit{}
+			command, readyReader, readyWriter := workspaceLockCommand(t, workspacePath, lockPath)
+			backend := &orphanLockAgentBackend{
+				command:       command,
+				readyReader:   readyReader,
+				readyWriter:   readyWriter,
+				expireSession: durationLimit.Expire,
+				completed:     tt.completed,
+			}
+			t.Cleanup(func() {
+				if backend.command.Process != nil {
+					_ = backend.command.Process.Kill()
+				}
+				if backend.waitDone != nil {
+					<-backend.waitDone
+				}
+			})
+			var reaped int
+			var reapErr error
 
-	select {
-	case <-backend.waitDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("workspace lock holder survived session cancellation")
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{Agent: config.Agent{MaxSessionDurationMS: 25}},
+					Prompt: "Work",
+				},
+				Workspace: &fakeWorkspaceBackend{
+					info: workspace.Info{Path: workspacePath, Key: "issue-orphan-lock"},
+				},
+				AgentBackend:    backend,
+				sessionLimit:    durationLimit.Context,
+				WorkerReapGrace: 5 * time.Second,
+				ReapWorkspaceProcesses: func(ctx context.Context, path string, grace time.Duration) (int, error) {
+					reaped, reapErr = workspace.ReapProcesses(ctx, path, grace)
+					return reaped, reapErr
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			_, runErr := runner.Run(context.Background(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-orphan-lock",
+					Identifier: "digitaldrywood/detent#2116",
+				},
+			})
+			if !errors.Is(runErr, tt.wantErr) {
+				t.Fatalf("Run() error = %v, want %v", runErr, tt.wantErr)
+			}
+			if reapErr != nil || reaped != 1 {
+				t.Fatalf("workspace reap = (%d, %v), want (1, nil)", reaped, reapErr)
+			}
+
+			select {
+			case <-backend.waitDone:
+			case <-time.After(5 * time.Second):
+				t.Fatal("workspace lock holder survived terminal session")
+			}
+			assertLockAvailable(t, lockPath)
+		})
 	}
-	assertLockAvailable(t, lockPath)
 }
 
 func TestWorkspaceLockProcess(t *testing.T) {
@@ -111,11 +126,19 @@ type orphanLockAgentBackend struct {
 	readyReader   *os.File
 	readyWriter   *os.File
 	expireSession func()
+	completed     bool
 	waitDone      chan struct{}
 }
 
-func (b *orphanLockAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+func (b *orphanLockAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
 	if err := b.command.Start(); err != nil {
+		return AgentTurnResult{}, err
+	}
+	identity, err := procgroup.Inspect(b.command)
+	if err != nil {
+		return AgentTurnResult{}, err
+	}
+	if err := onUpdate(AgentUpdate{Type: AgentUpdateProcessStarted, WorkerProcess: identity}); err != nil {
 		return AgentTurnResult{}, err
 	}
 	if err := b.readyWriter.Close(); err != nil {
@@ -128,6 +151,9 @@ func (b *orphanLockAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest
 	}()
 	if _, err := io.ReadFull(b.readyReader, make([]byte, 1)); err != nil {
 		return AgentTurnResult{}, err
+	}
+	if b.completed {
+		return AgentTurnResult{}, nil
 	}
 	b.expireSession()
 	<-ctx.Done()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5193,14 +5193,19 @@ func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T
 			Branch: "detent/digitaldrywood_detent_522",
 		},
 	}
+	processStartedAt := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
 	validatorBackend := &fakeCodexClient{
-		updates: []AgentUpdate{{
-			Type:  AgentUpdateMessageDelta,
-			Delta: `{"verdict":"pass","score":0.93,"summary":"Acceptance criteria are covered.","findings":[{"severity":"p2","body":"Follow-up polish.","path":"README.md","line":12}]}`,
-		}},
+		updates: []AgentUpdate{
+			{Type: AgentUpdateProcessStarted, WorkerProcess: procgroup.Identity{PID: 2116, GroupID: 2116, StartedAt: processStartedAt}},
+			{
+				Type:  AgentUpdateMessageDelta,
+				Delta: `{"verdict":"pass","score":0.93,"summary":"Acceptance criteria are covered.","findings":[{"severity":"p2","body":"Follow-up polish.","path":"README.md","line":12}]}`,
+			},
+		},
 		result: AgentTurnResult{ThreadID: "validator-thread", TurnID: "validator-turn"},
 	}
 	codeBackend := &fakeCodexClient{}
+	workspaceReaped := ""
 
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
@@ -5232,6 +5237,10 @@ func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T
 			"codex-code":      codeBackend,
 			"codex-validator": validatorBackend,
 		},
+		ReapWorkspaceProcesses: func(_ context.Context, path string, _ time.Duration) (int, error) {
+			workspaceReaped = path
+			return 0, nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
@@ -5256,6 +5265,9 @@ func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T
 
 	if !result.Submitted || result.Verdict != gate.ValidatorVerdictPass || result.Score != 0.93 {
 		t.Fatalf("Validate() result = %#v, want submitted pass score 0.93", result)
+	}
+	if workspaceReaped != workspacePath {
+		t.Fatalf("reaped workspace = %q, want %q", workspaceReaped, workspacePath)
 	}
 	if result.Summary != "Acceptance criteria are covered." {
 		t.Fatalf("Summary = %q, want parsed summary", result.Summary)


### PR DESCRIPTION
## Summary

- Reap escaped workspace processes after terminal implementation and validator turns that launched a provider worker, including successful and ordinary-failure completions.
- Preserve cancellation cleanup before process observation while reusing the bounded workspace TERM/KILL/verify primitive from #2081.
- Cover abandoned successful commands, cancellation, lifecycle telemetry, and validator cleanup with deterministic stdlib tests.

Fixes #2116

## UI Surface Contract

- [x] N/A; this PR has no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR does not change primary operator screens.

## Test Plan

- [x] `make check` (exact gate in a writable four-CPU Linux clone under Detent `TMPDIR`; 78.8% aggregate coverage)
- [x] `go test -race ./internal/runner -run "^(TestRunnerReapsWorkerAfterTerminalTurn|TestRunnerTerminalSessionReapsEscapedWorkspaceProcess|TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON)$" -count=10`
- [x] `go test -race ./internal/runner -count=1`