### PR TITLE
fix(merge): prevent stale CI wait deadlines

### DIFF
--- a/.detent/skills/macos-dyld-go-validation-fallback.md
+++ b/.detent/skills/macos-dyld-go-validation-fallback.md
@@ -16,6 +16,8 @@ Confirm that the failure precedes application startup before changing code:
 
 Run the repository's exact validation target in a Linux container when Docker is healthy. Mount the worktree, the worktree's shared Git metadata at its original absolute path, and Detent-scoped module, build, and tool caches. Pass `safe.directory` through `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_0`, and `GIT_CONFIG_VALUE_0` so generators can resolve repository-relative paths without changing global Git configuration.
 
+Run the validation container with an init process when tests spawn descendants. Without `--init`, exited orphan processes can remain observable as PID 1's unreaped zombies and make process-group cleanup tests report surviving workers after successful termination. Confirm this signature by repeating the focused test with and without container init before changing subprocess code.
+
 Run the container as the workspace owner. Use workspace-owned temporary directories for `node_modules` and npm cache; anonymous Docker volumes default to root ownership. Prefer repository-pinned prebuilt tools when host file-table pressure makes large `go install` dependency trees fail.
 
 Keep test `TMPDIR` on an executable container-local tmpfs. A Docker Desktop bind mount can change fsnotify behavior and create duplicate file events that do not occur on a native Linux filesystem. When the gate creates disposable Git repositories, scope `safe.directory=*` to the ephemeral container so those repositories remain usable without changing host Git configuration.

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -652,8 +652,13 @@ func (p dispatchPlanner) previewCurrentHeadCIWait(
 		state.Retry[issue.ID] = retry
 		return retry, false
 	}
+	timing := reconcileMergeWorkerCurrentHeadCIWait(state, issue, now)
 	retry.Issue = cloneIssue(issue)
 	retry.Error = mergeWorkerCurrentHeadCIWaitReason(issue)
+	if retry.Wait.StartedAt.IsZero() || !retry.Wait.StartedAt.Equal(timing.CIWaitStartedAt) {
+		retry.Wait.StartedAt = timing.CIWaitStartedAt
+		retry.Wait.PollCount = 0
+	}
 	retry.Wait.PollCount++
 	retry.Wait.PendingChecks = mergeWorkerCurrentHeadCIPendingChecks(issue)
 	retry.DueAt = mergeWorkerCurrentHeadCINextPollAt(retry.Wait.StartedAt, now, p.cfg.ContinuationRetryDelay)

--- a/internal/orchestrator/merge_timing.go
+++ b/internal/orchestrator/merge_timing.go
@@ -39,13 +39,17 @@ func (o *Orchestrator) recordMergeQueueEntered(state *State, issue connector.Iss
 		state.MergeTimings = map[string]MergeTiming{}
 	}
 	timing := state.MergeTimings[issueID]
