### PR TITLE
fix(workspace): reap residual cleanup paths

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -114,11 +114,20 @@ non-running issue can still clean up an existing Detent workspace without
 waiting for the idle cleanup sweep. The idle sweep interval still controls
 non-terminal observed workspace cleanup.
 
-Detent emits cleanup diagnostics in `/api/v1/state` under `events` and in
-published telemetry snapshots. A successful cleanup records
+Before deregistering a terminal Git worktree, Detent records a compact
+ownership marker under the configured workspace root. The idle sweep uses
+these markers to reconcile residual Detent directories without recursively
+scanning the root. Reconciliation skips paths for active issues, registered
+worktrees, active processes, and paths whose ownership marker cannot be
+validated against the configured source repository.
+
+Detent emits cleanup diagnostics in `/api/v1/state` and `/health` under
+`workspace_cleanup_failures`. The field reports the affected path count and
+last error without calculating directory sizes. A successful cleanup records
 `workspace_reap_succeeded` with `worktrees=`, `branches=`, and `processes=`
-counts. Cleanup failures record `workspace_reap_failed`, leave the workspace
-eligible for a later retry, and keep the diagnostic visible in recent events.
+counts. Cleanup failures record `workspace_reap_failed`, preserve the
+ownership marker for a later retry, and keep the diagnostic visible until
+reconciliation succeeds.
 If Detent completes a terminal run but no workspace reaper is configured, it
 records `workspace_reap_unverified`.
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -970,6 +970,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.SchedulerDecisions = append(current.SchedulerDecisions, next.SchedulerDecisions...)
 	current.Dispatch = mergeFleetDispatchStatus(current.Dispatch, next.Dispatch, next.GeneratedAt)
 	current.DispatchStalls = append(current.DispatchStalls, next.DispatchStalls...)
