### PR TITLE
fix(github): coalesce REST usage divergence

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -1227,6 +1227,7 @@ func mergeFleetRESTUsage(current *telemetry.RESTUsage, incoming *telemetry.RESTU
 	}
 	merged := &telemetry.RESTUsage{}
 	contributors := make(map[string]telemetry.RESTUsageContributor)
+	divergences := make(map[string]telemetry.RESTUsageDivergence)
 	for _, usage := range []*telemetry.RESTUsage{current, incoming} {
 		if usage == nil {
 			continue
@@ -1268,9 +1269,25 @@ func mergeFleetRESTUsage(current *telemetry.RESTUsage, incoming *telemetry.RESTU
 			}
 			contributors[key] = existing
 		}
+		for _, divergence := range usage.Divergences {
+			resetAt := ""
+			if divergence.ResetAt != nil {
+				resetAt = divergence.ResetAt.UTC().Format(time.RFC3339Nano)
+			}
+			key := divergence.CredentialIdentity + "\x00" + divergence.Resource + "\x00" + resetAt
+			existing, ok := divergences[key]
+			if !ok || divergence.ObservedRequests > existing.ObservedRequests ||
+				divergence.ObservedRequests == existing.ObservedRequests && divergence.LastObservedAt != nil &&
+					(existing.LastObservedAt == nil || divergence.LastObservedAt.After(*existing.LastObservedAt)) {
+				divergences[key] = cloneRESTUsageDivergence(divergence)
+			}
+		}
 	}
 	for _, contributor := range contributors {
 		merged.Contributors = append(merged.Contributors, contributor)
+	}
+	for _, divergence := range divergences {
+		merged.Divergences = append(merged.Divergences, divergence)
 	}
 	sort.Slice(merged.Contributors, func(i, j int) bool {
 		if restBudgetConsumer(merged.Contributors[i].Consumer) != restBudgetConsumer(merged.Contributors[j].Consumer) {
@@ -1281,7 +1298,30 @@ func mergeFleetRESTUsage(current *telemetry.RESTUsage, incoming *telemetry.RESTU
 		}
 		return merged.Contributors[i].EndpointFamily < merged.Contributors[j].EndpointFamily
 	})
+	sort.Slice(merged.Divergences, func(i, j int) bool {
+		if merged.Divergences[i].CredentialIdentity != merged.Divergences[j].CredentialIdentity {
+			return merged.Divergences[i].CredentialIdentity < merged.Divergences[j].CredentialIdentity
+		}
+		if merged.Divergences[i].Resource != merged.Divergences[j].Resource {
+			return merged.Divergences[i].Resource < merged.Divergences[j].Resource
+		}
+		return timePointerBefore(merged.Divergences[i].ResetAt, merged.Divergences[j].ResetAt)
+	})
 	return merged
+}
+
+func cloneRESTUsageDivergence(divergence telemetry.RESTUsageDivergence) telemetry.RESTUsageDivergence {
+	divergence.WindowStartedAt = cloneTimePointer(divergence.WindowStartedAt)
+	divergence.LastObservedAt = cloneTimePointer(divergence.LastObservedAt)
+	divergence.ResetAt = cloneTimePointer(divergence.ResetAt)
+	return divergence
+}
+
+func timePointerBefore(left *time.Time, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left != nil
+	}
+	return left.Before(*right)
 }
 
 func issueKey(issue telemetry.Issue) string {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1621,7 +1621,10 @@ func TestMergeSnapshotAttributesFleetRESTBudgets(t *testing.T) {
 			GitHubRESTBudgets: []telemetry.RESTBudget{
 				{CredentialIdentity: "github-rest:shared", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 4200, ResetAt: &coreReset, ObservedAt: &firstObserved},
 			},
-			RESTUsage: &telemetry.RESTUsage{TotalRequests: 3, BillableRequests: 3},
+			RESTUsage: &telemetry.RESTUsage{
+				TotalRequests: 3, BillableRequests: 3,
+				Divergences: []telemetry.RESTUsageDivergence{{CredentialIdentity: "github-rest:shared", Resource: "core", ObservedRequests: 11, AttributedRequests: 10, LastObservedAt: &firstObserved, ResetAt: &coreReset}},
+			},
 		},
 	})
 	got = mergeSnapshot(got, telemetry.Snapshot{
@@ -1632,7 +1635,10 @@ func TestMergeSnapshotAttributesFleetRESTBudgets(t *testing.T) {
 				{CredentialIdentity: "github-rest:shared", EndpointFamily: "issues", Resource: "core", Limit: 5000, Remaining: 300, ResetAt: &coreReset, ObservedAt: &secondObserved},
 				{CredentialIdentity: "github-rest:search", EndpointFamily: "issue search", Resource: "search", Limit: 30, Remaining: 20, ResetAt: &searchReset, ObservedAt: &secondObserved},
 			},
-			RESTUsage: &telemetry.RESTUsage{TotalRequests: 2, BillableRequests: 1},
+			RESTUsage: &telemetry.RESTUsage{
+				TotalRequests: 2, BillableRequests: 1,
+				Divergences: []telemetry.RESTUsageDivergence{{CredentialIdentity: "github-rest:shared", Resource: "core", ObservedRequests: 22, AttributedRequests: 20, LastObservedAt: &secondObserved, ResetAt: &coreReset}},
+			},
 		},
 	})
 