-	if !timing.EnteredMergingAt.IsZero() && timing.MergedAt.IsZero() && timing.MergeFailedAt.IsZero() {
+	enteredAt := mergeQueueEnteredAt(issue, now)
+	newEntry := issue.StageUpdatedAt != nil &&
+		!issue.StageUpdatedAt.IsZero() &&
+		issue.StageUpdatedAt.UTC().After(timing.EnteredMergingAt)
+	if !timing.EnteredMergingAt.IsZero() && timing.MergedAt.IsZero() && timing.MergeFailedAt.IsZero() && !newEntry {
 		return timing
 	}
-	if !timing.MergedAt.IsZero() || !timing.MergeFailedAt.IsZero() {
+	if newEntry || !timing.MergedAt.IsZero() || !timing.MergeFailedAt.IsZero() {
 		timing = MergeTiming{}
 	}
-	timing.EnteredMergingAt = mergeQueueEnteredAt(issue, now)
+	timing.EnteredMergingAt = enteredAt
 	timing = timing.withDurations(now)
 	state.MergeTimings[issueID] = timing
 	o.logMergeTimingInfo("merge_queue_entered", issue, timing, "source", strings.TrimSpace(source))
@@ -148,9 +152,7 @@ func (o *Orchestrator) markMergeStarted(state *State, issue connector.Issue, now
 		timing.BaseRefreshStartedAt = timing.MergeStartedAt
 		timing.BaseRefreshFinishedAt = time.Time{}
 	}
-	if timing.CIWaitStartedAt.IsZero() {
-		timing.CIWaitStartedAt = timing.MergeStartedAt
-	}
+	timing = timing.withCurrentHeadCIWait(issue, timing.MergeStartedAt)
 	timing.CIWaitFinishedAt = time.Time{}
 	timing = timing.withDurations(now)
 	state.MergeTimings[strings.TrimSpace(issue.ID)] = timing
@@ -159,6 +161,38 @@ func (o *Orchestrator) markMergeStarted(state *State, issue connector.Issue, now
 	}
 	o.logMergeTimingInfo("merge_ci_wait_started", issue, timing)
 	return timing
+}
+
+func reconcileMergeWorkerCurrentHeadCIWait(state *State, issue connector.Issue, now time.Time) MergeTiming {
+	if state == nil {
+		return MergeTiming{}
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return MergeTiming{}
+	}
+	if state.MergeTimings == nil {
+		state.MergeTimings = map[string]MergeTiming{}
+	}
+	timing := state.MergeTimings[issueID].withCurrentHeadCIWait(issue, now)
+	state.MergeTimings[issueID] = timing
+	return timing
+}
+
+func (t MergeTiming) withCurrentHeadCIWait(issue connector.Issue, now time.Time) MergeTiming {
+	headSHA := ""
+	if issue.PullRequest != nil {
+		headSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
+	}
+	headChanged := headSHA != "" && t.CIWaitHeadSHA != "" && headSHA != t.CIWaitHeadSHA
+	if t.CIWaitStartedAt.IsZero() || headChanged {
+		t.CIWaitStartedAt = now.UTC()
+		t.CIWaitFinishedAt = time.Time{}
+	}
+	if headSHA != "" {
+		t.CIWaitHeadSHA = headSHA
+	}
+	return t
 }
 
 func (o *Orchestrator) recordMergeCompleted(state *State, issue connector.Issue, at time.Time, finalState string) MergeTiming {

--- a/internal/orchestrator/merge_timing_test.go
+++ b/internal/orchestrator/merge_timing_test.go
@@ -237,8 +237,9 @@ func TestMarkMergeStartedPreservesCurrentHeadCIWaitDeadline(t *testing.T) {
 		Identifier: "digitaldrywood/detent#1634",
 		State:      "Merging",
 		PullRequest: &connector.PullRequest{
-			Number: 1636,
-			State:  "OPEN",
+			Number:  1636,
+			State:   "OPEN",
+			HeadSHA: "current-head",
 		},
 	}
 	state := newState(normalizeConfig(Config{}))
@@ -252,6 +253,116 @@ func TestMarkMergeStartedPreservesCurrentHeadCIWaitDeadline(t *testing.T) {
 	}
 	if !got.MergeStartedAt.Equal(retryStart) {
 		t.Fatalf("MergeStartedAt = %s, want current attempt start %s", got.MergeStartedAt, retryStart)
+	}
+}
+
+func TestMarkMergeStartedResetsCurrentHeadCIWaitDeadlineAfterRepromotion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		previousPromotion  time.Time
+		currentPromotion   time.Time
+		prematureTimeoutAt time.Time
+	}{
+		{
+			name:               "first recorded repromotion",
+			previousPromotion:  time.Date(2026, 9, 4, 3, 4, 50, 0, time.UTC),
+			currentPromotion:   time.Date(2026, 9, 4, 5, 14, 36, 0, time.UTC),
+			prematureTimeoutAt: time.Date(2026, 9, 4, 5, 19, 46, 0, time.UTC),
+		},
+		{
+			name:               "second recorded repromotion",
+			previousPromotion:  time.Date(2026, 9, 4, 5, 14, 36, 0, time.UTC),
+			currentPromotion:   time.Date(2026, 9, 4, 6, 22, 35, 0, time.UTC),
+			prematureTimeoutAt: time.Date(2026, 9, 4, 6, 37, 40, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{
+				ID:             "issue-2112-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Identifier:     "digitaldrywood/detent#2112",
+				State:          "Merging",
+				StageUpdatedAt: &tt.currentPromotion,
+				PullRequest: &connector.PullRequest{
+					Number:  2125,
+					State:   "OPEN",
+					HeadSHA: "eea58aa203f4a754081156460be2e4bcc56f8c48",
+				},
+			}
+			state := newState(normalizeConfig(Config{}))
+			state.MergeTimings[issue.ID] = MergeTiming{
+				EnteredMergingAt:          tt.previousPromotion,
+				MergeWorkerSlotAcquiredAt: tt.previousPromotion,
+				MergeStartedAt:            tt.previousPromotion,
+				CIWaitStartedAt:           tt.previousPromotion,
+			}
+			orch := &Orchestrator{}
+
+			got := orch.markMergeStarted(&state, issue, tt.currentPromotion)
+
+			if !got.EnteredMergingAt.Equal(tt.currentPromotion) {
+				t.Fatalf("EnteredMergingAt = %s, want current promotion %s", got.EnteredMergingAt, tt.currentPromotion)
+			}
+			if !got.CIWaitStartedAt.Equal(tt.currentPromotion) {
+				t.Fatalf("CIWaitStartedAt = %s, want current promotion %s", got.CIWaitStartedAt, tt.currentPromotion)
+			}
+			if orch.mergeWorkerCurrentHeadCIWaitExceeded(&state, issue, tt.prematureTimeoutAt) {
+				t.Fatalf("current-head CI wait exceeded at %s after promotion at %s", tt.prematureTimeoutAt, tt.currentPromotion)
+			}
+		})
+	}
+}
+
+func TestCurrentHeadCIWaitDeadlineReconcilesObservedHead(t *testing.T) {
+	t.Parallel()
+
+	firstStart := time.Date(2026, 9, 4, 6, 22, 35, 0, time.UTC)
+	newHeadStart := firstStart.Add(15 * time.Minute)
+	tests := []struct {
+		name        string
+		currentHead string
+		wantStart   time.Time
+	}{
+		{name: "same head preserves deadline", currentHead: "old-head", wantStart: firstStart},
+		{name: "new head resets deadline", currentHead: "new-head", wantStart: newHeadStart},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{
+				ID:         "issue-current-head-change-" + strings.ReplaceAll(tt.name, " ", "-"),
+				Identifier: "digitaldrywood/detent#2112",
+				State:      "Merging",
+				PullRequest: &connector.PullRequest{
+					Number:  2125,
+					State:   "OPEN",
+					HeadSHA: "old-head",
+				},
+			}
+			state := newState(normalizeConfig(Config{}))
+			orch := &Orchestrator{}
+
+			orch.markMergeStarted(&state, issue, firstStart)
+			issue.PullRequest.HeadSHA = tt.currentHead
+			if orch.mergeWorkerCurrentHeadCIWaitExceeded(&state, issue, newHeadStart) {
+				t.Fatalf("current-head CI wait exceeded at %s", newHeadStart)
+			}
+			got := state.MergeTimings[issue.ID]
+
+			if got.CIWaitHeadSHA != tt.currentHead {
+				t.Fatalf("CIWaitHeadSHA = %q, want %q", got.CIWaitHeadSHA, tt.currentHead)
+			}
+			if !got.CIWaitStartedAt.Equal(tt.wantStart) {
+				t.Fatalf("CIWaitStartedAt = %s, want %s", got.CIWaitStartedAt, tt.wantStart)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -598,6 +598,10 @@ func TestDispatchReadyIssuesPollsCurrentHeadCIWithoutWorkerAdmission(t *testing.
 				if !ok || !strings.Contains(blocked.Reason, pendingCheck) {
 					t.Fatalf("Blocked[%q] = %#v, want pending check at one-hour bound", issue.ID, blocked)
 				}
+				timing := state.MergeTimings[issue.ID]
+				if !timing.MergeFailedAt.Equal(now) || !timing.CIWaitFinishedAt.Equal(now) {
+					t.Fatalf("MergeTimings[%q] = %#v, want failed CI wait closed at %s", issue.ID, timing, now)
+				}
 			}
 		})
 	}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1658,7 +1658,7 @@ func (o *Orchestrator) waitForMergeWorkerCurrentHeadCI(
 		attempt = 1
 	}
 	retryError := mergeWorkerCurrentHeadCIWaitReason(issue)
