### PR TITLE
fix(admission): bound malformed retries

### DIFF
--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -59,6 +59,7 @@ const (
 	maxEffortRationaleSize                 = 2 * 1024
 	malformedAdmissionAttemptLimit         = 4
 	malformedAdmissionExcerptSize          = 512
+	admissionCandidateFingerprintVersion   = "admission-candidate-v1"
 	admissionPromptFingerprintVersion      = "admission-prompt-v1"
 )
 
@@ -505,7 +506,14 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 	validCandidates := make([]connector.Issue, 0, len(candidates))
 	evaluations := make([]AgentEvaluation, 0, len(candidates))
 	for _, candidate := range candidates {
-		evaluation, failure, deferredReason := m.evaluateCandidate(ctx, settings, candidate, startedAt)
+		evaluation, failure, deferredReason, err := m.evaluateCandidate(ctx, settings, candidate, startedAt)
+		if err != nil {
+			return result, fmt.Errorf(
+				"evaluate backlog admission candidate %s: transport runner_error: %w",
+				candidate.Identifier,
+				err,
+			)
+		}
 		if deferredReason != "" {
 			result.DeferredReason = deferredReason
 			return result, nil
@@ -544,7 +552,7 @@ func (m *Manager) evaluateCandidate(
 	settings Settings,
 	candidate connector.Issue,
 	startedAt time.Time,
-) (AgentEvaluation, *malformedEvaluation, string) {
+) (AgentEvaluation, *malformedEvaluation, string, error) {
 	collector := &proposalCollector{}
 	runResult, err := settings.Runner.Run(ctx, runner.RunRequest{
 		Issue:            admissionIssue(settings.ProjectID),
@@ -556,23 +564,19 @@ func (m *Manager) evaluateCandidate(
 	})
 	if err != nil {
 		if runner.IsCapacityError(err) {
-			return AgentEvaluation{}, nil, "agent_backend_capacity"
+			return AgentEvaluation{}, nil, "agent_backend_capacity", nil
 		}
-		return AgentEvaluation{}, &malformedEvaluation{
-			errorClass: "transport",
-			errorCode:  "runner_error",
-			output:     []byte(err.Error()),
-		}, ""
+		return AgentEvaluation{}, nil, "", err
 	}
 	if runResult.BudgetRefusal != nil {
-		return AgentEvaluation{}, nil, "budget"
+		return AgentEvaluation{}, nil, "budget", nil
 	}
 	if runResult.FinalState != "" && runResult.FinalState != runner.FinalStateCompleted {
 		return AgentEvaluation{}, &malformedEvaluation{
 			errorClass: "model",
 			errorCode:  "incomplete_final_state",
 			output:     []byte(runResult.Output),
-		}, ""
+		}, "", nil
 	}
 	evaluations, raw, proposalErr := collector.result()
 	if len(evaluations) == 0 && proposalErr == nil {
@@ -581,14 +585,14 @@ func (m *Manager) evaluateCandidate(
 	}
 	if proposalErr != nil {
 		class, code := classifyMalformedEvaluation(proposalErr)
-		return AgentEvaluation{}, &malformedEvaluation{errorClass: class, errorCode: code, output: raw}, ""
+		return AgentEvaluation{}, &malformedEvaluation{errorClass: class, errorCode: code, output: raw}, "", nil
 	}
 	if len(evaluations) != 1 {
 		return AgentEvaluation{}, &malformedEvaluation{
 			errorClass: "schema",
 			errorCode:  "evaluation_count",
 			output:     raw,
-		}, ""
+		}, "", nil
 	}
 	evaluation, err := validateCandidateEvaluation(settings, candidate, evaluations[0])
 	if err != nil {
@@ -596,9 +600,9 @@ func (m *Manager) evaluateCandidate(
 			errorClass: "schema",
 			errorCode:  "invalid_evaluation",
 			output:     raw,
-		}, ""
+		}, "", nil
 	}
-	return evaluation, nil, ""
+	return evaluation, nil, "", nil
 }
 
 func (m *Manager) recordMalformedResult(
@@ -2174,7 +2178,7 @@ type admissionFingerprints struct {
 }
 
 func admissionEvaluationFingerprints(settings Settings, candidate connector.Issue) admissionFingerprints {
-	candidateFingerprint := issueFingerprint(candidate)
+	candidateFingerprint := admissionCandidateFingerprint(candidate)
 	promptParts := []string{
 		admissionPromptFingerprintVersion,
 		settings.ProjectID,
@@ -2202,6 +2206,20 @@ func admissionEvaluationFingerprints(settings Settings, candidate connector.Issu
 			promptFingerprint,
 		),
 	}
+}
+
+func admissionCandidateFingerprint(candidate connector.Issue) string {
+	agentCandidate := admissionCandidate(candidate)
+	parts := []string{
+		admissionCandidateFingerprintVersion,
+		agentCandidate.ID,
+		agentCandidate.Identifier,
+		agentCandidate.Title,
+		agentCandidate.Description,
+		agentCandidate.State,
+		agentCandidate.AuthorID,
+	}
+	return stableAdmissionFingerprint(append(parts, agentCandidate.Labels...)...)
 }
 
 func admissionErrorFingerprint(errorClass string, errorCode string, output []byte) string {
@@ -2372,15 +2390,7 @@ func admissionRequest(settings Settings, candidates []connector.Issue) *runner.A
 	}
 	agentCandidates := make([]runner.AdmissionCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
-		agentCandidates = append(agentCandidates, runner.AdmissionCandidate{
-			ID:          candidate.ID,
-			Identifier:  candidate.Identifier,
-			Title:       candidate.Title,
-			Description: candidate.Description,
-			State:       candidate.State,
-			AuthorID:    candidate.AuthorID,
-			Labels:      append([]string(nil), candidate.Labels...),
-		})
+		agentCandidates = append(agentCandidates, admissionCandidate(candidate))
 	}
 	return &runner.AdmissionRequest{
 		Schedule:        settings.Config.Schedule,
@@ -2392,6 +2402,18 @@ func admissionRequest(settings Settings, candidates []connector.Issue) *runner.A
 		EffortText:      settings.EffortRubric.Text,
 		AllowedEfforts:  append([]string(nil), settings.EffortRubric.Efforts...),
 		Candidates:      agentCandidates,
+	}
+}
+
+func admissionCandidate(candidate connector.Issue) runner.AdmissionCandidate {
+	return runner.AdmissionCandidate{
+		ID:          candidate.ID,
+		Identifier:  candidate.Identifier,
+		Title:       candidate.Title,
+		Description: candidate.Description,
+		State:       candidate.State,
+		AuthorID:    candidate.AuthorID,
+		Labels:      append([]string(nil), candidate.Labels...),
 	}
 }
 

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -57,16 +57,22 @@ const (
 	admissionRESTFanoutScope               = "backlog_admission"
 	maxRationaleSize                       = 16 * 1024
 	maxEffortRationaleSize                 = 2 * 1024
+	malformedAdmissionAttemptLimit         = 4
+	malformedAdmissionExcerptSize          = 512
+	admissionPromptFingerprintVersion      = "admission-prompt-v1"
 )
 
 var (
-	ErrMissingStore       = errors.New("backlog admission store is required")
-	ErrMissingIssueStore  = errors.New("backlog admission issue store is required")
-	ErrMissingRunner      = errors.New("backlog admission runner is required")
-	ErrInvalidProposal    = errors.New("backlog admission proposal is invalid")
-	ErrInvalidOutput      = errors.New("backlog admission agent output is invalid")
-	artifactTitlePattern  = regexp.MustCompile(`(?i)(?:\(\s*(tracker|intake|study|research)\s*\)|\[\s*(tracker|intake|study|research)\s*\]|(?:^|[—–:]|\s-\s)\s*(master\s+tracker|tracker|intake|study|research)(?:\s+(?:issue|artifact))?)\s*$`)
-	issueReferencePattern = regexp.MustCompile(`(?i)(?:[a-z0-9_.-]+/[a-z0-9_.-]+)?#\d+|https://github\.com/[a-z0-9_.-]+/[a-z0-9_.-]+/issues/\d+`)
+	ErrMissingStore             = errors.New("backlog admission store is required")
+	ErrMissingIssueStore        = errors.New("backlog admission issue store is required")
+	ErrMissingRunner            = errors.New("backlog admission runner is required")
+	ErrInvalidProposal          = errors.New("backlog admission proposal is invalid")
+	ErrInvalidOutput            = errors.New("backlog admission agent output is invalid")
+	artifactTitlePattern        = regexp.MustCompile(`(?i)(?:\(\s*(tracker|intake|study|research)\s*\)|\[\s*(tracker|intake|study|research)\s*\]|(?:^|[—–:]|\s-\s)\s*(master\s+tracker|tracker|intake|study|research)(?:\s+(?:issue|artifact))?)\s*$`)
+	issueReferencePattern       = regexp.MustCompile(`(?i)(?:[a-z0-9_.-]+/[a-z0-9_.-]+)?#\d+|https://github\.com/[a-z0-9_.-]+/[a-z0-9_.-]+/issues/\d+`)
+	admissionSecretFieldPattern = regexp.MustCompile(`(?i)("(?:access_?token|api_?key|authorization|password|secret)"\s*:\s*)"[^"]*"`)
+	admissionBearerPattern      = regexp.MustCompile(`(?i)(bearer\s+)[a-z0-9._~+/=-]+`)
+	admissionLongTokenPattern   = regexp.MustCompile(`[A-Za-z0-9_~+/=-]{32,}`)
 )
 
 type Store interface {
@@ -85,6 +91,9 @@ type Store interface {
 	RefreshAdmissionOutcomes(context.Context, admissionmodel.OutcomeRefresh) error
 	RecordAdmissionRun(context.Context, admissionmodel.RunRecord) error
 	LatestAdmissionRun(context.Context, string) (admissionmodel.RunRecord, bool, error)
+	RecordAdmissionMalformedResult(context.Context, admissionmodel.MalformedResult, int) (admissionmodel.MalformedResult, error)
+	BlockedAdmissionMalformedResult(context.Context, string, string) (admissionmodel.MalformedResult, bool, error)
+	ResolveAdmissionMalformedResults(context.Context, string, string, time.Time) error
 }
 
 type IssueStore interface {
@@ -120,6 +129,7 @@ type Result struct {
 	Proposals       []admissionmodel.Proposal
 	Skipped         map[string]int
 	Truncated       map[string]int
+	Malformed       []admissionmodel.MalformedEvidence
 	DeferredReason  string
 	ResumeAt        time.Time
 	ProposalReason  string
@@ -357,6 +367,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 				ProposalID: proposal.ID,
 			})
 		}
+		record.Malformed = append([]admissionmodel.MalformedEvidence(nil), result.Malformed...)
 		if result.DeferredReason != "" {
 			record.Outcome = "deferred"
 		}
@@ -457,6 +468,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		commentsRemaining,
 		startedAt,
 		settings.Config.MaxCandidatesPerRun,
+		&result,
 	)
 	if err != nil {
 		return result, err
@@ -490,37 +502,156 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		return result, nil
 	}
 
