### PR TITLE
Reject dirty worktree completion attempts

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -48,6 +48,7 @@ type blockedCauseSignals struct {
 	UnpushedCommits                int               `json:"unpushed_commits,omitempty"`
 	UnpushedCommitRefs             []string          `json:"unpushed_commit_refs,omitempty"`
 	TrackedPaths                   []string          `json:"tracked_paths,omitempty"`
+	UntrackedPaths                 []string          `json:"untracked_paths,omitempty"`
 	CommitsNotInPullRequest        []string          `json:"commits_not_in_pull_request,omitempty"`
 	PullRequestComparisonAvailable bool              `json:"pull_request_comparison_available,omitempty"`
 	Health                         string            `json:"health,omitempty"`
@@ -140,6 +141,7 @@ func (o *Orchestrator) blockedCauseSignals(
 		snapshot.WorkspaceFiles = fallback.FilesChanged
 		snapshot.UnpushedCommitRefs = append([]string(nil), fallback.UnpushedCommitRefs...)
 		snapshot.TrackedPaths = append([]string(nil), fallback.TrackedPaths...)
+		snapshot.UntrackedPaths = append([]string(nil), fallback.UntrackedPaths...)
 		snapshot.CommitsNotInPullRequest = append([]string(nil), fallback.CommitsNotInPullRequest...)
 		snapshot.PullRequestComparisonAvailable = fallback.PullRequestComparisonAvailable
 		snapshot.WorkspaceStatus = "present"
@@ -156,6 +158,7 @@ func (o *Orchestrator) blockedCauseSignals(
 		UnpushedCommits:                snapshot.UnpushedCommits,
 		UnpushedCommitRefs:             append([]string(nil), snapshot.UnpushedCommitRefs...),
 		TrackedPaths:                   append([]string(nil), snapshot.TrackedPaths...),
+		UntrackedPaths:                 append([]string(nil), snapshot.UntrackedPaths...),
 		CommitsNotInPullRequest:        append([]string(nil), snapshot.CommitsNotInPullRequest...),
 		PullRequestComparisonAvailable: snapshot.PullRequestComparisonAvailable,
 		Health:                         strings.TrimSpace(snapshot.Health),
@@ -819,8 +822,8 @@ func (o *Orchestrator) blockedReadyPullRequestDeferredReason(
 	if !signals.WorkspacePresent || strings.TrimSpace(signals.WorkspaceStatus) != "present" || strings.TrimSpace(signals.WorkspaceHeadSHA) == "" {
 		return "workspace_head_unavailable"
 	}
-	if len(signals.TrackedPaths) > 0 {
-		return "workspace_tracked_changes_present"
+	if len(signals.TrackedPaths) > 0 || len(signals.UntrackedPaths) > 0 {
+		return "workspace_changes_present"
 	}
 	if signals.PullRequestComparisonAvailable {
 		if len(signals.CommitsNotInPullRequest) > 0 {

--- a/internal/orchestrator/completion_cleanliness.go
+++ b/internal/orchestrator/completion_cleanliness.go
@@ -81,6 +81,9 @@ func (o *Orchestrator) evaluateCompletionCleanliness(
 	if !attempted && intentionalStatement == "" {
 		return completionCleanlinessDecision{}
 	}
+	if !evidence.RecoveryStateExpected {
+		return completionCleanlinessDecision{}
+	}
 	decision := completionCleanlinessDecision{
 		Evidence: evidence,
 	}

--- a/internal/orchestrator/completion_cleanliness.go
+++ b/internal/orchestrator/completion_cleanliness.go
@@ -1,0 +1,346 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+const (
+	completionCleanlinessMetadataKey       = "completion_cleanliness"
+	completionCleanlinessAccepted          = "accepted"
+	completionCleanlinessRejected          = "rejected"
+	completionCleanlinessEscalated         = "escalated"
+	completionCleanlinessClean             = "clean"
+	completionCleanlinessCommitted         = "committed"
+	completionCleanlinessDiscarded         = "discarded"
+	completionCleanlinessIntentionallyLeft = "intentionally_left"
+	dirtyCompletionReason                  = "dirty_worktree_completion_rejected"
+	dirtyCompletionResolutionReason        = "dirty_worktree_resolution_required"
+	dirtyCompletionEscalationReason        = "dirty_worktree_completion_unresolved"
+	completionCleanlinessRejectionLimit    = 2
+)
+
+type completionCleanlinessDecision struct {
+	Attempted             bool
+	Outcome               string
+	Resolution            string
+	Declaration           string
+	Reason                string
+	Statement             string
+	Evidence              DiffStats
+	ConsecutiveRejections int
+	Block                 bool
+	Warning               string
+}
+
+type completionCleanlinessRecord struct {
+	Outcome               string                        `json:"outcome"`
+	Resolution            string                        `json:"resolution,omitempty"`
+	Declaration           string                        `json:"declaration,omitempty"`
+	Reason                string                        `json:"reason,omitempty"`
+	Statement             string                        `json:"statement,omitempty"`
+	Evidence              completionCleanlinessEvidence `json:"evidence"`
+	ConsecutiveRejections int                           `json:"consecutive_rejections,omitempty"`
+	Warning               string                        `json:"warning,omitempty"`
+}
+
+type completionCleanlinessEvidence struct {
+	FilesChanged            int      `json:"files_changed"`
+	AddedLines              int      `json:"added_lines"`
+	RemovedLines            int      `json:"removed_lines"`
+	TrackedPaths            []string `json:"tracked_paths,omitempty"`
+	UntrackedPaths          []string `json:"untracked_paths,omitempty"`
+	UnpushedCommits         int      `json:"unpushed_commits,omitempty"`
+	UnpushedCommitRefs      []string `json:"unpushed_commit_refs,omitempty"`
+	CommitsNotInPullRequest []string `json:"commits_not_in_pull_request,omitempty"`
+	RecoveryStateExpected   bool     `json:"recovery_state_expected,omitempty"`
+	RecoveryStateAvailable  bool     `json:"recovery_state_available,omitempty"`
+	HeadSHA                 string   `json:"head_sha,omitempty"`
+	Fingerprint             string   `json:"fingerprint,omitempty"`
+	Status                  string   `json:"status,omitempty"`
+}
+
+func (o *Orchestrator) evaluateCompletionCleanliness(
+	ctx context.Context,
+	running Running,
+	issue connector.Issue,
+	evidence DiffStats,
+) completionCleanlinessDecision {
+	attempted := completionCleanlinessAttempted(running, issue)
+	intentionalStatement := completionCleanlinessIntentionalStatement(issue)
+	if !attempted && intentionalStatement == "" {
+		return completionCleanlinessDecision{}
+	}
+	decision := completionCleanlinessDecision{
+		Evidence: evidence,
+	}
+	attempts, err := o.recentImplementCompletionAttempts(ctx, issue, running)
+	if err != nil {
+		if !attempted {
+			return completionCleanlinessDecision{}
+		}
+		decision.Attempted = true
+		decision.Warning = err.Error()
+		decision.Outcome = completionCleanlinessEscalated
+		decision.Reason = dirtyCompletionEscalationReason
+		decision.ConsecutiveRejections = 1
+		decision.Block = true
+		return decision
+	}
+	previousRejections := consecutiveCompletionCleanlinessRejections(attempts)
+	if !attempted && previousRejections == 0 {
+		return completionCleanlinessDecision{}
+	}
+	decision.Attempted = true
+	decision.Declaration = completionCleanlinessResolutionDeclaration(issue, running)
+	if intentionalStatement != "" {
+		decision.Outcome = completionCleanlinessEscalated
+		decision.Resolution = completionCleanlinessIntentionallyLeft
+		decision.Reason = dirtyCompletionEscalationReason
+		decision.Statement = intentionalStatement
+		decision.ConsecutiveRejections = previousRejections + 1
+		decision.Block = true
+		return decision
+	}
+	if !diffStatsPresent(evidence) {
+		decision.Outcome = completionCleanlinessRejected
+		decision.Reason = "workspace_cleanliness_unavailable"
+		decision.ConsecutiveRejections = previousRejections + 1
+		decision.Block = decision.ConsecutiveRejections >= completionCleanlinessRejectionLimit
+		if decision.Block {
+			decision.Outcome = completionCleanlinessEscalated
+			decision.Reason = dirtyCompletionEscalationReason
+		}
+		return decision
+	}
+	if evidence.RecoveryStateExpected && !evidence.RecoveryStateAvailable {
+		decision.Outcome = completionCleanlinessRejected
+		decision.Reason = "workspace_recovery_state_unavailable"
+		decision.ConsecutiveRejections = previousRejections + 1
+		decision.Block = decision.ConsecutiveRejections >= completionCleanlinessRejectionLimit
+		if decision.Block {
+			decision.Outcome = completionCleanlinessEscalated
+			decision.Reason = dirtyCompletionEscalationReason
+		}
+		return decision
+	}
+	if !completionCleanlinessDirty(evidence) {
+		if previousRejections > 0 && !completionCleanlinessResolutionValid(decision.Declaration) {
+			decision.Outcome = completionCleanlinessRejected
+			decision.Reason = dirtyCompletionResolutionReason
+			decision.ConsecutiveRejections = previousRejections + 1
+			decision.Block = decision.ConsecutiveRejections >= completionCleanlinessRejectionLimit
+			if decision.Block {
+				decision.Outcome = completionCleanlinessEscalated
+				decision.Reason = dirtyCompletionEscalationReason
+			}
+			return decision
+		}
+		decision.Outcome = completionCleanlinessAccepted
+		decision.Resolution = completionCleanlinessClean
+		if previousRejections > 0 {
+			decision.Resolution = decision.Declaration
+		}
+		return decision
+	}
+	decision.Outcome = completionCleanlinessRejected
+	decision.Resolution = "required"
+	decision.Reason = dirtyCompletionReason
+	decision.ConsecutiveRejections = previousRejections + 1
+	if decision.ConsecutiveRejections >= completionCleanlinessRejectionLimit {
+		decision.Outcome = completionCleanlinessEscalated
+		decision.Reason = dirtyCompletionEscalationReason
+		decision.Block = true
+	}
+	return decision
+}
+
+func completionCleanlinessResolutionDeclaration(issue connector.Issue, running Running) string {
+	signal := issue.WorkpadSignal
+	if signal == nil {
+		if current, ok := autoPromoteIssueWorkpadSignal(issue); ok {
+			signal = current
+		}
+	}
+	if !workpad.CurrentAttemptCompletion(signal, running.WorkAttemptID, running.Generation) {
+		return ""
+	}
+	resolution := strings.ToLower(strings.TrimSpace(signal.Fields[workpad.FieldCompletionCleanlinessResolution]))
+	resolution = strings.ReplaceAll(resolution, "-", "_")
+	return strings.Join(strings.Fields(resolution), "_")
+}
+
+func completionCleanlinessResolutionValid(resolution string) bool {
+	return resolution == completionCleanlinessCommitted || resolution == completionCleanlinessDiscarded
+}
+
+func completionCleanlinessAttempted(running Running, issue connector.Issue) bool {
+	if strings.TrimSpace(running.CompletionLane) != "" {
+		return true
+	}
+	signal := issue.WorkpadSignal
+	if signal == nil {
+		if current, ok := autoPromoteIssueWorkpadSignal(issue); ok {
+			signal = current
+		}
+	}
+	return workpad.CurrentAttemptCompletion(signal, running.WorkAttemptID, running.Generation)
+}
+
+func completionCleanlinessDirty(evidence DiffStats) bool {
+	return evidence.FilesChanged > 0 || evidence.AddedLines > 0 || evidence.RemovedLines > 0 ||
+		len(evidence.TrackedPaths) > 0 || len(evidence.UntrackedPaths) > 0 || evidence.UnpushedCommits > 0 ||
+		evidence.PullRequestComparisonAvailable && len(evidence.CommitsNotInPullRequest) > 0
+}
+
+func completionCleanlinessIntentionalStatement(issue connector.Issue) string {
+	signal := issue.WorkpadSignal
+	if signal == nil {
+		if current, ok := autoPromoteIssueWorkpadSignal(issue); ok {
+			signal = current
+		}
+	}
+	if signal == nil || signal.Source != workpad.SourceStructured || strings.TrimSpace(signal.Status) != workpad.StatusBlocked {
+		return ""
+	}
+	statements := []string{strings.TrimSpace(signal.HumanAction)}
+	for _, blocker := range signal.Blockers {
+		statements = append(statements, strings.TrimSpace(blocker.Reason))
+	}
+	statements = slices.DeleteFunc(statements, func(value string) bool { return value == "" })
+	return strings.Join(statements, "; ")
+}
+
+func consecutiveCompletionCleanlinessRejections(attempts []store.WorkAttempt) int {
+	count := 0
+	for _, attempt := range attempts {
+		record, ok := completionCleanlinessRecordFromAttempt(attempt)
+		if !ok || record.Outcome == completionCleanlinessAccepted {
+			break
+		}
+		if record.Outcome != completionCleanlinessRejected && record.Outcome != completionCleanlinessEscalated {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+func completionCleanlinessRecordFromAttempt(attempt store.WorkAttempt) (completionCleanlinessRecord, bool) {
+	var root struct {
+		CompletionCleanliness completionCleanlinessRecord `json:"completion_cleanliness"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(attempt.WorkerMetadataJSON)), &root); err != nil || strings.TrimSpace(root.CompletionCleanliness.Outcome) == "" {
+		return completionCleanlinessRecord{}, false
+	}
+	return root.CompletionCleanliness, true
+}
+
+func completionCleanlinessMetadata(decision completionCleanlinessDecision) map[string]any {
+	if !decision.Attempted {
+		return nil
+	}
+	return map[string]any{completionCleanlinessMetadataKey: completionCleanlinessRecord{
+		Outcome:               decision.Outcome,
+		Resolution:            decision.Resolution,
+		Declaration:           decision.Declaration,
+		Reason:                decision.Reason,
+		Statement:             decision.Statement,
+		Evidence:              completionCleanlinessEvidenceFromDiffStats(decision.Evidence),
+		ConsecutiveRejections: decision.ConsecutiveRejections,
+		Warning:               decision.Warning,
+	}}
+}
+
+func completionCleanlinessEvidenceFromDiffStats(evidence DiffStats) completionCleanlinessEvidence {
+	return completionCleanlinessEvidence{
+		FilesChanged:            evidence.FilesChanged,
+		AddedLines:              evidence.AddedLines,
+		RemovedLines:            evidence.RemovedLines,
+		TrackedPaths:            append([]string(nil), evidence.TrackedPaths...),
+		UntrackedPaths:          append([]string(nil), evidence.UntrackedPaths...),
+		UnpushedCommits:         evidence.UnpushedCommits,
+		UnpushedCommitRefs:      append([]string(nil), evidence.UnpushedCommitRefs...),
+		CommitsNotInPullRequest: append([]string(nil), evidence.CommitsNotInPullRequest...),
+		RecoveryStateExpected:   evidence.RecoveryStateExpected,
+		RecoveryStateAvailable:  evidence.RecoveryStateAvailable,
+		HeadSHA:                 strings.TrimSpace(evidence.HeadSHA),
+		Fingerprint:             strings.TrimSpace(evidence.Fingerprint),
+		Status:                  strings.TrimSpace(evidence.Status),
+	}
+}
+
+func (o *Orchestrator) commentCompletionCleanlinessRejection(ctx context.Context, issue connector.Issue, decision completionCleanlinessDecision) {
+	if o == nil || o.connector == nil || strings.TrimSpace(issue.ID) == "" {
+		return
+	}
+	if err := o.connector.CreateComment(ctx, issue.ID, completionCleanlinessRejectionComment(decision)); err != nil && o.logger != nil {
+		o.logger.Warn("dirty completion rejection comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+}
+
+func completionCleanlinessRejectionComment(decision completionCleanlinessDecision) string {
+	var b strings.Builder
+	b.WriteString("Detent rejected this completion attempt because the workspace is not clean.\n\n")
+	b.WriteString("- diffstat: ")
+	b.WriteString(strconv.Itoa(decision.Evidence.FilesChanged))
+	b.WriteString(" files, +")
+	b.WriteString(strconv.Itoa(decision.Evidence.AddedLines))
+	b.WriteString("/-")
+	b.WriteString(strconv.Itoa(decision.Evidence.RemovedLines))
+	if decision.Evidence.UnpushedCommits > 0 {
+		b.WriteString("\n- unpushed_commits: ")
+		b.WriteString(strconv.Itoa(decision.Evidence.UnpushedCommits))
+	}
+	appendQuotedEvidence(&b, "tracked_paths", decision.Evidence.TrackedPaths)
+	appendQuotedEvidence(&b, "untracked_paths", decision.Evidence.UntrackedPaths)
+	appendQuotedEvidence(&b, "unpushed_commit_refs", decision.Evidence.UnpushedCommitRefs)
+	appendQuotedEvidence(&b, "commits_not_in_pull_request", decision.Evidence.CommitsNotInPullRequest)
+	b.WriteString("\n\nInspect every path before the next completion attempt. Commit and publish work that belongs to the issue, discard stray artifacts or mistakes, or set the Workpad to `status: blocked` and state why files are intentionally left. For a clean retry, add `completion_cleanliness_resolution: committed` or `completion_cleanliness_resolution: discarded` under `fields:` in the current completion block. Detent will not accept `status: complete` while this evidence remains.")
+	return b.String()
+}
+
+func (o *Orchestrator) blockCompletionCleanliness(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	decision completionCleanlinessDecision,
+) bool {
+	detail := fmt.Sprintf(
+		"completion remained unresolved after %d rejection(s): %d files, +%d/-%d, %d unpushed commits, tracked paths %v, untracked paths %v",
+		decision.ConsecutiveRejections,
+		decision.Evidence.FilesChanged,
+		decision.Evidence.AddedLines,
+		decision.Evidence.RemovedLines,
+		decision.Evidence.UnpushedCommits,
+		decision.Evidence.TrackedPaths,
+		decision.Evidence.UntrackedPaths,
+	)
+	humanAction := strings.TrimSpace(decision.Statement)
+	if humanAction == "" {
+		humanAction = "inspect the preserved workspace, commit and publish required work or discard stray changes, move the issue to Rework, then record completion_cleanliness_resolution as committed or discarded under `fields:` on completion"
+	}
+	event.Err = errors.New(detail)
+	running.DiffStats = decision.Evidence
+	return o.blockHumanOwnedWorkerFailure(
+		ctx,
+		state,
+		event,
+		running,
+		dirtyCompletionEscalationReason,
+		detail,
+		humanAction,
+		"worker_dirty_completion_escalated",
+	)
+}

--- a/internal/orchestrator/completion_cleanliness_test.go
+++ b/internal/orchestrator/completion_cleanliness_test.go
@@ -48,6 +48,7 @@ func TestEvaluateCompletionCleanliness(t *testing.T) {
 		wantBlock      bool
 		withoutLane    bool
 		wantWarning    bool
+		wantSkipped    bool
 	}{
 		{
 			name:           "clean tree",
@@ -68,6 +69,11 @@ func TestEvaluateCompletionCleanliness(t *testing.T) {
 			wantOutcome:    completionCleanlinessRejected,
 			wantResolution: "required",
 			wantRejected:   1,
+		},
+		{
+			name:        "filesystem artifact output",
+			evidence:    DiffStats{FilesChanged: 1, Fingerprint: "artifact-fingerprint", Status: "changed"},
+			wantSkipped: true,
 		},
 		{
 			name: "unpushed commits without pull request",
@@ -178,13 +184,25 @@ func TestEvaluateCompletionCleanliness(t *testing.T) {
 			if tt.withoutLane {
 				completionLane = ""
 			}
+			evidence := tt.evidence
+			if !tt.wantSkipped && !evidence.RecoveryStateExpected {
+				evidence.RecoveryStateExpected = true
+				evidence.RecoveryStateAvailable = true
+			}
 			decision := orch.evaluateCompletionCleanliness(t.Context(), Running{
 				Issue:          issue,
 				Mode:           runpkg.RunModeImplement,
 				WorkAttemptID:  2147,
 				Generation:     7,
 				CompletionLane: completionLane,
-			}, issue, tt.evidence)
+			}, issue, evidence)
+
+			if tt.wantSkipped {
+				if decision.Attempted || completionCleanlinessMetadata(decision) != nil {
+					t.Fatalf("evaluateCompletionCleanliness() = %#v, want skipped", decision)
+				}
+				return
+			}
 
 			if !decision.Attempted || decision.Outcome != tt.wantOutcome || decision.Resolution != tt.wantResolution || decision.ConsecutiveRejections != tt.wantRejected || decision.Block != tt.wantBlock {
 				t.Fatalf("evaluateCompletionCleanliness() = %#v", decision)
@@ -272,13 +290,15 @@ func TestHandleRunResultRejectsDirtyCompletionAndEscalates(t *testing.T) {
 			}
 			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: base.Add(-time.Minute)}
 			diff := DiffStats{
-				FilesChanged:   2,
-				AddedLines:     9,
-				RemovedLines:   3,
-				TrackedPaths:   []string{"internal/worker.go"},
-				UntrackedPaths: []string{"debug.log"},
-				Fingerprint:    "dirty-fingerprint",
-				Status:         "changed",
+				FilesChanged:           2,
+				AddedLines:             9,
+				RemovedLines:           3,
+				TrackedPaths:           []string{"internal/worker.go"},
+				UntrackedPaths:         []string{"debug.log"},
+				RecoveryStateExpected:  true,
+				RecoveryStateAvailable: true,
+				Fingerprint:            "dirty-fingerprint",
+				Status:                 "changed",
 			}
 
 			orch.handleRunResult(t.Context(), &state, runpkg.Completion{

--- a/internal/orchestrator/completion_cleanliness_test.go
+++ b/internal/orchestrator/completion_cleanliness_test.go
@@ -1,0 +1,328 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+func TestEvaluateCompletionCleanliness(t *testing.T) {
+	t.Parallel()
+
+	previousRejected := store.WorkAttempt{
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			completionCleanlinessMetadataKey: completionCleanlinessRecord{Outcome: completionCleanlinessRejected},
+		}),
+	}
+	resolvedIssue := func(resolution string) connector.Issue {
+		return connector.Issue{WorkpadSignal: &workpad.Signal{
+			Source: workpad.SourceStructured,
+			Status: workpad.StatusComplete,
+			Fields: map[string]string{
+				workpad.FieldCompletionAttempt:               "2147",
+				workpad.FieldCompletionGeneration:            "7",
+				workpad.FieldCompletionCleanlinessResolution: resolution,
+			},
+		}}
+	}
+	tests := []struct {
+		name           string
+		evidence       DiffStats
+		history        []store.WorkAttempt
+		historyErr     error
+		issue          connector.Issue
+		wantOutcome    string
+		wantResolution string
+		wantRejected   int
+		wantBlock      bool
+		withoutLane    bool
+		wantWarning    bool
+	}{
+		{
+			name:           "clean tree",
+			evidence:       DiffStats{Status: "clean", HeadSHA: "head"},
+			wantOutcome:    completionCleanlinessAccepted,
+			wantResolution: completionCleanlinessClean,
+		},
+		{
+			name:           "tracked modifications",
+			evidence:       DiffStats{FilesChanged: 1, AddedLines: 4, RemovedLines: 2, TrackedPaths: []string{"internal/worker.go"}, Status: "changed"},
+			wantOutcome:    completionCleanlinessRejected,
+			wantResolution: "required",
+			wantRejected:   1,
+		},
+		{
+			name:           "untracked files",
+			evidence:       DiffStats{FilesChanged: 1, AddedLines: 8, UntrackedPaths: []string{"debug.log"}, Status: "changed"},
+			wantOutcome:    completionCleanlinessRejected,
+			wantResolution: "required",
+			wantRejected:   1,
+		},
+		{
+			name: "unpushed commits without pull request",
+			evidence: DiffStats{
+				UnpushedCommits:    1,
+				UnpushedCommitRefs: []string{"abc123 fix: retain work"},
+				HeadSHA:            "abc123",
+				Status:             "clean",
+			},
+			wantOutcome:    completionCleanlinessRejected,
+			wantResolution: "required",
+			wantRejected:   1,
+		},
+		{
+			name:           "committed after rejection",
+			evidence:       DiffStats{Status: "clean", HeadSHA: "resolved-head"},
+			history:        []store.WorkAttempt{previousRejected},
+			issue:          resolvedIssue(completionCleanlinessCommitted),
+			wantOutcome:    completionCleanlinessAccepted,
+			wantResolution: completionCleanlinessCommitted,
+		},
+		{
+			name:           "discarded after rejection",
+			evidence:       DiffStats{Status: "clean", HeadSHA: "original-head"},
+			history:        []store.WorkAttempt{previousRejected},
+			issue:          resolvedIssue(completionCleanlinessDiscarded),
+			wantOutcome:    completionCleanlinessAccepted,
+			wantResolution: completionCleanlinessDiscarded,
+		},
+		{
+			name:         "clean retry without explicit resolution escalates",
+			evidence:     DiffStats{Status: "clean", HeadSHA: "resolved-head"},
+			history:      []store.WorkAttempt{previousRejected},
+			wantOutcome:  completionCleanlinessEscalated,
+			wantRejected: 2,
+			wantBlock:    true,
+		},
+		{
+			name: "recovery evidence unavailable",
+			evidence: DiffStats{
+				Status:                "clean",
+				RecoveryStateExpected: true,
+			},
+			wantOutcome:  completionCleanlinessRejected,
+			wantRejected: 1,
+		},
+		{
+			name:         "audit history unavailable escalates",
+			evidence:     DiffStats{Status: "clean", HeadSHA: "head"},
+			historyErr:   errors.New("history unavailable"),
+			wantOutcome:  completionCleanlinessEscalated,
+			wantRejected: 1,
+			wantBlock:    true,
+			wantWarning:  true,
+		},
+		{
+			name:           "repeated dirty completion escalates",
+			evidence:       DiffStats{FilesChanged: 1, UntrackedPaths: []string{"debug.log"}, Status: "changed"},
+			history:        []store.WorkAttempt{previousRejected},
+			wantOutcome:    completionCleanlinessEscalated,
+			wantResolution: "required",
+			wantRejected:   2,
+			wantBlock:      true,
+		},
+		{
+			name:     "intentional remainder escalates",
+			evidence: DiffStats{FilesChanged: 1, TrackedPaths: []string{"fixture.patch"}, Status: "changed"},
+			issue: connector.Issue{WorkpadSignal: &workpad.Signal{
+				Source:      workpad.SourceStructured,
+				Status:      workpad.StatusBlocked,
+				HumanAction: "preserve fixture.patch for operator inspection",
+			}},
+			wantOutcome:    completionCleanlinessEscalated,
+			wantResolution: completionCleanlinessIntentionallyLeft,
+			wantRejected:   1,
+			wantBlock:      true,
+		},
+		{
+			name:     "intentional remainder resolves prior rejection without another completion declaration",
+			evidence: DiffStats{FilesChanged: 1, TrackedPaths: []string{"fixture.patch"}, Status: "changed"},
+			history:  []store.WorkAttempt{previousRejected},
+			issue: connector.Issue{WorkpadSignal: &workpad.Signal{
+				Source:      workpad.SourceStructured,
+				Status:      workpad.StatusBlocked,
+				HumanAction: "preserve fixture.patch for operator inspection",
+			}},
+			wantOutcome:    completionCleanlinessEscalated,
+			wantResolution: completionCleanlinessIntentionallyLeft,
+			wantRejected:   2,
+			wantBlock:      true,
+			withoutLane:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attempts := &implementProgressAttemptStore{history: tt.history, historyErr: tt.historyErr}
+			orch := &Orchestrator{
+				cfg:          normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}}),
+				workAttempts: attempts,
+			}
+			issue := tt.issue
+			issue.ID = "issue-2147"
+			issue.Identifier = "digitaldrywood/detent#2147"
+			completionLane := "In Progress"
+			if tt.withoutLane {
+				completionLane = ""
+			}
+			decision := orch.evaluateCompletionCleanliness(t.Context(), Running{
+				Issue:          issue,
+				Mode:           runpkg.RunModeImplement,
+				WorkAttemptID:  2147,
+				Generation:     7,
+				CompletionLane: completionLane,
+			}, issue, tt.evidence)
+
+			if !decision.Attempted || decision.Outcome != tt.wantOutcome || decision.Resolution != tt.wantResolution || decision.ConsecutiveRejections != tt.wantRejected || decision.Block != tt.wantBlock {
+				t.Fatalf("evaluateCompletionCleanliness() = %#v", decision)
+			}
+			if (decision.Warning != "") != tt.wantWarning {
+				t.Fatalf("evaluateCompletionCleanliness().Warning = %q", decision.Warning)
+			}
+			metadata := completionCleanlinessMetadata(decision)
+			persisted := store.WorkAttempt{WorkerMetadataJSON: marshalWorkAttemptJSON(metadata)}
+			record, ok := completionCleanlinessRecordFromAttempt(persisted)
+			if !ok || record.Outcome != tt.wantOutcome || record.Resolution != tt.wantResolution || record.ConsecutiveRejections != tt.wantRejected {
+				t.Fatalf("persisted completion cleanliness = %#v, ok=%t", record, ok)
+			}
+			if tt.wantResolution == completionCleanlinessCommitted || tt.wantResolution == completionCleanlinessDiscarded {
+				if record.Declaration != tt.wantResolution {
+					t.Fatalf("persisted declaration = %q, want %q", record.Declaration, tt.wantResolution)
+				}
+			}
+			if len(tt.evidence.UntrackedPaths) > 0 && len(record.Evidence.UntrackedPaths) == 0 {
+				t.Fatalf("persisted evidence = %#v, want untracked paths", record.Evidence)
+			}
+		})
+	}
+}
+
+func TestHandleRunResultRejectsDirtyCompletionAndEscalates(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	previousRejected := store.WorkAttempt{
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			completionCleanlinessMetadataKey: completionCleanlinessRecord{Outcome: completionCleanlinessRejected},
+		}),
+	}
+	tests := []struct {
+		name         string
+		history      []store.WorkAttempt
+		wantTerminal store.WorkAttemptTerminalState
+		wantRetry    bool
+		wantBlocked  bool
+		intentional  bool
+	}{
+		{name: "first rejection returns to agent", wantTerminal: store.WorkAttemptTerminalSuccess, wantRetry: true},
+		{name: "second rejection parks", history: []store.WorkAttempt{previousRejected}, wantTerminal: store.WorkAttemptTerminalNoProgress, wantBlocked: true},
+		{name: "intentional remainder parks", history: []store.WorkAttempt{previousRejected}, wantTerminal: store.WorkAttemptTerminalNoProgress, wantBlocked: true, intentional: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := connector.Issue{ID: "issue-2147", Identifier: "digitaldrywood/detent#2147", State: "In Progress"}
+			completionLane := "In Progress"
+			if tt.intentional {
+				completionLane = ""
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\nblockers: []\nhuman_action: preserve debug.log for operator inspection\n```",
+				}}
+			}
+			tracker := &implementProgressConnector{refreshed: issue}
+			attempts := &implementProgressAttemptStore{history: tt.history}
+			cfg := normalizeConfig(Config{
+				Project:                scheduler.ProjectCandidate{ID: "detent"},
+				ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates:         []string{"Blocked"},
+				TerminalStates:         []string{"Done", "Cancelled"},
+				ContinuationRetryDelay: time.Minute,
+			})
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: attempts,
+				logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{
+				Issue:          issue,
+				Attempt:        1,
+				WorkAttemptID:  2147,
+				Generation:     7,
+				Mode:           runpkg.RunModeImplement,
+				CompletionLane: completionLane,
+				StartedAt:      base.Add(-time.Minute),
+			}
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: base.Add(-time.Minute)}
+			diff := DiffStats{
+				FilesChanged:   2,
+				AddedLines:     9,
+				RemovedLines:   3,
+				TrackedPaths:   []string{"internal/worker.go"},
+				UntrackedPaths: []string{"debug.log"},
+				Fingerprint:    "dirty-fingerprint",
+				Status:         "changed",
+			}
+
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID:     issue.ID,
+				CompletedAt: base,
+				Request:     runpkg.RunRequest{Issue: issue, Mode: runpkg.RunModeImplement, WorkAttemptID: 2147, Generation: 7},
+				Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, DiffStats: diff},
+			})
+
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != tt.wantTerminal {
+				t.Fatalf("work attempt completions = %#v, want %q", attempts.completions, tt.wantTerminal)
+			}
+			var metadata struct {
+				CompletionCleanliness completionCleanlinessRecord `json:"completion_cleanliness"`
+			}
+			if err := json.Unmarshal([]byte(attempts.completions[0].WorkerMetadataJSON), &metadata); err != nil {
+				t.Fatalf("decode work attempt metadata: %v", err)
+			}
+			if metadata.CompletionCleanliness.Outcome == "" || len(metadata.CompletionCleanliness.Evidence.UntrackedPaths) != 1 {
+				t.Fatalf("completion cleanliness metadata = %#v", metadata.CompletionCleanliness)
+			}
+			_, retrying := state.Retry[issue.ID]
+			_, blocked := state.Blocked[issue.ID]
+			if retrying != tt.wantRetry || blocked != tt.wantBlocked {
+				t.Fatalf("state = retry %t blocked %t, want retry %t blocked %t", retrying, blocked, tt.wantRetry, tt.wantBlocked)
+			}
+			if len(tracker.comments) == 0 {
+				t.Fatal("expected a completion rejection or escalation comment")
+			}
+			comment := tracker.comments[len(tracker.comments)-1].body
+			for _, want := range []string{"2 files, +9/-3", "internal/worker.go", "debug.log"} {
+				if !strings.Contains(comment, want) {
+					t.Fatalf("comment missing %q:\n%s", want, comment)
+				}
+			}
+			if !tt.intentional {
+				for _, want := range []string{"completion_cleanliness_resolution", "committed", "discarded", "under `fields:`"} {
+					if !strings.Contains(comment, want) {
+						t.Fatalf("comment missing %q:\n%s", want, comment)
+					}
+				}
+			} else if !strings.Contains(comment, "preserve debug.log for operator inspection") {
+				t.Fatalf("comment missing intentional-left statement:\n%s", comment)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -330,8 +330,8 @@ func dispatchLoopWorkspaceDiffEqual(left dispatchLoopFingerprint, right dispatch
 
 func implementProgressDiffStatsPresent(diff implementProgressDiffStats) bool {
 	return diff.FilesChanged != 0 || diff.AddedLines != 0 || diff.RemovedLines != 0 ||
-		diff.UnpushedCommits != 0 || len(diff.UnpushedCommitRefs) != 0 || len(diff.TrackedPaths) != 0 ||
-		len(diff.CommitsNotInPullRequest) != 0 || diff.PullRequestComparisonAvailable || strings.TrimSpace(diff.HeadSHA) != "" ||
+		diff.UnpushedCommits != 0 || len(diff.UnpushedCommitRefs) != 0 || len(diff.TrackedPaths) != 0 || len(diff.UntrackedPaths) != 0 ||
+		len(diff.CommitsNotInPullRequest) != 0 || diff.PullRequestComparisonAvailable || diff.RecoveryStateExpected || diff.RecoveryStateAvailable || strings.TrimSpace(diff.HeadSHA) != "" ||
 		strings.TrimSpace(diff.Fingerprint) != "" || strings.TrimSpace(diff.Status) != ""
 }
 

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -114,8 +114,11 @@ type implementProgressDiffStats struct {
 	UnpushedCommits                int      `json:"unpushed_commits,omitempty"`
 	UnpushedCommitRefs             []string `json:"unpushed_commit_refs,omitempty"`
 	TrackedPaths                   []string `json:"tracked_paths,omitempty"`
+	UntrackedPaths                 []string `json:"untracked_paths,omitempty"`
 	CommitsNotInPullRequest        []string `json:"commits_not_in_pull_request,omitempty"`
 	PullRequestComparisonAvailable bool     `json:"pull_request_comparison_available,omitempty"`
+	RecoveryStateExpected          bool     `json:"recovery_state_expected,omitempty"`
+	RecoveryStateAvailable         bool     `json:"recovery_state_available,omitempty"`
 	HeadSHA                        string   `json:"head_sha,omitempty"`
 	Fingerprint                    string   `json:"fingerprint,omitempty"`
 	Status                         string   `json:"status,omitempty"`
@@ -824,8 +827,11 @@ func implementProgressDiffStatsFromDiffStats(diffStats DiffStats) implementProgr
 		UnpushedCommits:                diffStats.UnpushedCommits,
 		UnpushedCommitRefs:             append([]string(nil), diffStats.UnpushedCommitRefs...),
 		TrackedPaths:                   append([]string(nil), diffStats.TrackedPaths...),
+		UntrackedPaths:                 append([]string(nil), diffStats.UntrackedPaths...),
 		CommitsNotInPullRequest:        append([]string(nil), diffStats.CommitsNotInPullRequest...),
 		PullRequestComparisonAvailable: diffStats.PullRequestComparisonAvailable,
+		RecoveryStateExpected:          diffStats.RecoveryStateExpected,
+		RecoveryStateAvailable:         diffStats.RecoveryStateAvailable,
 		HeadSHA:                        strings.TrimSpace(diffStats.HeadSHA),
 		Fingerprint:                    strings.TrimSpace(diffStats.Fingerprint),
 		Status:                         strings.TrimSpace(diffStats.Status),
@@ -833,7 +839,7 @@ func implementProgressDiffStatsFromDiffStats(diffStats DiffStats) implementProgr
 }
 
 func implementProgressRecordedStrandedEvidence(diffStats implementProgressDiffStats) bool {
-	return diffStats.UnpushedCommits > 0 || len(diffStats.TrackedPaths) > 0 || len(diffStats.CommitsNotInPullRequest) > 0
+	return diffStats.UnpushedCommits > 0 || len(diffStats.TrackedPaths) > 0 || len(diffStats.UntrackedPaths) > 0 || len(diffStats.CommitsNotInPullRequest) > 0
 }
 
 func implementProgressSignatureUsable(signature autoPromoteReworkSignature) bool {
@@ -858,6 +864,7 @@ func implementProgressOperationalWorkspaceClean(diffStats DiffStats) bool {
 		diffStats.UnpushedCommits == 0 &&
 		diffStats.CommitsAhead == 0 &&
 		len(diffStats.TrackedPaths) == 0 &&
+		len(diffStats.UntrackedPaths) == 0 &&
 		len(diffStats.CommitsNotInPullRequest) == 0
 }
 
@@ -875,7 +882,7 @@ func implementProgressReconcilePullRequestEvidence(diffStats DiffStats, pullRequ
 
 func implementProgressUnpushedClassification(diffStats DiffStats, pullRequest *connector.PullRequest) (bool, string) {
 	if pullRequest != nil {
-		if len(diffStats.TrackedPaths) > 0 {
+		if len(diffStats.TrackedPaths) > 0 || len(diffStats.UntrackedPaths) > 0 {
 			return true, ""
 		}
 		if diffStats.PullRequestComparisonAvailable {
@@ -1188,11 +1195,12 @@ func implementProgressBlockComment(issue connector.Issue, decision implementComp
 }
 
 func implementProgressStrandedEvidence(diffStats DiffStats) bool {
-	return diffStats.UnpushedCommits > 0 || len(diffStats.TrackedPaths) > 0 || len(diffStats.CommitsNotInPullRequest) > 0
+	return diffStats.UnpushedCommits > 0 || len(diffStats.TrackedPaths) > 0 || len(diffStats.UntrackedPaths) > 0 || len(diffStats.CommitsNotInPullRequest) > 0
 }
 
 func appendStrandedWorkEvidence(b *strings.Builder, diffStats DiffStats) {
 	appendQuotedEvidence(b, "tracked_paths", diffStats.TrackedPaths)
+	appendQuotedEvidence(b, "untracked_paths", diffStats.UntrackedPaths)
 	appendQuotedEvidence(b, "commits_not_in_pull_request", diffStats.CommitsNotInPullRequest)
 	if len(diffStats.CommitsNotInPullRequest) == 0 {
 		appendQuotedEvidence(b, "unpushed_commit_refs", diffStats.UnpushedCommitRefs)

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -414,6 +414,7 @@ func TestCompletionLaneHandshakeClassifiesCurrentAttempt(t *testing.T) {
 					PullRequestUpdated:    !tt.wantRevoked,
 					PullRequestHeadPushed: !tt.wantRevoked,
 					TurnStarted:           true,
+					DiffStats:             runpkg.DiffStats{Status: "clean", RecoveryStateExpected: true, RecoveryStateAvailable: true},
 				},
 			}
 			if tt.wantRevoked {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -600,7 +600,13 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	progress = o.evaluateDispatchLoopProgress(ctx, running, progress)
 	progress, gateWaitReason := completedReworkGateWaitProgress(running, progress, o.cfg, finalState)
 	running.Issue = progress.Issue
-	if terminalState == store.WorkAttemptTerminalSuccess && implementCompletionHasDurableProgress(running, progress) {
+	completionEvidence := progress.WorkspaceDiffStats
+	if !diffStatsPresent(completionEvidence) {
+		completionEvidence = running.DiffStats
+	}
+	completionCleanliness := o.evaluateCompletionCleanliness(ctx, running, running.Issue, completionEvidence)
+	completionRejected := completionCleanliness.Attempted && completionCleanliness.Outcome != completionCleanlinessAccepted
+	if terminalState == store.WorkAttemptTerminalSuccess && !completionRejected && implementCompletionHasDurableProgress(running, progress) {
 		resetWorkerFailureBreakers(state, event.IssueID)
 	}
 	if event.Result.PullRequestHeadPushed && !event.Result.CITriggerLabelReapplied {
@@ -622,6 +628,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		running.Issue, evidenceWarning = o.refreshSpendProgressIssue(ctx, running.Issue)
 	}
 	accepted, acceptedReason := implementAcceptedStateChange(running, progress)
+	if completionRejected {
+		accepted = false
+		acceptedReason = ""
+	}
 	spendProgress := o.evaluateSpendProgress(ctx, running, event.CompletedAt, accepted, acceptedReason)
 	if evidenceWarning != "" {
 		spendProgress.Warning = evidenceWarning
@@ -662,9 +672,21 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		phase = "blocked"
 		statusMessage = "artifact gate convergence breaker tripped"
 	}
+	if completionRejected {
+		phase = "completion_rejected"
+		statusMessage = "completion rejected because workspace is not clean"
+	}
+	if completionCleanliness.Block {
+		terminalState = store.WorkAttemptTerminalNoProgress
+		phase = "blocked"
+		statusMessage = "dirty completion requires human resolution"
+		errorClass = dirtyCompletionEscalationReason
+		errorMessage = dirtyCompletionEscalationReason
+	}
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, terminalState, nil, errorClass, errorMessage)
 	attemptCompleted := o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(
 		implementCompletionProgressMetadata(progress),
+		completionCleanlinessMetadata(completionCleanliness),
 		spendProgressMetadata(spendProgress),
 		artifactGateConvergenceMetadata(artifactConvergence),
 		deliverableCommandEvidenceMetadata(event.Result),
@@ -698,6 +720,32 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	if artifactConvergence.Tripped {
 		o.parkArtifactGateConvergence(ctx, state, running.Issue, running.Attempt, event.CompletedAt, artifactConvergence)
+		return
+	}
+	if completionCleanliness.Block {
+		if attemptCompleted && o.blockCompletionCleanliness(ctx, state, event, running, completionCleanliness) {
+			return
+		}
+		if !attemptCompleted {
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      event.CompletedAt,
+				Event:   "dirty_completion_persist_failed",
+				Message: "retained claim for " + issueLabel(running.Issue) + " after dirty completion persistence failed",
+			})
+			return
+		}
+	}
+	if completionRejected {
+		if !attemptCompleted {
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      event.CompletedAt,
+				Event:   "dirty_completion_persist_failed",
+				Message: "retained claim for " + issueLabel(running.Issue) + " after dirty completion persistence failed",
+			})
+			return
+		}
+		o.commentCompletionCleanlinessRejection(ctx, running.Issue, completionCleanliness)
+		o.scheduleContinuationRetry(ctx, state, running.Issue, 1, event.CompletedAt, dirtyCompletionReason, running.WorkerHost)
 		return
 	}
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -1063,8 +1063,11 @@ func diffStatsPresent(diffStats DiffStats) bool {
 		diffStats.UnpushedCommits != 0 ||
 		len(diffStats.UnpushedCommitRefs) != 0 ||
 		len(diffStats.TrackedPaths) != 0 ||
+		len(diffStats.UntrackedPaths) != 0 ||
 		len(diffStats.CommitsNotInPullRequest) != 0 ||
 		diffStats.PullRequestComparisonAvailable ||
+		diffStats.RecoveryStateExpected ||
+		diffStats.RecoveryStateAvailable ||
 		diffStats.CommitsAhead != 0 ||
 		diffStats.RemoteBranchExists ||
 		diffStats.DeliveryStateChecked ||

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1907,6 +1907,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	result.DiffStats = diffStatsFromWorkspace(diffStat)
 	if mode == RunModeImplement {
+		_, result.DiffStats.RecoveryStateExpected = runWorkspace.(workspace.RecoveryStateProvider)
 		if recoveryState := r.workspaceRecoveryState(runWorkspace, ctx, info, workspaceIssue, "final"); recoveryState != nil {
 			applyRecoveryState(&result.DiffStats, recoveryState)
 		}
@@ -4928,8 +4929,10 @@ func applyRecoveryState(diffStats *DiffStats, state *workspace.RecoveryState) {
 	diffStats.UnpushedCommits = state.UnpushedCommits
 	diffStats.UnpushedCommitRefs = append([]string(nil), state.UnpushedCommitRefs...)
 	diffStats.TrackedPaths = append([]string(nil), state.TrackedPaths...)
+	diffStats.UntrackedPaths = append([]string(nil), state.UntrackedPaths...)
 	diffStats.CommitsNotInPullRequest = append([]string(nil), state.CommitsNotInPullRequest...)
 	diffStats.PullRequestComparisonAvailable = state.PullRequestComparisonAvailable
+	diffStats.RecoveryStateAvailable = true
 	diffStats.HeadSHA = strings.TrimSpace(state.HeadSHA)
 }
 
@@ -4940,8 +4943,11 @@ func diffStatsEmpty(diffStats DiffStats) bool {
 		diffStats.UnpushedCommits == 0 &&
 		len(diffStats.UnpushedCommitRefs) == 0 &&
 		len(diffStats.TrackedPaths) == 0 &&
+		len(diffStats.UntrackedPaths) == 0 &&
 		len(diffStats.CommitsNotInPullRequest) == 0 &&
 		!diffStats.PullRequestComparisonAvailable &&
+		!diffStats.RecoveryStateExpected &&
+		!diffStats.RecoveryStateAvailable &&
 		diffStats.CommitsAhead == 0 &&
 		!diffStats.RemoteBranchExists &&
 		!diffStats.DeliveryStateChecked &&

--- a/internal/runner/blocked_recovery.go
+++ b/internal/runner/blocked_recovery.go
@@ -52,6 +52,7 @@ func (r *Runner) BlockedRecoverySnapshot(ctx context.Context, req RunRequest) Bl
 	snapshot.UnpushedCommits = recovery.UnpushedCommits
 	snapshot.UnpushedCommitRefs = append([]string(nil), recovery.UnpushedCommitRefs...)
 	snapshot.TrackedPaths = append([]string(nil), recovery.TrackedPaths...)
+	snapshot.UntrackedPaths = append([]string(nil), recovery.UntrackedPaths...)
 	snapshot.CommitsNotInPullRequest = append([]string(nil), recovery.CommitsNotInPullRequest...)
 	snapshot.PullRequestComparisonAvailable = recovery.PullRequestComparisonAvailable
 	snapshot.WorkspaceFingerprint = strings.TrimSpace(recovery.WorkspaceFingerprint)

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -193,7 +193,7 @@ func BuildAdmissionPrompt(issue connector.Issue, request AdmissionRequest, opts 
 }
 
 func appendWorkspaceRecoveryBlock(prompt string, state *workspace.RecoveryState) string {
-	if state == nil || (state.UnpushedCommits == 0 && state.DiffStat == (workspace.DiffStat{})) {
+	if state == nil || (state.UnpushedCommits == 0 && state.DiffStat == (workspace.DiffStat{}) && len(state.TrackedPaths) == 0 && len(state.UntrackedPaths) == 0) {
 		return prompt
 	}
 
@@ -205,15 +205,35 @@ func appendWorkspaceRecoveryBlock(prompt string, state *workspace.RecoveryState)
 		b.WriteString(strconv.Itoa(state.UnpushedCommits))
 	}
 	if state.DiffStat != (workspace.DiffStat{}) {
-		b.WriteString("\n- uncommitted changes: ")
+		b.WriteString("\n- diffstat: ")
 		b.WriteString(strconv.Itoa(state.DiffStat.Files))
 		b.WriteString(" files, +")
 		b.WriteString(strconv.Itoa(state.DiffStat.Added))
 		b.WriteString("/-")
 		b.WriteString(strconv.Itoa(state.DiffStat.Removed))
 	}
-	b.WriteString("\n\nInspect, validate and preserve the existing work. Finish any remaining changes, run the required validation gate, then push the branch and open or update the pull request. Do not claim completion while commits or substantive changes remain only in the local workspace.")
+	appendWorkspaceRecoveryPaths(&b, "tracked paths", state.TrackedPaths)
+	appendWorkspaceRecoveryPaths(&b, "untracked paths", state.UntrackedPaths)
+	appendWorkspaceRecoveryPaths(&b, "unpushed commits", state.UnpushedCommitRefs)
+	b.WriteString("\n\nA prior completion cannot be accepted until you explicitly resolve this state. Inspect every path and choose the correct outcome: commit and publish work that belongs to the issue, discard stray artifacts or mistakes, or update the Workpad to `status: blocked` and state why the files are intentionally left. For a clean retry, add `completion_cleanliness_resolution: committed` or `completion_cleanliness_resolution: discarded` under `fields:` in the current completion block. Do not repeat `status: complete` while the worktree remains dirty. After resolving it, run the required validation gate and update the pull request.")
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + b.String()
+}
+
+func appendWorkspaceRecoveryPaths(b *strings.Builder, label string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	b.WriteString("\n- ")
+	b.WriteString(label)
+	b.WriteString(": ")
+	for index, value := range values {
+		if index > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("`")
+		b.WriteString(strings.TrimSpace(value))
+		b.WriteString("`")
+	}
 }
 
 func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOptions) (string, error) {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -1021,6 +1021,11 @@ func TestBuildPromptIncludesStrandedWorkspaceRecovery(t *testing.T) {
 		RecoveryState: &workspace.RecoveryState{
 			UnpushedCommits: 1,
 			DiffStat:        workspace.DiffStat{Files: 4, Added: 12, Removed: 3},
+			TrackedPaths:    []string{"internal/worker.go"},
+			UntrackedPaths:  []string{"worker.log"},
+			UnpushedCommitRefs: []string{
+				"abc123 fix: preserve work",
+			},
 		},
 	})
 	if err != nil {
@@ -1029,9 +1034,18 @@ func TestBuildPromptIncludesStrandedWorkspaceRecovery(t *testing.T) {
 	for _, want := range []string{
 		"## Existing workspace recovery",
 		"unpushed commits: 1",
-		"uncommitted changes: 4 files, +12/-3",
-		"validate and preserve the existing work",
-		"push the branch and open or update the pull request",
+		"diffstat: 4 files, +12/-3",
+		"tracked paths: `internal/worker.go`",
+		"untracked paths: `worker.log`",
+		"`abc123 fix: preserve work`",
+		"completion cannot be accepted",
+		"commit and publish",
+		"discard stray artifacts",
+		"completion_cleanliness_resolution: committed",
+		"completion_cleanliness_resolution: discarded",
+		"under `fields:`",
+		"`status: blocked`",
+		"Do not repeat `status: complete`",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -338,7 +338,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if usageUpdates[3].DiffStats.FilesChanged != 2 || usageUpdates[3].DiffStats.AddedLines != 5 || usageUpdates[3].DiffStats.RemovedLines != 1 {
 		t.Fatalf("fourth usage update DiffStats = %#v, want refreshed diff", usageUpdates[3].DiffStats)
 	}
-	if result.DiffStats.FilesChanged != 2 || result.DiffStats.AddedLines != 5 || result.DiffStats.RemovedLines != 1 || result.DiffStats.HeadSHA != "final-head" || result.DiffStats.Fingerprint != "final-diff" {
+	if result.DiffStats.FilesChanged != 2 || result.DiffStats.AddedLines != 5 || result.DiffStats.RemovedLines != 1 || result.DiffStats.HeadSHA != "final-head" || result.DiffStats.Fingerprint != "final-diff" || !result.DiffStats.RecoveryStateExpected || !result.DiffStats.RecoveryStateAvailable {
 		t.Fatalf("DiffStats = %#v, want 2 files, 5 added, 1 removed, final head, and final fingerprint", result.DiffStats)
 	}
 	if result.RateLimits == nil || result.RateLimits.LimitID != "codex-primary" {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -244,6 +244,7 @@ type BlockedRecoverySnapshot struct {
 	UnpushedCommits                int
 	UnpushedCommitRefs             []string
 	TrackedPaths                   []string
+	UntrackedPaths                 []string
 	CommitsNotInPullRequest        []string
 	PullRequestComparisonAvailable bool
 	Health                         string
@@ -797,8 +798,11 @@ type DiffStats struct {
 	UnpushedCommits                int
 	UnpushedCommitRefs             []string
 	TrackedPaths                   []string
+	UntrackedPaths                 []string
 	CommitsNotInPullRequest        []string
 	PullRequestComparisonAvailable bool
+	RecoveryStateExpected          bool
+	RecoveryStateAvailable         bool
 	CommitsAhead                   int
 	RemoteBranchExists             bool
 	DeliveryStateChecked           bool

--- a/internal/workpad/workpad.go
+++ b/internal/workpad/workpad.go
@@ -25,11 +25,12 @@ const (
 	StatusBlocked    = "blocked"
 	StatusComplete   = "complete"
 
-	FieldCompletionKind       = "completion_kind"
-	FieldCompletionEvidence   = "completion_evidence"
-	FieldCompletionAttempt    = "completion_work_attempt_id"
-	FieldCompletionGeneration = "completion_generation"
-	CompletionOperational     = "operational"
+	FieldCompletionKind                  = "completion_kind"
+	FieldCompletionEvidence              = "completion_evidence"
+	FieldCompletionAttempt               = "completion_work_attempt_id"
+	FieldCompletionGeneration            = "completion_generation"
+	FieldCompletionCleanlinessResolution = "completion_cleanliness_resolution"
+	CompletionOperational                = "operational"
 
 	BlockerOwnerOrchestrator = "orchestrator"
 	BlockerOwnerHuman        = "human"

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -72,6 +72,10 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 	if err != nil {
 		return RecoveryState{}, err
 	}
+	untrackedPaths, err := gitUntrackedPaths(ctx, normalized.Path)
+	if err != nil {
+		return RecoveryState{}, err
+	}
 	head, err := runGitAt(ctx, normalized.Path, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return RecoveryState{}, fmt.Errorf("git resolve recovery head: %w", err)
@@ -94,6 +98,7 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 		UnpushedCommits:                unpushedCommits,
 		UnpushedCommitRefs:             unpushedCommitRefs,
 		TrackedPaths:                   trackedPaths,
+		UntrackedPaths:                 untrackedPaths,
 		CommitsNotInPullRequest:        commitsNotInPullRequest,
 		PullRequestComparisonAvailable: comparisonAvailable,
 	}, nil
@@ -246,6 +251,14 @@ func gitTrackedPaths(ctx context.Context, workspacePath string) ([]string, error
 	output, err := runGitAt(ctx, workspacePath, "diff", "--name-only", "--no-ext-diff", "-z", "HEAD", "--")
 	if err != nil {
 		return nil, fmt.Errorf("git list tracked workspace changes: %w", err)
+	}
+	return boundedNULFields(output, recoveryEvidenceLimit, false), nil
+}
+
+func gitUntrackedPaths(ctx context.Context, workspacePath string) ([]string, error) {
+	output, err := runGitAt(ctx, workspacePath, "ls-files", "--others", "--exclude-standard", "-z", "--")
+	if err != nil {
+		return nil, fmt.Errorf("git list untracked workspace changes: %w", err)
 	}
 	return boundedNULFields(output, recoveryEvidenceLimit, false), nil
 }

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -241,7 +242,7 @@ func TestLocalGitRecoveryStateDetectsStrandedWork(t *testing.T) {
 	}
 }
 
-func TestLocalGitRecoveryStateExcludesUntrackedPathsFromStrandedEvidence(t *testing.T) {
+func TestLocalGitRecoveryStateReportsUntrackedPaths(t *testing.T) {
 	t.Parallel()
 
 	source := initSourceRepo(t)
@@ -272,8 +273,8 @@ func TestLocalGitRecoveryStateExcludesUntrackedPathsFromStrandedEvidence(t *test
 	if got.DiffStat.Files != 1 || got.UnpushedCommits != 0 {
 		t.Fatalf("RecoveryState() = %+v, want one aggregate diff file and no unpushed commits", got)
 	}
-	if len(got.TrackedPaths) != 0 || len(got.CommitsNotInPullRequest) != 0 || !got.PullRequestComparisonAvailable {
-		t.Fatalf("RecoveryState() stranded evidence = tracked %v commits %v available=%t, want no evidence and available comparison", got.TrackedPaths, got.CommitsNotInPullRequest, got.PullRequestComparisonAvailable)
+	if len(got.TrackedPaths) != 0 || !slices.Equal(got.UntrackedPaths, []string{"session-marker.ses"}) || len(got.CommitsNotInPullRequest) != 0 || !got.PullRequestComparisonAvailable {
+		t.Fatalf("RecoveryState() evidence = tracked %v untracked %v commits %v available=%t", got.TrackedPaths, got.UntrackedPaths, got.CommitsNotInPullRequest, got.PullRequestComparisonAvailable)
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -118,6 +118,7 @@ type RecoveryState struct {
 	UnpushedCommits                int
 	UnpushedCommitRefs             []string
 	TrackedPaths                   []string
+	UntrackedPaths                 []string
 	CommitsNotInPullRequest        []string
 	PullRequestComparisonAvailable bool
 }


### PR DESCRIPTION
## Summary

- reject current-attempt completion handshakes when the authoritative final Git snapshot is dirty or unavailable
- report tracked and untracked paths, diffstat, and unpublished commit evidence, and persist the decision under work-attempt metadata
- require an explicit committed, discarded, or intentional-left resolution and park repeated unresolved attempts instead of redispatching indefinitely

Fixes #2147

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check` with the repository-pinned Go 1.26.6 and golangci-lint 2.9.0 toolchain
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] `go test ./internal/workspace ./internal/runner ./internal/workpad ./internal/orchestrator -count=1`