### PR TITLE
fix: add degraded pressure admission

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -79,13 +79,32 @@ global:
     poll_interval_ms: 1000
   io:
     pressure_full_avg10_threshold: 5
+    degraded_max_concurrent_agents: 0
     poll_interval_ms: 1000
   cpu:
     pressure_some_avg10_threshold: 80
+    degraded_max_concurrent_agents: 0
     poll_interval_ms: 1000
 ```
 
-The defaults shown above are starting points. IO `full` is the strongest build
+`degraded_max_concurrent_agents` is an opt-in host-wide progress floor for IO
+and CPU pressure. Its default of `0` preserves the conservative hard stop. Set
+it to `1` to allow one worker across all named pools while that signal remains
+constrained. If IO and CPU pressure are active together, the lower configured
+floor wins. The pressure ceiling only blocks new admissions; it never preempts
+running workers, and pool, project/state, worker-host, startup pacing, and
+backend limits can reduce capacity further.
+
+A guard engages only above its configured threshold. Once engaged, IO and CPU
+guards stay constrained until the measured average falls to 80% of the trigger
+threshold, which prevents dispatch from flapping when PSI hovers around the
+boundary. For example, an IO threshold of `5` engages above `5` and recovers at
+or below `4`.
+
+The defaults shown above are starting points, not universal safe values. With
+the default degraded capacity of `0`, the sample IO threshold of `5` is a
+fleet-wide hard stop whenever IO `full avg10` stays above 5%, including when an
+unrelated host process creates the pressure. IO `full` is the strongest build
 host signal because it measures time when every non-idle task is stalled on IO.
 CPU uses `some`, because system-level CPU `full` is defined to report zero.
 Memory `some` remains useful for reclaim and swap pressure, but a compile-heavy
@@ -93,22 +112,28 @@ host can be IO- or CPU-saturated while memory PSI stays at zero. See the
 [Linux PSI interface](https://www.kernel.org/doc/html/latest/accounting/psi.html)
 for the kernel definitions.
 
-Treat `global.max_concurrent_agents` as the hard ceiling and use PSI as the
-dynamic admission brake. Start with the defaults, observe representative
-compile, test, browser, and database workloads, then lower a threshold if the
-interactive host becomes unresponsive before the guard engages. Raising the
-hard ceiling based only on free memory can overload a build host.
+Treat configured pool capacity as the hard ceiling and use PSI as the dynamic
+admission brake. Before enabling a low threshold, observe `/proc/pressure/io`
+and `/proc/pressure/cpu` during representative Detent and unrelated compile,
+test, browser, database, and media workloads. Calibrate the trigger above the
+host's acceptable sustained baseline, then lower it if the interactive host
+becomes unresponsive before the guard engages. Raising the hard ceiling based
+only on free memory can overload a build host.
 
 The ten-second IO and CPU windows respond faster than the sixty-second memory
 window. Keep `global.startup.jitter_seconds` and `max_spawn_per_second`
 conservative enough for those averages to react during service startup; PSI
-then opens and closes admission as contention changes. On systems without PSI,
+then constrains and restores admission as contention changes. On systems without PSI,
 or when a pressure file cannot be read, Detent fails open and reports the
 unsupported or unavailable signal rather than inventing a zero reading.
 
 `detent state`, `/api/v1/state`, `/health`, and the Health dashboard expose the
-current values, thresholds, read errors, and whether each signal is holding
-dispatch under `memory_pressure`, `io_pressure`, and `cpu_pressure`.
+current values, thresholds, read errors, configured degraded capacity,
+effective pressure capacity, constraint start time and duration, and whether
+each signal is holding dispatch under `memory_pressure`, `io_pressure`, and
+`cpu_pressure`. Durable scheduler decisions include pressure capacity, usage,
+availability, reason, and duration. Work-attempt capacity snapshots include the
+active pressure capacity, reason, and duration.
 
 When Detent starts inside tmux, it renames the current window to a compact
 running, ready, waiting, and blocked count summary. It restores the original

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -15,11 +15,12 @@ codes, retry timing, and tracker refresh timing.
 
 The Health dashboard also shows host memory, IO, and CPU PSI. Each row includes
 the current governing average, configured threshold, support or read-error
-state, and whether Detent is holding new dispatches. The same data appears in
-`detent state`, `/api/v1/state`, and `/health` as `memory_pressure`,
-`io_pressure`, and `cpu_pressure`. A pressure hold is admission backpressure,
-not a worker failure: existing agents continue while new starts wait for the
-next reading below the threshold.
+state, configured and effective pressure capacity, constraint duration, and
+whether Detent is holding new dispatches. The same data appears in `detent
+state`, `/api/v1/state`, and `/health` as `memory_pressure`, `io_pressure`, and
+`cpu_pressure`. A pressure constraint is admission backpressure, not a worker
+failure: existing agents continue while new starts wait for available degraded
+capacity or pressure recovery.
 
 When an agent backend reports `model_context_window`, Detent also surfaces
 context pressure for running and recent sessions. Context pressure is the

--- a/docs/examples/multi-project/global.yaml
+++ b/docs/examples/multi-project/global.yaml
@@ -28,9 +28,11 @@ global:
     poll_interval_ms: 1000
   io:
     pressure_full_avg10_threshold: 5
+    degraded_max_concurrent_agents: 1
     poll_interval_ms: 1000
   cpu:
     pressure_some_avg10_threshold: 80
+    degraded_max_concurrent_agents: 1
     poll_interval_ms: 1000
   # Preserve full width until a fresh provider bucket falls below 20%.
   rate_window_pacing:

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -56,9 +56,11 @@ global:
     poll_interval_ms: 1000
   io:
     pressure_full_avg10_threshold: 5
+    degraded_max_concurrent_agents: 1
     poll_interval_ms: 1000
   cpu:
     pressure_some_avg10_threshold: 80
+    degraded_max_concurrent_agents: 1
     poll_interval_ms: 1000
 projects:
   - id: detent

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -139,8 +140,26 @@ func statePressureLine(value any, label string, row string, average string, thre
 	status := "admitting"
 	if stateBool(pressure["dispatch_held"]) {
 		status = "holding dispatch"
+	} else if stateBool(pressure["capacity_constrained"]) {
+		effective := stateString(pressure["effective_max_concurrent_agents"])
+		agentLabel := " agents"
+		if effective == "1" {
+			agentLabel = " agent"
+		}
+		status = "limited to " + effective + agentLabel
+	}
+	if durationText := statePressureDuration(pressure["constrained_for_ms"]); durationText != "" {
+		status += " for " + durationText
 	}
 	return fmt.Sprintf("%s PSI %s %s: %s%% / %s%% threshold (%s)", label, row, average, current, threshold, status)
+}
+
+func statePressureDuration(value any) string {
+	milliseconds, err := strconv.ParseInt(stateString(value), 10, 64)
+	if err != nil || milliseconds <= 0 {
+		return ""
+	}
+	return (time.Duration(milliseconds) * time.Millisecond).Round(time.Second).String()
 }
 
 func stateBool(value any) bool {

--- a/internal/cli/state_test.go
+++ b/internal/cli/state_test.go
@@ -212,7 +212,7 @@ func TestStateCommandOutput(t *testing.T) {
 		wantJSONBuild bool
 	}{
 		{name: "JSON projection", args: []string{"--project", "detent"}, wantJSONBuild: true},
-		{name: "pretty projection", stdoutTTY: true, args: []string{"--project", "detent"}, wantPretty: []string{"Status: running", "Generated at: 2026-08-08T03:00:00Z", "Degraded: true", "Refresh status: degraded", "Running: 2", "Ready: 3", "Waiting: 4", "Blocked: 1", "Memory PSI some avg60: 0% / 10% threshold (admitting)", "I/O PSI full avg10: 63.64% / 5% threshold (holding dispatch)", "CPU PSI some avg10: 91.2% / 80% threshold (holding dispatch)", "Truncated: false"}},
+		{name: "pretty projection", stdoutTTY: true, args: []string{"--project", "detent"}, wantPretty: []string{"Status: running", "Generated at: 2026-08-08T03:00:00Z", "Degraded: true", "Refresh status: degraded", "Running: 2", "Ready: 3", "Waiting: 4", "Blocked: 1", "Memory PSI some avg60: 0% / 10% threshold (admitting)", "I/O PSI full avg10: 63.64% / 5% threshold (limited to 1 agent for 5m0s)", "CPU PSI some avg10: 91.2% / 80% threshold (holding dispatch)", "Truncated: false"}},
 	}
 
 	for _, tt := range tests {
@@ -356,7 +356,8 @@ func stateFixture() map[string]any {
 			"supported": true, "some": map[string]any{"avg60": 0}, "some_avg60_max": 10, "dispatch_held": false,
 		},
 		"io_pressure": map[string]any{
-			"supported": true, "full": map[string]any{"avg10": 63.64}, "full_avg10_max": 5, "dispatch_held": true,
+			"supported": true, "full": map[string]any{"avg10": 63.64}, "full_avg10_max": 5, "dispatch_held": false,
+			"capacity_constrained": true, "degraded_max_concurrent_agents": 1, "effective_max_concurrent_agents": 1, "constrained_for_ms": 300000,
 		},
 		"cpu_pressure": map[string]any{
 			"supported": true, "some": map[string]any{"avg10": 91.2}, "some_avg10_max": 80, "dispatch_held": true,

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -161,13 +161,15 @@ type ProjectMemory struct {
 }
 
 type IO struct {
-	PressureFullAvg10Threshold float64 `yaml:"pressure_full_avg10_threshold"`
-	PollIntervalMS             int     `yaml:"poll_interval_ms"`
+	PressureFullAvg10Threshold  float64 `yaml:"pressure_full_avg10_threshold"`
+	DegradedMaxConcurrentAgents int     `yaml:"degraded_max_concurrent_agents,omitempty"`
+	PollIntervalMS              int     `yaml:"poll_interval_ms"`
 }
 
 type CPU struct {
-	PressureSomeAvg10Threshold float64 `yaml:"pressure_some_avg10_threshold"`
-	PollIntervalMS             int     `yaml:"poll_interval_ms"`
+	PressureSomeAvg10Threshold  float64 `yaml:"pressure_some_avg10_threshold"`
+	DegradedMaxConcurrentAgents int     `yaml:"degraded_max_concurrent_agents,omitempty"`
+	PollIntervalMS              int     `yaml:"poll_interval_ms"`
 }
 
 func (m Memory) Normalized() Memory {
@@ -1395,6 +1397,9 @@ func pressureErrors(value any, prefix string, thresholdKey string) []string {
 	if value, ok := pressure["poll_interval_ms"]; ok && !positiveInteger(value) {
 		problems = append(problems, prefix+".poll_interval_ms: must be a positive integer")
 	}
+	if value, ok := pressure["degraded_max_concurrent_agents"]; ok {
+		problems = append(problems, optionalNonNegativeIntegerError(value, prefix+".degraded_max_concurrent_agents")...)
+	}
 	return problems
 }
 
@@ -1406,6 +1411,9 @@ func ioPressureProblems(pressure IO, prefix string) []string {
 	if pressure.PollIntervalMS <= 0 {
 		problems = append(problems, prefix+".poll_interval_ms: must be a positive integer")
 	}
+	if pressure.DegradedMaxConcurrentAgents < 0 {
+		problems = append(problems, prefix+".degraded_max_concurrent_agents: must be a non-negative integer")
+	}
 	return problems
 }
 
@@ -1416,6 +1424,9 @@ func cpuPressureProblems(pressure CPU, prefix string) []string {
 	}
 	if pressure.PollIntervalMS <= 0 {
 		problems = append(problems, prefix+".poll_interval_ms: must be a positive integer")
+	}
+	if pressure.DegradedMaxConcurrentAgents < 0 {
+		problems = append(problems, prefix+".degraded_max_concurrent_agents: must be a non-negative integer")
 	}
 	return problems
 }

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -267,9 +267,11 @@ global:
     poll_interval_ms: 250
   io:
     pressure_full_avg10_threshold: 7.5
+    degraded_max_concurrent_agents: 2
     poll_interval_ms: 500
   cpu:
     pressure_some_avg10_threshold: 85
+    degraded_max_concurrent_agents: 3
     poll_interval_ms: 750
 projects:
   - id: detent
@@ -289,10 +291,10 @@ projects:
 	if cfg.Global.Memory != wantGlobal {
 		t.Fatalf("Global.Memory = %#v, want %#v", cfg.Global.Memory, wantGlobal)
 	}
-	if want := (IO{PressureFullAvg10Threshold: 7.5, PollIntervalMS: 500}); cfg.Global.IO != want {
+	if want := (IO{PressureFullAvg10Threshold: 7.5, DegradedMaxConcurrentAgents: 2, PollIntervalMS: 500}); cfg.Global.IO != want {
 		t.Fatalf("Global.IO = %#v, want %#v", cfg.Global.IO, want)
 	}
-	if want := (CPU{PressureSomeAvg10Threshold: 85, PollIntervalMS: 750}); cfg.Global.CPU != want {
+	if want := (CPU{PressureSomeAvg10Threshold: 85, DegradedMaxConcurrentAgents: 3, PollIntervalMS: 750}); cfg.Global.CPU != want {
 		t.Fatalf("Global.CPU = %#v, want %#v", cfg.Global.CPU, want)
 	}
 	project := cfg.Projects[0]
@@ -1489,9 +1491,11 @@ global:
     poll_interval_ms: fast
   io:
     pressure_full_avg10_threshold: -1
+    degraded_max_concurrent_agents: -1
     poll_interval_ms: never
   cpu:
     pressure_some_avg10_threshold: false
+    degraded_max_concurrent_agents: many
     poll_interval_ms: 0
 projects:
   - id: detent
@@ -1507,8 +1511,10 @@ projects:
 				"global.memory.pressure_some_avg60_threshold: must be a positive number",
 				"global.memory.poll_interval_ms: must be a positive integer",
 				"global.io.pressure_full_avg10_threshold: must be a positive number",
+				"global.io.degraded_max_concurrent_agents: must be an integer greater than or equal to 0",
 				"global.io.poll_interval_ms: must be a positive integer",
 				"global.cpu.pressure_some_avg10_threshold: must be a positive number",
+				"global.cpu.degraded_max_concurrent_agents: must be an integer greater than or equal to 0",
 				"global.cpu.poll_interval_ms: must be a positive integer",
 				"projects[0].memory.max_agent_rss_bytes: must be a positive integer",
 			},

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -32,6 +32,8 @@ type dispatchGateSampleKey struct {
 	reason            string
 	globalCapacity    int
 	capacityExhausted bool
+	pressureCapacity  int
+	pressureExhausted bool
 	holders           string
 }
 
@@ -169,6 +171,9 @@ func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome s
 		"shared_capacity", decision.SharedCapacity,
 		"shared_used", decision.SharedUsed,
 		"shared_available", decision.SharedAvailable,
+		"pressure_capacity", decision.PressureCapacity,
+		"pressure_used", decision.PressureUsed,
+		"pressure_available", decision.PressureAvailable,
 		"project_state_capacity", projectStats.capacity,
 		"project_state_used", projectStats.used,
 		"project_state_available", projectStats.available,
@@ -214,12 +219,20 @@ func (o *Orchestrator) recordDispatchGateRefusal(
 		reason:            reason,
 		globalCapacity:    decision.GlobalCapacity,
 		capacityExhausted: decision.GlobalAvailable == 0,
+		pressureCapacity:  decision.PressureCapacity,
+		pressureExhausted: decision.PressureCapacity > 0 && decision.PressureAvailable == 0,
 		holders:           strings.Join(decision.Holders, "\x00"),
 	}
 	if !o.reserveDispatchGateSample(key, now) {
 		return
 	}
 
+	waitReason := reason
+	if reason == scheduler.DispatchGateReasonPressureCapacityFull {
+		if constraint, ok := activeHostPressureConstraint(state); ok {
+			waitReason = hostPressureWaitReason(state, constraint.reason)
+		}
+	}
 	record := store.SchedulerDecision{
 		ProjectID:            strings.TrimSpace(o.cfg.Project.ID),
 		IssueID:              strings.TrimSpace(issue.ID),
@@ -233,8 +246,8 @@ func (o *Orchestrator) recordDispatchGateRefusal(
 		AttemptNumber:        attempt,
 		WorkerHost:           strings.TrimSpace(workerHost),
 		DecisionAt:           now,
-		WaitReason:           reason,
-		CapacitySnapshotJSON: o.dispatchGateCapacitySnapshotJSON(issue, decision, projectStats),
+		WaitReason:           waitReason,
+		CapacitySnapshotJSON: o.dispatchGateCapacitySnapshotJSON(state, issue, decision, projectStats),
 		MetadataJSON: marshalWorkAttemptJSON(map[string]any{
 			"decision_kind":           "dispatch_gate_refusal",
 			"sample_interval_seconds": int64(dispatchGateSampleInterval / time.Second),
@@ -279,6 +292,7 @@ func (o *Orchestrator) releaseDispatchGateSample(key dispatchGateSampleKey, samp
 }
 
 func (o *Orchestrator) dispatchGateCapacitySnapshotJSON(
+	state *State,
 	issue connector.Issue,
 	decision scheduler.DispatchGateDecision,
 	projectStats projectStateSlotStats,
@@ -287,7 +301,7 @@ func (o *Orchestrator) dispatchGateCapacitySnapshotJSON(
 	if poolName == "" {
 		poolName = scheduler.DefaultPoolName
 	}
-	return marshalWorkAttemptJSON(map[string]any{
+	snapshot := map[string]any{
 		"project_id":              strings.TrimSpace(o.cfg.Project.ID),
 		"pool":                    poolName,
 		"pool_capacity":           decision.GlobalCapacity,
@@ -304,7 +318,16 @@ func (o *Orchestrator) dispatchGateCapacitySnapshotJSON(
 		"lower_priority_running":  decision.LowerPriorityRunning,
 		"ready_projects":          decision.ReadyProjects,
 		"running_projects":        decision.RunningProjects,
-	})
+		"pressure_capacity":       decision.PressureCapacity,
+		"pressure_used":           decision.PressureUsed,
+		"pressure_available":      decision.PressureAvailable,
+	}
+	if constraint, ok := activeHostPressureConstraint(state); ok {
+		snapshot["pressure_reason"] = constraint.reason
+		snapshot["pressure_constrained_since"] = constraint.constrainedAt
+		snapshot["pressure_constrained_for_ms"] = constraint.constrainedFor.Milliseconds()
+	}
+	return marshalWorkAttemptJSON(snapshot)
 }
 
 func normalizeDispatchGateHolders(holders []string) []string {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -342,6 +342,7 @@ const (
 type dispatchIssueOutcome struct {
 	dispatched bool
 	reason     string
+	waitReason string
 }
 
 func (o *Orchestrator) dispatchIssue(
@@ -441,11 +442,18 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		return dispatchIssueOutcome{reason: dispatchIssueFailureMemoryPressure}
 	}
 	if state.IOPressure.DispatchHeld {
-		return dispatchIssueOutcome{reason: dispatchIssueFailureIOPressure}
+		return dispatchIssueOutcome{
+			reason:     dispatchIssueFailureIOPressure,
+			waitReason: hostPressureWaitReason(state, dispatchIssueFailureIOPressure),
+		}
 	}
 	if state.CPUPressure.DispatchHeld {
-		return dispatchIssueOutcome{reason: dispatchIssueFailureCPUPressure}
+		return dispatchIssueOutcome{
+			reason:     dispatchIssueFailureCPUPressure,
+			waitReason: hostPressureWaitReason(state, dispatchIssueFailureCPUPressure),
+		}
 	}
+	pressureConstraint, pressureConstrained := activeHostPressureConstraint(state)
 	if reason := dispatchRecoveryBlockReason(state, now); reason != "" {
 		return dispatchIssueOutcome{reason: reason}
 	}
@@ -476,7 +484,11 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		return dispatchIssueOutcome{reason: dispatchIssueFailureWorkerHostUnavailable}
 	}
 
-	globalSlot, ok, decision := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now)
+	pressureCapacity := 0
+	if pressureConstrained {
+		pressureCapacity = pressureConstraint.capacity
+	}
+	globalSlot, ok, decision := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now, pressureCapacity)
 	if !ok {
 		o.recordDispatchGateRefusal(ctx, state, issue, attempt, workerHost, now, decision, projectStats)
 		o.logSchedulerSlotDecision(issue, "waiting", decision, projectStats)
@@ -486,6 +498,12 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		} else {
 			o.logDispatchSlotWait(issue, decision, projectStats)
 			o.recordDispatchSlotWait(state, issue, decision, projectStats, now)
+		}
+		if decision.Reason == scheduler.DispatchGateReasonPressureCapacityFull && pressureConstrained {
+			return dispatchIssueOutcome{
+				reason:     pressureConstraint.reason,
+				waitReason: hostPressureWaitReason(state, pressureConstraint.reason),
+			}
 		}
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGlobalSlotUnavailable}
 	}
@@ -877,6 +895,7 @@ func (o *Orchestrator) acquireGlobalDispatchSlot(
 	issue connector.Issue,
 	workerHost string,
 	now time.Time,
+	pressureCapacity int,
 ) (scheduler.Slot, bool, scheduler.DispatchGateDecision) {
 	if o.globalDispatchGate == nil {
 		return scheduler.Slot{}, true, scheduler.DispatchGateDecision{
@@ -886,9 +905,10 @@ func (o *Orchestrator) acquireGlobalDispatchSlot(
 	}
 
 	req := scheduler.SlotRequest{
-		State:    issue.State,
-		Host:     workerHost,
-		Priority: o.dispatchStatePriority(issue.State),
+		State:            issue.State,
+		Host:             workerHost,
+		Priority:         o.dispatchStatePriority(issue.State),
+		PressureCapacity: pressureCapacity,
 	}
 	var (
 		slot     scheduler.Slot

--- a/internal/orchestrator/dispatch_status.go
+++ b/internal/orchestrator/dispatch_status.go
@@ -95,7 +95,10 @@ func projectDispatchStatusFromCycle(
 			}
 			if attempted {
 				waitReasonCode = strings.TrimSpace(outcome.reason)
-				waitReason = schedulerDecisionWaitReason(outcome.reason)
+				waitReason = strings.TrimSpace(outcome.waitReason)
+				if waitReason == "" {
+					waitReason = schedulerDecisionWaitReason(outcome.reason)
+				}
 				if outcome.reason == projectFailureBreakerDispatchPaused {
 					status.EligibleCandidateCount++
 				}

--- a/internal/orchestrator/dispatch_status_test.go
+++ b/internal/orchestrator/dispatch_status_test.go
@@ -135,6 +135,16 @@ func TestProjectDispatchStatusScenarios(t *testing.T) {
 			wantCode:    dispatchIssueFailureBackendCapacityPaused,
 		},
 		{
+			name:        "pressure capacity rejection preserves duration detail",
+			candidates:  []connector.Issue{alpha},
+			decisions:   []dispatchPlanDecision{{Issue: alpha, Selected: true}},
+			outcomes:    dispatchStatusOutcomes(alpha, dispatchIssueOutcome{reason: dispatchIssueFailureIOPressure, waitReason: "I/O pressure has limited admission to 1 concurrent agent for 5m0s"}),
+			wantCount:   1,
+			wantSkipped: 1,
+			wantReason:  "I/O pressure has limited admission to 1 concurrent agent for 5m0s",
+			wantCode:    dispatchIssueFailureIOPressure,
+		},
+		{
 			name:        "failed selection does not advance dispatch",
 			candidates:  []connector.Issue{alpha},
 			decisions:   []dispatchPlanDecision{{Issue: alpha, Selected: true}},

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2966,6 +2966,83 @@ func TestRecordDispatchGateRefusalPersistsPoolArbitrationReasons(t *testing.T) {
 	}
 }
 
+func TestRecordDispatchGateRefusalPersistsPressureCapacity(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		configure  func(*State)
+		wantReason string
+	}{
+		{
+			name: "IO degraded capacity",
+			configure: func(state *State) {
+				state.IOPressure = telemetry.IOPressure{
+					CapacityConstrained: true, EffectiveMaxConcurrentAgents: 1,
+					ConstrainedSince: now.Add(-5 * time.Minute), ConstrainedForMS: 300000,
+				}
+			},
+			wantReason: "I/O pressure has limited admission to 1 concurrent agent for 5m0s",
+		},
+		{
+			name: "CPU degraded capacity",
+			configure: func(state *State) {
+				state.CPUPressure = telemetry.CPUPressure{
+					CapacityConstrained: true, EffectiveMaxConcurrentAgents: 2,
+					ConstrainedSince: now.Add(-time.Minute), ConstrainedForMS: 60000,
+				}
+			},
+			wantReason: "CPU pressure has limited admission to 2 concurrent agents for 1m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 4, Project: scheduler.ProjectCandidate{ID: "detent"}})
+			attempts := &recordingWorkAttemptStore{}
+			orch := Orchestrator{cfg: cfg, workAttempts: attempts}
+			state := newState(cfg)
+			tt.configure(&state)
+			orch.recordDispatchGateRefusal(
+				t.Context(),
+				&state,
+				dispatchTestIssue("issue-pressure", "Todo"),
+				1,
+				"",
+				now,
+				scheduler.DispatchGateDecision{
+					PoolName: scheduler.DefaultPoolName, Reason: scheduler.DispatchGateReasonPressureCapacityFull,
+					GlobalCapacity: 4, GlobalUsed: 1, GlobalAvailable: 3,
+					PressureCapacity: 1, PressureUsed: 1,
+				},
+				projectStateSlotStats{capacity: 4},
+			)
+
+			if len(attempts.decisions) != 1 {
+				t.Fatalf("scheduler decisions = %#v, want one", attempts.decisions)
+			}
+			decision := attempts.decisions[0]
+			if decision.Reason != scheduler.DispatchGateReasonPressureCapacityFull || decision.WaitReason != tt.wantReason {
+				t.Fatalf("pressure decision = %#v", decision)
+			}
+			for _, fragment := range []string{
+				`"pressure_capacity":1`,
+				`"pressure_used":1`,
+				`"pressure_available":0`,
+				`"pressure_constrained_for_ms":`,
+				`"pressure_reason":`,
+			} {
+				if !strings.Contains(decision.CapacitySnapshotJSON, fragment) {
+					t.Fatalf("capacity snapshot %q missing %q", decision.CapacitySnapshotJSON, fragment)
+				}
+			}
+		})
+	}
+}
+
 func TestRecordDispatchGateRefusalSamplesEquivalentCandidates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/host_pressure.go
+++ b/internal/orchestrator/host_pressure.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/hostpressure"
@@ -17,6 +18,8 @@ type pressureObservation struct {
 	observedAt   time.Time
 	lastError    string
 }
+
+const pressureRecoveryRatio = 0.8
 
 func (o *Orchestrator) observeHostPressure(ctx context.Context, state *State, now time.Time) {
 	if o == nil || state == nil {
@@ -62,6 +65,8 @@ func (o *Orchestrator) observeIOPressure(ctx context.Context, state *State, now 
 	if o == nil || state == nil || o.readIOPressure == nil || o.cfg.IOPressureFullAvg10Max <= 0 {
 		return
 	}
+	previous := state.IOPressure
+	wasConstrained := previous.CapacityConstrained || previous.DispatchHeld
 	observation, ok := o.observePressure(
 		ctx,
 		o.readIOPressure,
@@ -69,27 +74,40 @@ func (o *Orchestrator) observeIOPressure(ctx context.Context, state *State, now 
 		o.cfg.IOPressurePollInterval,
 		state.IOPressure.ObservedAt,
 		func(sample hostpressure.Sample) bool {
-			return sample.Full.Avg10 > o.cfg.IOPressureFullAvg10Max
+			return pressureConstrained(wasConstrained, sample.Full.Avg10, o.cfg.IOPressureFullAvg10Max)
 		},
 	)
 	if !ok {
+		refreshIOPressureDuration(&state.IOPressure, now)
 		return
 	}
+	constrainedSince, constrainedForMS := pressureConstraintDuration(
+		wasConstrained,
+		previous.ConstrainedSince,
+		observation.dispatchHeld,
+		now,
+	)
 	state.IOPressure = telemetry.IOPressure{
-		Supported:    observation.supported,
-		Some:         observation.some,
-		Full:         observation.full,
-		FullAvg10Max: o.cfg.IOPressureFullAvg10Max,
-		DispatchHeld: observation.dispatchHeld,
-		ObservedAt:   observation.observedAt,
-		LastError:    observation.lastError,
+		Supported:                   observation.supported,
+		Some:                        observation.some,
+		Full:                        observation.full,
+		FullAvg10Max:                o.cfg.IOPressureFullAvg10Max,
+		DegradedMaxConcurrentAgents: o.cfg.IOPressureDegradedMaxAgents,
+		CapacityConstrained:         observation.dispatchHeld,
+		ConstrainedSince:            constrainedSince,
+		ConstrainedForMS:            constrainedForMS,
+		ObservedAt:                  observation.observedAt,
+		LastError:                   observation.lastError,
 	}
+	refreshIOPressureCapacity(&state.IOPressure, o.cfg.IOPressureDegradedMaxAgents)
 }
 
 func (o *Orchestrator) observeCPUPressure(ctx context.Context, state *State, now time.Time) {
 	if o == nil || state == nil || o.readCPUPressure == nil || o.cfg.CPUPressureSomeAvg10Max <= 0 {
 		return
 	}
+	previous := state.CPUPressure
+	wasConstrained := previous.CapacityConstrained || previous.DispatchHeld
 	observation, ok := o.observePressure(
 		ctx,
 		o.readCPUPressure,
@@ -97,21 +115,176 @@ func (o *Orchestrator) observeCPUPressure(ctx context.Context, state *State, now
 		o.cfg.CPUPressurePollInterval,
 		state.CPUPressure.ObservedAt,
 		func(sample hostpressure.Sample) bool {
-			return sample.Some.Avg10 > o.cfg.CPUPressureSomeAvg10Max
+			return pressureConstrained(wasConstrained, sample.Some.Avg10, o.cfg.CPUPressureSomeAvg10Max)
 		},
 	)
 	if !ok {
+		refreshCPUPressureDuration(&state.CPUPressure, now)
 		return
 	}
+	constrainedSince, constrainedForMS := pressureConstraintDuration(
+		wasConstrained,
+		previous.ConstrainedSince,
+		observation.dispatchHeld,
+		now,
+	)
 	state.CPUPressure = telemetry.CPUPressure{
-		Supported:    observation.supported,
-		Some:         observation.some,
-		Full:         observation.full,
-		SomeAvg10Max: o.cfg.CPUPressureSomeAvg10Max,
-		DispatchHeld: observation.dispatchHeld,
-		ObservedAt:   observation.observedAt,
-		LastError:    observation.lastError,
+		Supported:                   observation.supported,
+		Some:                        observation.some,
+		Full:                        observation.full,
+		SomeAvg10Max:                o.cfg.CPUPressureSomeAvg10Max,
+		DegradedMaxConcurrentAgents: o.cfg.CPUPressureDegradedMaxAgents,
+		CapacityConstrained:         observation.dispatchHeld,
+		ConstrainedSince:            constrainedSince,
+		ConstrainedForMS:            constrainedForMS,
+		ObservedAt:                  observation.observedAt,
+		LastError:                   observation.lastError,
 	}
+	refreshCPUPressureCapacity(&state.CPUPressure, o.cfg.CPUPressureDegradedMaxAgents)
+}
+
+func pressureConstrained(previous bool, value float64, threshold float64) bool {
+	if previous {
+		return value > threshold*pressureRecoveryRatio
+	}
+	return value > threshold
+}
+
+func pressureConstraintDuration(previous bool, since time.Time, constrained bool, now time.Time) (time.Time, int64) {
+	if !constrained {
+		return time.Time{}, 0
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+	if !previous || since.IsZero() {
+		since = now
+	}
+	return since, max(now.Sub(since).Milliseconds(), 0)
+}
+
+func refreshIOPressureCapacity(pressure *telemetry.IOPressure, degraded int) {
+	if pressure == nil {
+		return
+	}
+	pressure.DegradedMaxConcurrentAgents = max(degraded, 0)
+	pressure.EffectiveMaxConcurrentAgents = 0
+	pressure.DispatchHeld = false
+	if pressure.CapacityConstrained {
+		pressure.EffectiveMaxConcurrentAgents = pressure.DegradedMaxConcurrentAgents
+		pressure.DispatchHeld = pressure.EffectiveMaxConcurrentAgents == 0
+	}
+}
+
+func refreshCPUPressureCapacity(pressure *telemetry.CPUPressure, degraded int) {
+	if pressure == nil {
+		return
+	}
+	pressure.DegradedMaxConcurrentAgents = max(degraded, 0)
+	pressure.EffectiveMaxConcurrentAgents = 0
+	pressure.DispatchHeld = false
+	if pressure.CapacityConstrained {
+		pressure.EffectiveMaxConcurrentAgents = pressure.DegradedMaxConcurrentAgents
+		pressure.DispatchHeld = pressure.EffectiveMaxConcurrentAgents == 0
+	}
+}
+
+func refreshIOPressureDuration(pressure *telemetry.IOPressure, now time.Time) {
+	if pressure == nil || !pressure.CapacityConstrained || pressure.ConstrainedSince.IsZero() {
+		return
+	}
+	pressure.ConstrainedForMS = max(now.UTC().Sub(pressure.ConstrainedSince).Milliseconds(), 0)
+}
+
+func refreshCPUPressureDuration(pressure *telemetry.CPUPressure, now time.Time) {
+	if pressure == nil || !pressure.CapacityConstrained || pressure.ConstrainedSince.IsZero() {
+		return
+	}
+	pressure.ConstrainedForMS = max(now.UTC().Sub(pressure.ConstrainedSince).Milliseconds(), 0)
+}
+
+type hostPressureConstraint struct {
+	resource       string
+	reason         string
+	capacity       int
+	constrainedAt  time.Time
+	constrainedFor time.Duration
+}
+
+func activeHostPressureConstraint(state *State) (hostPressureConstraint, bool) {
+	if state == nil {
+		return hostPressureConstraint{}, false
+	}
+	constraints := make([]hostPressureConstraint, 0, 2)
+	if pressure := state.IOPressure; pressure.CapacityConstrained {
+		constraints = append(constraints, hostPressureConstraint{
+			resource:       "I/O",
+			reason:         dispatchIssueFailureIOPressure,
+			capacity:       pressure.EffectiveMaxConcurrentAgents,
+			constrainedAt:  pressure.ConstrainedSince,
+			constrainedFor: time.Duration(pressure.ConstrainedForMS) * time.Millisecond,
+		})
+	}
+	if pressure := state.CPUPressure; pressure.CapacityConstrained {
+		constraints = append(constraints, hostPressureConstraint{
+			resource:       "CPU",
+			reason:         dispatchIssueFailureCPUPressure,
+			capacity:       pressure.EffectiveMaxConcurrentAgents,
+			constrainedAt:  pressure.ConstrainedSince,
+			constrainedFor: time.Duration(pressure.ConstrainedForMS) * time.Millisecond,
+		})
+	}
+	if len(constraints) == 0 {
+		return hostPressureConstraint{}, false
+	}
+	selected := constraints[0]
+	for _, constraint := range constraints[1:] {
+		if constraint.capacity < selected.capacity {
+			selected = constraint
+		}
+	}
+	return selected, true
+}
+
+func hostPressureWaitReason(state *State, reason string) string {
+	constraint, ok := activeHostPressureConstraint(state)
+	if !ok {
+		return schedulerDecisionWaitReason(reason)
+	}
+	if reason == dispatchIssueFailureIOPressure && state.IOPressure.CapacityConstrained {
+		constraint = hostPressureConstraint{
+			resource:       "I/O",
+			reason:         reason,
+			capacity:       state.IOPressure.EffectiveMaxConcurrentAgents,
+			constrainedAt:  state.IOPressure.ConstrainedSince,
+			constrainedFor: time.Duration(state.IOPressure.ConstrainedForMS) * time.Millisecond,
+		}
+	}
+	if reason == dispatchIssueFailureCPUPressure && state.CPUPressure.CapacityConstrained {
+		constraint = hostPressureConstraint{
+			resource:       "CPU",
+			reason:         reason,
+			capacity:       state.CPUPressure.EffectiveMaxConcurrentAgents,
+			constrainedAt:  state.CPUPressure.ConstrainedSince,
+			constrainedFor: time.Duration(state.CPUPressure.ConstrainedForMS) * time.Millisecond,
+		}
+	}
+	duration := constraint.constrainedFor.Round(time.Second).String()
+	if constraint.capacity == 0 {
+		return constraint.resource + " pressure has held dispatch for " + duration
+	}
+	agentLabel := "agent"
+	if constraint.capacity != 1 {
+		agentLabel = "agents"
+	}
+	return fmt.Sprintf(
+		"%s pressure has limited admission to %d concurrent %s for %s",
+		constraint.resource,
+		constraint.capacity,
+		agentLabel,
+		duration,
+	)
 }
 
 func (o *Orchestrator) observePressure(

--- a/internal/orchestrator/host_pressure_regression_test.go
+++ b/internal/orchestrator/host_pressure_regression_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hostpressure"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestRecordedBuildHostPressureHoldsAdmission(t *testing.T) {
@@ -148,6 +150,216 @@ func TestObserveIOAndCPUPressureControlsAdmission(t *testing.T) {
 			supported, held, value, lastError := tt.observed(state)
 			if supported != tt.wantSupported || held != tt.wantHeld || value != tt.value || lastError != tt.wantError {
 				t.Fatalf("pressure = supported %t held %t value %.2f error %q", supported, held, value, lastError)
+			}
+		})
+	}
+}
+
+func TestIOAndCPUPressureUseHysteresis(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		threshold float64
+		floor     int
+		configure func(*Orchestrator, *float64)
+		observed  func(State) (bool, bool, int, time.Time, int64)
+	}{
+		{
+			name:      "IO",
+			threshold: 5,
+			floor:     1,
+			configure: func(orch *Orchestrator, value *float64) {
+				orch.cfg.IOPressureFullAvg10Max = 5
+				orch.cfg.IOPressureDegradedMaxAgents = 1
+				orch.cfg.IOPressurePollInterval = time.Second
+				orch.readIOPressure = func(context.Context) (hostpressure.Sample, error) {
+					return hostpressure.Sample{Full: hostpressure.Pressure{Avg10: *value}}, nil
+				}
+			},
+			observed: func(state State) (bool, bool, int, time.Time, int64) {
+				pressure := state.IOPressure
+				return pressure.CapacityConstrained, pressure.DispatchHeld, pressure.EffectiveMaxConcurrentAgents, pressure.ConstrainedSince, pressure.ConstrainedForMS
+			},
+		},
+		{
+			name:      "CPU",
+			threshold: 80,
+			floor:     2,
+			configure: func(orch *Orchestrator, value *float64) {
+				orch.cfg.CPUPressureSomeAvg10Max = 80
+				orch.cfg.CPUPressureDegradedMaxAgents = 2
+				orch.cfg.CPUPressurePollInterval = time.Second
+				orch.readCPUPressure = func(context.Context) (hostpressure.Sample, error) {
+					return hostpressure.Sample{Some: hostpressure.Pressure{Avg10: *value}}, nil
+				}
+			},
+			observed: func(state State) (bool, bool, int, time.Time, int64) {
+				pressure := state.CPUPressure
+				return pressure.CapacityConstrained, pressure.DispatchHeld, pressure.EffectiveMaxConcurrentAgents, pressure.ConstrainedSince, pressure.ConstrainedForMS
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+			value := tt.threshold + 1
+			orch := &Orchestrator{now: func() time.Time { return now }}
+			tt.configure(orch, &value)
+			state := newState(normalizeConfig(orch.cfg))
+
+			orch.observeHostPressure(t.Context(), &state, now)
+			constrained, held, effective, since, constrainedForMS := tt.observed(state)
+			if !constrained || held || effective != tt.floor || !since.Equal(now) || constrainedForMS != 0 {
+				t.Fatalf("triggered pressure = constrained %t held %t effective %d since %s duration %d", constrained, held, effective, since, constrainedForMS)
+			}
+
+			values := []struct {
+				name            string
+				value           float64
+				wantConstrained bool
+				wantDurationMS  int64
+			}{
+				{name: "at trigger threshold stays constrained", value: tt.threshold, wantConstrained: true, wantDurationMS: 1000},
+				{name: "above recovery threshold stays constrained", value: tt.threshold*pressureRecoveryRatio + 0.01, wantConstrained: true, wantDurationMS: 2000},
+				{name: "at recovery threshold resumes", value: tt.threshold * pressureRecoveryRatio},
+			}
+			for _, sample := range values {
+				now = now.Add(time.Second)
+				value = sample.value
+				orch.observeHostPressure(t.Context(), &state, now)
+				constrained, held, effective, since, constrainedForMS = tt.observed(state)
+				if constrained != sample.wantConstrained || held {
+					t.Fatalf("%s: constrained %t held %t, want constrained %t held false", sample.name, constrained, held, sample.wantConstrained)
+				}
+				if sample.wantConstrained {
+					if effective != tt.floor || !since.Equal(now.Add(-time.Duration(sample.wantDurationMS)*time.Millisecond)) || constrainedForMS != sample.wantDurationMS {
+						t.Fatalf("%s: effective %d since %s duration %d", sample.name, effective, since, constrainedForMS)
+					}
+				} else if effective != 0 || !since.IsZero() || constrainedForMS != 0 {
+					t.Fatalf("%s: cleared pressure = effective %d since %s duration %d", sample.name, effective, since, constrainedForMS)
+				}
+			}
+		})
+	}
+}
+
+func TestSustainedIOPressureUsesConfiguredAdmissionFloor(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	project := scheduler.ProjectCandidate{ID: "detent"}
+	gate := scheduler.NewGlobalDispatchGate(
+		scheduler.NewRoundRobin(scheduler.Config{Capacity: 4}),
+		project,
+	)
+	orch := &Orchestrator{
+		cfg: Config{
+			Project:                     project,
+			IOPressureFullAvg10Max:      5,
+			IOPressureDegradedMaxAgents: 1,
+			IOPressurePollInterval:      time.Second,
+		},
+		globalDispatchGate: gate,
+		readIOPressure: func(context.Context) (hostpressure.Sample, error) {
+			return hostpressure.Sample{Full: hostpressure.Pressure{Avg10: 63.64}}, nil
+		},
+		now: func() time.Time { return now },
+	}
+	state := newState(normalizeConfig(orch.cfg))
+	orch.observeHostPressure(t.Context(), &state, now)
+	constraint, constrained := activeHostPressureConstraint(&state)
+	if !constrained || constraint.capacity != 1 || state.IOPressure.DispatchHeld {
+		t.Fatalf("IO pressure = %#v, constraint = %#v, %t", state.IOPressure, constraint, constrained)
+	}
+
+	first, acquired, decision := orch.acquireGlobalDispatchSlot(
+		t.Context(),
+		connector.Issue{ID: "issue-1", State: "Todo"},
+		"",
+		now,
+		constraint.capacity,
+	)
+	if !acquired {
+		t.Fatalf("first pressure-limited acquisition = false: %#v", decision)
+	}
+	defer orch.releaseGlobalDispatchSlot(first)
+
+	_, acquired, decision = orch.acquireGlobalDispatchSlot(
+		t.Context(),
+		connector.Issue{ID: "issue-2", State: "Todo"},
+		"",
+		now,
+		constraint.capacity,
+	)
+	if acquired || decision.Reason != scheduler.DispatchGateReasonPressureCapacityFull || decision.PressureCapacity != 1 || decision.PressureUsed != 1 || decision.PressureAvailable != 0 {
+		t.Fatalf("second pressure-limited acquisition = %t, %#v", acquired, decision)
+	}
+	if snapshot := gate.PoolSnapshot(); snapshot.Used != 1 {
+		t.Fatalf("running work was preempted: %#v", snapshot)
+	}
+}
+
+func TestActiveHostPressureConstraintUsesLowestFloor(t *testing.T) {
+	t.Parallel()
+
+	ioSince := time.Date(2026, 9, 4, 11, 55, 0, 0, time.UTC)
+	cpuSince := ioSince.Add(time.Minute)
+	tests := []struct {
+		name       string
+		state      State
+		wantReason string
+		wantFloor  int
+		wantSince  time.Time
+	}{
+		{
+			name: "IO only",
+			state: State{IOPressure: telemetry.IOPressure{
+				CapacityConstrained: true, EffectiveMaxConcurrentAgents: 2, ConstrainedSince: ioSince,
+			}},
+			wantReason: dispatchIssueFailureIOPressure,
+			wantFloor:  2,
+			wantSince:  ioSince,
+		},
+		{
+			name: "CPU lower",
+			state: State{
+				IOPressure: telemetry.IOPressure{
+					CapacityConstrained: true, EffectiveMaxConcurrentAgents: 2, ConstrainedSince: ioSince,
+				},
+				CPUPressure: telemetry.CPUPressure{
+					CapacityConstrained: true, EffectiveMaxConcurrentAgents: 1, ConstrainedSince: cpuSince,
+				},
+			},
+			wantReason: dispatchIssueFailureCPUPressure,
+			wantFloor:  1,
+			wantSince:  cpuSince,
+		},
+		{
+			name: "IO hard stop wins",
+			state: State{
+				IOPressure: telemetry.IOPressure{
+					CapacityConstrained: true, ConstrainedSince: ioSince,
+				},
+				CPUPressure: telemetry.CPUPressure{
+					CapacityConstrained: true, EffectiveMaxConcurrentAgents: 1, ConstrainedSince: cpuSince,
+				},
+			},
+			wantReason: dispatchIssueFailureIOPressure,
+			wantSince:  ioSince,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			constraint, ok := activeHostPressureConstraint(&tt.state)
+			if !ok || constraint.reason != tt.wantReason || constraint.capacity != tt.wantFloor || !constraint.constrainedAt.Equal(tt.wantSince) {
+				t.Fatalf("activeHostPressureConstraint() = %#v, %t", constraint, ok)
 			}
 		})
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -140,8 +140,10 @@ type Config struct {
 	MemoryPressureSomeAvg60Max    float64
 	MemoryPressurePollInterval    time.Duration
 	IOPressureFullAvg10Max        float64
+	IOPressureDegradedMaxAgents   int
 	IOPressurePollInterval        time.Duration
 	CPUPressureSomeAvg10Max       float64
+	CPUPressureDegradedMaxAgents  int
 	CPUPressurePollInterval       time.Duration
 }
 
@@ -1229,7 +1231,11 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	state.DispatchStallThreshold = cfg.DispatchStallThreshold
 	state.MemoryPressure.SomeAvg60Max = cfg.MemoryPressureSomeAvg60Max
 	state.IOPressure.FullAvg10Max = cfg.IOPressureFullAvg10Max
+	state.IOPressure.DegradedMaxConcurrentAgents = cfg.IOPressureDegradedMaxAgents
 	state.CPUPressure.SomeAvg10Max = cfg.CPUPressureSomeAvg10Max
+	state.CPUPressure.DegradedMaxConcurrentAgents = cfg.CPUPressureDegradedMaxAgents
+	refreshIOPressureCapacity(&state.IOPressure, cfg.IOPressureDegradedMaxAgents)
+	refreshCPUPressureCapacity(&state.CPUPressure, cfg.CPUPressureDegradedMaxAgents)
 	state.AutoPromoteQuietDuration = cfg.AutoPromote.QuietDuration
 	state.AutoPromote = cloneAutoPromoteConfig(cfg.AutoPromote)
 	state.ActiveStates = append([]string(nil), cfg.ActiveStates...)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -366,10 +366,12 @@ func newState(cfg Config) State {
 			SomeAvg60Max: cfg.MemoryPressureSomeAvg60Max,
 		},
 		IOPressure: telemetry.IOPressure{
-			FullAvg10Max: cfg.IOPressureFullAvg10Max,
+			FullAvg10Max:                cfg.IOPressureFullAvg10Max,
+			DegradedMaxConcurrentAgents: cfg.IOPressureDegradedMaxAgents,
 		},
 		CPUPressure: telemetry.CPUPressure{
-			SomeAvg10Max: cfg.CPUPressureSomeAvg10Max,
+			SomeAvg10Max:                cfg.CPUPressureSomeAvg10Max,
+			DegradedMaxConcurrentAgents: cfg.CPUPressureDegradedMaxAgents,
 		},
 		AutoPromoteQuietDuration: cfg.AutoPromote.QuietDuration,
 		AutoPromote:              cloneAutoPromoteConfig(cfg.AutoPromote),

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -885,6 +885,12 @@ func (o *Orchestrator) capacitySnapshotJSON(state *State, issue connector.Issue)
 	if state != nil && len(state.DispatchRecoveries) > 0 {
 		snapshot["dispatch_recoveries"] = dispatchRecoveriesCapacitySnapshot(state.DispatchRecoveries, pool.Name, pool.Capacity)
 	}
+	if constraint, ok := activeHostPressureConstraint(state); ok {
+		snapshot["pressure_capacity"] = constraint.capacity
+		snapshot["pressure_reason"] = constraint.reason
+		snapshot["pressure_constrained_since"] = constraint.constrainedAt
+		snapshot["pressure_constrained_for_ms"] = constraint.constrainedFor.Milliseconds()
+	}
 	if state != nil && state.FailureBreaker.Active() {
 		snapshot["project_failure_breaker"] = map[string]any{
 			"class":           state.FailureBreaker.Class,

--- a/internal/project/connector_config_test.go
+++ b/internal/project/connector_config_test.go
@@ -173,19 +173,19 @@ func TestProjectOrchestratorConfigIncludesHostPressure(t *testing.T) {
 	project := globalconfig.Project{
 		ID:           "detent",
 		GlobalMemory: globalconfig.Memory{PressureSomeAvg60Threshold: 10, PollIntervalMS: 1000},
-		GlobalIO:     globalconfig.IO{PressureFullAvg10Threshold: 5, PollIntervalMS: 500},
-		GlobalCPU:    globalconfig.CPU{PressureSomeAvg10Threshold: 80, PollIntervalMS: 750},
+		GlobalIO:     globalconfig.IO{PressureFullAvg10Threshold: 5, DegradedMaxConcurrentAgents: 1, PollIntervalMS: 500},
+		GlobalCPU:    globalconfig.CPU{PressureSomeAvg10Threshold: 80, DegradedMaxConcurrentAgents: 2, PollIntervalMS: 750},
 	}
 	got := projectOrchestratorConfig(project, workflowconfig.Default())
 
 	if got.MemoryPressureSomeAvg60Max != 10 || got.MemoryPressurePollInterval != time.Second {
 		t.Fatalf("memory pressure config = %.2f %s", got.MemoryPressureSomeAvg60Max, got.MemoryPressurePollInterval)
 	}
-	if got.IOPressureFullAvg10Max != 5 || got.IOPressurePollInterval != 500*time.Millisecond {
-		t.Fatalf("IO pressure config = %.2f %s", got.IOPressureFullAvg10Max, got.IOPressurePollInterval)
+	if got.IOPressureFullAvg10Max != 5 || got.IOPressureDegradedMaxAgents != 1 || got.IOPressurePollInterval != 500*time.Millisecond {
+		t.Fatalf("IO pressure config = %.2f %d %s", got.IOPressureFullAvg10Max, got.IOPressureDegradedMaxAgents, got.IOPressurePollInterval)
 	}
-	if got.CPUPressureSomeAvg10Max != 80 || got.CPUPressurePollInterval != 750*time.Millisecond {
-		t.Fatalf("CPU pressure config = %.2f %s", got.CPUPressureSomeAvg10Max, got.CPUPressurePollInterval)
+	if got.CPUPressureSomeAvg10Max != 80 || got.CPUPressureDegradedMaxAgents != 2 || got.CPUPressurePollInterval != 750*time.Millisecond {
+		t.Fatalf("CPU pressure config = %.2f %d %s", got.CPUPressureSomeAvg10Max, got.CPUPressureDegradedMaxAgents, got.CPUPressurePollInterval)
 	}
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1666,8 +1666,10 @@ func projectOrchestratorConfig(project globalconfig.Project, workflow workflowco
 	cfg.MemoryPressureSomeAvg60Max = memory.PressureSomeAvg60Threshold
 	cfg.MemoryPressurePollInterval = time.Duration(memory.PollIntervalMS) * time.Millisecond
 	cfg.IOPressureFullAvg10Max = project.GlobalIO.PressureFullAvg10Threshold
+	cfg.IOPressureDegradedMaxAgents = project.GlobalIO.DegradedMaxConcurrentAgents
 	cfg.IOPressurePollInterval = time.Duration(project.GlobalIO.PollIntervalMS) * time.Millisecond
 	cfg.CPUPressureSomeAvg10Max = project.GlobalCPU.PressureSomeAvg10Threshold
+	cfg.CPUPressureDegradedMaxAgents = project.GlobalCPU.DegradedMaxConcurrentAgents
 	cfg.CPUPressurePollInterval = time.Duration(project.GlobalCPU.PollIntervalMS) * time.Millisecond
 	overrideUntil := activehours.ParsePersistedOverride(project.ActiveHoursOverrideUntil)
 	cfg.Project = scheduler.ProjectCandidate{

--- a/internal/scheduler/elastic_pool.go
+++ b/internal/scheduler/elastic_pool.go
@@ -65,8 +65,8 @@ func (r *PoolRegistry) allowPoolCapacity(
 	req SlotRequest,
 ) string {
 	if req.PressureCapacity > 0 {
-		_, currentSharedUsed := r.elasticTotals(runtime, currentUsed)
-		if currentSharedUsed+req.Weight > req.PressureCapacity {
+		currentPressureUsed := r.pressureUsed(runtime, currentUsed)
+		if currentPressureUsed+req.Weight > req.PressureCapacity {
 			return DispatchGateReasonPressureCapacityFull
 		}
 	}
@@ -188,6 +188,25 @@ func (r *PoolRegistry) elasticTotals(current *poolRuntime, projectedUsed int) (i
 	return capacity, used
 }
 
+func (r *PoolRegistry) pressureUsed(current *poolRuntime, currentUsed int) int {
+	r.mu.RLock()
+	runtimes := make([]*poolRuntime, 0, len(r.byGeneration))
+	for _, runtime := range r.byGeneration {
+		runtimes = append(runtimes, runtime)
+	}
+	r.mu.RUnlock()
+
+	used := 0
+	for _, runtime := range runtimes {
+		if runtime == current {
+			used += currentUsed
+			continue
+		}
+		used += runtime.gate.PoolSnapshot().Used
+	}
+	return used
+}
+
 func (r *PoolRegistry) cleanupElasticWaiters() {
 	r.mu.RLock()
 	runtimes := make(map[uint64]*poolRuntime, len(r.active))
@@ -260,7 +279,7 @@ func (r *PoolRegistry) elasticDecision(
 	decision.SharedCapacity = sharedCapacity
 	decision.SharedUsed = sharedUsed
 	decision.SharedAvailable = max(0, sharedCapacity-sharedUsed)
-	decision.PressureUsed = sharedUsed
-	decision.PressureAvailable = max(0, decision.PressureCapacity-sharedUsed)
+	decision.PressureUsed = r.pressureUsed(nil, 0)
+	decision.PressureAvailable = max(0, decision.PressureCapacity-decision.PressureUsed)
 	return decision
 }

--- a/internal/scheduler/elastic_pool.go
+++ b/internal/scheduler/elastic_pool.go
@@ -49,8 +49,8 @@ func reconfigurePoolRuntime(runtime *poolRuntime, cfg PoolConfig) error {
 
 func (r *PoolRegistry) setCapacityAdmission(runtime *poolRuntime) {
 	runtime.gate.admit = &poolCapacityAdmission{
-		allow: func(currentUsed int, projectedUsed int) bool {
-			return r.allowPoolCapacity(runtime, currentUsed, projectedUsed)
+		allow: func(currentUsed int, projectedUsed int, req SlotRequest) string {
+			return r.allowPoolCapacity(runtime, currentUsed, projectedUsed, req)
 		},
 		complete: func(used int) {
 			r.completePoolAdmission(runtime, used)
@@ -62,11 +62,18 @@ func (r *PoolRegistry) allowPoolCapacity(
 	runtime *poolRuntime,
 	currentUsed int,
 	projectedUsed int,
-) bool {
+	req SlotRequest,
+) string {
+	if req.PressureCapacity > 0 {
+		_, currentSharedUsed := r.elasticTotals(runtime, currentUsed)
+		if currentSharedUsed+req.Weight > req.PressureCapacity {
+			return DispatchGateReasonPressureCapacityFull
+		}
+	}
 	sharedCapacity, sharedUsed := r.elasticTotals(runtime, projectedUsed)
 	if projectedUsed <= runtime.guaranteed {
 		if sharedUsed <= sharedCapacity {
-			return true
+			return ""
 		}
 		target := min(runtime.guaranteed, projectedUsed)
 		if target > currentUsed {
@@ -75,22 +82,22 @@ func (r *PoolRegistry) allowPoolCapacity(
 				target,
 			)
 		}
-		return false
+		return DispatchGateReasonGlobalCapacityFull
 	}
 	if projectedUsed > runtime.burstTo || runtime.burstTo == runtime.guaranteed {
-		return false
+		return DispatchGateReasonGlobalCapacityFull
 	}
 	if r.hasReclaimDemand(runtime, currentUsed) ||
 		r.hasGuaranteedReadyDemand(runtime) ||
 		sharedUsed > sharedCapacity {
 		r.elastic.enqueue(runtime.generation)
-		return false
+		return DispatchGateReasonGlobalCapacityFull
 	}
 	if len(r.elastic.borrowers) > 0 && r.elastic.borrowers[0] != runtime.generation {
 		r.elastic.enqueue(runtime.generation)
-		return false
+		return DispatchGateReasonGlobalCapacityFull
 	}
-	return true
+	return ""
 }
 
 func (r *PoolRegistry) completePoolAdmission(runtime *poolRuntime, used int) {
@@ -253,5 +260,7 @@ func (r *PoolRegistry) elasticDecision(
 	decision.SharedCapacity = sharedCapacity
 	decision.SharedUsed = sharedUsed
 	decision.SharedAvailable = max(0, sharedCapacity-sharedUsed)
+	decision.PressureUsed = sharedUsed
+	decision.PressureAvailable = max(0, decision.PressureCapacity-sharedUsed)
 	return decision
 }

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -18,6 +18,7 @@ const (
 	DispatchGateReasonReservedForHigherPriority        = "reserved_for_higher_priority_state"
 	DispatchGateReasonReservedForHigherPriorityProject = "reserved_for_higher_priority_project"
 	DispatchGateReasonSelectedProjectWaiting           = "selected_project_waiting"
+	DispatchGateReasonPressureCapacityFull             = "pressure_capacity_full"
 )
 
 type ProjectDispatchGate interface {
@@ -51,10 +52,13 @@ type DispatchGateDecision struct {
 	SharedCapacity       int
 	SharedUsed           int
 	SharedAvailable      int
+	PressureCapacity     int
+	PressureUsed         int
+	PressureAvailable    int
 }
 
 type poolCapacityAdmission struct {
-	allow    func(int, int) bool
+	allow    func(int, int, SlotRequest) string
 	complete func(int)
 }
 
@@ -409,9 +413,14 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 		return Slot{}, false, g.decisionLocked(project.ID, req, reason), nil
 	}
 	currentUsed := g.capacitySnapshotLocked("").globalUsed
+	if req.PressureCapacity > 0 && currentUsed+req.Weight > req.PressureCapacity {
+		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonPressureCapacityFull), nil
+	}
 	projectedUsed := currentUsed - g.preemptionWeightLocked(selected.preemptions) + req.Weight
-	if g.admit != nil && !g.admit.allow(currentUsed, projectedUsed) {
-		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull), nil
+	if g.admit != nil {
+		if reason := g.admit.allow(currentUsed, projectedUsed, req); reason != "" {
+			return Slot{}, false, g.decisionLocked(project.ID, req, reason), nil
+		}
 	}
 	if err := g.preemptProjectsLocked(selected.preemptions); err != nil {
 		delete(g.selected, project.ID)
@@ -710,6 +719,9 @@ func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, r
 		StateCapacity:        stats.stateCapacity,
 		StateUsed:            stats.stateUsed,
 		StateAvailable:       nonNegativeInt(stats.stateCapacity - stats.stateUsed),
+		PressureCapacity:     req.PressureCapacity,
+		PressureUsed:         stats.globalUsed,
+		PressureAvailable:    nonNegativeInt(req.PressureCapacity - stats.globalUsed),
 		LowerPriorityRunning: g.lowerPriorityRunningLocked(req.Priority),
 		ReadyProjects:        len(g.ready),
 		RunningProjects:      len(g.running),
@@ -924,10 +936,11 @@ func normalizeSlotRequest(req SlotRequest) (SlotRequest, error) {
 		return SlotRequest{}, err
 	}
 	return SlotRequest{
-		State:    slot.State,
-		Host:     slot.Host,
-		Weight:   slot.Weight,
-		Priority: slot.Priority,
+		State:            slot.State,
+		Host:             slot.Host,
+		Weight:           slot.Weight,
+		Priority:         slot.Priority,
+		PressureCapacity: normalizedCapacity(req.PressureCapacity),
 	}, nil
 }
 

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -774,6 +774,47 @@ func TestGlobalDispatchGateHonorsStrictPriorityPreemption(t *testing.T) {
 	}
 }
 
+func TestGlobalDispatchGatePressureCapacityDoesNotPreemptRunningWork(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}))
+	low := scheduler.ProjectCandidate{ID: "low", Weight: 1, Priority: 4}
+	urgent := scheduler.ProjectCandidate{ID: "urgent", Weight: 1, Priority: 1}
+
+	lowSlot, acquired, err := gate.TryAcquire(ctx, low, scheduler.SlotRequest{State: "Todo"}, now)
+	if err != nil || !acquired {
+		t.Fatalf("low TryAcquire() = %t, %v; want grant", acquired, err)
+	}
+	preempted := false
+	gate.SetPreempt(lowSlot, func() {
+		preempted = true
+	})
+
+	_, acquired, decision, err := gate.TryAcquireWithDecision(
+		ctx,
+		urgent,
+		scheduler.SlotRequest{State: "Todo", PressureCapacity: 1},
+		now.Add(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("urgent TryAcquireWithDecision() error = %v", err)
+	}
+	if acquired || decision.Reason != scheduler.DispatchGateReasonPressureCapacityFull {
+		t.Fatalf("urgent pressure-limited acquisition = %t, %#v", acquired, decision)
+	}
+	if preempted {
+		t.Fatal("pressure-limited acquisition preempted running work")
+	}
+	if snapshot := gate.PoolSnapshot(); snapshot.Used != 1 {
+		t.Fatalf("running slot after pressure refusal = %#v", snapshot)
+	}
+	if err := gate.Release(lowSlot); err != nil {
+		t.Fatalf("low Release() error = %v", err)
+	}
+}
+
 func TestGlobalDispatchGateStrictProjectPriorityIsIndependentOfDemandOrder(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/pool_registry_test.go
+++ b/internal/scheduler/pool_registry_test.go
@@ -95,6 +95,46 @@ func TestPoolRegistryPressureCapacityComposesAcrossPools(t *testing.T) {
 	}
 }
 
+func TestPoolRegistryPressureCapacityCountsDrainingPools(t *testing.T) {
+	t.Parallel()
+
+	video := scheduler.ProjectCandidate{ID: "video", Pool: "video"}
+	registry := newPoolRegistry(t,
+		[]scheduler.PoolConfig{
+			poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil),
+			poolConfig("video", "weighted", 1, nil),
+		},
+		[]scheduler.ProjectCandidate{video},
+	)
+	oldSlot := acquirePoolSlots(t, registry, time.Time{}, video)[0]
+
+	reassigned := scheduler.ProjectCandidate{ID: "video"}
+	if err := registry.Reconfigure(
+		[]scheduler.PoolConfig{poolConfig(scheduler.DefaultPoolName, "weighted", 1, nil)},
+		[]scheduler.ProjectCandidate{reassigned},
+	); err != nil {
+		t.Fatalf("remove Reconfigure() error = %v", err)
+	}
+
+	request := scheduler.SlotRequest{State: "Todo", PressureCapacity: 1}
+	_, acquired, decision, err := registry.TryAcquireWithDecision(t.Context(), reassigned, request, time.Time{})
+	if err != nil {
+		t.Fatalf("TryAcquireWithDecision() error = %v", err)
+	}
+	if acquired || decision.Reason != scheduler.DispatchGateReasonPressureCapacityFull || decision.PressureUsed != 1 || decision.PressureAvailable != 0 {
+		t.Fatalf("pressure decision with draining pool = %t, %#v", acquired, decision)
+	}
+	if err := registry.Release(oldSlot); err != nil {
+		t.Fatalf("Release(oldSlot) error = %v", err)
+	}
+
+	newSlot, acquired, decision, err := registry.TryAcquireWithDecision(t.Context(), reassigned, request, time.Time{})
+	if err != nil || !acquired {
+		t.Fatalf("TryAcquireWithDecision() after drain = %t, %v; decision = %#v", acquired, err, decision)
+	}
+	releasePoolSlots(t, registry, []scheduler.Slot{newSlot})
+}
+
 func TestPoolRegistryWithoutBurstRemainsRigid(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/pool_registry_test.go
+++ b/internal/scheduler/pool_registry_test.go
@@ -39,6 +39,62 @@ func TestPoolRegistryGrantsIndependentCapacity(t *testing.T) {
 	releasePoolSlots(t, registry, slots)
 }
 
+func TestPoolRegistryPressureCapacityComposesAcrossPools(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		capacity      int
+		wantGranted   bool
+		wantUsed      int
+		wantAvailable int
+	}{
+		{name: "one worker degraded floor", capacity: 1, wantUsed: 1},
+		{name: "two worker degraded floor", capacity: 2, wantGranted: true, wantUsed: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projects := []scheduler.ProjectCandidate{
+				{ID: "code"},
+				{ID: "video", Pool: "video"},
+			}
+			registry := newPoolRegistry(t,
+				[]scheduler.PoolConfig{
+					poolConfig(scheduler.DefaultPoolName, "round_robin", 2, nil),
+					poolConfig("video", "round_robin", 2, nil),
+				},
+				projects,
+			)
+			request := scheduler.SlotRequest{State: "Todo", PressureCapacity: tt.capacity}
+			first, acquired, _, err := registry.TryAcquireWithDecision(t.Context(), projects[0], request, time.Time{})
+			if err != nil || !acquired {
+				t.Fatalf("first TryAcquireWithDecision() = %t, %v; want grant", acquired, err)
+			}
+
+			second, granted, decision, err := registry.TryAcquireWithDecision(t.Context(), projects[1], request, time.Time{})
+			if err != nil {
+				t.Fatalf("second TryAcquireWithDecision() error = %v", err)
+			}
+			if granted != tt.wantGranted {
+				t.Fatalf("second TryAcquireWithDecision() granted = %t, want %t; decision = %#v", granted, tt.wantGranted, decision)
+			}
+			if decision.PressureCapacity != tt.capacity || decision.PressureUsed != tt.wantUsed || decision.PressureAvailable != tt.wantAvailable {
+				t.Fatalf("pressure decision = %#v, want capacity %d used %d available %d", decision, tt.capacity, tt.wantUsed, tt.wantAvailable)
+			}
+			if !granted && decision.Reason != scheduler.DispatchGateReasonPressureCapacityFull {
+				t.Fatalf("decision reason = %q, want %q", decision.Reason, scheduler.DispatchGateReasonPressureCapacityFull)
+			}
+			if snapshot := registry.PoolSnapshotFor("code"); snapshot.Used != 1 {
+				t.Fatalf("running code slot was preempted: %#v", snapshot)
+			}
+
+			releasePoolSlots(t, registry, []scheduler.Slot{first, second})
+		})
+	}
+}
+
 func TestPoolRegistryWithoutBurstRemainsRigid(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -51,10 +51,11 @@ type Config struct {
 }
 
 type SlotRequest struct {
-	State    string
-	Host     string
-	Weight   int
-	Priority int
+	State            string
+	Host             string
+	Weight           int
+	Priority         int
+	PressureCapacity int
 }
 
 type Slot struct {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -81,23 +81,33 @@ type MemoryPressure struct {
 }
 
 type IOPressure struct {
-	Supported    bool             `json:"supported"`
-	Some         PressureAverages `json:"some"`
-	Full         PressureAverages `json:"full"`
-	FullAvg10Max float64          `json:"full_avg10_max"`
-	DispatchHeld bool             `json:"dispatch_held"`
-	ObservedAt   time.Time        `json:"observed_at,omitzero"`
-	LastError    string           `json:"last_error,omitempty"`
+	Supported                    bool             `json:"supported"`
+	Some                         PressureAverages `json:"some"`
+	Full                         PressureAverages `json:"full"`
+	FullAvg10Max                 float64          `json:"full_avg10_max"`
+	DegradedMaxConcurrentAgents  int              `json:"degraded_max_concurrent_agents"`
+	EffectiveMaxConcurrentAgents int              `json:"effective_max_concurrent_agents"`
+	CapacityConstrained          bool             `json:"capacity_constrained"`
+	DispatchHeld                 bool             `json:"dispatch_held"`
+	ConstrainedSince             time.Time        `json:"constrained_since,omitzero"`
+	ConstrainedForMS             int64            `json:"constrained_for_ms"`
+	ObservedAt                   time.Time        `json:"observed_at,omitzero"`
+	LastError                    string           `json:"last_error,omitempty"`
 }
 
 type CPUPressure struct {
-	Supported    bool             `json:"supported"`
-	Some         PressureAverages `json:"some"`
-	Full         PressureAverages `json:"full"`
-	SomeAvg10Max float64          `json:"some_avg10_max"`
-	DispatchHeld bool             `json:"dispatch_held"`
-	ObservedAt   time.Time        `json:"observed_at,omitzero"`
-	LastError    string           `json:"last_error,omitempty"`
+	Supported                    bool             `json:"supported"`
+	Some                         PressureAverages `json:"some"`
+	Full                         PressureAverages `json:"full"`
+	SomeAvg10Max                 float64          `json:"some_avg10_max"`
+	DegradedMaxConcurrentAgents  int              `json:"degraded_max_concurrent_agents"`
+	EffectiveMaxConcurrentAgents int              `json:"effective_max_concurrent_agents"`
+	CapacityConstrained          bool             `json:"capacity_constrained"`
+	DispatchHeld                 bool             `json:"dispatch_held"`
+	ConstrainedSince             time.Time        `json:"constrained_since,omitzero"`
+	ConstrainedForMS             int64            `json:"constrained_for_ms"`
+	ObservedAt                   time.Time        `json:"observed_at,omitzero"`
+	LastError                    string           `json:"last_error,omitempty"`
 }
 
 type PressureAverages struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1270,7 +1270,7 @@ func (s *Server) health(c echo.Context) error {
 	if status != "draining" {
 		budgets = s.enforcedBudgets()
 		workflows = s.workflowSources()
-		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(faultDispatchStalls) > 0 || len(actionableBreakers) > 0 || len(dispatchLoops) > 0 || len(actionableOutages) > 0 || len(faultStalenessWarnings(stalenessWarnings)) > 0 || len(strandedActiveIssues) > 0 || len(cleanupFaults) > 0 || strings.TrimSpace(updateStatus.LastError) != "" || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld || ioPressure.DispatchHeld || cpuPressure.DispatchHeld || orphanedProcesses.Count > 0 {
+		if len(trackerUnavailable) > 0 || len(forgeUnavailable) > 0 || len(ciUnavailable) > 0 || len(faultDispatchStalls) > 0 || len(actionableBreakers) > 0 || len(dispatchLoops) > 0 || len(actionableOutages) > 0 || len(faultStalenessWarnings(stalenessWarnings)) > 0 || len(strandedActiveIssues) > 0 || len(cleanupFaults) > 0 || strings.TrimSpace(updateStatus.LastError) != "" || tickLivenessNeedsAttention(tickLiveness) || len(refreshFailures) > 0 || memoryPressure.DispatchHeld || ioPressure.CapacityConstrained || ioPressure.DispatchHeld || cpuPressure.CapacityConstrained || cpuPressure.DispatchHeld || orphanedProcesses.Count > 0 {
 			status = "needs_attention"
 		}
 		if pauseExitNeedsAttention(projectHealth) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7031,12 +7031,16 @@ func TestHealthAndStateReportHostPressureAndAgentRSS(t *testing.T) {
 			ObservedAt:   observedAt,
 		},
 		IOPressure: telemetry.IOPressure{
-			Supported:    true,
-			Some:         telemetry.PressureAverages{Avg10: 78.81},
-			Full:         telemetry.PressureAverages{Avg10: 63.64},
-			FullAvg10Max: 5,
-			DispatchHeld: true,
-			ObservedAt:   observedAt,
+			Supported:                    true,
+			Some:                         telemetry.PressureAverages{Avg10: 78.81},
+			Full:                         telemetry.PressureAverages{Avg10: 63.64},
+			FullAvg10Max:                 5,
+			DegradedMaxConcurrentAgents:  1,
+			EffectiveMaxConcurrentAgents: 1,
+			CapacityConstrained:          true,
+			ConstrainedSince:             now.Add(-5 * time.Minute),
+			ConstrainedForMS:             300000,
+			ObservedAt:                   observedAt,
 		},
 		CPUPressure: telemetry.CPUPressure{
 			Supported:    true,
@@ -7068,7 +7072,7 @@ func TestHealthAndStateReportHostPressureAndAgentRSS(t *testing.T) {
 	if pressure["dispatch_held"] != true || pressure["some"].(map[string]any)["avg60"] != 12.5 {
 		t.Fatalf("health memory_pressure = %#v", pressure)
 	}
-	if pressure := health["io_pressure"].(map[string]any); pressure["dispatch_held"] != true || pressure["full"].(map[string]any)["avg10"] != 63.64 {
+	if pressure := health["io_pressure"].(map[string]any); pressure["dispatch_held"] != false || pressure["capacity_constrained"] != true || pressure["degraded_max_concurrent_agents"] != float64(1) || pressure["effective_max_concurrent_agents"] != float64(1) || pressure["constrained_for_ms"] != float64(300000) || pressure["full"].(map[string]any)["avg10"] != 63.64 {
 		t.Fatalf("health io_pressure = %#v", pressure)
 	}
 	if pressure := health["cpu_pressure"].(map[string]any); pressure["dispatch_held"] != true || pressure["some"].(map[string]any)["avg10"] != 91.2 {
@@ -7083,7 +7087,7 @@ func TestHealthAndStateReportHostPressureAndAgentRSS(t *testing.T) {
 	if state["memory_pressure"].(map[string]any)["dispatch_held"] != true {
 		t.Fatalf("state memory_pressure = %#v", state["memory_pressure"])
 	}
-	if state["io_pressure"].(map[string]any)["dispatch_held"] != true {
+	if pressure := state["io_pressure"].(map[string]any); pressure["dispatch_held"] != false || pressure["capacity_constrained"] != true || pressure["effective_max_concurrent_agents"] != float64(1) {
 		t.Fatalf("state io_pressure = %#v", state["io_pressure"])
 	}
 	if state["cpu_pressure"].(map[string]any)["dispatch_held"] != true {

--- a/internal/web/templates/health_data.go
+++ b/internal/web/templates/health_data.go
@@ -100,7 +100,10 @@ func healthViewFromDashboard(data DashboardData) healthView {
 	}
 	if detail := hostPressureHoldDetail(snapshot); detail != "" {
 		view.Kind = primitives.KindWarn
-		view.Verdict = "Dispatch is waiting for host pressure."
+		view.Verdict = "Dispatch is constrained by host pressure."
+		if snapshot.MemoryPressure.DispatchHeld || snapshot.IOPressure.DispatchHeld || snapshot.CPUPressure.DispatchHeld {
+			view.Verdict = "Dispatch is waiting for host pressure."
+		}
 		view.Detail = detail
 		return view
 	}
@@ -268,24 +271,43 @@ func healthRows(snapshot telemetry.Snapshot) []healthRow {
 }
 
 func hostPressureHoldDetail(snapshot telemetry.Snapshot) string {
-	held := make([]string, 0, 3)
+	constraints := make([]string, 0, 3)
 	if snapshot.MemoryPressure.DispatchHeld {
-		held = append(held, "memory some avg60 "+percentLabel(snapshot.MemoryPressure.Some.Avg60))
+		constraints = append(constraints, "memory some avg60 "+percentLabel(snapshot.MemoryPressure.Some.Avg60)+" holds dispatch")
 	}
-	if snapshot.IOPressure.DispatchHeld {
-		held = append(held, "IO full avg10 "+percentLabel(snapshot.IOPressure.Full.Avg10))
+	if pressure := snapshot.IOPressure; pressure.CapacityConstrained || pressure.DispatchHeld {
+		constraints = append(constraints, hostPressureCapacityDetail(
+			"IO full avg10 "+percentLabel(pressure.Full.Avg10),
+			pressure.DispatchHeld,
+			pressure.EffectiveMaxConcurrentAgents,
+			pressure.ConstrainedForMS,
+		))
 	}
-	if snapshot.CPUPressure.DispatchHeld {
-		held = append(held, "CPU some avg10 "+percentLabel(snapshot.CPUPressure.Some.Avg10))
+	if pressure := snapshot.CPUPressure; pressure.CapacityConstrained || pressure.DispatchHeld {
+		constraints = append(constraints, hostPressureCapacityDetail(
+			"CPU some avg10 "+percentLabel(pressure.Some.Avg10),
+			pressure.DispatchHeld,
+			pressure.EffectiveMaxConcurrentAgents,
+			pressure.ConstrainedForMS,
+		))
 	}
-	if len(held) == 0 {
+	if len(constraints) == 0 {
 		return ""
 	}
-	verb := "exceeds"
-	if len(held) > 1 {
-		verb = "exceed"
+	return strings.Join(constraints, ", ") + "."
+}
+
+func hostPressureCapacityDetail(metric string, held bool, capacity int, constrainedForMS int64) string {
+	detail := metric
+	if held {
+		detail += " holds dispatch"
+	} else {
+		detail += " limits admission to " + boardCountLabel(capacity, "concurrent agent", "concurrent agents")
 	}
-	return strings.Join(held, ", ") + " " + verb + " the configured admission threshold."
+	if constrainedForMS > 0 {
+		detail += " for " + (time.Duration(constrainedForMS) * time.Millisecond).Round(time.Second).String()
+	}
+	return detail
 }
 
 func healthPressureRows(snapshot telemetry.Snapshot) []healthRow {
@@ -295,6 +317,10 @@ func healthPressureRows(snapshot telemetry.Snapshot) []healthRow {
 			"memory",
 			pressure.Supported,
 			pressure.DispatchHeld,
+			pressure.DispatchHeld,
+			0,
+			0,
+			false,
 			pressure.LastError,
 			pressure.ObservedAt,
 			"some avg60",
@@ -308,6 +334,10 @@ func healthPressureRows(snapshot telemetry.Snapshot) []healthRow {
 			"IO",
 			pressure.Supported,
 			pressure.DispatchHeld,
+			pressure.CapacityConstrained,
+			pressure.EffectiveMaxConcurrentAgents,
+			pressure.ConstrainedForMS,
+			true,
 			pressure.LastError,
 			pressure.ObservedAt,
 			"full avg10",
@@ -321,6 +351,10 @@ func healthPressureRows(snapshot telemetry.Snapshot) []healthRow {
 			"CPU",
 			pressure.Supported,
 			pressure.DispatchHeld,
+			pressure.CapacityConstrained,
+			pressure.EffectiveMaxConcurrentAgents,
+			pressure.ConstrainedForMS,
+			true,
 			pressure.LastError,
 			pressure.ObservedAt,
 			"some avg10",
@@ -336,6 +370,10 @@ func healthPressureRow(
 	resource string,
 	supported bool,
 	held bool,
+	constrained bool,
+	effectiveCapacity int,
+	constrainedForMS int64,
+	hysteresis bool,
 	lastError string,
 	observedAt time.Time,
 	metric string,
@@ -366,10 +404,19 @@ func healthPressureRow(
 		row.Status = "Unsupported"
 		row.Detail = "Linux PSI is unavailable on this host"
 		row.Resets = "—"
-	case held:
+	case constrained || held:
 		row.Kind = primitives.KindWarn
 		row.Status = "Holding dispatch"
+		if !held {
+			row.Status = "Limited to " + boardCountLabel(effectiveCapacity, "agent", "agents")
+		}
+		if constrainedForMS > 0 {
+			row.Detail += " · constrained for " + (time.Duration(constrainedForMS) * time.Millisecond).Round(time.Second).String()
+		}
 		row.Resets = "when pressure falls"
+		if hysteresis {
+			row.Resets = "at 80% of threshold"
+		}
 	}
 	return row
 }

--- a/internal/web/templates/health_data_test.go
+++ b/internal/web/templates/health_data_test.go
@@ -61,6 +61,19 @@ func TestHealthViewVerdicts(t *testing.T) {
 			wantVerdict: "Dispatch is waiting for host pressure.",
 		},
 		{
+			name: "degraded pressure capacity explains bounded dispatch",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				IOPressure: telemetry.IOPressure{
+					Supported: true, Full: telemetry.PressureAverages{Avg10: 37}, FullAvg10Max: 5,
+					DegradedMaxConcurrentAgents: 1, EffectiveMaxConcurrentAgents: 1,
+					CapacityConstrained: true, ConstrainedSince: now.Add(-5 * time.Minute), ConstrainedForMS: 300000,
+				},
+			},
+			wantKind:    primitives.KindWarn,
+			wantVerdict: "Dispatch is constrained by host pressure.",
+		},
+		{
 			name: "tracker unavailability requires attention",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,
@@ -225,7 +238,9 @@ func TestHealthRowsSurfaceHostPressure(t *testing.T) {
 			Supported: true, Some: telemetry.PressureAverages{Avg60: 0}, SomeAvg60Max: 10, ObservedAt: now,
 		},
 		IOPressure: telemetry.IOPressure{
-			Supported: true, Some: telemetry.PressureAverages{Avg10: 78.81}, Full: telemetry.PressureAverages{Avg10: 63.64}, FullAvg10Max: 5, DispatchHeld: true, ObservedAt: now,
+			Supported: true, Some: telemetry.PressureAverages{Avg10: 78.81}, Full: telemetry.PressureAverages{Avg10: 63.64}, FullAvg10Max: 5,
+			DegradedMaxConcurrentAgents: 1, EffectiveMaxConcurrentAgents: 1, CapacityConstrained: true,
+			ConstrainedSince: now.Add(-5 * time.Minute), ConstrainedForMS: 300000, ObservedAt: now,
 		},
 		CPUPressure: telemetry.CPUPressure{
 			SomeAvg10Max: 80, LastError: "read /proc/pressure/cpu: permission denied", ObservedAt: now,
@@ -238,7 +253,7 @@ func TestHealthRowsSurfaceHostPressure(t *testing.T) {
 	if rows[0].Status != "Healthy" || !strings.Contains(rows[0].Detail, "some avg60 0.00% / 10.00%") {
 		t.Fatalf("memory row = %#v", rows[0])
 	}
-	if rows[1].Status != "Holding dispatch" || !strings.Contains(rows[1].Detail, "full avg10 63.64% / 5.00%") || !strings.Contains(rows[1].Detail, "some avg10 78.81%") {
+	if rows[1].Status != "Limited to 1 agent" || !strings.Contains(rows[1].Detail, "full avg10 63.64% / 5.00%") || !strings.Contains(rows[1].Detail, "some avg10 78.81%") || !strings.Contains(rows[1].Detail, "constrained for 5m0s") {
 		t.Fatalf("IO row = %#v", rows[1])
 	}
 	if rows[2].Status != "Unavailable" || !strings.Contains(rows[2].Detail, "permission denied") {


### PR DESCRIPTION
## Summary

- add opt-in degraded IO and CPU pressure capacities while preserving the zero-capacity default
- enforce the lowest active pressure ceiling across named pools without preempting running work
- expose pressure capacity, duration, and hysteresis through health/state telemetry, wait diagnostics, CLI, dashboard, and documentation

Fixes #2148

## UI Surface Contract

- [x] The linked issue explicitly requests dashboard pressure-capacity visibility; this change does not alter layout, density, first-viewport placement, or responsive visibility.
- [x] The existing host-pressure message is updated to distinguish degraded capacity from a hard hold; no new persistent messaging surface is added.
- [x] Visual changes were verified with the real dashboard on an isolated random-port server. `/health/ui` rendered “Limited to 1 agent,” the five-minute duration, and 80% recovery threshold; `/health` exposed the matching JSON. The live port-4000 process was untouched.

## Test Plan

- [x] `make check` with CI-pinned Go 1.26.6 and golangci-lint 2.9.0
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] focused config, project, scheduler, orchestrator, web, template, telemetry, and CLI tests
- [x] isolated Chrome DevTools verification of `/health/ui` and `/health`