+	validCandidates := make([]connector.Issue, 0, len(candidates))
+	evaluations := make([]AgentEvaluation, 0, len(candidates))
+	for _, candidate := range candidates {
+		evaluation, failure, deferredReason := m.evaluateCandidate(ctx, settings, candidate, startedAt)
+		if deferredReason != "" {
+			result.DeferredReason = deferredReason
+			return result, nil
+		}
+		if failure != nil {
+			evidence, err := m.recordMalformedResult(ctx, settings, candidate, *failure, startedAt)
+			if err != nil {
+				return result, err
+			}
+			result.Malformed = append(result.Malformed, evidence)
+			result.Skipped[malformedSkipReason(evidence.Status)]++
+			continue
+		}
+		fingerprints := admissionEvaluationFingerprints(settings, candidate)
+		if err := m.store.ResolveAdmissionMalformedResults(ctx, settings.ProjectID, fingerprints.proposal, startedAt); err != nil {
+			return result, err
+		}
+		validCandidates = append(validCandidates, candidate)
+		evaluations = append(evaluations, evaluation)
+	}
+	if len(validCandidates) == 0 {
+		result.ProposalReason = "malformed_output"
+		return result, nil
+	}
+	return m.executeEvaluations(connector.WithRESTFanoutBudget(ctx, admissionRESTFanoutScope+"_evaluation"), settings, validCandidates, evaluations, result, commentsRemaining, autoAdmitsRemaining, startedAt)
+}
+
+type malformedEvaluation struct {
+	errorClass string
+	errorCode  string
+	output     []byte
+}
+
+func (m *Manager) evaluateCandidate(
+	ctx context.Context,
+	settings Settings,
+	candidate connector.Issue,
+	startedAt time.Time,
+) (AgentEvaluation, *malformedEvaluation, string) {
 	collector := &proposalCollector{}
 	runResult, err := settings.Runner.Run(ctx, runner.RunRequest{
 		Issue:            admissionIssue(settings.ProjectID),
 		Mode:             runner.RunModeRoutine,
 		StartedAt:        startedAt,
-		Admission:        admissionRequest(settings, candidates),
+		Admission:        admissionRequest(settings, []connector.Issue{candidate}),
 		AgentTools:       []runner.AgentTool{proposalTool(settings.Config.RequireEffort)},
 		AgentToolHandler: collector.handle,
 	})
 	if err != nil {
 		if runner.IsCapacityError(err) {
-			result.DeferredReason = "agent_backend_capacity"
-			return result, nil
+			return AgentEvaluation{}, nil, "agent_backend_capacity"
 		}
-		return result, fmt.Errorf("run backlog admission agent: %w", err)
+		return AgentEvaluation{}, &malformedEvaluation{
+			errorClass: "transport",
+			errorCode:  "runner_error",
+			output:     []byte(err.Error()),
+		}, ""
 	}
 	if runResult.BudgetRefusal != nil {
-		result.DeferredReason = "budget"
-		return result, nil
+		return AgentEvaluation{}, nil, "budget"
 	}
 	if runResult.FinalState != "" && runResult.FinalState != runner.FinalStateCompleted {
-		return result, fmt.Errorf("run backlog admission agent: final state %s", runResult.FinalState)
+		return AgentEvaluation{}, &malformedEvaluation{
+			errorClass: "model",
+			errorCode:  "incomplete_final_state",
+			output:     []byte(runResult.Output),
+		}, ""
 	}
-	evaluations, proposalErr := collector.result()
+	evaluations, raw, proposalErr := collector.result()
 	if len(evaluations) == 0 && proposalErr == nil {
+		raw = []byte(runResult.Output)
 		evaluations, proposalErr = parseEvaluations(runResult.Output)
 	}
 	if proposalErr != nil {
-		return result, proposalErr
+		class, code := classifyMalformedEvaluation(proposalErr)
+		return AgentEvaluation{}, &malformedEvaluation{errorClass: class, errorCode: code, output: raw}, ""
 	}
-	return m.executeEvaluations(connector.WithRESTFanoutBudget(ctx, admissionRESTFanoutScope+"_evaluation"), settings, candidates, evaluations, result, commentsRemaining, autoAdmitsRemaining, startedAt)
+	if len(evaluations) != 1 {
+		return AgentEvaluation{}, &malformedEvaluation{
+			errorClass: "schema",
+			errorCode:  "evaluation_count",
+			output:     raw,
+		}, ""
+	}
+	evaluation, err := validateCandidateEvaluation(settings, candidate, evaluations[0])
+	if err != nil {
+		return AgentEvaluation{}, &malformedEvaluation{
+			errorClass: "schema",
+			errorCode:  "invalid_evaluation",
+			output:     raw,
+		}, ""
+	}
+	return evaluation, nil, ""
+}
+
+func (m *Manager) recordMalformedResult(
+	ctx context.Context,
+	settings Settings,
+	candidate connector.Issue,
+	failure malformedEvaluation,
+	at time.Time,
+) (admissionmodel.MalformedEvidence, error) {
+	fingerprints := admissionEvaluationFingerprints(settings, candidate)
+	record := admissionmodel.MalformedResult{
+		ProjectID:            settings.ProjectID,
+		IssueID:              candidate.ID,
+		IssueIdentifier:      candidate.Identifier,
+		IssueURL:             candidate.URL,
+		CandidateFingerprint: fingerprints.candidate,
+		PromptFingerprint:    fingerprints.prompt,
+		ProposalFingerprint:  fingerprints.proposal,
+		ErrorFingerprint:     admissionErrorFingerprint(failure.errorClass, failure.errorCode, failure.output),
+		ErrorClass:           failure.errorClass,
+		ErrorCode:            failure.errorCode,
+		OutputExcerpt:        redactAdmissionOutput(failure.output),
+		LastSeenAt:           at,
+	}
+	stored, err := m.store.RecordAdmissionMalformedResult(ctx, record, malformedAdmissionAttemptLimit)
+	if err != nil {
+		return admissionmodel.MalformedEvidence{}, err
+	}
+	return malformedEvidence(stored), nil
+}
+
+func malformedEvidence(record admissionmodel.MalformedResult) admissionmodel.MalformedEvidence {
+	return admissionmodel.MalformedEvidence{
+		IssueID:              record.IssueID,
+		IssueIdentifier:      record.IssueIdentifier,
+		IssueURL:             record.IssueURL,
+		CandidateFingerprint: record.CandidateFingerprint,
+		PromptFingerprint:    record.PromptFingerprint,
+		ProposalFingerprint:  record.ProposalFingerprint,
+		ErrorFingerprint:     record.ErrorFingerprint,
+		ErrorClass:           record.ErrorClass,
+		ErrorCode:            record.ErrorCode,
+		OutputExcerpt:        record.OutputExcerpt,
+		AttemptCount:         record.AttemptCount,
+		Status:               record.Status,
+	}
+}
+
+func malformedSkipReason(status admissionmodel.MalformedStatus) string {
+	if status == admissionmodel.MalformedBlocked {
+		return "malformed_output_blocked"
+	}
+	return "malformed_output_retryable"
 }
 
 func candidateReadLimit(maxCandidates int) int {
@@ -874,6 +1005,7 @@ func (m *Manager) unproposedCandidates(
 	commentsRemaining int,
 	at time.Time,
 	candidateLimit int,
+	result *Result,
 ) ([]connector.Issue, int, int, error) {
 	out := make([]connector.Issue, 0, min(len(candidates), candidateLimit))
 	processed := 0
@@ -898,6 +1030,22 @@ func (m *Manager) unproposedCandidates(
 			}
 		}
 		if suppress {
+			continue
+		}
+		fingerprints := admissionEvaluationFingerprints(settings, candidate)
+		malformed, blocked, err := m.store.BlockedAdmissionMalformedResult(
+			ctx,
+			settings.ProjectID,
+			fingerprints.proposal,
+		)
+		if err != nil {
+			return nil, commentsRemaining, truncated, err
+		}
+		if blocked {
+			skipped["malformed_output_blocked"]++
+			if result != nil {
+				result.Malformed = append(result.Malformed, malformedEvidence(malformed))
+			}
 			continue
 		}
 		decline, found, err := m.store.AdmissionDecline(ctx, settings.ProjectID, candidate.ID, fingerprint)
@@ -1205,42 +1353,16 @@ func (m *Manager) executeEvaluations(
 	evaluationByID := make(map[string]AgentEvaluation, len(evaluations))
 	for _, evaluation := range evaluations {
 		issueID := strings.TrimSpace(evaluation.IssueID)
-		if _, supplied := candidateByID[issueID]; !supplied {
+		candidate, supplied := candidateByID[issueID]
+		if !supplied {
 			return result, fmt.Errorf("%w: evaluation references unknown candidate %q", ErrInvalidOutput, issueID)
 		}
 		if _, duplicate := evaluationByID[issueID]; duplicate {
 			return result, fmt.Errorf("%w: duplicate evaluation for candidate %q", ErrInvalidOutput, issueID)
 		}
-		evaluation.Disposition = strings.TrimSpace(evaluation.Disposition)
-		if evaluation.Disposition != admissionDispositionProposed && evaluation.Disposition != admissionDispositionDeclined {
-			return result, fmt.Errorf("%w: invalid disposition for candidate %q", ErrInvalidOutput, issueID)
-		}
-		if err := validateAdmissionConfidence(evaluation.Confidence); err != nil {
-			return result, fmt.Errorf("%w: invalid confidence for candidate %q", ErrInvalidOutput, issueID)
-		}
-		if evaluation.Disposition == admissionDispositionDeclined {
-			failed, err := validateDeclineFindings(evaluation.Findings, settings.Criteria)
-			if err != nil || strings.TrimSpace(evaluation.RecommendedEffort) != "" || strings.TrimSpace(evaluation.EffortRationale) != "" {
-				return result, fmt.Errorf("%w: invalid decline for candidate %q", ErrInvalidOutput, issueID)
-			}
-			evaluation.Findings = []admissionmodel.Finding{failed}
-		} else {
-			findings, err := validateFindings(evaluation.Findings, settings.Criteria)
-			if err != nil {
-				return result, fmt.Errorf("%w: invalid proposal for candidate %q", ErrInvalidOutput, issueID)
-			}
-			evaluation.Findings = findings
-			recommendedEffort, effortRationale, err := validateRecommendedEffort(
-				evaluation.RecommendedEffort,
-				evaluation.EffortRationale,
-				settings.EffortRubric,
-				settings.Config.RequireEffort,
-			)
-			if err != nil {
-				return result, fmt.Errorf("%w: invalid effort for candidate %q", ErrInvalidOutput, issueID)
-			}
-			evaluation.RecommendedEffort = recommendedEffort
-			evaluation.EffortRationale = effortRationale
+		evaluation, err := validateCandidateEvaluation(settings, candidate, evaluation)
+		if err != nil {
+			return result, err
 		}
 		evaluationByID[issueID] = evaluation
 	}
@@ -1367,6 +1489,48 @@ func (m *Manager) executeEvaluations(
 		}
 	}
 	return result, nil
+}
+
+func validateCandidateEvaluation(
+	settings Settings,
+	candidate connector.Issue,
+	evaluation AgentEvaluation,
+) (AgentEvaluation, error) {
+	issueID := strings.TrimSpace(evaluation.IssueID)
+	if issueID != strings.TrimSpace(candidate.ID) {
+		return AgentEvaluation{}, fmt.Errorf("%w: evaluation references unknown candidate %q", ErrInvalidOutput, issueID)
+	}
+	evaluation.IssueID = issueID
+	evaluation.Disposition = strings.TrimSpace(evaluation.Disposition)
+	if evaluation.Disposition != admissionDispositionProposed && evaluation.Disposition != admissionDispositionDeclined {
+		return AgentEvaluation{}, fmt.Errorf("%w: invalid disposition for candidate %q", ErrInvalidOutput, issueID)
+	}
+	if err := validateAdmissionConfidence(evaluation.Confidence); err != nil {
+		return AgentEvaluation{}, fmt.Errorf("%w: invalid confidence for candidate %q", ErrInvalidOutput, issueID)
+	}
+	if evaluation.Disposition == admissionDispositionDeclined {
+		findings, matched, err := validateEvaluationFindings(evaluation.Findings, settings.Criteria)
+		if err != nil || matched || strings.TrimSpace(evaluation.RecommendedEffort) != "" || strings.TrimSpace(evaluation.EffortRationale) != "" {
+			return AgentEvaluation{}, fmt.Errorf("%w: invalid decline for candidate %q", ErrInvalidOutput, issueID)
+		}
+		evaluation.Findings = findings
+		return evaluation, nil
+	}
+	findings, err := validateFindings(evaluation.Findings, settings.Criteria)
+	if err != nil {
+		return AgentEvaluation{}, fmt.Errorf("%w: invalid proposal for candidate %q", ErrInvalidOutput, issueID)
+	}
+	evaluation.Findings = findings
+	evaluation.RecommendedEffort, evaluation.EffortRationale, err = validateRecommendedEffort(
+		evaluation.RecommendedEffort,
+		evaluation.EffortRationale,
+		settings.EffortRubric,
+		settings.Config.RequireEffort,
+	)
+	if err != nil {
+		return AgentEvaluation{}, fmt.Errorf("%w: invalid effort for candidate %q", ErrInvalidOutput, issueID)
+	}
+	return evaluation, nil
 }
 
 func (m *Manager) commentProposal(
@@ -1891,26 +2055,6 @@ func validateFindings(findings []admissionmodel.Finding, criteria config.Admissi
 	return out, nil
 }
 
-func validateDeclineFindings(
-	findings []admissionmodel.Finding,
-	criteria config.AdmissionCriteria,
-) (admissionmodel.Finding, error) {
-	out, matched, err := validateEvaluationFindings(findings, criteria)
-	if err != nil || matched {
-		return admissionmodel.Finding{}, ErrInvalidProposal
-	}
-	byDimension := make(map[string]admissionmodel.Finding, len(out))
-	for _, finding := range out {
-		byDimension[strings.ToLower(finding.Dimension)] = finding
-	}
-	for _, dimension := range criteria.Dimensions {
-		if finding, ok := byDimension[strings.ToLower(strings.TrimSpace(dimension.Name))]; ok {
-			return finding, nil
-		}
-	}
-	return admissionmodel.Finding{}, ErrInvalidProposal
-}
-
 func validateEvaluationFindings(
 	findings []admissionmodel.Finding,
 	criteria config.AdmissionCriteria,
@@ -2021,6 +2165,92 @@ func issueFingerprint(issue connector.Issue) string {
 			strconv.Itoa(len(issue.Description)) + ":" + issue.Description,
 	))
 	return hex.EncodeToString(sum[:])
+}
+
+type admissionFingerprints struct {
+	candidate string
+	prompt    string
+	proposal  string
+}
+
+func admissionEvaluationFingerprints(settings Settings, candidate connector.Issue) admissionFingerprints {
+	candidateFingerprint := issueFingerprint(candidate)
+	promptParts := []string{
+		admissionPromptFingerprintVersion,
+		settings.ProjectID,
+		settings.Config.Schedule,
+		settings.Config.TargetState,
+		settings.Criteria.Section,
+		settings.Criteria.Text,
+		settings.EffortRubric.Section,
+		settings.EffortRubric.Text,
+		strconv.FormatBool(settings.Config.RequireEffort),
+		string(proposalTool(settings.Config.RequireEffort).InputSchema),
+	}
+	for _, dimension := range settings.Criteria.Dimensions {
+		promptParts = append(promptParts, dimension.Name, dimension.Text)
+	}
+	promptParts = append(promptParts, settings.EffortRubric.Efforts...)
+	promptFingerprint := stableAdmissionFingerprint(promptParts...)
+	return admissionFingerprints{
+		candidate: candidateFingerprint,
+		prompt:    promptFingerprint,
+		proposal: stableAdmissionFingerprint(
+			settings.ProjectID,
+			candidate.ID,
+			candidateFingerprint,
+			promptFingerprint,
+		),
+	}
+}
+
+func admissionErrorFingerprint(errorClass string, errorCode string, output []byte) string {
+	outputSum := sha256.Sum256(output)
+	return stableAdmissionFingerprint(errorClass, errorCode, hex.EncodeToString(outputSum[:]))
+}
+
+func stableAdmissionFingerprint(parts ...string) string {
+	var input strings.Builder
+	for _, part := range parts {
+		input.WriteString(strconv.Itoa(len(part)))
+		input.WriteByte(':')
+		input.WriteString(part)
+	}
+	sum := sha256.Sum256([]byte(input.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func classifyMalformedEvaluation(err error) (string, string) {
+	var syntaxError *json.SyntaxError
+	if errors.As(err, &syntaxError) || errors.Is(err, io.ErrUnexpectedEOF) || strings.Contains(err.Error(), "unexpected EOF") {
+		return "parse", "invalid_json"
+	}
+	var typeError *json.UnmarshalTypeError
+	if errors.As(err, &typeError) {
+		return "schema", "invalid_type"
+	}
+	if strings.Contains(err.Error(), "unknown field") {
+		return "schema", "unknown_field"
+	}
+	return "schema", "invalid_envelope"
+}
+
+func redactAdmissionOutput(raw []byte) string {
+	excerpt := strings.TrimSpace(string(raw))
+	excerpt = strings.Map(func(value rune) rune {
+		if value < ' ' && value != '\n' && value != '\t' {
+			return ' '
+		}
+		return value
+	}, excerpt)
+	excerpt = admissionSecretFieldPattern.ReplaceAllString(excerpt, `${1}"<redacted>"`)
+	excerpt = admissionBearerPattern.ReplaceAllString(excerpt, `${1}<redacted>`)
+	excerpt = admissionLongTokenPattern.ReplaceAllString(excerpt, "<redacted>")
+	runes := []rune(excerpt)
+	if len(runes) > malformedAdmissionExcerptSize {
+		excerpt = string(runes[:malformedAdmissionExcerptSize])
+	}
+	return excerpt
 }
 
 func criteriaDeclineFingerprint(issue connector.Issue, criteria config.AdmissionCriteria) string {
@@ -2189,6 +2419,7 @@ func proposalTool(requireEffort bool) runner.AgentTool {
 type proposalCollector struct {
 	mu          sync.Mutex
 	evaluations []AgentEvaluation
+	raw         []byte
 	err         error
 }
 
@@ -2199,20 +2430,29 @@ func (c *proposalCollector) handle(_ context.Context, call runner.AgentToolCall)
 	var evaluation AgentEvaluation
 	if err := decodeStrictJSON(call.Arguments, &evaluation); err != nil {
 		c.mu.Lock()
+		c.raw = appendAdmissionRaw(c.raw, call.Arguments)
 		c.err = errors.Join(c.err, fmt.Errorf("%w: %w", ErrInvalidOutput, err))
 		c.mu.Unlock()
 		return runner.AgentToolResult{Content: "invalid evaluation", Success: false}, nil
 	}
 	c.mu.Lock()
+	c.raw = appendAdmissionRaw(c.raw, call.Arguments)
 	c.evaluations = append(c.evaluations, evaluation)
 	c.mu.Unlock()
 	return runner.AgentToolResult{Content: "evaluation received", Success: true}, nil
 }
 
-func (c *proposalCollector) result() ([]AgentEvaluation, error) {
+func (c *proposalCollector) result() ([]AgentEvaluation, []byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return append([]AgentEvaluation(nil), c.evaluations...), c.err
+	return append([]AgentEvaluation(nil), c.evaluations...), append([]byte(nil), c.raw...), c.err
+}
+
+func appendAdmissionRaw(existing []byte, raw []byte) []byte {
+	if len(existing) > 0 {
+		existing = append(existing, '\n')
+	}
+	return append(existing, raw...)
 }
 
 func parseEvaluations(output string) ([]AgentEvaluation, error) {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -3342,6 +3342,70 @@ func TestManagerAcceptsCorrectedAdmissionBeforeMalformedLimit(t *testing.T) {
 	}
 }
 
+func TestManagerBoundsVaryingMalformedAdmissionOutputs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 12, 45, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
+	agent := &malformedAdmissionRunner{malformedOutputs: []string{
+		`{`,
+		`[`,
+		`{"evaluations":`,
+		`{"evaluations":[`,
+	}}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, agent),
+		openManagerTestStore(t),
+		func() time.Time { return now },
+	)
+
+	for attempt := 1; attempt <= 4; attempt++ {
+		result, err := manager.RunOnce(t.Context())
+		if err != nil || len(result.Malformed) != 1 || result.Malformed[0].AttemptCount != attempt {
+			t.Fatalf("RunOnce() attempt %d = %#v, %v", attempt, result, err)
+		}
+	}
+	result, err := manager.RunOnce(t.Context())
+	if err != nil || result.Skipped["malformed_output_blocked"] != 1 || agent.calls != 4 {
+		t.Fatalf("RunOnce() after bound = %#v, %v; runner calls = %d", result, err, agent.calls)
+	}
+}
+
+func TestManagerRecoversAfterRunnerErrors(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 12, 50, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
+	wantErr := errors.New("backend authentication failed")
+	agent := &recoveringAdmissionRunner{errorsRemaining: 4, err: wantErr}
+	backend := openManagerTestStore(t)
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, agent),
+		backend,
+		func() time.Time { return now },
+	)
+
+	for attempt := 1; attempt <= 4; attempt++ {
+		result, err := manager.RunOnce(t.Context())
+		if !errors.Is(err, wantErr) || len(result.Malformed) != 0 {
+			t.Fatalf("RunOnce() attempt %d = %#v, %v", attempt, result, err)
+		}
+	}
+	result, err := manager.RunOnce(t.Context())
+	if err != nil || len(result.Proposals) != 1 || result.Proposals[0].IssueID != issue.ID || agent.calls != 5 {
+		t.Fatalf("corrected RunOnce() = %#v, %v; runner calls = %d", result, err, agent.calls)
+	}
+	runs, err := backend.RecentAdmissionRuns(t.Context(), "detent", 5)
+	if err != nil || len(runs) != 5 || runs[1].Outcome != "failed" || len(runs[1].Malformed) != 0 ||
+		!strings.Contains(runs[1].Error, "runner_error") {
+		t.Fatalf("RecentAdmissionRuns() = %#v, %v", runs, err)
+	}
+}
+
 func TestManagerContinuesMixedMalformedAdmissionCandidates(t *testing.T) {
 	t.Parallel()
 
@@ -3564,9 +3628,51 @@ func TestAdmissionEvaluationFingerprintsChangeWithMaterialInput(t *testing.T) {
 		wantPromptChange    bool
 	}{
 		{
+			name: "candidate id",
+			change: func(_ *Settings, issue *connector.Issue) {
+				issue.ID += "-changed"
+			},
+			wantCandidateChange: true,
+		},
+		{
+			name: "candidate identifier",
+			change: func(_ *Settings, issue *connector.Issue) {
+				issue.Identifier += "-changed"
+			},
+			wantCandidateChange: true,
+		},
+		{
+			name: "candidate title",
+			change: func(_ *Settings, issue *connector.Issue) {
+				issue.Title += " changed"
+			},
+			wantCandidateChange: true,
+		},
+		{
 			name: "candidate body",
 			change: func(_ *Settings, issue *connector.Issue) {
 				issue.Description += " changed"
+			},
+			wantCandidateChange: true,
+		},
+		{
+			name: "candidate state",
+			change: func(_ *Settings, issue *connector.Issue) {
+				issue.State += " changed"
+			},
+			wantCandidateChange: true,
+		},
+		{
+			name: "candidate author",
+			change: func(_ *Settings, issue *connector.Issue) {
+				issue.AuthorID += "changed"
+			},
+			wantCandidateChange: true,
+		},
+		{
+			name: "candidate labels",
+			change: func(_ *Settings, issue *connector.Issue) {
+				issue.Labels = append(append([]string(nil), issue.Labels...), "changed")
 			},
 			wantCandidateChange: true,
 		},
@@ -3715,14 +3821,45 @@ func (r staticAdmissionRunner) Run(context.Context, runner.RunRequest) (runner.R
 type malformedAdmissionRunner struct {
 	malformedCalls   int
 	malformedIssueID string
+	malformedOutputs []string
 	calls            int
 }
 
 func (r *malformedAdmissionRunner) Run(_ context.Context, request runner.RunRequest) (runner.RunResult, error) {
 	r.calls++
 	if r.calls <= r.malformedCalls ||
+		r.calls <= len(r.malformedOutputs) ||
 		(len(request.Admission.Candidates) > 0 && request.Admission.Candidates[0].ID == r.malformedIssueID) {
-		return runner.RunResult{Output: `{`, FinalState: runner.FinalStateCompleted}, nil
+		output := `{`
+		if r.calls <= len(r.malformedOutputs) {
+			output = r.malformedOutputs[r.calls-1]
+		}
+		return runner.RunResult{Output: output, FinalState: runner.FinalStateCompleted}, nil
+	}
+	evaluations := make([]AgentEvaluation, 0, len(request.Admission.Candidates))
+	for _, candidate := range request.Admission.Candidates {
+		evaluations = append(evaluations, admissionProposalEvaluation(candidate.ID))
+	}
+	raw, err := json.Marshal(struct {
+		Evaluations []AgentEvaluation `json:"evaluations"`
+	}{Evaluations: evaluations})
+	if err != nil {
+		return runner.RunResult{}, err
+	}
+	return runner.RunResult{Output: string(raw), FinalState: runner.FinalStateCompleted}, nil
+}
+
+type recoveringAdmissionRunner struct {
+	errorsRemaining int
+	err             error
+	calls           int
+}
+
+func (r *recoveringAdmissionRunner) Run(_ context.Context, request runner.RunRequest) (runner.RunResult, error) {
+	r.calls++
+	if r.errorsRemaining > 0 {
+		r.errorsRemaining--
+		return runner.RunResult{}, r.err
 	}
 	evaluations := make([]AgentEvaluation, 0, len(request.Admission.Candidates))
 	for _, candidate := range request.Admission.Candidates {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -325,6 +325,7 @@ func TestManagerPropagatesCandidateDeclineStoreErrors(t *testing.T) {
 				1,
 				now,
 				1,
+				nil,
 			)
 			if !errors.Is(err, wantErr) {
 				t.Fatalf("unproposedCandidates() error = %v, want %v", err, wantErr)
@@ -1350,7 +1351,7 @@ func TestManagerRequiredEffortAdmissionModes(t *testing.T) {
 		wantState         string
 		wantBody          string
 		wantBodyUpdates   int
-		wantInvalidOutput bool
+		wantMalformed     bool
 		wantResolution    string
 	}{
 		{
@@ -1360,12 +1361,12 @@ func TestManagerRequiredEffortAdmissionModes(t *testing.T) {
 			wantBody:  "Actionable problem.",
 		},
 		{
-			name:              "required recommendation unavailable fails evaluation",
-			requireEffort:     true,
-			body:              "Actionable problem.",
-			wantState:         "Backlog",
-			wantBody:          "Actionable problem.",
-			wantInvalidOutput: true,
+			name:          "required recommendation unavailable fails evaluation",
+			requireEffort: true,
+			body:          "Actionable problem.",
+			wantState:     "Backlog",
+			wantBody:      "Actionable problem.",
+			wantMalformed: true,
 		},
 		{
 			name:              "required recommendation writes absent block",
@@ -1418,11 +1419,11 @@ func TestManagerRequiredEffortAdmissionModes(t *testing.T) {
 			manager := newAdmissionTestManager(t, settings, openManagerTestStore(t), func() time.Time { return now })
 
 			result, err := manager.RunOnce(t.Context())
-			if tt.wantInvalidOutput && !errors.Is(err, ErrInvalidOutput) {
-				t.Fatalf("RunOnce() error = %v, want ErrInvalidOutput", err)
-			}
-			if !tt.wantInvalidOutput && err != nil {
+			if err != nil {
 				t.Fatalf("RunOnce() error = %v", err)
+			}
+			if tt.wantMalformed && result.Skipped["malformed_output_retryable"] != 1 {
+				t.Fatalf("RunOnce() result = %#v, want malformed output", result)
 			}
 			issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
 			if err != nil || len(issues) != 1 {
@@ -2667,7 +2668,7 @@ func TestManagerOrderingAndParsingBoundaries(t *testing.T) {
 	if result, err := collector.handle(t.Context(), runner.AgentToolCall{Name: ProposalToolName, Arguments: []byte("{")}); err != nil || result.Success {
 		t.Fatalf("collector invalid = %#v, %v", result, err)
 	}
-	if _, err := collector.result(); err == nil {
+	if _, _, err := collector.result(); err == nil {
 		t.Fatal("collector result error = nil")
 	}
 
@@ -2794,13 +2795,14 @@ func TestManagerFiltersLocallyAndRejectsFabricatedCriteria(t *testing.T) {
 	settings.Config.Authors.Allow = []string{"octocat"}
 	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return now })
 	result, err := manager.RunOnce(context.Background())
-	if !errors.Is(err, ErrInvalidOutput) {
-		t.Fatalf("RunOnce() error = %v, want ErrInvalidOutput", err)
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
 	}
 	if got, want := agent.candidateIDs[0], []string{"allowed"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("candidate ids = %#v, want %#v", got, want)
 	}
-	if len(result.Proposals) != 0 || result.Skipped["excluded_label"] != 1 ||
+	if len(result.Proposals) != 0 || result.Skipped["malformed_output_retryable"] != 1 ||
+		result.Skipped["excluded_label"] != 1 ||
 		result.Skipped["author"] != 1 {
 		t.Fatalf("result = %#v", result)
 	}
@@ -2852,7 +2854,7 @@ func TestManagerUnionsLabelCandidatesAndSkipsIneligibleStates(t *testing.T) {
 		result.Skipped["excluded_label"] != 1 {
 		t.Fatalf("skipped = %#v", result.Skipped)
 	}
-	if got, want := agent.candidateIDs[0], []string{"both", "label"}; !reflect.DeepEqual(got, want) {
+	if got, want := agent.candidateIDs, [][]string{{"both"}, {"label"}}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("candidate ids = %#v, want %#v", got, want)
 	}
 }
@@ -3206,7 +3208,7 @@ func TestManagerRejectsMissingConfidence(t *testing.T) {
 	}}
 	manager := newAdmissionTestManager(t, admissionTestSettings(tracker, agent), backend, func() time.Time { return now })
 	result, err := manager.RunOnce(context.Background())
-	if !errors.Is(err, ErrInvalidOutput) || len(result.Proposals) != 0 {
+	if err != nil || len(result.Proposals) != 0 || result.Skipped["malformed_output_retryable"] != 1 {
 		t.Fatalf("result = %#v", result)
 	}
 }
@@ -3251,17 +3253,136 @@ func TestManagerPersistsDeclinedCandidateEvaluation(t *testing.T) {
 	}
 }
 
+func TestManagerBoundsMalformedAdmissionAcrossRestart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
+	backend := openManagerTestStore(t)
+	agent := &malformedAdmissionRunner{malformedCalls: 4}
+	clock := now
+	settings := admissionTestSettings(tracker, agent)
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return clock })
+
+	for attempt := 1; attempt <= 4; attempt++ {
+		result, err := manager.RunOnce(t.Context())
+		if err != nil || len(result.Proposals) != 0 {
+			t.Fatalf("RunOnce() attempt %d = %#v, %v", attempt, result, err)
+		}
+		clock = clock.Add(time.Minute)
+	}
+	runs, err := backend.RecentAdmissionRuns(t.Context(), "detent", 4)
+	if err != nil || len(runs) != 4 {
+		t.Fatalf("RecentAdmissionRuns() = %#v, %v", runs, err)
+	}
+	for index, run := range runs {
+		wantAttempt := 4 - index
+		if len(run.Malformed) != 1 || run.Malformed[0].AttemptCount != wantAttempt ||
+			run.Malformed[0].ErrorClass != "parse" || run.Malformed[0].ErrorCode != "invalid_json" ||
+			run.Malformed[0].OutputExcerpt != "{" || run.Malformed[0].CandidateFingerprint == "" ||
+			run.Malformed[0].PromptFingerprint == "" || run.Malformed[0].ProposalFingerprint == "" ||
+			run.Malformed[0].ErrorFingerprint == "" {
+			t.Fatalf("run %d malformed evidence = %#v", index, run.Malformed)
+		}
+		if run.Malformed[0].ErrorFingerprint != runs[0].Malformed[0].ErrorFingerprint {
+			t.Fatalf("run %d error fingerprint = %q, want %q", index, run.Malformed[0].ErrorFingerprint, runs[0].Malformed[0].ErrorFingerprint)
+		}
+	}
+	if runs[0].Malformed[0].Status != admissionmodel.MalformedBlocked {
+		t.Fatalf("fourth malformed status = %q, want blocked", runs[0].Malformed[0].Status)
+	}
+
+	manager = newAdmissionTestManager(t, settings, backend, func() time.Time { return clock })
+	result, err := manager.RunOnce(t.Context())
+	if err != nil || len(result.Proposals) != 0 || result.Skipped["malformed_output_blocked"] != 1 {
+		t.Fatalf("RunOnce() after restart = %#v, %v", result, err)
+	}
+	if agent.calls != 4 {
+		t.Fatalf("runner calls = %d, want 4", agent.calls)
+	}
+
+	if err := tracker.UpdateIssueBody(t.Context(), issue.ID, issue.Description+"\n\nCorrected scope."); err != nil {
+		t.Fatalf("UpdateIssueBody() error = %v", err)
+	}
+	clock = clock.Add(time.Minute)
+	result, err = manager.RunOnce(t.Context())
+	if err != nil || len(result.Proposals) != 1 || result.Proposals[0].IssueID != issue.ID {
+		t.Fatalf("RunOnce() after candidate change = %#v, %v", result, err)
+	}
+	if agent.calls != 5 {
+		t.Fatalf("runner calls = %d, want 5", agent.calls)
+	}
+}
+
+func TestManagerAcceptsCorrectedAdmissionBeforeMalformedLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 12, 30, 0, 0, time.UTC)
+	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
+	agent := &malformedAdmissionRunner{malformedCalls: 1}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, agent),
+		openManagerTestStore(t),
+		func() time.Time { return now },
+	)
+
+	result, err := manager.RunOnce(t.Context())
+	if err != nil || len(result.Proposals) != 0 || result.Skipped["malformed_output_retryable"] != 1 {
+		t.Fatalf("first RunOnce() = %#v, %v", result, err)
+	}
+	result, err = manager.RunOnce(t.Context())
+	if err != nil || len(result.Proposals) != 1 || result.Proposals[0].IssueID != issue.ID {
+		t.Fatalf("corrected RunOnce() = %#v, %v", result, err)
+	}
+	if agent.calls != 2 {
+		t.Fatalf("runner calls = %d, want 2", agent.calls)
+	}
+}
+
+func TestManagerContinuesMixedMalformedAdmissionCandidates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 13, 0, 0, 0, time.UTC)
+	issues := []connector.Issue{
+		admissionIssueFixture("issue-1", "DD-1", 1, now),
+		admissionIssueFixture("issue-2", "DD-2", 2, now.Add(time.Minute)),
+	}
+	tracker := memory.New(memory.Config{Issues: issues, Stateful: true})
+	agent := &malformedAdmissionRunner{malformedIssueID: issues[0].ID}
+	manager := newAdmissionTestManager(
+		t,
+		admissionTestSettings(tracker, agent),
+		openManagerTestStore(t),
+		func() time.Time { return now },
+	)
+
+	result, err := manager.RunOnce(t.Context())
+	if err != nil || len(result.Proposals) != 1 || result.Proposals[0].IssueID != issues[1].ID {
+		t.Fatalf("RunOnce() = %#v, %v", result, err)
+	}
+	if result.Skipped["malformed_output_retryable"] != 1 || agent.calls != 2 {
+		t.Fatalf("result = %#v, runner calls = %d", result, agent.calls)
+	}
+}
+
 func TestManagerRequiresOneEvaluationPerCandidate(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name        string
-		evaluations []AgentEvaluation
+		name          string
+		evaluations   []AgentEvaluation
+		wantProposals int
+		wantMalformed int
 	}{
 		{
-			name:        "missing candidate",
-			evaluations: []AgentEvaluation{admissionProposalEvaluation("issue-1")},
+			name:          "missing candidate",
+			evaluations:   []AgentEvaluation{admissionProposalEvaluation("issue-1")},
+			wantProposals: 1,
+			wantMalformed: 1,
 		},
 		{
 			name: "duplicate candidate",
@@ -3269,6 +3390,7 @@ func TestManagerRequiresOneEvaluationPerCandidate(t *testing.T) {
 				admissionProposalEvaluation("issue-1"),
 				admissionProposalEvaluation("issue-1"),
 			},
+			wantMalformed: 2,
 		},
 		{
 			name: "unknown candidate",
@@ -3276,6 +3398,7 @@ func TestManagerRequiresOneEvaluationPerCandidate(t *testing.T) {
 				admissionProposalEvaluation("issue-1"),
 				admissionProposalEvaluation("unknown"),
 			},
+			wantMalformed: 2,
 		},
 		{
 			name: "invalid disposition",
@@ -3283,6 +3406,7 @@ func TestManagerRequiresOneEvaluationPerCandidate(t *testing.T) {
 				admissionProposalEvaluation("issue-1"),
 				admissionProposalEvaluation("issue-2"),
 			},
+			wantMalformed: 2,
 		},
 	}
 	tests[3].evaluations[1].Disposition = "pending"
@@ -3309,14 +3433,15 @@ func TestManagerRequiresOneEvaluationPerCandidate(t *testing.T) {
 			)
 
 			result, err := manager.RunOnce(t.Context())
-			if !errors.Is(err, ErrInvalidOutput) || result.Candidates != len(issues) || len(result.Proposals) != 0 {
+			if err != nil || result.Candidates != len(issues) ||
+				len(result.Proposals) != tt.wantProposals || len(result.Malformed) != tt.wantMalformed {
 				t.Fatalf("RunOnce() = %#v, %v", result, err)
 			}
 		})
 	}
 }
 
-func TestManagerValidatesEntireEvaluationBatchBeforeSideEffects(t *testing.T) {
+func TestManagerKeepsValidSemanticEvaluationWhenPeerIsMalformed(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
@@ -3324,35 +3449,30 @@ func TestManagerValidatesEntireEvaluationBatchBeforeSideEffects(t *testing.T) {
 		admissionIssueFixture("issue-1", "DD-1", 1, now),
 		admissionIssueFixture("issue-2", "DD-2", 2, now),
 	}
-	evaluations := []AgentEvaluation{
-		admissionProposalEvaluation(issues[0].ID),
-		admissionProposalEvaluation(issues[1].ID),
-	}
-	evaluations[1].Confidence = float64Pointer(2)
-	raw, err := json.Marshal(struct {
-		Evaluations []AgentEvaluation `json:"evaluations"`
-	}{Evaluations: evaluations})
-	if err != nil {
-		t.Fatalf("Marshal() error = %v", err)
-	}
 	tracker := memory.New(memory.Config{Issues: issues, Stateful: true})
 	backend := openManagerTestStore(t)
+	agent := &scriptedAdmissionRunner{propose: func(request runner.RunRequest) []AgentProposal {
+		evaluation := admissionProposalEvaluation(request.Admission.Candidates[0].ID)
+		if evaluation.IssueID == issues[1].ID {
+			evaluation.Confidence = float64Pointer(2)
+		}
+		return []AgentProposal{evaluation}
+	}}
 	manager := newAdmissionTestManager(
 		t,
-		admissionTestSettings(tracker, staticAdmissionRunner{output: string(raw)}),
+		admissionTestSettings(tracker, agent),
 		backend,
 		func() time.Time { return now },
 	)
 
 	result, err := manager.RunOnce(t.Context())
-	if !errors.Is(err, ErrInvalidOutput) || len(result.Proposals) != 0 {
+	if err != nil || len(result.Proposals) != 1 || result.Proposals[0].IssueID != issues[0].ID ||
+		len(result.Malformed) != 1 || result.Malformed[0].IssueID != issues[1].ID {
 		t.Fatalf("RunOnce() = %#v, %v", result, err)
 	}
-	for _, issue := range issues {
-		history, historyErr := backend.AdmissionProposalHistory(t.Context(), "detent", issue.ID)
-		if historyErr != nil || len(history) != 0 {
-			t.Fatalf("AdmissionProposalHistory(%s) = %#v, %v", issue.ID, history, historyErr)
-		}
+	history, historyErr := backend.AdmissionProposalHistory(t.Context(), "detent", issues[1].ID)
+	if historyErr != nil || len(history) != 0 {
+		t.Fatalf("AdmissionProposalHistory(%s) = %#v, %v", issues[1].ID, history, historyErr)
 	}
 }
 
@@ -3392,6 +3512,83 @@ func TestParseEvaluationsRequiresTypedEnvelope(t *testing.T) {
 	evaluations, err := parseEvaluations(`{"evaluations":[]}`)
 	if err != nil || len(evaluations) != 0 {
 		t.Fatalf("parseEvaluations(empty) = %#v, %v", evaluations, err)
+	}
+}
+
+func TestAdmissionMalformedEvidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		wantClass string
+		wantCode  string
+	}{
+		{name: "syntax", raw: `{`, wantClass: "parse", wantCode: "invalid_json"},
+		{name: "unknown field", raw: `{"unexpected":true}`, wantClass: "schema", wantCode: "unknown_field"},
+		{name: "invalid type", raw: `{"evaluations":"wrong"}`, wantClass: "schema", wantCode: "invalid_type"},
+		{name: "missing envelope", raw: `{}`, wantClass: "schema", wantCode: "invalid_envelope"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseEvaluations(tt.raw)
+			if err == nil {
+				t.Fatalf("parseEvaluations(%q) error = nil", tt.raw)
+			}
+			gotClass, gotCode := classifyMalformedEvaluation(err)
+			if gotClass != tt.wantClass || gotCode != tt.wantCode {
+				t.Fatalf("classifyMalformedEvaluation() = %q, %q, want %q, %q", gotClass, gotCode, tt.wantClass, tt.wantCode)
+			}
+		})
+	}
+
+	secret := "abcdefghijklmnopqrstuvwxyz0123456789SECRET"
+	excerpt := redactAdmissionOutput([]byte(`{"token":"` + secret + `","authorization":"Bearer ` + secret + `","detail":"safe"}`))
+	if strings.Contains(excerpt, secret) || !strings.Contains(excerpt, "<redacted>") || !strings.Contains(excerpt, `"detail":"safe"`) {
+		t.Fatalf("redactAdmissionOutput() = %q", excerpt)
+	}
+}
+
+func TestAdmissionEvaluationFingerprintsChangeWithMaterialInput(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	candidate := admissionIssueFixture("issue-1", "DD-1", 1, now)
+	settings := admissionTestSettings(nil, nil)
+	base := admissionEvaluationFingerprints(settings, candidate)
+	tests := []struct {
+		name                string
+		change              func(*Settings, *connector.Issue)
+		wantCandidateChange bool
+		wantPromptChange    bool
+	}{
+		{
+			name: "candidate body",
+			change: func(_ *Settings, issue *connector.Issue) {
+				issue.Description += " changed"
+			},
+			wantCandidateChange: true,
+		},
+		{
+			name: "criteria prompt",
+			change: func(settings *Settings, _ *connector.Issue) {
+				settings.Criteria.Text += " changed"
+			},
+			wantPromptChange: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changedSettings := cloneSettings(settings)
+			changedCandidate := candidate
+			tt.change(&changedSettings, &changedCandidate)
+			got := admissionEvaluationFingerprints(changedSettings, changedCandidate)
+			if (got.candidate != base.candidate) != tt.wantCandidateChange ||
+				(got.prompt != base.prompt) != tt.wantPromptChange || got.proposal == base.proposal {
+				t.Fatalf("fingerprints = %#v, base %#v", got, base)
+			}
+		})
 	}
 }
 