@@ -1647,6 +1653,9 @@ func TestMergeSnapshotAttributesFleetRESTBudgets(t *testing.T) {
 	}
 	if got.RateLimits.RESTUsage == nil || got.RateLimits.RESTUsage.TotalRequests != 5 || got.RateLimits.RESTUsage.BillableRequests != 4 {
 		t.Fatalf("RESTUsage = %#v, want aggregated project request counts", got.RateLimits.RESTUsage)
+	}
+	if divergences := got.RateLimits.RESTUsage.Divergences; len(divergences) != 1 || divergences[0].AttributedRequests != 20 {
+		t.Fatalf("RESTUsage.Divergences = %#v, want latest shared registry counters without double counting", divergences)
 	}
 	if got.RateLimits.GitHubREST == nil || got.RateLimits.GitHubREST.Remaining != 300 {
 		t.Fatalf("GitHubREST = %#v, want most constrained compatibility bucket", got.RateLimits.GitHubREST)

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -38,6 +38,7 @@ const (
 )
 
 var defaultRESTBackoffs = newRESTBackoffRegistry()
+var defaultRESTDivergences = newRESTDivergenceRegistry()
 
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
@@ -76,8 +77,9 @@ type Client struct {
 	graphQLRateLimitStatus string
 	restRateLimit          connector.RESTRateLimit
 	restRateLimits         map[string]connector.RESTRateLimit
-	restCredentialLimits   map[string]connector.RESTRateLimit
 	restBudgets            map[string]connector.RESTRateLimitBudget
+	restDivergenceKeys     map[string]struct{}
+	restDivergences        *restDivergenceRegistry
 	restRequests           map[string]connector.RESTEndpointUsage
 	restFanoutUnits        int64
 	restCache              map[string]restCacheEntry
@@ -134,6 +136,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		restDebugLogging:    cfg.RESTDebugLogging,
 		logger:              logger,
 		restBackoffs:        defaultRESTBackoffs,
+		restDivergences:     defaultRESTDivergences,
 		conditionalRequests: !cfg.DisableConditionalRequests,
 		restCache:           map[string]restCacheEntry{},
 	}, nil
@@ -337,7 +340,7 @@ func (c *Client) restTextWithTokenRefresh(ctx context.Context, path, accept stri
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, http.MethodGet, path, resp.StatusCode, resp.Header, raw, receivedAt, false)
+	c.recordRESTRateLimitFromHeaders(ctx, backoffKey, credentialIdentity, http.MethodGet, path, resp.StatusCode, resp.Header, raw, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest text response", http.MethodGet, path, family, resp.StatusCode)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		responseErr := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
@@ -417,7 +420,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, false)
+	c.recordRESTRateLimitFromHeaders(ctx, backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest probe response", method, path, family, resp.StatusCode)
 	result := restProbeResult{
 		StatusCode: resp.StatusCode,
@@ -524,7 +527,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, conditional)
+	c.recordRESTRateLimitFromHeaders(ctx, backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, conditional)
 	if resp.StatusCode == http.StatusNotModified {
 		if !conditional {
 			return nil, ErrInvalidResponse
@@ -769,6 +772,7 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 		HasRateLimit: c.hasRestRateLimit,
 		Requests:     sortedRESTEndpointUsages(c.restRequests),
 		Budgets:      sortedRESTRateLimitBudgets(c.restBudgets),
+		Divergences:  c.restDivergences.snapshots(c.restDivergenceKeys),
 		BackoffUntil: backoffUntil,
 	}
 	for _, request := range usage.Requests {
@@ -978,7 +982,7 @@ func (c *Client) rememberRESTBackoffKey(backoffKey string) {
 	c.mu.Unlock()
 }
 
-func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, credentialIdentity string, method string, path string, status int, headers http.Header, body []byte, now time.Time, conditional bool) {
+func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey string, credentialIdentity string, method string, path string, status int, headers http.Header, body []byte, now time.Time, conditional bool) {
 	limit, hasLimit := int64Header(headers, "X-RateLimit-Limit")
 	used, hasUsed := int64Header(headers, "X-RateLimit-Used")
 	remaining, hasRemaining := int64Header(headers, "X-RateLimit-Remaining")
@@ -1036,25 +1040,22 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, credentialIde
 	}
 	if hasSnapshot {
 		snapshot.UpdatedAt = now
-		credentialLimitKey := restCredentialResourceKey(credentialIdentity, resource)
-		if previous, ok := c.restCredentialLimits[credentialLimitKey]; ok {
-			if divergence, ok := restBudgetDivergence(previous, snapshot, status != http.StatusNotModified); ok {
-				c.logger.Warn(
-					"github rest observed usage diverged from detent requests",
-					"credential_identity", credentialIdentity,
-					"endpoint_family", family,
-					"resource", resource,
-					"observed_drop", divergence.ObservedDrop,
-					"detent_billable_requests", divergence.DetentBillableRequests,
-					"unexplained_requests", divergence.UnexplainedRequests,
-					"likely_external_consumer", "worker gh subprocess sharing credential",
-				)
+		divergenceKey := restDivergenceKey(c.restEndpoint, credentialIdentity, resource)
+		divergence, report := c.restDivergences.observe(
+			divergenceKey,
+			credentialIdentity,
+			snapshot,
+			status != http.StatusNotModified,
+			restDivergenceAttribution(credentialIdentity),
+			c.restPolicy.MinRemainingReserve,
+		)
+		if divergence.ObservedRequests > 0 {
+			if c.restDivergenceKeys == nil {
+				c.restDivergenceKeys = make(map[string]struct{})
 			}
+			c.restDivergenceKeys[divergenceKey] = struct{}{}
 		}
-		if c.restCredentialLimits == nil {
-			c.restCredentialLimits = make(map[string]connector.RESTRateLimit)
-		}
-		c.restCredentialLimits[credentialLimitKey] = snapshot
+		c.logRESTUsageDivergence(ctx, divergence, report)
 		c.restRateLimit = snapshot
 		if resource != "" {
 			if c.restRateLimits == nil {
@@ -1849,6 +1850,19 @@ func sortedRESTRateLimitBudgets(budgets map[string]connector.RESTRateLimitBudget
 	return out
 }
 
+func sortedRESTUsageDivergences(divergences []connector.RESTUsageDivergence) []connector.RESTUsageDivergence {
+	sort.Slice(divergences, func(i, j int) bool {
+		if divergences[i].CredentialIdentity != divergences[j].CredentialIdentity {
+			return divergences[i].CredentialIdentity < divergences[j].CredentialIdentity
+		}
+		if divergences[i].Resource != divergences[j].Resource {
+			return divergences[i].Resource < divergences[j].Resource
+		}
+		return divergences[i].ResetAt.Before(divergences[j].ResetAt)
+	})
+	return divergences
+}
+
 type restUsageDivergence struct {
 	ObservedDrop           int64
 	DetentBillableRequests int64
@@ -1870,7 +1884,7 @@ func restBudgetDivergence(previous connector.RESTRateLimit, current connector.RE
 		DetentBillableRequests: detentRequests,
 		UnexplainedRequests:    unexplained,
 	}
-	return divergence, unexplained >= restDivergenceMinUnexplained
+	return divergence, unexplained > 0
 }
 
 func restCredentialFamilyKey(credentialIdentity string, family string) string {
@@ -1879,6 +1893,158 @@ func restCredentialFamilyKey(credentialIdentity string, family string) string {
 
 func restCredentialResourceKey(credentialIdentity string, resource string) string {
 	return credentialIdentity + "\x00" + resource
+}
+
+func restDivergenceKey(endpoint string, credentialIdentity string, resource string) string {
+	return endpoint + "\x00" + restCredentialResourceKey(credentialIdentity, resource)
+}
+
+func restDivergenceAttribution(credentialIdentity string) string {
+	if strings.HasPrefix(strings.TrimSpace(credentialIdentity), "github-rest:") {
+		return connector.RESTDivergenceExpectedShared
+	}
+	return connector.RESTDivergenceUnattributed
+}
+
+type restDivergenceReport struct {
+	Level  slog.Level
+	Reason string
+	Emit   bool
+}
+
+type restDivergenceWindow struct {
+	last              connector.RESTRateLimit
+	usage             connector.RESTUsageDivergence
+	telemetryReported bool
+	warningReported   bool
+}
+
+type restDivergenceRegistry struct {
+	mu      sync.Mutex
+	windows map[string]restDivergenceWindow
+}
+
+func newRESTDivergenceRegistry() *restDivergenceRegistry {
+	return &restDivergenceRegistry{windows: make(map[string]restDivergenceWindow)}
+}
+
+func (r *restDivergenceRegistry) observe(
+	key string,
+	credentialIdentity string,
+	current connector.RESTRateLimit,
+	billable bool,
+	attribution string,
+	reserve int64,
+) (connector.RESTUsageDivergence, restDivergenceReport) {
+	if r == nil || strings.TrimSpace(key) == "" {
+		return connector.RESTUsageDivergence{}, restDivergenceReport{}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for existingKey, existing := range r.windows {
+		if existingKey != key && !existing.last.ResetAt.IsZero() && existing.last.ResetAt.Add(restRateLimitResetSkew).Before(current.UpdatedAt) {
+			delete(r.windows, existingKey)
+		}
+	}
+
+	window, ok := r.windows[key]
+	if !ok || window.last.Limit <= 0 || current.Limit != window.last.Limit ||
+		window.last.ResetAt.IsZero() || !current.ResetAt.Equal(window.last.ResetAt) {
+		r.windows[key] = restDivergenceWindow{last: current}
+		return connector.RESTUsageDivergence{}, restDivergenceReport{}
+	}
+	if current.Remaining > window.last.Remaining || current.Used < window.last.Used {
+		return window.usage, restDivergenceReport{}
+	}
+
+	divergence, diverged := restBudgetDivergence(window.last, current, billable)
+	previous := window.last
+	window.last = current
+	if !diverged {
+		r.windows[key] = window
+		return window.usage, restDivergenceReport{}
+	}
+
+	if window.usage.ObservedRequests == 0 {
+		window.usage = connector.RESTUsageDivergence{
+			CredentialIdentity: credentialIdentity,
+			Resource:           current.Resource,
+			Attribution:        attribution,
+			WindowStartedAt:    previous.UpdatedAt,
+			ResetAt:            current.ResetAt,
+		}
+	}
+	window.usage.ObservedRequests += divergence.ObservedDrop
+	window.usage.DetentRequests += divergence.DetentBillableRequests
+	window.usage.LastObservedAt = current.UpdatedAt
+	if attribution == connector.RESTDivergenceExpectedShared {
+		window.usage.AttributedRequests += divergence.UnexplainedRequests
+	} else {
+		window.usage.UnattributedRequests += divergence.UnexplainedRequests
+	}
+
+	report := restDivergenceReport{}
+	reserveThreat := reserve > 0 && current.Remaining <= reserve
+	if reserveThreat && !window.warningReported {
+		report = restDivergenceReport{Level: slog.LevelWarn, Reason: "reserve_threat", Emit: true}
+		window.warningReported = true
+		window.telemetryReported = true
+		window.usage.WarningEmitted = true
+	} else if window.usage.UnattributedRequests >= restDivergenceMinUnexplained && !window.warningReported {
+		report = restDivergenceReport{Level: slog.LevelWarn, Reason: "unattributed_threshold", Emit: true}
+		window.warningReported = true
+		window.telemetryReported = true
+		window.usage.WarningEmitted = true
+	} else if window.usage.AttributedRequests >= restDivergenceMinUnexplained && !window.telemetryReported {
+		report = restDivergenceReport{Level: slog.LevelDebug, Reason: "expected_shared_usage", Emit: true}
+		window.telemetryReported = true
+	}
+
+	r.windows[key] = window
+	return window.usage, report
+}
+
+func (r *restDivergenceRegistry) snapshots(keys map[string]struct{}) []connector.RESTUsageDivergence {
+	if r == nil || len(keys) == 0 {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]connector.RESTUsageDivergence, 0, len(keys))
+	for key := range keys {
+		window, ok := r.windows[key]
+		if ok && window.usage.ObservedRequests > 0 {
+			out = append(out, window.usage)
+		}
+	}
+	return sortedRESTUsageDivergences(out)
+}
+
+func (c *Client) logRESTUsageDivergence(ctx context.Context, divergence connector.RESTUsageDivergence, report restDivergenceReport) {
+	if !report.Emit {
+		return
+	}
+
+	c.logger.Log(
+		ctx,
+		report.Level,
+		"github rest usage divergence coalesced",
+		"credential_identity", divergence.CredentialIdentity,
+		"resource", divergence.Resource,
+		"attribution", divergence.Attribution,
+		"report_reason", report.Reason,
+		"observed_requests", divergence.ObservedRequests,
+		"detent_requests", divergence.DetentRequests,
+		"attributed_requests", divergence.AttributedRequests,
+		"unattributed_requests", divergence.UnattributedRequests,
+		"window_started_at", divergence.WindowStartedAt,
+		"last_observed_at", divergence.LastObservedAt,
+		"reset_at", divergence.ResetAt,
+		"reserve", c.restPolicy.MinRemainingReserve,
+	)
 }
 
 type restBackoffRegistry struct {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -1567,18 +1567,16 @@ func TestClientRESTCredentialIdentityStaysStableAcrossInstallationTokenRotation(
 	}
 }
 
-func TestClientWarnsOnUnexplainedRESTBudgetDivergence(t *testing.T) {
+func TestClientDoesNotWarnOnExpectedSharedRESTBudgetUsage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		remaining       []string
-		wantWarning     bool
-		wantUnexplained string
+		name      string
+		remaining []string
 	}{
 		{name: "detent request explains drop", remaining: []string{"4999", "4998"}},
 		{name: "small external drop stays quiet", remaining: []string{"4999", "4990"}},
-		{name: "worker consumption emits warning", remaining: []string{"4999", "4988"}, wantWarning: true, wantUnexplained: "10"},
+		{name: "worker consumption is expected telemetry", remaining: []string{"4999", "4988"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1615,15 +1613,170 @@ func TestClientWarnsOnUnexplainedRESTBudgetDivergence(t *testing.T) {
 			}
 
 			output := logs.String()
-			warning := strings.Contains(output, "github rest observed usage diverged from detent requests")
-			if warning != test.wantWarning {
-				t.Fatalf("warning = %v, want %v; logs = %s", warning, test.wantWarning, output)
+			if strings.Contains(output, "level=WARN msg=\"github rest usage divergence coalesced\"") {
+				t.Fatalf("expected shared usage emitted warning; logs = %s", output)
 			}
-			if test.wantWarning {
-				for _, want := range []string{"credential_identity=github-rest:", "unexplained_requests=" + test.wantUnexplained, `likely_external_consumer="worker gh subprocess sharing credential"`} {
-					if !strings.Contains(output, want) {
-						t.Fatalf("logs = %s, want %q", output, want)
-					}
+		})
+	}
+}
+
+func TestClientCoalescesExpectedSharedRESTBudgetDivergence(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	remaining := []string{"4999", "4988", "4977"}
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		index := int(calls.Add(1)) - 1
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Used", strconv.Itoa(5000-mustAtoi(t, remaining[index])))
+		w.Header().Set("X-RateLimit-Remaining", remaining[index])
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	var logs bytes.Buffer
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("shared-divergence-token"),
+		HTTPClient:  server.Client(),
+		Logger:      slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	for range remaining {
+		if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/issues", nil, &[]json.RawMessage{}); err != nil {
+			t.Fatalf("REST() error = %v", err)
+		}
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+	if len(usage.Divergences) != 1 || usage.Divergences[0].AttributedRequests != 20 || usage.Divergences[0].UnattributedRequests != 0 {
+		t.Fatalf("Divergences = %#v, want 20 attributed requests", usage.Divergences)
+	}
+
+	output := logs.String()
+	if got := strings.Count(output, "level=WARN msg=\"github rest usage divergence coalesced\""); got != 0 {
+		t.Fatalf("warning count = %d, want 0; logs = %s", got, output)
+	}
+	if got := strings.Count(output, "level=DEBUG msg=\"github rest usage divergence coalesced\""); got != 1 {
+		t.Fatalf("debug report count = %d, want 1; logs = %s", got, output)
+	}
+}
+
+func TestClientRESTBudgetDivergenceEscalationAndRollover(t *testing.T) {
+	t.Parallel()
+
+	type observation struct {
+		client    int
+		remaining int64
+		window    int
+	}
+	tests := []struct {
+		name               string
+		credentialIdentity string
+		reserve            int64
+		observations       []observation
+		wantAttributed     int64
+		wantUnattributed   int64
+		wantWarnings       int
+		wantDebug          int
+		wantWindow         int
+		wantLogFields      []string
+	}{
+		{
+			name:               "unexplained usage stays quiet below threshold",
+			credentialIdentity: "github-app-installation:42",
+			observations:       []observation{{remaining: 4999}, {remaining: 4993}},
+			wantUnattributed:   5,
+		},
+		{
+			name:               "unexplained usage warns once at accumulated threshold",
+			credentialIdentity: "github-app-installation:43",
+			observations:       []observation{{remaining: 4999}, {remaining: 4993}, {remaining: 4987}, {remaining: 4981}},
+			wantUnattributed:   15,
+			wantWarnings:       1,
+			wantLogFields:      []string{"report_reason=unattributed_threshold", "observed_requests=12", "detent_requests=2", "unattributed_requests=10", "window_started_at=", "last_observed_at=", "reset_at="},
+		},
+		{
+			name:               "shared usage warns once when reserve is threatened",
+			credentialIdentity: "github-rest:reserve",
+			reserve:            10,
+			observations:       []observation{{remaining: 20}, {remaining: 9}, {remaining: 3}},
+			wantAttributed:     15,
+			wantWarnings:       1,
+			wantLogFields:      []string{"report_reason=reserve_threat", "attribution=expected_shared_credential", "reserve=10"},
+		},
+		{
+			name:               "shared usage coalesces across clients",
+			credentialIdentity: "github-rest:clients",
+			observations:       []observation{{remaining: 4999}, {client: 1, remaining: 4988}, {remaining: 4977}},
+			wantAttributed:     20,
+			wantDebug:          1,
+		},
+		{
+			name:               "provider reset starts a new window",
+			credentialIdentity: "github-rest:rollover",
+			observations:       []observation{{remaining: 4999}, {remaining: 4988}, {remaining: 4999, window: 1}, {remaining: 4988, window: 1}},
+			wantAttributed:     10,
+			wantDebug:          2,
+			wantWindow:         1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			start := time.Date(2026, time.September, 4, 12, 0, 0, 0, time.UTC)
+			registry := newRESTDivergenceRegistry()
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			clients := []*Client{
+				{restEndpoint: "https://api.github.test", restPolicy: RESTBudgetPolicy{MinRemainingReserve: test.reserve}, restDivergences: registry, logger: logger},
+				{restEndpoint: "https://api.github.test", restPolicy: RESTBudgetPolicy{MinRemainingReserve: test.reserve}, restDivergences: registry, logger: logger},
+			}
+			paths := []string{"/repos/example/repo/issues", "/repos/example/repo/issues/1/comments", "/repos/example/repo/pulls"}
+			for index, current := range test.observations {
+				at := start.Add(time.Duration(index) * time.Minute)
+				resetAt := start.Add(time.Duration(current.window+1) * time.Hour)
+				headers := http.Header{
+					"X-Ratelimit-Limit":     []string{"5000"},
+					"X-Ratelimit-Used":      []string{strconv.FormatInt(5000-current.remaining, 10)},
+					"X-Ratelimit-Remaining": []string{strconv.FormatInt(current.remaining, 10)},
+					"X-Ratelimit-Reset":     []string{strconv.FormatInt(resetAt.Unix(), 10)},
+					"X-Ratelimit-Resource":  []string{"core"},
+				}
+				clients[current.client].recordRESTRateLimitFromHeaders(context.Background(), "", test.credentialIdentity, http.MethodGet, paths[index%len(paths)], http.StatusOK, headers, nil, at, false)
+			}
+
+			usage := clients[0].FlushRESTRateLimitUsage()
+			if len(usage.Divergences) != 1 {
+				t.Fatalf("Divergences = %#v, want one active provider window", usage.Divergences)
+			}
+			divergence := usage.Divergences[0]
+			if divergence.AttributedRequests != test.wantAttributed || divergence.UnattributedRequests != test.wantUnattributed {
+				t.Fatalf("divergence = %#v, want attributed %d unattributed %d", divergence, test.wantAttributed, test.wantUnattributed)
+			}
+			wantReset := start.Add(time.Duration(test.wantWindow+1) * time.Hour)
+			if !divergence.ResetAt.Equal(wantReset) {
+				t.Fatalf("ResetAt = %s, want %s", divergence.ResetAt, wantReset)
+			}
+
+			output := logs.String()
+			if got := strings.Count(output, "level=WARN msg=\"github rest usage divergence coalesced\""); got != test.wantWarnings {
+				t.Fatalf("warning count = %d, want %d; logs = %s", got, test.wantWarnings, output)
+			}
+			if got := strings.Count(output, "level=DEBUG msg=\"github rest usage divergence coalesced\""); got != test.wantDebug {
+				t.Fatalf("debug count = %d, want %d; logs = %s", got, test.wantDebug, output)
+			}
+			for _, field := range test.wantLogFields {
+				if !strings.Contains(output, field) {
+					t.Fatalf("logs = %s, want field %q", output, field)
 				}
 			}
 		})

--- a/internal/connector/ratelimit.go
+++ b/internal/connector/ratelimit.go
@@ -86,11 +86,31 @@ type RESTRateLimitBudget struct {
 	RateLimit          RESTRateLimit
 }
 
+const (
+	RESTDivergenceExpectedShared = "expected_shared_credential"
+	RESTDivergenceUnattributed   = "unattributed"
+)
+
+type RESTUsageDivergence struct {
+	CredentialIdentity   string
+	Resource             string
+	Attribution          string
+	ObservedRequests     int64
+	DetentRequests       int64
+	AttributedRequests   int64
+	UnattributedRequests int64
+	WindowStartedAt      time.Time
+	LastObservedAt       time.Time
+	ResetAt              time.Time
+	WarningEmitted       bool
+}
+
 type RESTRateLimitUsage struct {
 	RateLimit           RESTRateLimit
 	HasRateLimit        bool
 	Requests            []RESTEndpointUsage
 	Budgets             []RESTRateLimitBudget
+	Divergences         []RESTUsageDivergence
 	TotalRequests       int64
 	ConditionalRequests int64
 	NotModifiedRequests int64

--- a/internal/operatortool/executor.go
+++ b/internal/operatortool/executor.go
@@ -305,6 +305,7 @@ func boundedRateLimits(rateLimits *telemetry.RateLimits) *telemetry.RateLimits {
 	if rateLimits.RESTUsage != nil {
 		rest := *rateLimits.RESTUsage
 		rest.Contributors = boundedClone(rest.Contributors, MaxItemLimit)
+		rest.Divergences = boundedClone(rest.Divergences, MaxItemLimit)
 		result.RESTUsage = &rest
 	}
 	return &result

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -449,6 +449,53 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 	}
 }
 
+func TestRESTUsageSummaryPresence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		usage      connector.RESTRateLimitUsage
+		want       bool
+		divergence string
+	}{
+		{name: "empty"},
+		{
+			name: "divergence only",
+			usage: connector.RESTRateLimitUsage{Divergences: []connector.RESTUsageDivergence{{
+				CredentialIdentity: "github-rest:shared",
+				Resource:           "core",
+				Attribution:        connector.RESTDivergenceExpectedShared,
+				ObservedRequests:   12,
+				AttributedRequests: 12,
+			}}},
+			want:       true,
+			divergence: "github-rest:shared",
+		},
+		{
+			name:  "rate limited only",
+			usage: connector.RESTRateLimitUsage{RateLimited: true},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := restUsageSummary(tt.usage)
+			if (got != nil) != tt.want {
+				t.Fatalf("restUsageSummary() = %#v, want present %t", got, tt.want)
+			}
+			if tt.divergence == "" {
+				return
+			}
+			if len(got.Divergences) != 1 || got.Divergences[0].CredentialIdentity != tt.divergence {
+				t.Fatalf("restUsageSummary().Divergences = %#v, want credential %q", got.Divergences, tt.divergence)
+			}
+		})
+	}
+}
+
 func TestReplaceRESTConsumerBudgetsPreservesWorkerBudget(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -397,6 +397,11 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 				{CredentialIdentity: "github-rest:shared", EndpointFamily: "label issues", RateLimit: connector.RESTRateLimit{Limit: 5000, Remaining: 4879, Resource: "core", ResetAt: now.Add(time.Hour), UpdatedAt: now}},
 				{CredentialIdentity: "github-rest:shared", EndpointFamily: "issue comments", RateLimit: connector.RESTRateLimit{Limit: 5000, Remaining: 4878, Resource: "core", ResetAt: now.Add(2 * time.Hour), UpdatedAt: now}},
 			},
+			Divergences: []connector.RESTUsageDivergence{{
+				CredentialIdentity: "github-rest:shared", Resource: "core", Attribution: connector.RESTDivergenceExpectedShared,
+				ObservedRequests: 22, DetentRequests: 2, AttributedRequests: 20,
+				WindowStartedAt: now.Add(-time.Minute), LastObservedAt: now, ResetAt: now.Add(time.Hour),
+			}},
 			TotalRequests:       2,
 			ConditionalRequests: 1,
 			NotModifiedRequests: 1,
@@ -429,6 +434,9 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 	}
 	if len(state.RateLimits.RESTUsage.Contributors) != 2 || state.RateLimits.RESTUsage.Contributors[1].EndpointFamily != "issue comments" {
 		t.Fatalf("RESTUsage.Contributors = %#v, want issue comments contributor", state.RateLimits.RESTUsage.Contributors)
+	}
+	if got := state.RateLimits.RESTUsage.Divergences; len(got) != 1 || got[0].AttributedRequests != 20 || got[0].ResetAt == nil || !got[0].ResetAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("RESTUsage.Divergences = %#v, want shared credential window counters", got)
 	}
 	if len(state.RateLimits.GitHubRESTBudgets) != 2 || state.RateLimits.GitHubRESTBudgets[0].CredentialIdentity != "github-rest:shared" {
 		t.Fatalf("GitHubRESTBudgets = %#v, want attributed endpoint budgets", state.RateLimits.GitHubRESTBudgets)

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -79,7 +79,7 @@ func (o *Orchestrator) captureConnectorRESTRateLimits(state *State, now time.Tim
 		return restRateLimitCycle{}
 	}
 	usage := reporter.FlushRESTRateLimitUsage()
-	if !usage.HasRateLimit && usage.TotalRequests == 0 && len(usage.Requests) == 0 {
+	if !usage.HasRateLimit && usage.TotalRequests == 0 && len(usage.Requests) == 0 && len(usage.Divergences) == 0 {
 		return restRateLimitCycle{}
 	}
 
@@ -126,6 +126,7 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 		BillableRequests:    usage.BillableRequests,
 		RateLimited:         usage.RateLimited,
 		Contributors:        make([]telemetry.RESTUsageContributor, 0, len(usage.Requests)),
+		Divergences:         make([]telemetry.RESTUsageDivergence, 0, len(usage.Divergences)),
 	}
 	if !usage.BackoffUntil.IsZero() {
 		backoffUntil := usage.BackoffUntil
@@ -154,6 +155,31 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 			contributor.RetryAfterMS = request.RetryAfter.Milliseconds()
 		}
 		out.Contributors = append(out.Contributors, contributor)
+	}
+	for _, divergence := range usage.Divergences {
+		summary := telemetry.RESTUsageDivergence{
+			CredentialIdentity:   divergence.CredentialIdentity,
+			Resource:             divergence.Resource,
+			Attribution:          divergence.Attribution,
+			ObservedRequests:     divergence.ObservedRequests,
+			DetentRequests:       divergence.DetentRequests,
+			AttributedRequests:   divergence.AttributedRequests,
+			UnattributedRequests: divergence.UnattributedRequests,
+			WarningEmitted:       divergence.WarningEmitted,
+		}
+		if !divergence.WindowStartedAt.IsZero() {
+			value := divergence.WindowStartedAt
+			summary.WindowStartedAt = &value
+		}
+		if !divergence.LastObservedAt.IsZero() {
+			value := divergence.LastObservedAt
+			summary.LastObservedAt = &value
+		}
+		if !divergence.ResetAt.IsZero() {
+			value := divergence.ResetAt
+			summary.ResetAt = &value
+		}
+		out.Divergences = append(out.Divergences, summary)
 	}
 	return out
 }

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -115,7 +115,7 @@ func replaceRESTConsumerBudgets(current []telemetry.RESTBudget, replacement []te
 }
 
 func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
-	if usage.TotalRequests == 0 && len(usage.Requests) == 0 && !usage.RateLimited {
+	if usage.TotalRequests == 0 && len(usage.Requests) == 0 && len(usage.Divergences) == 0 && !usage.RateLimited {
 		return nil
 	}
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -929,6 +929,14 @@ func cloneRESTUsage(usage *telemetry.RESTUsage) *telemetry.RESTUsage {
 			cloned.Contributors[index].ResetAt = &resetAt
 		}
 	}
+	if len(usage.Divergences) > 0 {
+		cloned.Divergences = append([]telemetry.RESTUsageDivergence(nil), usage.Divergences...)
+		for index := range cloned.Divergences {
+			cloned.Divergences[index].WindowStartedAt = cloneTimePointer(usage.Divergences[index].WindowStartedAt)
+			cloned.Divergences[index].LastObservedAt = cloneTimePointer(usage.Divergences[index].LastObservedAt)
+			cloned.Divergences[index].ResetAt = cloneTimePointer(usage.Divergences[index].ResetAt)
+		}
+	}
 	return &cloned
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1573,6 +1573,21 @@ type RESTUsage struct {
 	RateLimited         bool                   `json:"rate_limited,omitempty"`
 	BackoffUntil        *time.Time             `json:"backoff_until,omitempty"`
 	Contributors        []RESTUsageContributor `json:"contributors,omitempty"`
+	Divergences         []RESTUsageDivergence  `json:"divergences,omitempty"`
+}
+
+type RESTUsageDivergence struct {
+	CredentialIdentity   string     `json:"credential_identity"`
+	Resource             string     `json:"resource"`
+	Attribution          string     `json:"attribution"`
+	ObservedRequests     int64      `json:"observed_requests"`
+	DetentRequests       int64      `json:"detent_requests"`
+	AttributedRequests   int64      `json:"attributed_requests,omitempty"`
+	UnattributedRequests int64      `json:"unattributed_requests,omitempty"`
+	WindowStartedAt      *time.Time `json:"window_started_at,omitempty"`
+	LastObservedAt       *time.Time `json:"last_observed_at,omitempty"`
+	ResetAt              *time.Time `json:"reset_at,omitempty"`
+	WarningEmitted       bool       `json:"warning_emitted,omitempty"`
 }
 
 const (

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -17,6 +17,8 @@ func TestSnapshotJSONShape(t *testing.T) {
 	generatedAt := time.Date(2026, 5, 30, 22, 15, 0, 0, time.UTC)
 	startedAt := generatedAt.Add(-5 * time.Minute)
 	completedAt := generatedAt.Add(-time.Minute)
+	divergenceStartedAt := generatedAt.Add(-10 * time.Minute)
+	divergenceResetAt := generatedAt.Add(45 * time.Minute)
 	perDay := 50.0
 	perIssue := 5.0
 
@@ -159,6 +161,11 @@ func TestSnapshotJSONShape(t *testing.T) {
 				Unlimited:  false,
 				Balance:    "7.25",
 			},
+			RESTUsage: &telemetry.RESTUsage{Divergences: []telemetry.RESTUsageDivergence{{
+				CredentialIdentity: "github-rest:shared", Resource: "core", Attribution: "expected_shared_credential",
+				ObservedRequests: 22, DetentRequests: 2, AttributedRequests: 20,
+				WindowStartedAt: &divergenceStartedAt, LastObservedAt: &generatedAt, ResetAt: &divergenceResetAt,
+			}}},
 		},
 		Tokens: telemetry.Tokens{
 			Input:          110,
@@ -341,6 +348,15 @@ func TestSnapshotJSONShape(t *testing.T) {
 	credits := rateLimits["credits"].(map[string]any)
 	if credits["has_credits"] != true || credits["balance"] != "7.25" {
 		t.Fatalf("credits = %#v", credits)
+	}
+	restUsage := rateLimits["rest_usage"].(map[string]any)
+	divergences := restUsage["divergences"].([]any)
+	if len(divergences) != 1 {
+		t.Fatalf("rest_usage.divergences = %#v, want one window", divergences)
+	}
+	divergence := divergences[0].(map[string]any)
+	if divergence["credential_identity"] != "github-rest:shared" || divergence["attributed_requests"] != float64(20) || divergence["reset_at"] != divergenceResetAt.Format(time.RFC3339) {
+		t.Fatalf("rest_usage.divergences[0] = %#v", divergence)
 	}
 
 	tokens := got["tokens"].(map[string]any)


### PR DESCRIPTION
## Summary

- coalesce GitHub REST usage divergence by credential, resource, and provider reset window across project clients
- downgrade expected shared-token consumption to one debug record unless it threatens the configured reserve
- expose cumulative attributed and unattributed request counters through REST health/state telemetry
- warn once when unattributed usage accumulates past the material threshold or shared usage reaches reserve risk

Fixes #2144

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI-visible changes.

## Test Plan

- [x] `go test -race ./internal/connector/github ./internal/orchestrator ./internal/cli ./internal/operatortool ./internal/telemetry -run 'REST|RateLimit|Divergence|SnapshotJSONShape' -count=1`
- [x] `make check` with CI-pinned Go 1.26.6 and golangci-lint 2.9.0 (78.8% aggregate coverage)