-	exceeded := o.mergeWorkerCurrentHeadCIWaitExceeded(state, issue.ID, event.CompletedAt)
+	exceeded := o.mergeWorkerCurrentHeadCIWaitExceeded(state, issue, event.CompletedAt)
 	running.Issue = issue
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
 	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", retryError)
@@ -1699,13 +1699,12 @@ func (o *Orchestrator) pollMergeWorkerCurrentHeadCI(
 		return retry, false, ""
 	}
 
+	timing := reconcileMergeWorkerCurrentHeadCIWait(state, issue, now)
 	retry.Issue = cloneIssue(issue)
 	retry.Error = mergeWorkerCurrentHeadCIWaitReason(issue)
-	if retry.Wait.StartedAt.IsZero() {
-		retry.Wait.StartedAt = state.MergeTimings[strings.TrimSpace(issue.ID)].CIWaitStartedAt
-		if retry.Wait.StartedAt.IsZero() {
-			retry.Wait.StartedAt = now.UTC()
-		}
+	if retry.Wait.StartedAt.IsZero() || !retry.Wait.StartedAt.Equal(timing.CIWaitStartedAt) {
+		retry.Wait.StartedAt = timing.CIWaitStartedAt
+		retry.Wait.PollCount = 0
 	}
 	retry.Wait.PollCount++
 	retry.Wait.PendingChecks = mergeWorkerCurrentHeadCIPendingChecks(issue)
@@ -1886,17 +1885,11 @@ func (o *Orchestrator) waitForMergeWorkerRetry(
 	})
 }
 