@@ -3513,6 +3710,31 @@ type staticAdmissionRunner struct {
 
 func (r staticAdmissionRunner) Run(context.Context, runner.RunRequest) (runner.RunResult, error) {
 	return runner.RunResult{Output: r.output, FinalState: runner.FinalStateCompleted}, nil
+}
+
+type malformedAdmissionRunner struct {
+	malformedCalls   int
+	malformedIssueID string
+	calls            int
+}
+
+func (r *malformedAdmissionRunner) Run(_ context.Context, request runner.RunRequest) (runner.RunResult, error) {
+	r.calls++
+	if r.calls <= r.malformedCalls ||
+		(len(request.Admission.Candidates) > 0 && request.Admission.Candidates[0].ID == r.malformedIssueID) {
+		return runner.RunResult{Output: `{`, FinalState: runner.FinalStateCompleted}, nil
+	}
+	evaluations := make([]AgentEvaluation, 0, len(request.Admission.Candidates))
+	for _, candidate := range request.Admission.Candidates {
+		evaluations = append(evaluations, admissionProposalEvaluation(candidate.ID))
+	}
+	raw, err := json.Marshal(struct {
+		Evaluations []AgentEvaluation `json:"evaluations"`
+	}{Evaluations: evaluations})
+	if err != nil {
+		return runner.RunResult{}, err
+	}
+	return runner.RunResult{Output: string(raw), FinalState: runner.FinalStateCompleted}, nil
 }
 
 type capacityScheduler struct {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -1931,6 +1931,7 @@ func TestManagerScheduledFanoutDeferralResumesWithoutDuplicateAdmission(t *testi
 	if err != nil || len(initial.Proposals) != 2 {
 		t.Fatalf("initial RunOnce() = %#v, %v, want two proposals", initial, err)
 	}
+	initialRunnerCalls := agent.calls
 	open, err := backend.OpenAdmissionProposals(t.Context(), settings.ProjectID, 0)
 	if err != nil || len(open) != 2 {
 		t.Fatalf("OpenAdmissionProposals() = %#v, %v, want two proposals", open, err)
@@ -1984,8 +1985,8 @@ func TestManagerScheduledFanoutDeferralResumesWithoutDuplicateAdmission(t *testi
 	if got := countAdmissionStateUpdates(tracker.Events(), settings.Config.TargetState); got != 2 {
 		t.Fatalf("target state updates after resume = %d, want 2", got)
 	}
-	if agent.calls != 1 {
-		t.Fatalf("runner calls = %d, want original proposal run only", agent.calls)
+	if agent.calls != initialRunnerCalls {
+		t.Fatalf("runner calls = %d, want %d original candidate evaluations only", agent.calls, initialRunnerCalls)
 	}
 	latest, found, err := backend.LatestAdmissionRun(t.Context(), settings.ProjectID)
 	if err != nil || !found || latest.Outcome != "completed" ||
@@ -2041,11 +2042,12 @@ func TestManagerScheduledEvaluationFanoutDeferralCheckpointsBeforeResume(t *test
 	if err != nil || completed.DeferredReason != "" || !completed.ResumeAt.IsZero() || len(completed.Proposals) != 1 {
 		t.Fatalf("resumed run = %#v, %v", completed, err)
 	}
-	if agent.calls != 2 || len(agent.candidateIDs) != 2 || len(agent.candidateIDs[0]) != 2 || len(agent.candidateIDs[1]) != 1 {
+	if agent.calls != 3 || len(agent.candidateIDs) != 3 || len(agent.candidateIDs[0]) != 1 ||
+		len(agent.candidateIDs[1]) != 1 || len(agent.candidateIDs[2]) != 1 {
 		t.Fatalf("runner calls = %d candidates = %#v", agent.calls, agent.candidateIDs)
 	}
-	if agent.candidateIDs[1][0] == firstProposalID {
-		t.Fatalf("resumed candidate = %q, want candidate not already checkpointed", agent.candidateIDs[1][0])
+	if agent.candidateIDs[2][0] == firstProposalID || agent.candidateIDs[2][0] != agent.candidateIDs[1][0] {
+		t.Fatalf("resumed candidate = %q, want interrupted candidate %q rather than checkpointed candidate %q", agent.candidateIDs[2][0], agent.candidateIDs[1][0], firstProposalID)
 	}
 	open, err := backend.OpenAdmissionProposals(t.Context(), settings.ProjectID, 0)
 	if err != nil || len(open) != 2 {

--- a/internal/admission/model/model.go
+++ b/internal/admission/model/model.go
@@ -77,6 +77,7 @@ type RunRecord struct {
 	Skipped         map[string]int
 	Truncated       map[string]int
 	Issues          []IssueRecord
+	Malformed       []MalformedEvidence
 	Error           string
 }
 
@@ -85,6 +86,48 @@ type IssueRecord struct {
 	Identifier string `json:"identifier,omitempty"`
 	URL        string `json:"url,omitempty"`
 	ProposalID string `json:"proposal_id,omitempty"`
+}
+
+type MalformedStatus string
+
+const (
+	MalformedRetryable MalformedStatus = "retryable"
+	MalformedBlocked   MalformedStatus = "blocked"
+	MalformedResolved  MalformedStatus = "resolved"
+)
+
+type MalformedResult struct {
+	ProjectID            string
+	IssueID              string
+	IssueIdentifier      string
+	IssueURL             string
+	CandidateFingerprint string
+	PromptFingerprint    string
+	ProposalFingerprint  string
+	ErrorFingerprint     string
+	ErrorClass           string
+	ErrorCode            string
+	OutputExcerpt        string
+	AttemptCount         int
+	Status               MalformedStatus
+	FirstSeenAt          time.Time
+	LastSeenAt           time.Time
+	ResolvedAt           time.Time
+}
+
+type MalformedEvidence struct {
+	IssueID              string          `json:"issue_id,omitempty"`
+	IssueIdentifier      string          `json:"issue_identifier,omitempty"`
+	IssueURL             string          `json:"issue_url,omitempty"`
+	CandidateFingerprint string          `json:"candidate_fingerprint"`
+	PromptFingerprint    string          `json:"prompt_fingerprint"`
+	ProposalFingerprint  string          `json:"proposal_fingerprint"`
+	ErrorFingerprint     string          `json:"error_fingerprint"`
+	ErrorClass           string          `json:"error_class"`
+	ErrorCode            string          `json:"error_code"`
+	OutputExcerpt        string          `json:"output_excerpt,omitempty"`
+	AttemptCount         int             `json:"attempt_count"`
+	Status               MalformedStatus `json:"status"`
 }
 
 type Decision struct {

--- a/internal/cli/doctor_admission.go
+++ b/internal/cli/doctor_admission.go
@@ -25,40 +25,41 @@ const (
 )
 
 type doctorAdmissionDiagnostic struct {
-	Schedule              string                    `json:"schedule"`
-	MaximumGapSeconds     int64                     `json:"maximum_gap_seconds,omitempty"`
-	CriteriaSection       string                    `json:"criteria_section"`
-	Dimensions            []string                  `json:"dimensions,omitempty"`
-	NeverRun              bool                      `json:"never_run,omitempty"`
-	ObservedRuns          int                       `json:"observed_runs,omitempty"`
-	CandidateBearingRuns  int                       `json:"candidate_bearing_runs,omitempty"`
-	CandidatesObserved    int                       `json:"candidates_observed,omitempty"`
-	EligibleCandidates    int                       `json:"eligible_candidates_observed,omitempty"`
-	AverageRunSeconds     int64                     `json:"average_run_seconds,omitempty"`
-	AdmissionSessions     int                       `json:"admission_sessions,omitempty"`
-	AverageSessionSeconds int64                     `json:"average_session_seconds,omitempty"`
-	AverageSessionTokens  int64                     `json:"average_session_tokens,omitempty"`
-	LastRun               string                    `json:"last_run,omitempty"`
-	Outcome               string                    `json:"outcome,omitempty"`
-	DeferredReason        string                    `json:"deferred_reason,omitempty"`
-	CandidatesFound       int                       `json:"candidates_found,omitempty"`
-	CandidatesEvaluated   int                       `json:"candidates_evaluated,omitempty"`
-	Proposed              int                       `json:"proposed,omitempty"`
-	Skipped               map[string]int            `json:"skipped,omitempty"`
-	Truncated             map[string]int            `json:"truncated,omitempty"`
-	IssueReferences       []string                  `json:"issue_references,omitempty"`
-	ConsecutiveFailures   int                       `json:"consecutive_failures,omitempty"`
-	LatestError           string                    `json:"latest_error,omitempty"`
-	Warnings              []string                  `json:"warnings,omitempty"`
-	Origins               map[string]int            `json:"origins,omitempty"`
-	ProposalOutcomes      map[string]int            `json:"proposal_outcomes,omitempty"`
-	DecisionSeconds       map[string]int64          `json:"average_decision_seconds,omitempty"`
-	AcceptedCompleted     int                       `json:"accepted_completed,omitempty"`
-	ReworkCount           int                       `json:"rework_count,omitempty"`
-	ReviewChurnCount      int                       `json:"review_churn_count,omitempty"`
-	SpendUSD              float64                   `json:"spend_usd,omitempty"`
-	RepositoryVisibility  string                    `json:"repository_visibility,omitempty"`
-	OpenProposals         []doctorAdmissionProposal `json:"open_proposals_awaiting_decision,omitempty"`
+	Schedule              string                     `json:"schedule"`
+	MaximumGapSeconds     int64                      `json:"maximum_gap_seconds,omitempty"`
+	CriteriaSection       string                     `json:"criteria_section"`
+	Dimensions            []string                   `json:"dimensions,omitempty"`
+	NeverRun              bool                       `json:"never_run,omitempty"`
+	ObservedRuns          int                        `json:"observed_runs,omitempty"`
+	CandidateBearingRuns  int                        `json:"candidate_bearing_runs,omitempty"`
+	CandidatesObserved    int                        `json:"candidates_observed,omitempty"`
+	EligibleCandidates    int                        `json:"eligible_candidates_observed,omitempty"`
+	AverageRunSeconds     int64                      `json:"average_run_seconds,omitempty"`
+	AdmissionSessions     int                        `json:"admission_sessions,omitempty"`
+	AverageSessionSeconds int64                      `json:"average_session_seconds,omitempty"`
+	AverageSessionTokens  int64                      `json:"average_session_tokens,omitempty"`
+	LastRun               string                     `json:"last_run,omitempty"`
+	Outcome               string                     `json:"outcome,omitempty"`
+	DeferredReason        string                     `json:"deferred_reason,omitempty"`
+	CandidatesFound       int                        `json:"candidates_found,omitempty"`
+	CandidatesEvaluated   int                        `json:"candidates_evaluated,omitempty"`
+	Proposed              int                        `json:"proposed,omitempty"`
+	Skipped               map[string]int             `json:"skipped,omitempty"`
+	Truncated             map[string]int             `json:"truncated,omitempty"`
+	IssueReferences       []string                   `json:"issue_references,omitempty"`
+	ConsecutiveFailures   int                        `json:"consecutive_failures,omitempty"`
+	LatestError           string                     `json:"latest_error,omitempty"`
+	Warnings              []string                   `json:"warnings,omitempty"`
+	Origins               map[string]int             `json:"origins,omitempty"`
+	ProposalOutcomes      map[string]int             `json:"proposal_outcomes,omitempty"`
+	DecisionSeconds       map[string]int64           `json:"average_decision_seconds,omitempty"`
+	AcceptedCompleted     int                        `json:"accepted_completed,omitempty"`
+	ReworkCount           int                        `json:"rework_count,omitempty"`
+	ReviewChurnCount      int                        `json:"review_churn_count,omitempty"`
+	SpendUSD              float64                    `json:"spend_usd,omitempty"`
+	RepositoryVisibility  string                     `json:"repository_visibility,omitempty"`
+	OpenProposals         []doctorAdmissionProposal  `json:"open_proposals_awaiting_decision,omitempty"`
+	MalformedBlocked      []doctorAdmissionMalformed `json:"blocked_malformed_results,omitempty"`
 }
 
 type doctorAdmissionProposal struct {
@@ -67,6 +68,19 @@ type doctorAdmissionProposal struct {
 	Confidence       float64 `json:"confidence"`
 	AgeSeconds       int64   `json:"age_seconds"`
 	ExpiresInSeconds int64   `json:"expires_in_seconds"`
+}
+
+type doctorAdmissionMalformed struct {
+	Identifier           string `json:"identifier"`
+	CandidateFingerprint string `json:"candidate_fingerprint"`
+	PromptFingerprint    string `json:"prompt_fingerprint"`
+	ProposalFingerprint  string `json:"proposal_fingerprint"`
+	ErrorFingerprint     string `json:"error_fingerprint"`
+	ErrorClass           string `json:"error_class"`
+	ErrorCode            string `json:"error_code"`
+	AttemptCount         int    `json:"attempt_count"`
+	OutputExcerpt        string `json:"output_excerpt,omitempty"`
+	LastSeenAt           string `json:"last_seen_at"`
 }
 
 func checkDoctorAdmission(
@@ -296,6 +310,9 @@ func readDoctorAdmissionEvidence(
 	if err := readDoctorOpenAdmissionProposals(ctx, db, projectID, observedAt, &diagnostic); err != nil {
 		return diagnostic, err
 	}
+	if err := readDoctorBlockedAdmissionMalformed(ctx, db, projectID, &diagnostic); err != nil {
+		return diagnostic, err
+	}
 	diagnostic.ProposalOutcomes = map[string]int{}
 	diagnostic.DecisionSeconds = map[string]int64{}
 	rows, err := db.QueryContext(ctx, `
@@ -497,6 +514,10 @@ func doctorAdmissionCheck(name string, diagnostic doctorAdmissionDiagnostic, una
 		check.Status = doctorWarn
 		details = append(details, "awaiting_decision="+doctorAdmissionOpenProposals(diagnostic.OpenProposals))
 	}
+	if len(diagnostic.MalformedBlocked) > 0 {
+		check.Status = doctorWarn
+		details = append(details, "blocked_malformed="+doctorAdmissionMalformedResults(diagnostic.MalformedBlocked))
+	}
 	if counts := doctorAdmissionCounts(diagnostic.Origins); counts != "" {
 		details = append(details, "origins="+counts)
 	}
@@ -533,6 +554,69 @@ func doctorAdmissionOpenProposals(proposals []doctorAdmissionProposal) string {
 			formatDoctorConfidence(proposal.Confidence),
 			(time.Duration(proposal.AgeSeconds)*time.Second).String(),
 			(time.Duration(proposal.ExpiresInSeconds)*time.Second).String(),
+		))
+	}
+	return strings.Join(values, ",")
+}
+
+func readDoctorBlockedAdmissionMalformed(
+	ctx context.Context,
+	db doctorTelemetryStore,
+	projectID string,
+	diagnostic *doctorAdmissionDiagnostic,
+) error {
+	rows, err := db.QueryContext(ctx, `
+SELECT COALESCE(issue_identifier, ''), issue_id, candidate_fingerprint,
+       prompt_fingerprint, proposal_fingerprint, error_fingerprint, error_class,
+       error_code, attempt_count, output_excerpt, last_seen_at
+FROM backlog_admission_malformed_results
+WHERE project_id = ? AND status = 'blocked'
+ORDER BY last_seen_at DESC, id DESC`, strings.TrimSpace(projectID))
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table: backlog_admission_malformed_results") {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var issueID string
+		var malformed doctorAdmissionMalformed
+		if err := rows.Scan(
+			&malformed.Identifier,
+			&issueID,
+			&malformed.CandidateFingerprint,
+			&malformed.PromptFingerprint,
+			&malformed.ProposalFingerprint,
+			&malformed.ErrorFingerprint,
+			&malformed.ErrorClass,
+			&malformed.ErrorCode,
+			&malformed.AttemptCount,
+			&malformed.OutputExcerpt,
+			&malformed.LastSeenAt,
+		); err != nil {
+			return err
+		}
+		if malformed.Identifier = strings.TrimSpace(malformed.Identifier); malformed.Identifier == "" {
+			malformed.Identifier = strings.TrimSpace(issueID)
+		}
+		diagnostic.MalformedBlocked = append(diagnostic.MalformedBlocked, malformed)
+	}
+	return rows.Err()
+}
+
+func doctorAdmissionMalformedResults(results []doctorAdmissionMalformed) string {
+	values := make([]string, 0, len(results))
+	for _, result := range results {
+		values = append(values, fmt.Sprintf(
+			"%s(class=%s,code=%s,attempts=%d,proposal_fingerprint=%s,error_fingerprint=%s,excerpt=%s)",
+			result.Identifier,
+			result.ErrorClass,
+			result.ErrorCode,
+			result.AttemptCount,
+			result.ProposalFingerprint,
+			result.ErrorFingerprint,
+			strconvQuote(result.OutputExcerpt),
 		))
 	}
 	return strings.Join(values, ",")

--- a/internal/cli/doctor_admission_test.go
+++ b/internal/cli/doctor_admission_test.go
@@ -89,6 +89,31 @@ CREATE TABLE backlog_admission_downstream_outcomes (
 INSERT INTO backlog_admission_downstream_outcomes (
   project_id, completed_at, rework_count, review_churn_count, spend_usd
 ) VALUES ('detent', '2026-07-29T11:00:00Z', 2, 3, 4.5);
+CREATE TABLE backlog_admission_malformed_results (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  issue_identifier TEXT,
+  candidate_fingerprint TEXT NOT NULL,
+  prompt_fingerprint TEXT NOT NULL,
+  proposal_fingerprint TEXT NOT NULL,
+  error_fingerprint TEXT NOT NULL,
+  error_class TEXT NOT NULL,
+  error_code TEXT NOT NULL,
+  attempt_count INTEGER NOT NULL,
+  output_excerpt TEXT NOT NULL,
+  status TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL
+);
+INSERT INTO backlog_admission_malformed_results (
+  project_id, issue_id, issue_identifier, candidate_fingerprint, prompt_fingerprint,
+  proposal_fingerprint, error_fingerprint, error_class, error_code, attempt_count,
+  output_excerpt, status, last_seen_at
+) VALUES (
+  'detent', 'issue-malformed', 'digitaldrywood/detent#1600', 'candidate-fingerprint',
+  'prompt-fingerprint', 'proposal-fingerprint', 'error-fingerprint', 'schema',
+  'unknown_field', 4, '{"unexpected":"<redacted>"}', 'blocked', '2026-07-29T10:04:00Z'
+);
 CREATE TABLE workflow_phase_events (
   id INTEGER PRIMARY KEY,
   project_id TEXT NOT NULL,
@@ -133,6 +158,7 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 		"truncated=candidate_cap:8",
 		"issues=digitaldrywood/detent#1535",
 		"awaiting_decision=digitaldrywood/detent#1586(confidence=88%,age=2h0m0s,expires_in=166h0m0s)",
+		"blocked_malformed=digitaldrywood/detent#1600(class=schema,code=unknown_field,attempts=4,proposal_fingerprint=proposal-fingerprint,error_fingerprint=error-fingerprint,excerpt=\"{\\\"unexpected\\\":\\\"<redacted>\\\"}\")",
 		"origins=admission:1,routine:1,unknown:1",
 		"proposal_outcomes=accepted:1,expired:1",
 		"average_decision_seconds=accepted:60,expired:604800",
@@ -165,6 +191,11 @@ INSERT INTO workflow_phase_events (project_id, phase_type, status, metadata_json
 	if len(diagnostic.OpenProposals) != 1 || diagnostic.OpenProposals[0].Identifier != "digitaldrywood/detent#1586" ||
 		diagnostic.OpenProposals[0].AgeSeconds != 7200 {
 		t.Fatalf("open proposals = %#v", diagnostic.OpenProposals)
+	}
+	if len(diagnostic.MalformedBlocked) != 1 ||
+		diagnostic.MalformedBlocked[0].CandidateFingerprint != "candidate-fingerprint" ||
+		diagnostic.MalformedBlocked[0].PromptFingerprint != "prompt-fingerprint" {
+		t.Fatalf("blocked malformed results = %#v", diagnostic.MalformedBlocked)
 	}
 }
 

--- a/internal/store/admission.go
+++ b/internal/store/admission.go
@@ -891,16 +891,19 @@ func (s *sqliteStore) RecordAdmissionMalformedResult(
 	if err != nil {
 		return admissionmodel.MalformedResult{}, err
 	}
-	status := admissionmodel.MalformedRetryable
-	if attemptLimit == 1 {
-		status = admissionmodel.MalformedBlocked
-	}
 	row := s.db.QueryRowContext(ctx, `
 INSERT INTO backlog_admission_malformed_results (
   project_id, issue_id, issue_identifier, issue_url, candidate_fingerprint,
   prompt_fingerprint, proposal_fingerprint, error_fingerprint, error_class,
   error_code, output_excerpt, attempt_count, status, first_seen_at, last_seen_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, next_attempt,
+         CASE WHEN next_attempt >= ? THEN 'blocked' ELSE 'retryable' END, ?, ?
+FROM (
+  SELECT COALESCE(MAX(attempt_count), 0) + 1 AS next_attempt
+  FROM backlog_admission_malformed_results
+  WHERE project_id = ? AND proposal_fingerprint = ? AND status <> 'resolved'
+)
+WHERE true
 ON CONFLICT(project_id, proposal_fingerprint, error_fingerprint) DO UPDATE SET
   issue_id = excluded.issue_id,
   issue_identifier = excluded.issue_identifier,
@@ -910,15 +913,8 @@ ON CONFLICT(project_id, proposal_fingerprint, error_fingerprint) DO UPDATE SET
   error_class = excluded.error_class,
   error_code = excluded.error_code,
   output_excerpt = excluded.output_excerpt,
-  attempt_count = CASE
-    WHEN backlog_admission_malformed_results.status = 'resolved' THEN 1
-    ELSE backlog_admission_malformed_results.attempt_count + 1
-  END,
-  status = CASE
-    WHEN backlog_admission_malformed_results.status <> 'resolved'
-      AND backlog_admission_malformed_results.attempt_count + 1 >= ? THEN 'blocked'
-    ELSE 'retryable'
-  END,
+  attempt_count = excluded.attempt_count,
+  status = excluded.status,
   first_seen_at = CASE
     WHEN backlog_admission_malformed_results.status = 'resolved' THEN excluded.first_seen_at
     ELSE backlog_admission_malformed_results.first_seen_at
@@ -940,10 +936,11 @@ RETURNING project_id, issue_id, issue_identifier, issue_url, candidate_fingerpri
 		strings.TrimSpace(record.ErrorClass),
 		strings.TrimSpace(record.ErrorCode),
 		record.OutputExcerpt,
-		status,
-		seenAt,
-		seenAt,
 		attemptLimit,
+		seenAt,
+		seenAt,
+		strings.TrimSpace(record.ProjectID),
+		strings.TrimSpace(record.ProposalFingerprint),
 	)
 	stored, err := scanAdmissionMalformedResult(row.Scan)
 	if err != nil {

--- a/internal/store/admission.go
+++ b/internal/store/admission.go
@@ -879,6 +879,127 @@ WHERE id = ? AND status = 'open'`,
 	return nil
 }
 
+func (s *sqliteStore) RecordAdmissionMalformedResult(
+	ctx context.Context,
+	record admissionmodel.MalformedResult,
+	attemptLimit int,
+) (admissionmodel.MalformedResult, error) {
+	if err := validateAdmissionMalformedResult(record, attemptLimit); err != nil {
+		return admissionmodel.MalformedResult{}, err
+	}
+	seenAt, err := requiredTimestamp("last_seen_at", record.LastSeenAt)
+	if err != nil {
+		return admissionmodel.MalformedResult{}, err
+	}
+	status := admissionmodel.MalformedRetryable
+	if attemptLimit == 1 {
+		status = admissionmodel.MalformedBlocked
+	}
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO backlog_admission_malformed_results (
+  project_id, issue_id, issue_identifier, issue_url, candidate_fingerprint,
+  prompt_fingerprint, proposal_fingerprint, error_fingerprint, error_class,
+  error_code, output_excerpt, attempt_count, status, first_seen_at, last_seen_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+ON CONFLICT(project_id, proposal_fingerprint, error_fingerprint) DO UPDATE SET
+  issue_id = excluded.issue_id,
+  issue_identifier = excluded.issue_identifier,
+  issue_url = excluded.issue_url,
+  candidate_fingerprint = excluded.candidate_fingerprint,
+  prompt_fingerprint = excluded.prompt_fingerprint,
+  error_class = excluded.error_class,
+  error_code = excluded.error_code,
+  output_excerpt = excluded.output_excerpt,
+  attempt_count = CASE
+    WHEN backlog_admission_malformed_results.status = 'resolved' THEN 1
+    ELSE backlog_admission_malformed_results.attempt_count + 1
+  END,
+  status = CASE
+    WHEN backlog_admission_malformed_results.status <> 'resolved'
+      AND backlog_admission_malformed_results.attempt_count + 1 >= ? THEN 'blocked'
+    ELSE 'retryable'
+  END,
+  first_seen_at = CASE
+    WHEN backlog_admission_malformed_results.status = 'resolved' THEN excluded.first_seen_at
+    ELSE backlog_admission_malformed_results.first_seen_at
+  END,
+  last_seen_at = excluded.last_seen_at,
+  resolved_at = NULL
+RETURNING project_id, issue_id, issue_identifier, issue_url, candidate_fingerprint,
+  prompt_fingerprint, proposal_fingerprint, error_fingerprint, error_class,
+  error_code, output_excerpt, attempt_count, status, first_seen_at, last_seen_at,
+  COALESCE(resolved_at, '')`,
+		strings.TrimSpace(record.ProjectID),
+		strings.TrimSpace(record.IssueID),
+		strings.TrimSpace(record.IssueIdentifier),
+		strings.TrimSpace(record.IssueURL),
+		strings.TrimSpace(record.CandidateFingerprint),
+		strings.TrimSpace(record.PromptFingerprint),
+		strings.TrimSpace(record.ProposalFingerprint),
+		strings.TrimSpace(record.ErrorFingerprint),
+		strings.TrimSpace(record.ErrorClass),
+		strings.TrimSpace(record.ErrorCode),
+		record.OutputExcerpt,
+		status,
+		seenAt,
+		seenAt,
+		attemptLimit,
+	)
+	stored, err := scanAdmissionMalformedResult(row.Scan)
+	if err != nil {
+		return admissionmodel.MalformedResult{}, fmt.Errorf("record backlog admission malformed result: %w", err)
+	}
+	return stored, nil
+}
+
+func (s *sqliteStore) BlockedAdmissionMalformedResult(
+	ctx context.Context,
+	projectID string,
+	proposalFingerprint string,
+) (admissionmodel.MalformedResult, bool, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT project_id, issue_id, issue_identifier, issue_url, candidate_fingerprint,
+       prompt_fingerprint, proposal_fingerprint, error_fingerprint, error_class,
+       error_code, output_excerpt, attempt_count, status, first_seen_at, last_seen_at,
+       COALESCE(resolved_at, '')
+FROM backlog_admission_malformed_results
+WHERE project_id = ? AND proposal_fingerprint = ? AND status = 'blocked'
+ORDER BY last_seen_at DESC, id DESC
+LIMIT 1`, strings.TrimSpace(projectID), strings.TrimSpace(proposalFingerprint))
+	record, err := scanAdmissionMalformedResult(row.Scan)
+	if errors.Is(err, ErrNotFound) {
+		return admissionmodel.MalformedResult{}, false, nil
+	}
+	if err != nil {
+		return admissionmodel.MalformedResult{}, false, fmt.Errorf("read blocked backlog admission malformed result: %w", err)
+	}
+	return record, true, nil
+}
+
+func (s *sqliteStore) ResolveAdmissionMalformedResults(
+	ctx context.Context,
+	projectID string,
+	proposalFingerprint string,
+	at time.Time,
+) error {
+	resolvedAt, err := requiredTimestamp("resolved_at", at)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
+UPDATE backlog_admission_malformed_results
+SET status = 'resolved', resolved_at = ?
+WHERE project_id = ? AND proposal_fingerprint = ? AND status <> 'resolved'`,
+		resolvedAt,
+		strings.TrimSpace(projectID),
+		strings.TrimSpace(proposalFingerprint),
+	)
+	if err != nil {
+		return fmt.Errorf("resolve backlog admission malformed results: %w", err)
+	}
+	return nil
+}
+
 func (s *sqliteStore) RecordAdmissionRun(ctx context.Context, record admissionmodel.RunRecord) error {
 	scheduledFor, err := requiredTimestamp("scheduled_for", record.ScheduledFor)
 	if err != nil {
@@ -908,12 +1029,16 @@ func (s *sqliteStore) RecordAdmissionRun(ctx context.Context, record admissionmo
 	if err != nil {
 		return err
 	}
+	malformedJSON, err := admissionJSON(record.Malformed, []admissionmodel.MalformedEvidence{})
+	if err != nil {
+		return fmt.Errorf("encoding backlog admission malformed results: %w", err)
+	}
 	_, err = s.db.ExecContext(ctx, `
 INSERT INTO backlog_admission_runs (
   project_id, scheduled_for, started_at, completed_at, outcome, deferred_reason, resume_at, proposal_reason,
   candidates_found_count, candidates_count, proposed_count, skipped_json,
-  truncated_json, issues_json, error
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  truncated_json, issues_json, malformed_json, error
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strings.TrimSpace(record.ProjectID),
 		scheduledFor,
 		startedAt,
@@ -928,6 +1053,7 @@ INSERT INTO backlog_admission_runs (
 		skippedJSON,
 		truncatedJSON,
 		issuesJSON,
+		malformedJSON,
 		nullString(record.Error),
 	)
 	if err != nil {
@@ -940,7 +1066,7 @@ func (s *sqliteStore) LatestAdmissionRun(ctx context.Context, projectID string) 
 	row := s.db.QueryRowContext(ctx, `
 SELECT project_id, scheduled_for, started_at, completed_at, outcome,
        COALESCE(deferred_reason, ''), COALESCE(resume_at, ''), COALESCE(proposal_reason, ''), candidates_found_count, candidates_count,
-       proposed_count, skipped_json, truncated_json, issues_json, COALESCE(error, '')
+       proposed_count, skipped_json, truncated_json, issues_json, malformed_json, COALESCE(error, '')
 FROM backlog_admission_runs
 WHERE project_id = ?
 ORDER BY completed_at DESC, id DESC
@@ -962,7 +1088,7 @@ func (s *sqliteStore) RecentAdmissionRuns(ctx context.Context, projectID string,
 	rows, err := s.db.QueryContext(ctx, `
 SELECT project_id, scheduled_for, started_at, completed_at, outcome,
        COALESCE(deferred_reason, ''), COALESCE(resume_at, ''), COALESCE(proposal_reason, ''), candidates_found_count, candidates_count,
-       proposed_count, skipped_json, truncated_json, issues_json, COALESCE(error, '')
+       proposed_count, skipped_json, truncated_json, issues_json, malformed_json, COALESCE(error, '')
 FROM backlog_admission_runs
 WHERE project_id = ?
 ORDER BY completed_at DESC, id DESC
@@ -1039,6 +1165,41 @@ func validateAdmissionDecline(decline admissionmodel.Decline) error {
 		return errors.New("backlog admission decline created at is required")
 	}
 	return nil
+}
+
+func validateAdmissionMalformedResult(record admissionmodel.MalformedResult, attemptLimit int) error {
+	switch {
+	case strings.TrimSpace(record.ProjectID) == "":
+		return errors.New("backlog admission malformed result project id is required")
+	case strings.TrimSpace(record.IssueID) == "":
+		return errors.New("backlog admission malformed result issue id is required")
+	case strings.TrimSpace(record.CandidateFingerprint) == "":
+		return errors.New("backlog admission malformed result candidate fingerprint is required")
+	case strings.TrimSpace(record.PromptFingerprint) == "":
+		return errors.New("backlog admission malformed result prompt fingerprint is required")
+	case strings.TrimSpace(record.ProposalFingerprint) == "":
+		return errors.New("backlog admission malformed result proposal fingerprint is required")
+	case strings.TrimSpace(record.ErrorFingerprint) == "":
+		return errors.New("backlog admission malformed result error fingerprint is required")
+	case !admissionMalformedErrorClass(record.ErrorClass):
+		return errors.New("backlog admission malformed result error class is invalid")
+	case strings.TrimSpace(record.ErrorCode) == "":
+		return errors.New("backlog admission malformed result error code is required")
+	case record.LastSeenAt.IsZero():
+		return errors.New("backlog admission malformed result observation time is required")
+	case attemptLimit <= 0:
+		return errors.New("backlog admission malformed result attempt limit must be greater than zero")
+	}
+	return nil
+}
+
+func admissionMalformedErrorClass(value string) bool {
+	switch strings.TrimSpace(value) {
+	case "model", "parse", "schema", "transport":
+		return true
+	default:
+		return false
+	}
 }
 
 func validAdmissionProposalStatus(status admissionmodel.ProposalStatus) bool {
@@ -1189,6 +1350,7 @@ func scanAdmissionRun(scan admissionScan) (admissionmodel.RunRecord, error) {
 	var skippedJSON string
 	var truncatedJSON string
 	var issuesJSON string
+	var malformedJSON string
 	if err := scan(
 		&record.ProjectID,
 		&scheduledFor,
@@ -1204,6 +1366,7 @@ func scanAdmissionRun(scan admissionScan) (admissionmodel.RunRecord, error) {
 		&skippedJSON,
 		&truncatedJSON,
 		&issuesJSON,
+		&malformedJSON,
 		&record.Error,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1232,6 +1395,50 @@ func scanAdmissionRun(scan admissionScan) (admissionmodel.RunRecord, error) {
 	}
 	if err := json.Unmarshal([]byte(issuesJSON), &record.Issues); err != nil {
 		return admissionmodel.RunRecord{}, fmt.Errorf("decoding backlog admission issues: %w", err)
+	}
+	if err := json.Unmarshal([]byte(malformedJSON), &record.Malformed); err != nil {
+		return admissionmodel.RunRecord{}, fmt.Errorf("decoding backlog admission malformed results: %w", err)
+	}
+	return record, nil
+}
+
+func scanAdmissionMalformedResult(scan admissionScan) (admissionmodel.MalformedResult, error) {
+	var record admissionmodel.MalformedResult
+	var firstSeenAt string
+	var lastSeenAt string
+	var resolvedAt string
+	if err := scan(
+		&record.ProjectID,
+		&record.IssueID,
+		&record.IssueIdentifier,
+		&record.IssueURL,
+		&record.CandidateFingerprint,
+		&record.PromptFingerprint,
+		&record.ProposalFingerprint,
+		&record.ErrorFingerprint,
+		&record.ErrorClass,
+		&record.ErrorCode,
+		&record.OutputExcerpt,
+		&record.AttemptCount,
+		&record.Status,
+		&firstSeenAt,
+		&lastSeenAt,
+		&resolvedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return admissionmodel.MalformedResult{}, ErrNotFound
+		}
+		return admissionmodel.MalformedResult{}, err
+	}
+	var err error
+	if record.FirstSeenAt, err = parseTimestamp("first_seen_at", firstSeenAt); err != nil {
+		return admissionmodel.MalformedResult{}, err
+	}
+	if record.LastSeenAt, err = parseTimestamp("last_seen_at", lastSeenAt); err != nil {
+		return admissionmodel.MalformedResult{}, err
+	}
+	if record.ResolvedAt, err = parseAdmissionOptionalTimestamp("resolved_at", resolvedAt); err != nil {
+		return admissionmodel.MalformedResult{}, err
 	}
 	return record, nil
 }

--- a/internal/store/admission_test.go
+++ b/internal/store/admission_test.go
@@ -201,6 +201,17 @@ func TestAdmissionProposalExpiryAndRunLedger(t *testing.T) {
 			URL:        "https://example.test/issues/1",
 			ProposalID: "proposal-expiring",
 		}},
+		Malformed: []admissionmodel.MalformedEvidence{{
+			IssueID:              "issue-malformed",
+			CandidateFingerprint: "candidate-fingerprint",
+			PromptFingerprint:    "prompt-fingerprint",
+			ProposalFingerprint:  "proposal-fingerprint",
+			ErrorFingerprint:     "error-fingerprint",
+			ErrorClass:           "schema",
+			ErrorCode:            "unknown_field",
+			AttemptCount:         4,
+			Status:               admissionmodel.MalformedBlocked,
+		}},
 	}
 	if err := backend.RecordAdmissionRun(ctx, record); err != nil {
 		t.Fatalf("RecordAdmissionRun() error = %v", err)
@@ -214,12 +225,66 @@ func TestAdmissionProposalExpiryAndRunLedger(t *testing.T) {
 		!got.ResumeAt.Equal(record.ResumeAt) ||
 		got.ProposalReason != "criteria_not_met" ||
 		got.Skipped["author"] != 1 || got.Truncated["candidates"] != 1 ||
-		len(got.Issues) != 1 || got.Issues[0].ProposalID != "proposal-expiring" {
+		len(got.Issues) != 1 || got.Issues[0].ProposalID != "proposal-expiring" ||
+		len(got.Malformed) != 1 || got.Malformed[0].AttemptCount != 4 ||
+		got.Malformed[0].Status != admissionmodel.MalformedBlocked {
 		t.Fatalf("LatestAdmissionRun() = %#v", got)
 	}
 	runs, err := backend.RecentAdmissionRuns(ctx, "detent", 3)
 	if err != nil || len(runs) != 1 {
 		t.Fatalf("RecentAdmissionRuns() = %#v, %v", runs, err)
+	}
+}
+
+func TestAdmissionMalformedResultLifecycle(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	backend := openAdmissionTestStore(t, ctx)
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	record := admissionmodel.MalformedResult{
+		ProjectID:            "detent",
+		IssueID:              "issue-1",
+		IssueIdentifier:      "DD-1",
+		CandidateFingerprint: "candidate-fingerprint",
+		PromptFingerprint:    "prompt-fingerprint",
+		ProposalFingerprint:  "proposal-fingerprint",
+		ErrorFingerprint:     "error-fingerprint",
+		ErrorClass:           "schema",
+		ErrorCode:            "unknown_field",
+		OutputExcerpt:        `{"token":"<redacted>"}`,
+	}
+
+	for attempt := 1; attempt <= 4; attempt++ {
+		record.LastSeenAt = now.Add(time.Duration(attempt) * time.Minute)
+		stored, err := backend.RecordAdmissionMalformedResult(ctx, record, 4)
+		if err != nil {
+			t.Fatalf("RecordAdmissionMalformedResult() attempt %d error = %v", attempt, err)
+		}
+		wantStatus := admissionmodel.MalformedRetryable
+		if attempt == 4 {
+			wantStatus = admissionmodel.MalformedBlocked
+		}
+		if stored.AttemptCount != attempt || stored.Status != wantStatus ||
+			stored.OutputExcerpt != record.OutputExcerpt {
+			t.Fatalf("attempt %d stored = %#v", attempt, stored)
+		}
+	}
+
+	blocked, found, err := backend.BlockedAdmissionMalformedResult(ctx, "detent", record.ProposalFingerprint)
+	if err != nil || !found || blocked.AttemptCount != 4 || blocked.Status != admissionmodel.MalformedBlocked {
+		t.Fatalf("BlockedAdmissionMalformedResult() = %#v, %t, %v", blocked, found, err)
+	}
+	if err := backend.ResolveAdmissionMalformedResults(ctx, "detent", record.ProposalFingerprint, now.Add(5*time.Minute)); err != nil {
+		t.Fatalf("ResolveAdmissionMalformedResults() error = %v", err)
+	}
+	if blocked, found, err := backend.BlockedAdmissionMalformedResult(ctx, "detent", record.ProposalFingerprint); err != nil || found {
+		t.Fatalf("BlockedAdmissionMalformedResult() after resolve = %#v, %t, %v", blocked, found, err)
+	}
+	record.LastSeenAt = now.Add(6 * time.Minute)
+	stored, err := backend.RecordAdmissionMalformedResult(ctx, record, 4)
+	if err != nil || stored.AttemptCount != 1 || stored.Status != admissionmodel.MalformedRetryable {
+		t.Fatalf("RecordAdmissionMalformedResult() after resolve = %#v, %v", stored, err)
 	}
 }
 

--- a/internal/store/admission_test.go
+++ b/internal/store/admission_test.go
@@ -255,19 +255,27 @@ func TestAdmissionMalformedResultLifecycle(t *testing.T) {
 		OutputExcerpt:        `{"token":"<redacted>"}`,
 	}
 
-	for attempt := 1; attempt <= 4; attempt++ {
-		record.LastSeenAt = now.Add(time.Duration(attempt) * time.Minute)
+	errorFingerprints := []string{
+		"error-fingerprint-1",
+		"error-fingerprint-2",
+		"error-fingerprint-3",
+		"error-fingerprint-4",
+	}
+	for attempt, errorFingerprint := range errorFingerprints {
+		record.ErrorFingerprint = errorFingerprint
+		record.OutputExcerpt = `{"variation":"` + errorFingerprint + `"}`
+		record.LastSeenAt = now.Add(time.Duration(attempt+1) * time.Minute)
 		stored, err := backend.RecordAdmissionMalformedResult(ctx, record, 4)
 		if err != nil {
-			t.Fatalf("RecordAdmissionMalformedResult() attempt %d error = %v", attempt, err)
+			t.Fatalf("RecordAdmissionMalformedResult() attempt %d error = %v", attempt+1, err)
 		}
 		wantStatus := admissionmodel.MalformedRetryable
-		if attempt == 4 {
+		if attempt == len(errorFingerprints)-1 {
 			wantStatus = admissionmodel.MalformedBlocked
 		}
-		if stored.AttemptCount != attempt || stored.Status != wantStatus ||
+		if stored.AttemptCount != attempt+1 || stored.Status != wantStatus ||
 			stored.OutputExcerpt != record.OutputExcerpt {
-			t.Fatalf("attempt %d stored = %#v", attempt, stored)
+			t.Fatalf("attempt %d stored = %#v", attempt+1, stored)
 		}
 	}
 

--- a/internal/store/migrations/00053_bound_malformed_admission.sql
+++ b/internal/store/migrations/00053_bound_malformed_admission.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+CREATE TABLE backlog_admission_malformed_results (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  issue_identifier TEXT NOT NULL DEFAULT '',
+  issue_url TEXT NOT NULL DEFAULT '',
+  candidate_fingerprint TEXT NOT NULL,
+  prompt_fingerprint TEXT NOT NULL,
+  proposal_fingerprint TEXT NOT NULL,
+  error_fingerprint TEXT NOT NULL,
+  error_class TEXT NOT NULL,
+  error_code TEXT NOT NULL,
+  output_excerpt TEXT NOT NULL DEFAULT '',
+  attempt_count INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'retryable',
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  resolved_at TEXT,
+  UNIQUE (project_id, proposal_fingerprint, error_fingerprint),
+  CHECK (error_class IN ('model', 'parse', 'schema', 'transport')),
+  CHECK (attempt_count > 0),
+  CHECK (status IN ('retryable', 'blocked', 'resolved'))
+);
+
+CREATE INDEX backlog_admission_malformed_blocked_idx
+ON backlog_admission_malformed_results(project_id, proposal_fingerprint, status);
+
+ALTER TABLE backlog_admission_runs
+ADD COLUMN malformed_json TEXT NOT NULL DEFAULT '[]';
+
+-- +goose Down
+ALTER TABLE backlog_admission_runs DROP COLUMN malformed_json;
+DROP TABLE IF EXISTS backlog_admission_malformed_results;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -78,6 +78,26 @@ type BacklogAdmissionDownstreamOutcome struct {
 	UpdatedAt        string         `json:"updated_at"`
 }
 
+type BacklogAdmissionMalformedResult struct {
+	ID                   int64          `json:"id"`
+	ProjectID            string         `json:"project_id"`
+	IssueID              string         `json:"issue_id"`
+	IssueIdentifier      string         `json:"issue_identifier"`
+	IssueURL             string         `json:"issue_url"`
+	CandidateFingerprint string         `json:"candidate_fingerprint"`
+	PromptFingerprint    string         `json:"prompt_fingerprint"`
+	ProposalFingerprint  string         `json:"proposal_fingerprint"`
+	ErrorFingerprint     string         `json:"error_fingerprint"`
+	ErrorClass           string         `json:"error_class"`
+	ErrorCode            string         `json:"error_code"`
+	OutputExcerpt        string         `json:"output_excerpt"`
+	AttemptCount         int64          `json:"attempt_count"`
+	Status               string         `json:"status"`
+	FirstSeenAt          string         `json:"first_seen_at"`
+	LastSeenAt           string         `json:"last_seen_at"`
+	ResolvedAt           sql.NullString `json:"resolved_at"`
+}
+
 type BacklogAdmissionProposal struct {
 	ID                 string         `json:"id"`
 	ProjectID          string         `json:"project_id"`
@@ -122,6 +142,7 @@ type BacklogAdmissionRun struct {
 	Error                sql.NullString `json:"error"`
 	ProposalReason       sql.NullString `json:"proposal_reason"`
 	ResumeAt             sql.NullString `json:"resume_at"`
+	MalformedJson        string         `json:"malformed_json"`
 }
 
 type BudgetOverride struct {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -96,6 +96,7 @@ func (s *sqliteStore) RuntimeEvidence(ctx context.Context, query RuntimeEvidence
 		{name: "backlog_admission_proposals", projectScoped: true},
 		{name: "backlog_admission_declines", projectScoped: true},
 		{name: "backlog_admission_runs", projectScoped: true},
+		{name: "backlog_admission_malformed_results", projectScoped: true},
 		{name: "scheduled_runs", projectScoped: true},
 		{name: "health_notification_states"},
 		{name: "api_keys"},
@@ -1274,6 +1275,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_declines WHERE project_id = ?", projectID)
 		case "backlog_admission_runs":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_runs WHERE project_id = ?", projectID)
+		case "backlog_admission_malformed_results":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_malformed_results WHERE project_id = ?", projectID)
 		case "scheduled_runs":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduled_runs WHERE project_id = ?", projectID)
 		default:
@@ -1315,6 +1318,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_declines")
 		case "backlog_admission_runs":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_runs")
+		case "backlog_admission_malformed_results":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM backlog_admission_malformed_results")
 		case "scheduled_runs":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduled_runs")
 		case "health_notification_states":

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -286,6 +286,9 @@ type AdmissionStore interface {
 	RecordAdmissionRun(context.Context, admissionmodel.RunRecord) error
 	LatestAdmissionRun(context.Context, string) (admissionmodel.RunRecord, bool, error)
 	RecentAdmissionRuns(context.Context, string, int) ([]admissionmodel.RunRecord, error)
+	RecordAdmissionMalformedResult(context.Context, admissionmodel.MalformedResult, int) (admissionmodel.MalformedResult, error)
+	BlockedAdmissionMalformedResult(context.Context, string, string) (admissionmodel.MalformedResult, bool, error)
+	ResolveAdmissionMalformedResults(context.Context, string, string, time.Time) error
 }
 
 type AdmissionProposalDecisionReader interface {


### PR DESCRIPTION
## Summary

- evaluate admission candidates independently so malformed output cannot poison valid peers
- persist fingerprint-scoped malformed attempts and block unchanged retries after four failures
- record redacted structured evidence in admission runs and surface blocked diagnostics through `detent doctor`

Fixes #2143

## UI Surface Contract

- [x] N/A; this change does not alter a high-impact UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `PATH="$TMPDIR/detent-tools/bin:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] `GOTOOLCHAIN=go1.26.6 go test ./internal/admission ./internal/store ./internal/cli -count=1`