+	current.CleanupFaults = append(current.CleanupFaults, next.CleanupFaults...)
 	if !next.Release.IsZero() {
 		current.Releases = append(current.Releases, next.Release)
 		if current.Release.IsZero() {
@@ -1467,6 +1468,11 @@ func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	for i := range snapshot.StrandedActiveIssues {
 		if strings.TrimSpace(snapshot.StrandedActiveIssues[i].ProjectID) == "" {
 			snapshot.StrandedActiveIssues[i].ProjectID = projectID
+		}
+	}
+	for i := range snapshot.CleanupFaults {
+		if strings.TrimSpace(snapshot.CleanupFaults[i].ProjectID) == "" {
+			snapshot.CleanupFaults[i].ProjectID = projectID
 		}
 	}
 	return snapshot

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -242,6 +242,10 @@ type WorkspaceReapResult = runpkg.WorkspaceReapResult
 
 type WorkspaceReaper = runpkg.WorkspaceReaper
 
+type WorkspaceReconciler = runpkg.WorkspaceReconciler
+
+type WorkspaceReconcileResult = runpkg.WorkspaceReconcileResult
+
 type RuntimeUpdate struct {
 	Config         Config
 	Connector      connector.Connector

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -1252,6 +1252,7 @@ func TestReapWorkspacesFallsBackToStateSweepWhenKnownWorkspaceIssueIDFetchFails(
 	orch.reaper = rateLimitWorkspaceReaper{}
 
 	orch.reapWorkspacesIfDue(context.Background(), &state, now)
+	orch.reapDueWorkspacesAfterRefresh(context.Background(), &state, now)
 
 	if tracker.fetchByIDCalls != 1 {
 		t.Fatalf("FetchIssueStatesByIDs() calls = %d, want 1", tracker.fetchByIDCalls)
@@ -1301,6 +1302,7 @@ func TestReapWorkspacesStillSweepsWhenKnownWorkspaceIsActive(t *testing.T) {
 	orch.reaper = rateLimitWorkspaceReaper{}
 
 	orch.reapWorkspacesIfDue(context.Background(), &state, now)
+	orch.reapDueWorkspacesAfterRefresh(context.Background(), &state, now)
 
 	if tracker.fetchByIDCalls != 1 {
 		t.Fatalf("FetchIssueStatesByIDs() calls = %d, want 1", tracker.fetchByIDCalls)
@@ -1360,6 +1362,7 @@ func TestReapWorkspacesScopesScheduledCleanupFetch(t *testing.T) {
 			orch.reaper = rateLimitWorkspaceReaper{}
 
 			orch.reapWorkspacesIfDue(context.Background(), &state, now)
+			orch.reapDueWorkspacesAfterRefresh(context.Background(), &state, now)
 
 			if tracker.probeCalls != test.wantProbeCalls {
 				t.Fatalf("FetchIssueStateProbe() calls = %d, want %d", tracker.probeCalls, test.wantProbeCalls)

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -34,13 +34,7 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 		}
 	}
 
-	states := cleanupFetchStates(o.cfg)
 	if due {
-		swept := len(states) == 0 || o.reapWorkspaceStates(ctx, state, states, now)
-		reconciled := o.reconcileResidualWorkspaces(ctx, state, now)
-		if swept && reconciled {
-			state.LastWorkspaceCleanupAt = now
-		}
 		return
 	}
 
@@ -51,26 +45,45 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 	o.reapWorkspaceStates(ctx, state, terminalStates, now)
 }
 
+func (o *Orchestrator) reapDueWorkspacesAfterRefresh(ctx context.Context, state *State, now time.Time) {
+	if o.reaper == nil {
+		return
+	}
+	if !state.LastWorkspaceCleanupAt.IsZero() && now.Before(state.LastWorkspaceCleanupAt.Add(o.cfg.WorkspaceCleanupSweepInterval)) {
+		return
+	}
+	states := cleanupFetchStates(o.cfg)
+	swept := len(states) == 0 || o.reapWorkspaceStates(ctx, state, states, now)
+	reconciled := o.reconcileResidualWorkspaces(ctx, state, now)
+	if swept && reconciled {
+		state.LastWorkspaceCleanupAt = now
+	}
+}
+
 func (o *Orchestrator) reconcileResidualWorkspaces(ctx context.Context, state *State, now time.Time) bool {
 	reconciler, ok := o.reaper.(WorkspaceReconciler)
 	if !ok {
 		return true
 	}
 	result, err := reconciler.ReconcileWorkspaces(ctx, activeWorkspaceIssues(state, o.cfg.TerminalStates))
-	failures := make(map[string]string, len(result.Failures))
+	if state.CleanupFailures == nil {
+		state.CleanupFailures = map[string]string{}
+	}
+	for _, path := range result.CompletedPaths {
+		delete(state.CleanupFailures, strings.TrimSpace(path))
+	}
 	for _, failure := range result.Failures {
 		if path := strings.TrimSpace(failure.Path); path != "" {
-			failures[path] = strings.TrimSpace(failure.Error)
+			state.CleanupFailures[path] = strings.TrimSpace(failure.Error)
 		}
 	}
-	state.CleanupFailures = failures
-	if len(failures) > 0 {
+	if len(result.Failures) > 0 {
 		state.CleanupFailureAt = cleanupEventAt(now)
 	}
 	if err != nil {
 		o.logger.Warn(
 			"workspace residual reconciliation failed",
-			slog.Int("affected_path_count", len(failures)),
+			slog.Int("affected_path_count", len(state.CleanupFailures)),
 			slog.Int("removed", result.Removed),
 			slog.Int("active_skipped", result.ActiveSkipped),
 			slog.Int("registered_skipped", result.RegisteredSkipped),
@@ -80,7 +93,7 @@ func (o *Orchestrator) reconcileResidualWorkspaces(ctx context.Context, state *S
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      cleanupEventAt(now),
 			Event:   "workspace_residual_cleanup_failed",
-			Message: fmt.Sprintf("workspace residual cleanup failed affected_paths=%d: %v", len(failures), err),
+			Message: fmt.Sprintf("workspace residual cleanup failed affected_paths=%d: %v", len(state.CleanupFailures), err),
 		})
 		return false
 	}

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,21 +24,21 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 	if o.reaper == nil {
 		return
 	}
+	due := state.LastWorkspaceCleanupAt.IsZero() || !now.Before(state.LastWorkspaceCleanupAt.Add(o.cfg.WorkspaceCleanupSweepInterval))
 
 	if ids := workspaceCleanupIssueIDs(state); len(ids) > 0 {
 		ok, cleaned := o.reapWorkspaceIssueIDs(ctx, state, ids, now)
-		if ok && cleaned {
+		if ok && cleaned && !due {
 			state.LastWorkspaceCleanupAt = now
 			return
 		}
 	}
 
 	states := cleanupFetchStates(o.cfg)
-	if len(states) == 0 {
-		return
-	}
-	if state.LastWorkspaceCleanupAt.IsZero() || !now.Before(state.LastWorkspaceCleanupAt.Add(o.cfg.WorkspaceCleanupSweepInterval)) {
-		if o.reapWorkspaceStates(ctx, state, states, now) {
+	if due {
+		swept := len(states) == 0 || o.reapWorkspaceStates(ctx, state, states, now)
+		reconciled := o.reconcileResidualWorkspaces(ctx, state, now)
+		if swept && reconciled {
 			state.LastWorkspaceCleanupAt = now
 		}
 		return
@@ -48,6 +49,87 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 		return
 	}
 	o.reapWorkspaceStates(ctx, state, terminalStates, now)
+}
+
+func (o *Orchestrator) reconcileResidualWorkspaces(ctx context.Context, state *State, now time.Time) bool {
+	reconciler, ok := o.reaper.(WorkspaceReconciler)
+	if !ok {
+		return true
+	}
+	result, err := reconciler.ReconcileWorkspaces(ctx, activeWorkspaceIssues(state, o.cfg.TerminalStates))
+	failures := make(map[string]string, len(result.Failures))
+	for _, failure := range result.Failures {
+		if path := strings.TrimSpace(failure.Path); path != "" {
+			failures[path] = strings.TrimSpace(failure.Error)
+		}
+	}
+	state.CleanupFailures = failures
+	if len(failures) > 0 {
+		state.CleanupFailureAt = cleanupEventAt(now)
+	}
+	if err != nil {
+		o.logger.Warn(
+			"workspace residual reconciliation failed",
+			slog.Int("affected_path_count", len(failures)),
+			slog.Int("removed", result.Removed),
+			slog.Int("active_skipped", result.ActiveSkipped),
+			slog.Int("registered_skipped", result.RegisteredSkipped),
+			slog.Int("unowned_skipped", result.UnownedSkipped),
+			slog.Any("error", err),
+		)
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(now),
+			Event:   "workspace_residual_cleanup_failed",
+			Message: fmt.Sprintf("workspace residual cleanup failed affected_paths=%d: %v", len(failures), err),
+		})
+		return false
+	}
+	if result.Removed > 0 {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(now),
+			Event:   "workspace_residual_cleanup_succeeded",
+			Message: fmt.Sprintf("workspace residual cleanup succeeded removed=%d active_skipped=%d", result.Removed, result.ActiveSkipped),
+		})
+	}
+	return true
+}
+
+func activeWorkspaceIssues(state *State, terminalStates []string) []connector.Issue {
+	if state == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	active := []connector.Issue{}
+	appendIssue := func(issue connector.Issue) {
+		if strings.TrimSpace(issue.Identifier) == "" || workspaceIssueTerminal(issue, terminalStates) {
+			return
+		}
+		key := strings.TrimSpace(issue.ID)
+		if key == "" {
+			key = strings.TrimSpace(issue.Identifier)
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		active = append(active, issue)
+	}
+	for _, issue := range state.BoardIssues {
+		appendIssue(issue)
+	}
+	for _, issue := range state.Pipeline {
+		appendIssue(issue)
+	}
+	for _, running := range state.Running {
+		appendIssue(running.Issue)
+	}
+	for _, retry := range state.Retry {
+		appendIssue(retry.Issue)
+	}
+	for _, blocked := range state.Blocked {
+		appendIssue(blocked.Issue)
+	}
+	return active
 }
 
 func (o *Orchestrator) reapWorkspaceIssueIDs(ctx context.Context, state *State, issueIDs []string, now time.Time) (bool, bool) {
@@ -286,6 +368,11 @@ func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue co
 		if errors.As(err, &diagnostic) {
 			if path := strings.TrimSpace(diagnostic.WorkspacePath()); path != "" {
 				args = append(args, slog.String("workspace_path", path))
+				if state.CleanupFailures == nil {
+					state.CleanupFailures = map[string]string{}
+				}
+				state.CleanupFailures[path] = err.Error()
+				state.CleanupFailureAt = cleanupEventAt(now)
 			}
 			if remediation := strings.TrimSpace(diagnostic.Remediation()); remediation != "" {
 				args = append(args, slog.String("remediation", remediation))
@@ -298,6 +385,9 @@ func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue co
 			Message: workspaceReapFailedMessage(issue, reason, err),
 		})
 		return false
+	}
+	if path := strings.TrimSpace(result.Path); path != "" {
+		delete(state.CleanupFailures, path)
 	}
 	state.ReapedWorkspaces[issue.ID] = cleanupEventAt(now)
 	recordStateEvent(state, telemetry.ActivityEvent{
@@ -315,6 +405,22 @@ func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue co
 		slog.Int("processes", result.Processes),
 	)
 	return true
+}
+
+func workspaceCleanupFailureSnapshots(state State) []telemetry.CleanupFault {
+	if len(state.CleanupFailures) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(state.CleanupFailures))
+	for path := range state.CleanupFailures {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return []telemetry.CleanupFault{{
+		AffectedPathCount: len(paths),
+		LastError:         state.CleanupFailures[paths[0]],
+		ObservedAt:        state.CleanupFailureAt,
+	}}
 }
 
 func cleanupEventAt(now time.Time) time.Time {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -826,6 +826,62 @@ func TestTickWorkspaceCleanupFailureRecordsDiagnosticEvent(t *testing.T) {
 			t.Fatalf("cleanup failure logs = %q, want %q", logs.String(), want)
 		}
 	}
+	snapshot := state.Snapshot(now)
+	if len(snapshot.CleanupFaults) != 1 || snapshot.CleanupFaults[0].AffectedPathCount != 1 {
+		t.Fatalf("CleanupFaults = %+v, want one affected path", snapshot.CleanupFaults)
+	}
+}
+
+func TestWorkspaceResidualReconciliationRetriesAndProtectsActiveIssues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	active := connector.Issue{ID: "issue-active", Identifier: "digitaldrywood/detent#2141", State: "In Progress"}
+	cfg := normalizeConfig(Config{
+		Project:                       scheduler.ProjectCandidate{ID: "detent"},
+		ActiveStates:                  []string{"In Progress"},
+		ObservedStates:                []string{"Blocked"},
+		TerminalStates:                []string{"Done"},
+		WorkspaceCleanupSweepInterval: time.Hour,
+	})
+	state := newState(cfg)
+	state.BoardIssues = []connector.Issue{active}
+	reaper := &residualCleanupReaper{
+		cleanupSweepReaper: &cleanupSweepReaper{},
+		results: []WorkspaceReconcileResult{
+			{Failures: []runpkg.WorkspaceCleanupFailure{{Path: "/workspaces/residual", Error: "permission denied"}}},
+			{Removed: 1},
+		},
+		errors: []error{errors.New("permission denied"), nil},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: &runningStateConnector{},
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.reapWorkspacesIfDue(t.Context(), &state, now)
+	if len(reaper.active) != 1 || len(reaper.active[0]) != 1 || reaper.active[0][0].ID != active.ID {
+		t.Fatalf("first reconciliation active issues = %+v", reaper.active)
+	}
+	if len(state.CleanupFailures) != 1 {
+		t.Fatalf("CleanupFailures = %+v, want one failure", state.CleanupFailures)
+	}
+	if _, ok := recentStateEvent(state, "workspace_residual_cleanup_failed"); !ok {
+		t.Fatalf("RecentEvents = %+v, want residual cleanup failure", state.RecentEvents)
+	}
+
+	orch.reapWorkspacesIfDue(t.Context(), &state, now.Add(time.Minute))
+	if len(reaper.active) != 2 {
+		t.Fatalf("reconciliation calls = %d, want retry", len(reaper.active))
+	}
+	if len(state.CleanupFailures) != 0 {
+		t.Fatalf("CleanupFailures after retry = %+v, want none", state.CleanupFailures)
+	}
+	if _, ok := recentStateEvent(state, "workspace_residual_cleanup_succeeded"); !ok {
+		t.Fatalf("RecentEvents = %+v, want residual cleanup success", state.RecentEvents)
+	}
 }
 
 func TestTickMarksClosedCompletedRunningIssueDoneBeforeReaping(t *testing.T) {
@@ -1207,6 +1263,22 @@ type cleanupSweepReaper struct {
 	result WorkspaceReapResult
 	err    error
 	issues []connector.Issue
+}
+
+type residualCleanupReaper struct {
+	*cleanupSweepReaper
+	results []WorkspaceReconcileResult
+	errors  []error
+	active  [][]connector.Issue
+}
+
+func (r *residualCleanupReaper) ReconcileWorkspaces(_ context.Context, active []connector.Issue) (WorkspaceReconcileResult, error) {
+	r.active = append(r.active, cloneIssues(active))
+	index := len(r.active) - 1
+	if index >= len(r.results) {
+		index = len(r.results) - 1
+	}
+	return r.results[index], r.errors[index]
 }
 
 func (r *cleanupSweepReaper) ReapWorkspace(_ context.Context, issue connector.Issue) (WorkspaceReapResult, error) {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -850,7 +850,7 @@ func TestWorkspaceResidualReconciliationRetriesAndProtectsActiveIssues(t *testin
 		cleanupSweepReaper: &cleanupSweepReaper{},
 		results: []WorkspaceReconcileResult{
 			{Failures: []runpkg.WorkspaceCleanupFailure{{Path: "/workspaces/residual", Error: "permission denied"}}},
-			{Removed: 1},
+			{Removed: 1, CompletedPaths: []string{"/workspaces/residual"}},
 		},
 		errors: []error{errors.New("permission denied"), nil},
 	}
@@ -861,7 +861,7 @@ func TestWorkspaceResidualReconciliationRetriesAndProtectsActiveIssues(t *testin
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
-	orch.reapWorkspacesIfDue(t.Context(), &state, now)
+	orch.reapDueWorkspacesAfterRefresh(t.Context(), &state, now)
 	if len(reaper.active) != 1 || len(reaper.active[0]) != 1 || reaper.active[0][0].ID != active.ID {
 		t.Fatalf("first reconciliation active issues = %+v", reaper.active)
 	}
@@ -872,7 +872,7 @@ func TestWorkspaceResidualReconciliationRetriesAndProtectsActiveIssues(t *testin
 		t.Fatalf("RecentEvents = %+v, want residual cleanup failure", state.RecentEvents)
 	}
 
-	orch.reapWorkspacesIfDue(t.Context(), &state, now.Add(time.Minute))
+	orch.reapDueWorkspacesAfterRefresh(t.Context(), &state, now.Add(time.Minute))
 	if len(reaper.active) != 2 {
 		t.Fatalf("reconciliation calls = %d, want retry", len(reaper.active))
 	}
@@ -881,6 +881,78 @@ func TestWorkspaceResidualReconciliationRetriesAndProtectsActiveIssues(t *testin
 	}
 	if _, ok := recentStateEvent(state, "workspace_residual_cleanup_succeeded"); !ok {
 		t.Fatalf("RecentEvents = %+v, want residual cleanup success", state.RecentEvents)
+	}
+}
+
+func TestResidualReconciliationRunsOnlyAfterFreshTrackerStatePublished(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	active := connector.Issue{ID: "issue-active", Identifier: "digitaldrywood/detent#2141", State: "In Progress"}
+	cfg := normalizeConfig(Config{
+		ActiveStates:                  []string{"In Progress"},
+		TerminalStates:                []string{"Done"},
+		WorkspaceCleanupSweepInterval: time.Hour,
+	})
+	state := newState(cfg)
+	reaper := &residualCleanupReaper{
+		cleanupSweepReaper: &cleanupSweepReaper{},
+		results:            []WorkspaceReconcileResult{{ActiveSkipped: 1}},
+		errors:             []error{nil},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: &runningStateConnector{},
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.reapWorkspacesIfDue(t.Context(), &state, now)
+	if len(reaper.active) != 0 {
+		t.Fatalf("pre-refresh reconciliation calls = %d, want 0", len(reaper.active))
+	}
+	state.BoardIssues = []connector.Issue{active}
+	state.LastRefreshAt = now
+	orch.reapDueWorkspacesAfterRefresh(t.Context(), &state, now)
+	if len(reaper.active) != 1 || len(reaper.active[0]) != 1 || reaper.active[0][0].ID != active.ID {
+		t.Fatalf("post-refresh reconciliation active issues = %+v, want current active issue", reaper.active)
+	}
+}
+
+func TestResidualReconciliationPreservesSkippedCleanupFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	const path = "/workspaces/residual"
+	cfg := normalizeConfig(Config{WorkspaceCleanupSweepInterval: time.Hour})
+	state := newState(cfg)
+	state.CleanupFailures[path] = "permission denied"
+	reaper := &residualCleanupReaper{
+		cleanupSweepReaper: &cleanupSweepReaper{},
+		results: []WorkspaceReconcileResult{
+			{RegisteredSkipped: 1},
+			{CompletedPaths: []string{path}},
+		},
+		errors: []error{nil, nil},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: &runningStateConnector{},
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if !orch.reconcileResidualWorkspaces(t.Context(), &state, now) {
+		t.Fatal("skipped reconciliation failed")
+	}
+	if got := state.CleanupFailures[path]; got != "permission denied" {
+		t.Fatalf("skipped cleanup failure = %q, want preserved diagnostic", got)
+	}
+	if !orch.reconcileResidualWorkspaces(t.Context(), &state, now.Add(time.Minute)) {
+		t.Fatal("completed reconciliation failed")
+	}
+	if len(state.CleanupFailures) != 0 {
+		t.Fatalf("completed cleanup failures = %+v, want none", state.CleanupFailures)
 	}
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -127,6 +127,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		DispatchRecoveries:      dispatchRecoverySnapshots(s.DispatchRecoveries, s.PoolName, poolCapacity),
 		StalenessWarnings:       stalenessWarningSnapshots(s.StalenessWarnings),
 		StrandedActiveIssues:    strandedActiveIssues,
+		CleanupFaults:           workspaceCleanupFailureSnapshots(s),
 		OverloadRetriesLastHour: overloadRetriesLastHour(s.WorkAttempts, now),
 		Tokens:                  tokensFromTokenTotals(s.liveTokenTotals()),
 		Budget: telemetry.Budget{

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -62,6 +62,8 @@ type State struct {
 	ManualRefresh            telemetry.RefreshAttempt
 	LastRunningReconcileAt   time.Time
 	LastWorkspaceCleanupAt   time.Time
+	CleanupFailures          map[string]string
+	CleanupFailureAt         time.Time
 	RecentEvents             []telemetry.ActivityEvent
 	Auth                     connector.AuthHealth
 	StatusDrift              connector.StatusDrift
@@ -409,6 +411,7 @@ func newState(cfg Config) State {
 		BackendRecoveries:        map[string]BackendRecovery{},
 		DiffStats:                map[string]DiffStats{},
 		ReapedWorkspaces:         map[string]time.Time{},
+		CleanupFailures:          map[string]string{},
 		laneEntries:              map[string]time.Time{},
 		laneProvenance:           map[string]provenance.Attribution{},
 		planRework:               map[string]struct{}{},
@@ -454,6 +457,8 @@ func (s State) clone() State {
 		ManualRefresh:            cloneRefreshAttempt(s.ManualRefresh),
 		LastRunningReconcileAt:   s.LastRunningReconcileAt,
 		LastWorkspaceCleanupAt:   s.LastWorkspaceCleanupAt,
+		CleanupFailures:          maps.Clone(s.CleanupFailures),
+		CleanupFailureAt:         s.CleanupFailureAt,
 		RecentEvents:             cloneActivityEvents(s.RecentEvents),
 		Auth:                     s.Auth,
 		StatusDrift:              cloneStatusDrift(s.StatusDrift),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -245,7 +245,8 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	timing.next("dispatch")
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
 	timing.next("publish")
-	if refreshSucceeded(state) {
+	refreshOK := refreshSucceeded(state)
+	if refreshOK {
 		state.BoardIssues = overlayIssueStateSnapshots(
 			boardIssuesFromFetched(fetched),
 			state.tickTransitions.boardIssues,
@@ -255,6 +256,9 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		o.markRefreshSucceeded(state, now)
 	}
 	state.Pipeline = overlayIssueStateSnapshots(state.Pipeline, state.tickTransitions.pipeline)
+	if refreshOK {
+		o.reapDueWorkspacesAfterRefresh(ctx, state, now)
+	}
 	completed = true
 }
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -3122,6 +3122,7 @@ func (r *Runner) ReconcileWorkspaces(ctx context.Context, activeIssues []connect
 		ActiveSkipped:     result.ActiveSkipped,
 		RegisteredSkipped: result.RegisteredSkipped,
 		UnownedSkipped:    result.UnownedSkipped,
+		CompletedPaths:    result.CompletedPaths,
 		Failures:          failures,
 	}, err
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -3088,6 +3088,7 @@ func (r *Runner) ReapWorkspace(ctx context.Context, issue connector.Issue) (Work
 	if cleaner, ok := r.workspace.(workspace.IssueCleaner); ok {
 		result, err := cleaner.CleanupIssue(ctx, workspaceIssue)
 		return WorkspaceReapResult{
+			Path:      result.Path,
 			Worktrees: result.Worktrees,
 			Branches:  result.Branches,
 			Processes: result.Processes,
@@ -3097,6 +3098,32 @@ func (r *Runner) ReapWorkspace(ctx context.Context, issue connector.Issue) (Work
 		return WorkspaceReapResult{}, err
 	}
 	return WorkspaceReapResult{}, nil
+}
+
+func (r *Runner) ReconcileWorkspaces(ctx context.Context, activeIssues []connector.Issue) (WorkspaceReconcileResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	reconciler, ok := r.workspace.(workspace.ResidualReconciler)
+	if !ok {
+		return WorkspaceReconcileResult{}, nil
+	}
+	active := make([]workspace.Issue, 0, len(activeIssues))
+	for _, issue := range activeIssues {
+		active = append(active, workspaceIssue(r.projectID, issue))
+	}
+	result, err := reconciler.ReconcileResiduals(ctx, active)
+	failures := make([]WorkspaceCleanupFailure, 0, len(result.Failures))
+	for _, failure := range result.Failures {
+		failures = append(failures, WorkspaceCleanupFailure{Path: failure.Path, Error: failure.Error})
+	}
+	return WorkspaceReconcileResult{
+		Removed:           result.Removed,
+		ActiveSkipped:     result.ActiveSkipped,
+		RegisteredSkipped: result.RegisteredSkipped,
+		UnownedSkipped:    result.UnownedSkipped,
+		Failures:          failures,
+	}, err
 }
 
 func (r *Runner) runtimeSnapshot() (config.Workflow, agentRuntime, BudgetChecker, DispatchEstimator) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -6513,6 +6513,39 @@ func TestRunnerReapWorkspaceUsesWorkspaceIssueCleanup(t *testing.T) {
 	}
 }
 
+func TestRunnerReconcileWorkspacesUsesResidualReconciler(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeResidualWorkspaceBackend{
+		fakeWorkspaceBackend: &fakeWorkspaceBackend{},
+		result: workspace.ReconcileResult{
+			Removed:       1,
+			ActiveSkipped: 2,
+			Failures:      []workspace.CleanupFailure{{Path: "/workspaces/residual", Error: "permission denied"}},
+		},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: &fakeCodexClient{},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+	active := []connector.Issue{{ID: "issue-2140", Identifier: "digitaldrywood/detent#2140"}}
+
+	result, err := runner.ReconcileWorkspaces(t.Context(), active)
+	if err != nil {
+		t.Fatalf("ReconcileWorkspaces() error = %v", err)
+	}
+	if result.Removed != 1 || result.ActiveSkipped != 2 || len(result.Failures) != 1 {
+		t.Fatalf("ReconcileWorkspaces() = %+v", result)
+	}
+	if len(workspaceBackend.active) != 1 || workspaceBackend.active[0].ProjectID != "default" || workspaceBackend.active[0].Identifier != active[0].Identifier {
+		t.Fatalf("ReconcileResiduals() active issues = %+v", workspaceBackend.active)
+	}
+}
+
 type committingAgentBackend struct {
 	request AgentTurnRequest
 }
@@ -6595,6 +6628,18 @@ type fakeWorkspaceBackend struct {
 	recoveryStates []workspace.RecoveryState
 	recoveryErr    error
 	recoveryCalls  int
+}
+
+type fakeResidualWorkspaceBackend struct {
+	*fakeWorkspaceBackend
+	active []workspace.Issue
+	result workspace.ReconcileResult
+	err    error
+}
+
+func (b *fakeResidualWorkspaceBackend) ReconcileResiduals(_ context.Context, active []workspace.Issue) (workspace.ReconcileResult, error) {
+	b.active = append([]workspace.Issue(nil), active...)
+	return b.result, b.err
 }
 
 type fakeDeliverableWorkspaceBackend struct {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -6521,7 +6521,10 @@ func TestRunnerReconcileWorkspacesUsesResidualReconciler(t *testing.T) {
 		result: workspace.ReconcileResult{
 			Removed:       1,
 			ActiveSkipped: 2,
-			Failures:      []workspace.CleanupFailure{{Path: "/workspaces/residual", Error: "permission denied"}},
+			CompletedPaths: []string{
+				"/workspaces/removed",
+			},
+			Failures: []workspace.CleanupFailure{{Path: "/workspaces/residual", Error: "permission denied"}},
 		},
 	}
 	runner, err := NewRunner(Dependencies{
@@ -6538,7 +6541,7 @@ func TestRunnerReconcileWorkspacesUsesResidualReconciler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileWorkspaces() error = %v", err)
 	}
-	if result.Removed != 1 || result.ActiveSkipped != 2 || len(result.Failures) != 1 {
+	if result.Removed != 1 || result.ActiveSkipped != 2 || len(result.CompletedPaths) != 1 || result.CompletedPaths[0] != "/workspaces/removed" || len(result.Failures) != 1 {
 		t.Fatalf("ReconcileWorkspaces() = %+v", result)
 	}
 	if len(workspaceBackend.active) != 1 || workspaceBackend.active[0].ProjectID != "default" || workspaceBackend.active[0].Identifier != active[0].Identifier {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -302,6 +302,7 @@ type WorkspaceReconcileResult struct {
 	ActiveSkipped     int
 	RegisteredSkipped int
 	UnownedSkipped    int
+	CompletedPaths    []string
 	Failures          []WorkspaceCleanupFailure
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -261,6 +261,10 @@ type WorkspaceReaper interface {
 	ReapWorkspace(context.Context, connector.Issue) (WorkspaceReapResult, error)
 }
 
+type WorkspaceReconciler interface {
+	ReconcileWorkspaces(context.Context, []connector.Issue) (WorkspaceReconcileResult, error)
+}
+
 type DailyBudgetStatusProvider interface {
 	DailyBudgetStatus(context.Context, time.Time) (DailyBudgetStatus, bool, error)
 }
@@ -282,9 +286,23 @@ type IssueBudgetStatus struct {
 }
 
 type WorkspaceReapResult struct {
+	Path      string
 	Worktrees int
 	Branches  int
 	Processes int
+}
+
+type WorkspaceCleanupFailure struct {
+	Path  string
+	Error string
+}
+
+type WorkspaceReconcileResult struct {
+	Removed           int
+	ActiveSkipped     int
+	RegisteredSkipped int
+	UnownedSkipped    int
+	Failures          []WorkspaceCleanupFailure
 }
 
 type AgentBackend interface {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -55,6 +55,7 @@ type Snapshot struct {
 	DispatchRecoveries      []DispatchRecovery  `json:"dispatch_recoveries,omitempty"`
 	StalenessWarnings       []StalenessWarning  `json:"staleness_warnings,omitempty"`
 	StrandedActiveIssues    []StrandedIssue     `json:"stranded_active_issues,omitempty"`
+	CleanupFaults           []CleanupFault      `json:"workspace_cleanup_failures,omitempty"`
 	AdmissionProposals      []AdmissionProposal `json:"admission_proposals_awaiting_decision,omitempty"`
 	OverloadRetriesLastHour int                 `json:"overload_retries_last_hour,omitempty"`
 	Tokens                  Tokens              `json:"tokens"`
@@ -124,6 +125,13 @@ type OrphanedAgentProcess struct {
 	RSSBytes     int64     `json:"rss_bytes"`
 	ProcessCount int       `json:"process_count"`
 	FinalState   string    `json:"final_state,omitempty"`
+}
+
+type CleanupFault struct {
+	ProjectID         string    `json:"project_id,omitempty"`
+	AffectedPathCount int       `json:"affected_path_count"`
+	LastError         string    `json:"last_error"`
+	ObservedAt        time.Time `json:"observed_at"`
 }
 
 func (s Snapshot) AgeSeconds(now time.Time) int64 {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -496,6 +496,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, observedA
 		Dispatch:           snapshot.Dispatch,
 		DispatchStalls:     append([]telemetry.DispatchStatus(nil), snapshot.DispatchStalls...),
 		StalenessWarnings:  append([]telemetry.StalenessWarning(nil), snapshot.StalenessWarnings...),
+		CleanupFaults:      append([]telemetry.CleanupFault(nil), snapshot.CleanupFaults...),
 		Budget:             budgetResponse(snapshot.Budget),
 	}
 }
@@ -1467,6 +1468,7 @@ type stateAPIResponse struct {
 	Dispatch           telemetry.DispatchStatus     `json:"dispatch"`
 	DispatchStalls     []telemetry.DispatchStatus   `json:"dispatch_stalls,omitempty"`
 	StalenessWarnings  []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
+	CleanupFaults      []telemetry.CleanupFault     `json:"workspace_cleanup_failures,omitempty"`
 	Budget             budgetAPIResponse            `json:"budget"`
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1180,6 +1180,7 @@ func (s *Server) health(c echo.Context) error {
 	ciUnavailable := []telemetry.CICondition{}
 	stalenessWarnings := []telemetry.StalenessWarning{}
 	strandedActiveIssues := []telemetry.StrandedIssue{}
+	cleanupFaults := []telemetry.CleanupFault{}
 	dispatch := telemetry.DispatchStatus{}
 	dispatchStalls := []telemetry.DispatchStatus{}
 	notificationFailures := []healthnotify.Failure{}
@@ -1221,6 +1222,7 @@ func (s *Server) health(c echo.Context) error {
 			ciUnavailable = append(ciUnavailable, snapshot.CIUnavailable...)
 			stalenessWarnings = append(stalenessWarnings, snapshot.StalenessWarnings...)
 			strandedActiveIssues = append(strandedActiveIssues, snapshot.StrandedActiveIssues...)
+			cleanupFaults = append(cleanupFaults, snapshot.CleanupFaults...)
 			dispatch = snapshot.Dispatch
 			dispatchStalls = append(dispatchStalls, snapshot.DispatchStalls...)
 			if snapshot.Shutdown.Draining {
@@ -1268,7 +1270,7 @@ func (s *Server) health(c echo.Context) error {
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(faultDispatchStalls) > 0 || len(actionableBreakers) > 0 || len(dispatchLoops) > 0 || len(actionableOutages) > 0 || len(faultStalenessWarnings(stalenessWarnings)) > 0 || len(strandedActiveIssues) > 0 || strings.TrimSpace(updateStatus.LastError) != "" || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld || ioPressure.DispatchHeld || cpuPressure.DispatchHeld || orphanedProcesses.Count > 0 {
+		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(faultDispatchStalls) > 0 || len(actionableBreakers) > 0 || len(dispatchLoops) > 0 || len(actionableOutages) > 0 || len(faultStalenessWarnings(stalenessWarnings)) > 0 || len(strandedActiveIssues) > 0 || len(cleanupFaults) > 0 || strings.TrimSpace(updateStatus.LastError) != "" || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld || ioPressure.DispatchHeld || cpuPressure.DispatchHeld || orphanedProcesses.Count > 0 {
 			status = "needs_attention"
 		}
 		if pauseExitNeedsAttention(projectHealth) {
@@ -1305,6 +1307,7 @@ func (s *Server) health(c echo.Context) error {
 		DispatchLoops:          dispatchLoops,
 		StalenessWarnings:      stalenessWarnings,
 		StrandedIssues:         strandedActiveIssues,
+		CleanupFaults:          cleanupFaults,
 		Dispatch:               dispatch,
 		DispatchStalls:         dispatchStalls,
 		NotificationFailures:   notificationFailures,
@@ -1791,6 +1794,7 @@ type healthResponse struct {
 	DispatchLoops          []telemetry.DispatchLoop         `json:"dispatch_loops,omitempty"`
 	StalenessWarnings      []telemetry.StalenessWarning     `json:"staleness_warnings,omitempty"`
 	StrandedIssues         []telemetry.StrandedIssue        `json:"stranded_active_issues,omitempty"`
+	CleanupFaults          []telemetry.CleanupFault         `json:"workspace_cleanup_failures,omitempty"`
 	Dispatch               telemetry.DispatchStatus         `json:"dispatch"`
 	DispatchStalls         []telemetry.DispatchStatus       `json:"dispatch_stalls,omitempty"`
 	NotificationFailures   []healthnotify.Failure           `json:"health_notification_failures,omitempty"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6939,6 +6939,40 @@ func TestStateAPIIncludesGitHubGraphQLRateLimitStatus(t *testing.T) {
 	}
 }
 
+func TestStateAndHealthReportWorkspaceCleanupFailures(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	observedAt := time.Date(2026, 9, 4, 15, 30, 0, 0, time.UTC)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: observedAt,
+		CleanupFaults: []telemetry.CleanupFault{{
+			ProjectID:         "detent",
+			AffectedPathCount: 3,
+			LastError:         "permission denied",
+			ObservedAt:        observedAt,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	for _, path := range []string{"/api/v1/state", "/health"} {
+		response := requestJSON(t, server, http.MethodGet, path, http.StatusOK)
+		failures := response["workspace_cleanup_failures"].([]any)
+		if len(failures) != 1 || failures[0].(map[string]any)["affected_path_count"] != float64(3) {
+			t.Fatalf("%s workspace cleanup failures = %#v", path, failures)
+		}
+	}
+	health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	if health["status"] != "needs_attention" {
+		t.Fatalf("health status = %v, want needs_attention", health["status"])
+	}
+}
+
 func TestStateAPIIncludesProjectFailureBreakerEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/cleanup_registry.go
+++ b/internal/workspace/cleanup_registry.go
@@ -275,7 +275,9 @@ func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue)
 		if removeErr := l.removeOwnershipRecord(record.Path); removeErr != nil {
 			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: removeErr.Error()})
 			reconcileErrors = append(reconcileErrors, removeErr)
+			continue
 		}
+		result.CompletedPaths = append(result.CompletedPaths, record.Path)
 	}
 	return result, errors.Join(reconcileErrors...)
 }

--- a/internal/workspace/cleanup_registry.go
+++ b/internal/workspace/cleanup_registry.go
@@ -1,0 +1,281 @@
+package workspace
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	cleanupOwnershipSchema      = 1
+	cleanupOwnershipRegistryDir = ".detent/cleanup-ownership"
+)
+
+type cleanupOwnershipRecord struct {
+	Schema          int    `json:"schema"`
+	Path            string `json:"path"`
+	Key             string `json:"key"`
+	ProjectID       string `json:"project_id,omitempty"`
+	IssueID         string `json:"issue_id,omitempty"`
+	Identifier      string `json:"identifier,omitempty"`
+	Branch          string `json:"branch,omitempty"`
+	SourceCommonDir string `json:"source_common_dir"`
+}
+
+func (l *LocalGit) recordCleanupOwnership(ctx context.Context, info Info, issue Issue, isDir bool) error {
+	if isDir && !l.isSourceWorktree(ctx, info.Path) && l.isGitWorkspace(ctx, info.Path) {
+		return fmt.Errorf("refusing to record cleanup ownership for git workspace not managed by source: %s", info.Path)
+	}
+	path, err := validateWorkspacePath(l.root, info.Path)
+	if err != nil {
+		return err
+	}
+	sourceCommonDir, err := gitCommonDir(ctx, l.sourceRoot)
+	if err != nil {
+		return fmt.Errorf("resolve cleanup ownership source: %w", err)
+	}
+	record := cleanupOwnershipRecord{
+		Schema:          cleanupOwnershipSchema,
+		Path:            path,
+		Key:             info.Key,
+		ProjectID:       strings.TrimSpace(issue.ProjectID),
+		IssueID:         strings.TrimSpace(issue.ID),
+		Identifier:      strings.TrimSpace(issue.Identifier),
+		Branch:          strings.TrimSpace(info.Branch),
+		SourceCommonDir: sourceCommonDir,
+	}
+	if record.Key == "" {
+		record.Key = filepath.Base(path)
+	}
+	if record.Key != filepath.Base(path) {
+		return fmt.Errorf("cleanup ownership key %q does not match workspace path %q", record.Key, path)
+	}
+	if record.Identifier != "" && issueKey(issue) != record.Key {
+		return fmt.Errorf("cleanup ownership issue does not match workspace key %q", record.Key)
+	}
+	if err := l.writeOwnershipRecord(record); err != nil {
+		return fmt.Errorf("record cleanup ownership: %w", err)
+	}
+	return nil
+}
+
+func (l *LocalGit) writeOwnershipRecord(record cleanupOwnershipRecord) (returnErr error) {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	root, err := os.OpenRoot(l.root)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+	if err := root.MkdirAll(cleanupOwnershipRegistryDir, 0o700); err != nil {
+		return err
+	}
+	recordPath := cleanupOwnershipRecordRelativePath(record.Path)
+	temporaryPath, err := cleanupOwnershipTemporaryPath(recordPath)
+	if err != nil {
+		return err
+	}
+	file, err := root.OpenFile(temporaryPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			returnErr = errors.Join(returnErr, file.Close())
+		}
+		if cleanupErr := root.Remove(temporaryPath); cleanupErr != nil && !errors.Is(cleanupErr, fs.ErrNotExist) {
+			returnErr = errors.Join(returnErr, cleanupErr)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	closed = true
+	if err := root.Rename(temporaryPath, recordPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupOwnershipTemporaryPath(recordPath string) (string, error) {
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", err
+	}
+	return recordPath + ".tmp-" + hex.EncodeToString(suffix[:]), nil
+}
+
+func cleanupOwnershipRecordRelativePath(path string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(path)))
+	return filepath.Join(cleanupOwnershipRegistryDir, hex.EncodeToString(sum[:])[:24]+".json")
+}
+
+func (l *LocalGit) removeOwnershipRecord(path string) (returnErr error) {
+	root, err := os.OpenRoot(l.root)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+	err = root.Remove(cleanupOwnershipRecordRelativePath(path))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("remove cleanup ownership record: %w", err)
+	}
+	return nil
+}
+
+func (l *LocalGit) cleanupOwnershipRecorded(ctx context.Context, path string) (bool, error) {
+	record, err := l.readOwnershipRecord(cleanupOwnershipRecordRelativePath(path))
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return l.validOwnershipRecord(ctx, cleanupOwnershipRecordRelativePath(path), record), nil
+}
+
+func (l *LocalGit) readOwnershipRecord(relativePath string) (_ cleanupOwnershipRecord, returnErr error) {
+	root, err := os.OpenRoot(l.root)
+	if err != nil {
+		return cleanupOwnershipRecord{}, err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, root.Close())
+	}()
+	info, err := root.Lstat(relativePath)
+	if err != nil {
+		return cleanupOwnershipRecord{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return cleanupOwnershipRecord{}, fmt.Errorf("cleanup ownership record is not a regular file: %s", relativePath)
+	}
+	data, err := root.ReadFile(relativePath)
+	if err != nil {
+		return cleanupOwnershipRecord{}, err
+	}
+	var decoded cleanupOwnershipRecord
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return cleanupOwnershipRecord{}, err
+	}
+	return decoded, nil
+}
+
+func (l *LocalGit) validOwnershipRecord(ctx context.Context, relativePath string, record cleanupOwnershipRecord) bool {
+	if record.Schema != cleanupOwnershipSchema || record.Path == "" || record.Key == "" || record.SourceCommonDir == "" {
+		return false
+	}
+	path, err := validateWorkspacePath(l.root, record.Path)
+	if err != nil || path != filepath.Clean(record.Path) || filepath.Base(path) != record.Key {
+		return false
+	}
+	if cleanupOwnershipRecordRelativePath(path) != relativePath {
+		return false
+	}
+	if record.Identifier != "" && issueKey(Issue{ProjectID: record.ProjectID, Identifier: record.Identifier}) != record.Key {
+		return false
+	}
+	sourceCommonDir, err := gitCommonDir(ctx, l.sourceRoot)
+	return err == nil && sourceCommonDir == filepath.Clean(record.SourceCommonDir)
+}
+
+func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue) (ReconcileResult, error) {
+	entries, err := os.ReadDir(filepath.Join(l.root, cleanupOwnershipRegistryDir))
+	if errors.Is(err, fs.ErrNotExist) {
+		return ReconcileResult{}, nil
+	}
+	if err != nil {
+		return ReconcileResult{}, fmt.Errorf("read cleanup ownership registry: %w", err)
+	}
+	activeKeys := make(map[string]struct{}, len(activeIssues))
+	for _, issue := range activeIssues {
+		activeKeys[issueKey(issue)] = struct{}{}
+	}
+	result := ReconcileResult{}
+	var reconcileErrors []error
+	for _, entry := range entries {
+		relativePath := filepath.Join(cleanupOwnershipRegistryDir, entry.Name())
+		record, readErr := l.readOwnershipRecord(relativePath)
+		if readErr != nil || !l.validOwnershipRecord(ctx, relativePath, record) {
+			result.UnownedSkipped++
+			continue
+		}
+		if _, active := activeKeys[record.Key]; active {
+			result.ActiveSkipped++
+			continue
+		}
+		exists, _, statErr := pathExists(record.Path)
+		if statErr != nil {
+			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: statErr.Error()})
+			reconcileErrors = append(reconcileErrors, statErr)
+			continue
+		}
+		if exists {
+			registered, registrationErr := l.sourceWorktreeRegistered(ctx, record.Path)
+			if registrationErr != nil {
+				result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: registrationErr.Error()})
+				reconcileErrors = append(reconcileErrors, registrationErr)
+				continue
+			}
+			if registered {
+				result.RegisteredSkipped++
+				continue
+			}
+			pids, processErr := scanOwnedWorkspaceProcessIDs(ctx, record.Path, l.scanWorkspacePaths)
+			if processErr != nil {
+				result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: processErr.Error()})
+				reconcileErrors = append(reconcileErrors, processErr)
+				continue
+			}
+			if len(pids) > 0 {
+				result.ActiveSkipped++
+				continue
+			}
+			if removeErr := l.removeOwnedPath(l.root, record.Path); removeErr != nil {
+				result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: removeErr.Error()})
+				reconcileErrors = append(reconcileErrors, removeErr)
+				continue
+			}
+			result.Removed++
+		}
+		if _, pruneErr := l.runGit(ctx, "worktree", "prune"); pruneErr != nil {
+			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: pruneErr.Error()})
+			reconcileErrors = append(reconcileErrors, pruneErr)
+			continue
+		}
+		if _, branchErr := l.deleteBranch(ctx, record.Branch); branchErr != nil {
+			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: branchErr.Error()})
+			reconcileErrors = append(reconcileErrors, branchErr)
+			continue
+		}
+		if removeErr := l.removeOwnershipRecord(record.Path); removeErr != nil {
+			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: removeErr.Error()})
+			reconcileErrors = append(reconcileErrors, removeErr)
+		}
+	}
+	return result, errors.Join(reconcileErrors...)
+}

--- a/internal/workspace/cleanup_registry_test.go
+++ b/internal/workspace/cleanup_registry_test.go
@@ -187,6 +187,9 @@ func TestLocalGitReconcileResiduals(t *testing.T) {
 			if result.Removed != tt.wantRemoved || result.ActiveSkipped != tt.wantActive || result.RegisteredSkipped != tt.wantRegistered {
 				t.Fatalf("ReconcileResiduals() = %+v, want removed=%d active=%d registered=%d", result, tt.wantRemoved, tt.wantActive, tt.wantRegistered)
 			}
+			if got := len(result.CompletedPaths); got != tt.wantRemoved {
+				t.Fatalf("ReconcileResiduals() completed paths = %d, want %d", got, tt.wantRemoved)
+			}
 			_, statErr := os.Stat(info.Path)
 			if got := statErr == nil; got != tt.wantExists {
 				t.Fatalf("residual workspace exists = %t, want %t, stat error = %v", got, tt.wantExists, statErr)

--- a/internal/workspace/cleanup_registry_test.go
+++ b/internal/workspace/cleanup_registry_test.go
@@ -1,0 +1,267 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalGitCleanupRemovesHookArtifacts(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewLocalGit(LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks:      Hooks{AfterCreate: "mkdir -p node_modules/pkg uploads .local/state && touch node_modules/pkg/index.js uploads/generated.bin .local/state/cache"},
+	})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+	issue := Issue{ProjectID: "detent", ID: "2140", Identifier: "digitaldrywood/detent#2140"}
+	info, err := backend.Create(t.Context(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	artifacts := []struct {
+		name string
+		path string
+	}{
+		{name: "node modules", path: "node_modules/pkg/index.js"},
+		{name: "generated upload", path: "uploads/generated.bin"},
+		{name: "local state", path: ".local/state/cache"},
+	}
+	for _, artifact := range artifacts {
+		t.Run(artifact.name, func(t *testing.T) {
+			if _, err := os.Stat(filepath.Join(info.Path, filepath.FromSlash(artifact.path))); err != nil {
+				t.Fatalf("hook artifact stat error = %v", err)
+			}
+		})
+	}
+
+	if _, err := backend.CleanupIssue(t.Context(), issue); err != nil {
+		t.Fatalf("CleanupIssue() error = %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("workspace exists after cleanup, stat error = %v", err)
+	}
+}
+
+func TestLocalGitCleanupRetriesAfterGitDeregistration(t *testing.T) {
+	skipWindows(t)
+
+	enclosing := initSourceRepo(t)
+	source := filepath.Join(enclosing, "source")
+	initSourceRepoAt(t, source)
+	root := filepath.Join(enclosing, "workspaces")
+	backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+	issue := Issue{ProjectID: "detent", ID: "2140", Identifier: "digitaldrywood/detent#2140"}
+	info, err := backend.Create(t.Context(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	locked := filepath.Join(info.Path, "node_modules", "locked")
+	if err := os.MkdirAll(locked, 0o700); err != nil {
+		t.Fatalf("create locked artifact directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "generated.js"), []byte("generated"), 0o400); err != nil {
+		t.Fatalf("write locked artifact: %v", err)
+	}
+	if err := os.Chmod(locked, 0o500); err != nil {
+		t.Fatalf("lock artifact directory: %v", err)
+	}
+	t.Cleanup(func() { restoreWritableTree(t, info.Path) })
+
+	removeCalls := 0
+	backend.removeOwnedPath = func(root string, path string) error {
+		removeCalls++
+		if removeCalls == 1 {
+			return fs.ErrPermission
+		}
+		return removeWorkspacePath(root, path)
+	}
+	_, err = backend.CleanupIssue(t.Context(), issue)
+	if err == nil {
+		t.Fatal("first CleanupIssue() error = nil, want final removal failure")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("first CleanupIssue() error = %v, want permission denial", err)
+	}
+	registered, err := backend.sourceWorktreeRegistered(t.Context(), info.Path)
+	if err != nil {
+		t.Fatalf("sourceWorktreeRegistered() error = %v", err)
+	}
+	if registered {
+		t.Fatal("workspace remains registered after partial Git removal")
+	}
+	if _, err := os.Stat(info.Path); err != nil {
+		t.Fatalf("residual workspace stat error = %v", err)
+	}
+	if recorded, err := backend.cleanupOwnershipRecorded(t.Context(), info.Path); err != nil || !recorded {
+		t.Fatalf("cleanup ownership recorded = %t, error = %v", recorded, err)
+	}
+
+	if _, err := backend.CleanupIssue(t.Context(), issue); err != nil {
+		t.Fatalf("second CleanupIssue() error = %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("workspace exists after retry, stat error = %v", err)
+	}
+	if recorded, err := backend.cleanupOwnershipRecorded(t.Context(), info.Path); err != nil || recorded {
+		t.Fatalf("cleanup ownership recorded after retry = %t, error = %v", recorded, err)
+	}
+}
+
+func TestLocalGitReconcileResiduals(t *testing.T) {
+	skipWindows(t)
+
+	tests := []struct {
+		name           string
+		active         bool
+		activeProcess  bool
+		registered     bool
+		wantRemoved    int
+		wantActive     int
+		wantRegistered int
+		wantExists     bool
+	}{
+		{name: "removes owned residual", wantRemoved: 1},
+		{name: "skips active issue", active: true, wantActive: 1, wantExists: true},
+		{name: "skips active process", activeProcess: true, wantActive: 1, wantExists: true},
+		{name: "skips registered worktree", registered: true, wantRegistered: 1, wantExists: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enclosing := initSourceRepo(t)
+			source := filepath.Join(enclosing, "source")
+			initSourceRepoAt(t, source)
+			root := filepath.Join(enclosing, "workspaces")
+			backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+			if err != nil {
+				t.Fatalf("NewLocalGit() error = %v", err)
+			}
+			issue := Issue{ProjectID: "detent", ID: "2140", Identifier: "digitaldrywood/detent#2140"}
+			var info Info
+			if tt.registered {
+				info, err = backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				if err := backend.recordCleanupOwnership(t.Context(), info, issue, true); err != nil {
+					t.Fatalf("recordCleanupOwnership() error = %v", err)
+				}
+			} else {
+				info = strandCleanupWorkspace(t, backend, source, issue)
+			}
+			t.Cleanup(func() { restoreWritableTree(t, info.Path) })
+			if tt.activeProcess {
+				backend.scanWorkspacePaths = func(context.Context, string) ([]int, error) {
+					return []int{os.Getpid() + 1000}, nil
+				}
+			}
+			var active []Issue
+			if tt.active {
+				active = []Issue{issue}
+			}
+
+			result, err := backend.ReconcileResiduals(t.Context(), active)
+			if err != nil {
+				t.Fatalf("ReconcileResiduals() error = %v", err)
+			}
+			if result.Removed != tt.wantRemoved || result.ActiveSkipped != tt.wantActive || result.RegisteredSkipped != tt.wantRegistered {
+				t.Fatalf("ReconcileResiduals() = %+v, want removed=%d active=%d registered=%d", result, tt.wantRemoved, tt.wantActive, tt.wantRegistered)
+			}
+			_, statErr := os.Stat(info.Path)
+			if got := statErr == nil; got != tt.wantExists {
+				t.Fatalf("residual workspace exists = %t, want %t, stat error = %v", got, tt.wantExists, statErr)
+			}
+		})
+	}
+}
+
+func TestLocalGitReconcileResidualsRejectsInsufficientOwnership(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+	if err != nil {
+		t.Fatalf("NewLocalGit() error = %v", err)
+	}
+	foreign := filepath.Join(root, "detent-digitaldrywood_detent_9999-000000000000")
+	if err := os.MkdirAll(filepath.Join(foreign, "node_modules"), 0o700); err != nil {
+		t.Fatalf("create foreign directory: %v", err)
+	}
+	sourceCommonDir, err := gitCommonDir(t.Context(), source)
+	if err != nil {
+		t.Fatalf("gitCommonDir() error = %v", err)
+	}
+	record := cleanupOwnershipRecord{
+		Schema:          cleanupOwnershipSchema,
+		Path:            foreign,
+		Key:             filepath.Base(foreign),
+		SourceCommonDir: sourceCommonDir + "-other",
+	}
+	if err := backend.writeOwnershipRecord(record); err != nil {
+		t.Fatalf("writeOwnershipRecord() error = %v", err)
+	}
+
+	result, err := backend.ReconcileResiduals(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("ReconcileResiduals() error = %v", err)
+	}
+	if result.UnownedSkipped != 1 || result.Removed != 0 {
+		t.Fatalf("ReconcileResiduals() = %+v, want one unowned skip", result)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Fatalf("foreign directory was changed, stat error = %v", err)
+	}
+}
+
+func strandCleanupWorkspace(t *testing.T, backend *LocalGit, source string, issue Issue) Info {
+	t.Helper()
+
+	info, err := backend.Create(t.Context(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := backend.recordCleanupOwnership(t.Context(), info, issue, true); err != nil {
+		t.Fatalf("recordCleanupOwnership() error = %v", err)
+	}
+	locked := filepath.Join(info.Path, "node_modules", "locked")
+	if err := os.MkdirAll(locked, 0o700); err != nil {
+		t.Fatalf("create locked artifact directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "generated.js"), []byte("generated"), 0o400); err != nil {
+		t.Fatalf("write locked artifact: %v", err)
+	}
+	if err := os.Chmod(locked, 0o500); err != nil {
+		t.Fatalf("lock artifact directory: %v", err)
+	}
+	cmd := exec.CommandContext(t.Context(), "git", "-C", source, "worktree", "remove", "--force", info.Path)
+	if output, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("git worktree remove succeeded, want partial removal failure: %s", output)
+	}
+	if err := os.Chmod(locked, 0o700); err != nil {
+		t.Fatalf("restore locked artifact directory: %v", err)
+	}
+	registered, err := backend.sourceWorktreeRegistered(t.Context(), info.Path)
+	if err != nil {
+		t.Fatalf("sourceWorktreeRegistered() error = %v", err)
+	}
+	if registered {
+		t.Fatal("workspace remains registered after partial removal")
+	}
+	return info
+}

--- a/internal/workspace/cleanup_registry_test.go
+++ b/internal/workspace/cleanup_registry_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -16,11 +17,15 @@ func TestLocalGitCleanupRemovesHookArtifacts(t *testing.T) {
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
+	hookCommand := "mkdir -p node_modules/pkg uploads .local/state && touch node_modules/pkg/index.js uploads/generated.bin .local/state/cache"
+	if runtime.GOOS == "windows" {
+		hookCommand = "mkdir node_modules\\pkg uploads .local\\state && type nul > node_modules\\pkg\\index.js && type nul > uploads\\generated.bin && type nul > .local\\state\\cache"
+	}
 	backend, err := NewLocalGit(LocalGitOptions{
 		Root:       root,
 		SourceRoot: source,
 		AutoBranch: true,
-		Hooks:      Hooks{AfterCreate: "mkdir -p node_modules/pkg uploads .local/state && touch node_modules/pkg/index.js uploads/generated.bin .local/state/cache"},
+		Hooks:      Hooks{AfterCreate: hookCommand},
 	})
 	if err != nil {
 		t.Fatalf("NewLocalGit() error = %v", err)

--- a/internal/workspace/process_other.go
+++ b/internal/workspace/process_other.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+func workspaceProcessIDs(context.Context, string) ([]int, error) {
+	return nil, nil
+}
+
 func reapWorkspaceProcesses(context.Context, string, *slog.Logger) int {
 	return 0
 }

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -50,7 +50,6 @@ func ReapProcesses(ctx context.Context, path string, grace time.Duration) (int, 
 	return reapProcesses(ctx, path, grace, workspaceProcessIDs, syscall.Kill)
 }
 
-type workspaceProcessScanner func(context.Context, string) ([]int, error)
 type workspaceProcessSignaler func(int, syscall.Signal) error
 type workspaceProcessWaiter func(context.Context, string, time.Duration, workspaceProcessScanner) ([]int, error)
 
@@ -103,26 +102,6 @@ func reapProcessesWithWait(
 		)
 	}
 	return len(reaped), errors.Join(termErr, killErr)
-}
-
-func scanOwnedWorkspaceProcessIDs(ctx context.Context, path string, scan workspaceProcessScanner) ([]int, error) {
-	pids, err := scan(ctx, path)
-	if err != nil {
-		return nil, err
-	}
-	owned := make([]int, 0, len(pids))
-	seen := make(map[int]struct{}, len(pids))
-	for _, pid := range pids {
-		if pid <= 0 || pid == os.Getpid() {
-			continue
-		}
-		if _, ok := seen[pid]; ok {
-			continue
-		}
-		seen[pid] = struct{}{}
-		owned = append(owned, pid)
-	}
-	return owned, nil
 }
 
 func signalWorkspaceProcesses(

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -55,6 +55,28 @@ type sourceOperationLock struct {
 	permit chan struct{}
 }
 
+type workspaceProcessScanner func(context.Context, string) ([]int, error)
+
+func scanOwnedWorkspaceProcessIDs(ctx context.Context, path string, scan workspaceProcessScanner) ([]int, error) {
+	pids, err := scan(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	owned := make([]int, 0, len(pids))
+	seen := make(map[int]struct{}, len(pids))
+	for _, pid := range pids {
+		if pid <= 0 || pid == os.Getpid() {
+			continue
+		}
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		owned = append(owned, pid)
+	}
+	return owned, nil
+}
+
 type Backend interface {
 	Create(context.Context, Issue) (Info, error)
 	Cleanup(context.Context, string) error
@@ -140,6 +162,7 @@ const (
 )
 
 type CleanupResult struct {
+	Path      string
 	Worktrees int
 	Branches  int
 	Processes int
@@ -147,6 +170,23 @@ type CleanupResult struct {
 
 type IssueCleaner interface {
 	CleanupIssue(context.Context, Issue) (CleanupResult, error)
+}
+
+type CleanupFailure struct {
+	Path  string
+	Error string
+}
+
+type ReconcileResult struct {
+	Removed           int
+	ActiveSkipped     int
+	RegisteredSkipped int
+	UnownedSkipped    int
+	Failures          []CleanupFailure
+}
+
+type ResidualReconciler interface {
+	ReconcileResiduals(context.Context, []Issue) (ReconcileResult, error)
 }
 
 type Issue struct {
@@ -184,12 +224,14 @@ type LocalGitOptions struct {
 }
 
 type LocalGit struct {
-	root       string
-	sourceRoot string
-	autoBranch bool
-	hooks      Hooks
-	logger     *slog.Logger
-	createMu   sync.Mutex
+	root               string
+	sourceRoot         string
+	autoBranch         bool
+	hooks              Hooks
+	logger             *slog.Logger
+	createMu           sync.Mutex
+	removeOwnedPath    func(string, string) error
+	scanWorkspacePaths workspaceProcessScanner
 }
 
 type PathError struct {
@@ -379,11 +421,13 @@ func NewLocalGit(opts LocalGitOptions) (*LocalGit, error) {
 	}
 
 	return &LocalGit{
-		root:       root,
-		sourceRoot: sourceRoot,
-		autoBranch: opts.AutoBranch,
-		hooks:      hooks,
-		logger:     logger,
+		root:               root,
+		sourceRoot:         sourceRoot,
+		autoBranch:         opts.AutoBranch,
+		hooks:              hooks,
+		logger:             logger,
+		removeOwnedPath:    removeWorkspacePath,
+		scanWorkspacePaths: workspaceProcessIDs,
 	}, nil
 }
 
@@ -501,24 +545,30 @@ func (l *LocalGit) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult
 		return CleanupResult{}, err
 	}
 
-	result := CleanupResult{}
+	result := CleanupResult{Path: info.Path}
 	exists, isDir, err := pathExists(info.Path)
 	if err != nil {
-		return CleanupResult{}, err
+		return result, err
 	}
 	if !exists {
 		_, pruneErr := l.runGit(ctx, "worktree", "prune")
 		if pruneErr != nil {
-			return CleanupResult{}, pruneErr
+			return result, pruneErr
 		}
 		branchRemoved, branchErr := l.deleteBranch(ctx, info.Branch)
 		if branchErr != nil {
-			return CleanupResult{}, branchErr
+			return result, branchErr
 		}
 		if branchRemoved {
 			result.Branches = 1
 		}
+		if err := l.removeOwnershipRecord(info.Path); err != nil {
+			return result, err
+		}
 		return result, nil
+	}
+	if err := l.recordCleanupOwnership(ctx, info, issue, isDir); err != nil {
+		return result, err
 	}
 	result.Processes = reapWorkspaceProcesses(ctx, info.Path, l.logger)
 	if isDir && l.isSourceWorktree(ctx, info.Path) {
@@ -528,18 +578,21 @@ func (l *LocalGit) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult
 	}
 
 	if err := l.removePath(ctx, info.Path); err != nil {
-		return CleanupResult{}, err
+		return result, err
 	}
 	result.Worktrees = 1
 	if _, err := l.runGit(ctx, "worktree", "prune"); err != nil {
-		return CleanupResult{}, err
+		return result, err
 	}
 	branchRemoved, err := l.deleteBranch(ctx, info.Branch)
 	if err != nil {
-		return CleanupResult{}, err
+		return result, err
 	}
 	if branchRemoved {
 		result.Branches = 1
+	}
+	if err := l.removeOwnershipRecord(info.Path); err != nil {
+		return result, err
 	}
 	return result, nil
 }
@@ -1403,8 +1456,24 @@ func (l *LocalGit) removePath(ctx context.Context, path string) error {
 		if l.isGitWorkspace(ctx, path) {
 			return fmt.Errorf("refusing to remove git workspace not managed by source: %s", path)
 		}
-		if err := removeWorkspacePath(l.root, path); err != nil {
-			return err
+		if owned, ownershipErr := l.cleanupOwnershipRecorded(ctx, path); ownershipErr != nil {
+			return ownershipErr
+		} else if !owned {
+			return fmt.Errorf("refusing to remove unregistered workspace without Detent ownership evidence: %s", path)
+		}
+		if err := l.removeOwnedPath(l.root, path); err != nil {
+			return &workspaceRemovalError{path: path, remediation: workspaceRemovalRemediation, err: err}
+		}
+		return nil
+	}
+	if exists, _, err := pathExists(path); err != nil {
+		return err
+	} else if exists {
+		if !sourceWorktree {
+			return fmt.Errorf("refusing to remove residual workspace without pre-removal source ownership: %s", path)
+		}
+		if err := l.removeOwnedPath(l.root, path); err != nil {
+			return &workspaceRemovalError{path: path, remediation: workspaceRemovalRemediation, err: err}
 		}
 	}
 	return nil
@@ -1422,7 +1491,7 @@ func (l *LocalGit) retrySourceWorktreeRemoveAfterPermissionRemediation(ctx conte
 		}
 	}
 	if !l.isSourceWorktree(ctx, path) {
-		if retryErr := removeWorkspacePath(l.root, path); retryErr != nil {
+		if retryErr := l.removeOwnedPath(l.root, path); retryErr != nil {
 			return &workspaceRemovalError{
 				path:        path,
 				remediation: workspaceRemovalRemediation,
@@ -1436,6 +1505,13 @@ func (l *LocalGit) retrySourceWorktreeRemoveAfterPermissionRemediation(ctx conte
 			path:        path,
 			remediation: workspaceRemovalRemediation,
 			err:         retryErr,
+		}
+	}
+	if exists, _, retryErr := pathExists(path); retryErr != nil {
+		return &workspaceRemovalError{path: path, remediation: workspaceRemovalRemediation, err: retryErr}
+	} else if exists {
+		if retryErr := l.removeOwnedPath(l.root, path); retryErr != nil {
+			return &workspaceRemovalError{path: path, remediation: workspaceRemovalRemediation, err: retryErr}
 		}
 	}
 	return nil
@@ -1464,6 +1540,11 @@ func removeWorkspacePath(root string, path string) error {
 				err:         retryErr,
 			}
 		}
+	}
+	if exists, _, err := pathExists(path); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("workspace path still exists after removal: %s", path)
 	}
 	return nil
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -182,6 +182,7 @@ type ReconcileResult struct {
 	ActiveSkipped     int
 	RegisteredSkipped int
 	UnownedSkipped    int
+	CompletedPaths    []string
 	Failures          []CleanupFailure
 }
 


### PR DESCRIPTION
## Summary

- record durable, source-validated workspace ownership before terminal cleanup begins
- retry deregistered residual removal through a bounded reconciliation sweep that protects active and unowned paths
- expose residual cleanup failure counts through state and health telemetry

Fixes #2140

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: JSON state and health fields only.

## Test Plan

- [x] `PATH="$PWD/tmp/tools-go126:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] `go test ./internal/workspace ./internal/runner ./internal/orchestrator ./internal/telemetry ./internal/cli ./internal/web`