-func (o *Orchestrator) mergeWorkerCurrentHeadCIWaitExceeded(state *State, issueID string, completedAt time.Time) bool {
+func (o *Orchestrator) mergeWorkerCurrentHeadCIWaitExceeded(state *State, issue connector.Issue, completedAt time.Time) bool {
 	if state == nil || completedAt.IsZero() {
 		return false
 	}
-	issueID = strings.TrimSpace(issueID)
-	timing := state.MergeTimings[issueID]
-	if timing.CIWaitStartedAt.IsZero() {
-		timing.CIWaitStartedAt = completedAt.UTC()
-		state.MergeTimings[issueID] = timing
-		return false
-	}
+	timing := reconcileMergeWorkerCurrentHeadCIWait(state, issue, completedAt)
 	return !completedAt.Before(timing.CIWaitStartedAt.Add(mergeWorkerCurrentHeadCIWaitTimeout))
 }
 
@@ -2443,6 +2436,9 @@ func (o *Orchestrator) blockExhaustedMergeWorker(
 	}
 	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
 		o.logger.Warn("abandon exhausted merge worker claim failed", "issue_id", issueID, "error", err)
+	}
+	if state.MergeTimings[issueID].MergeFailedAt.IsZero() {
+		o.recordMergeFailed(state, running.Issue, completedAt, reasonCode, err)
 	}
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -245,6 +245,7 @@ type MergeTiming struct {
 	MergeStartedAt             time.Time
 	BaseRefreshStartedAt       time.Time
 	BaseRefreshFinishedAt      time.Time
+	CIWaitHeadSHA              string
 	CIWaitStartedAt            time.Time
 	CIWaitFinishedAt           time.Time
 	MergedAt                   time.Time


### PR DESCRIPTION
## Summary

- reset merge timing when an issue enters Merging again instead of inheriting an earlier attempt's spent CI deadline
- scope current-head CI wait telemetry to the observed PR head and keep retry polling synchronized with that authoritative timestamp
- close merge timing when an exhausted wait parks the issue, with regressions for the recorded #2112 promotion sequence

Fixes #2134

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR makes no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/orchestrator -run '^(TestMarkMergeStartedPreservesCurrentHeadCIWaitDeadline|TestMarkMergeStartedResetsCurrentHeadCIWaitDeadlineAfterRepromotion|TestCurrentHeadCIWaitDeadlineReconcilesObservedHead|TestDispatchReadyIssuesPollsCurrentHeadCIWithoutWorkerAdmission)$' -count=1`
- [x] focused regression suite with `-race -count=10`
- [x] `go test -race ./internal/orchestrator -count=10`
- [x] `make check` (Linux arm64 container with init; 78.8% aggregate coverage)