### PR TITLE
fix(github): isolate REST fanout deferrals

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -263,7 +263,11 @@ Detent persists a last-known board snapshot beside the runtime database every
 tracker hydration completes. `server.board_snapshot_stale_after_seconds`
 controls the maximum cache age; older snapshots are ignored.
 
-Set `github_rest_fanout_max_requests` to `0` to disable the per-cycle fanout cap while retaining the REST remaining-reserve guard.
+`github_rest_fanout_max_requests` caps each bounded REST operation independently,
+so dependency hydration cannot consume the capacity reserved for scheduled
+admission reconciliation. Reaching the cap defers that operation locally and
+does not report a GitHub rate-limit response. Set it to `0` to disable fanout
+caps while retaining the REST remaining-reserve guard.
 
 Tag-based projects can opt into release cadence in the same workflow file:
 

--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -293,6 +293,15 @@ the run ledger instead of making the bounded result look complete. A run defers
 instead of queueing when project or fleet capacity is unavailable or its agent
 would exceed the configured daily budget.
 
+GitHub REST fanout is budgeted independently for proposal reconciliation,
+candidate discovery, and evaluation. If one of those local budgets is
+exhausted, the scheduled occurrence checkpoints its completed proposal and
+state transitions, records a retry time, and resumes the same occurrence after
+backoff. Restarting Detent preserves that retry; already-admitted proposals are
+not admitted or commented twice. This local deferral remains distinct from a
+provider rate-limit response and from the configured REST reserve floor in
+health telemetry and logs.
+
 Before an admission agent runs, Detent declines tracker, intake, study, and
 research artifacts without an explicit completion contract, plus bodies that
 are predominantly cross-issue task lists. The body marker

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -54,6 +54,7 @@ const (
 	admissionDeclineCriteriaNotMet         = "criteria_not_met"
 	admissionDispositionProposed           = "proposed"
 	admissionDispositionDeclined           = "declined"
+	admissionRESTFanoutScope               = "backlog_admission"
 	maxRationaleSize                       = 16 * 1024
 	maxEffortRationaleSize                 = 2 * 1024
 )
@@ -120,6 +121,7 @@ type Result struct {
 	Skipped         map[string]int
 	Truncated       map[string]int
 	DeferredReason  string
+	ResumeAt        time.Time
 	ProposalReason  string
 }
 
@@ -231,7 +233,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		ctx = context.Background()
 	}
 	for {
-		next, scheduled, err := m.nextScheduled(ctx)
+		attempt, scheduled, err := m.nextScheduledAttempt(ctx)
 		if err != nil {
 			m.logger.ErrorContext(ctx, "backlog admission schedule lookup failed", "error", err)
 			timer := time.NewTimer(time.Minute)
@@ -253,7 +255,7 @@ func (m *Manager) Run(ctx context.Context) error {
 				continue
 			}
 		}
-		timer := time.NewTimer(max(next.Sub(m.now()), 0))
+		timer := time.NewTimer(max(attempt.RunAt.Sub(m.now()), 0))
 		select {
 		case <-ctx.Done():
 			stopTimer(timer)
@@ -262,7 +264,7 @@ func (m *Manager) Run(ctx context.Context) error {
 			stopTimer(timer)
 			continue
 		case <-timer.C:
-			m.runAndLog(ctx, next)
+			m.runAndLog(ctx, attempt.ScheduledFor)
 		}
 	}
 }
@@ -286,18 +288,24 @@ func (m *Manager) run(ctx context.Context, scheduledFor time.Time, scheduled boo
 		return newResult(), nil
 	}
 	if scheduled {
-		schedule, err := cron.ParseStandard(settings.Config.Schedule)
+		resuming, err := m.resumingScheduledRun(ctx, settings.ProjectID, scheduledFor)
 		if err != nil {
 			return newResult(), err
 		}
-		if next := schedule.Next(baseline); !next.Equal(scheduledFor) {
-			return newResult(), nil
+		if !resuming {
+			schedule, err := cron.ParseStandard(settings.Config.Schedule)
+			if err != nil {
+				return newResult(), err
+			}
+			if next := schedule.Next(baseline); !next.Equal(scheduledFor) {
+				return newResult(), nil
+			}
 		}
 	}
 	result, err := m.runOnce(ctx, settings, scheduledFor, scheduled)
 	completedAt := m.now()
 	m.mu.Lock()
-	if completedAt.After(m.baseline) {
+	if result.ResumeAt.IsZero() && completedAt.After(m.baseline) {
 		m.baseline = completedAt
 	}
 	m.mu.Unlock()
@@ -311,6 +319,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 	result = newResult()
 	result.ProjectID = strings.TrimSpace(settings.ProjectID)
 	startedAt := m.now().UTC()
+	var cleanupErr error
 	record := admissionmodel.RunRecord{
 		ProjectID:    settings.ProjectID,
 		ScheduledFor: scheduledFor.UTC(),
@@ -318,6 +327,16 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		Outcome:      "completed",
 	}
 	defer func() {
+		localDeferred := false
+		if deferral, ok := connector.ErrorLocalDeferral(runErr); ok {
+			localDeferred = true
+			result.DeferredReason = deferral.Reason
+			if scheduled && deferral.RetryAfter > 0 {
+				result.ResumeAt = m.now().UTC().Add(deferral.RetryAfter)
+			}
+			runErr = nil
+		}
+		runErr = errors.Join(runErr, cleanupErr)
 		record.CompletedAt = m.now().UTC()
 		record.CandidatesFound = result.CandidatesFound
 		record.Candidates = result.Candidates
@@ -325,6 +344,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		record.Skipped = cloneCounts(result.Skipped)
 		record.Truncated = cloneCounts(result.Truncated)
 		record.DeferredReason = result.DeferredReason
+		record.ResumeAt = result.ResumeAt
 		record.ProposalReason = result.ProposalReason
 		record.Issues = make([]admissionmodel.IssueRecord, 0, len(result.Proposals))
 		for _, proposal := range result.Proposals {
@@ -338,8 +358,10 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		if result.DeferredReason != "" {
 			record.Outcome = "deferred"
 		}
-		if runErr != nil {
+		if runErr != nil && !localDeferred {
 			record.Outcome = "failed"
+		}
+		if runErr != nil {
 			record.Error = runErr.Error()
 		}
 		if err := m.store.RecordAdmissionRun(context.WithoutCancel(ctx), record); err != nil {
@@ -368,7 +390,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 	commentsRemaining := settings.Config.MaxProposalsPerRun
 	autoAdmitsRemaining := settings.Config.MaxProposalsPerRun
 	commentsRemaining, autoAdmitsRemaining, err = m.reconcileOpenProposals(
-		ctx,
+		connector.WithRESTFanoutBudget(ctx, admissionRESTFanoutScope+"_reconciliation"),
 		settings,
 		commentsRemaining,
 		autoAdmitsRemaining,
@@ -400,10 +422,11 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		return result, nil
 	}
 	defer func() {
-		runErr = errors.Join(runErr, release())
+		cleanupErr = release()
 	}()
 
-	candidates, readerTruncations, itemsRead, readerFiltered, err := readAdmissionCandidates(ctx, settings.Issues, settings.Config)
+	candidateCtx := connector.WithRESTFanoutBudget(ctx, admissionRESTFanoutScope+"_candidates")
+	candidates, readerTruncations, itemsRead, readerFiltered, err := readAdmissionCandidates(candidateCtx, settings.Issues, settings.Config)
 	if err != nil {
 		return result, fmt.Errorf("fetch backlog admission candidates: %w", err)
 	}
@@ -425,7 +448,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 	sortCandidates(candidates, settings)
 	var truncatedCandidates int
 	candidates, commentsRemaining, truncatedCandidates, err = m.unproposedCandidates(
-		ctx,
+		candidateCtx,
 		settings,
 		candidates,
 		result.Skipped,
@@ -495,7 +518,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 	if proposalErr != nil {
 		return result, proposalErr
 	}
-	return m.executeEvaluations(ctx, settings, candidates, evaluations, result, commentsRemaining, autoAdmitsRemaining, startedAt)
+	return m.executeEvaluations(connector.WithRESTFanoutBudget(ctx, admissionRESTFanoutScope+"_evaluation"), settings, candidates, evaluations, result, commentsRemaining, autoAdmitsRemaining, startedAt)
 }
 
 func candidateReadLimit(maxCandidates int) int {
@@ -1637,26 +1660,56 @@ func admissionRejectCommand(proposalID string) string {
 	return "/detent admission reject " + strings.TrimSpace(proposalID)
 }
 
+type scheduledAttempt struct {
+	RunAt        time.Time
+	ScheduledFor time.Time
+}
+
 func (m *Manager) nextScheduled(ctx context.Context) (time.Time, bool, error) {
+	attempt, scheduled, err := m.nextScheduledAttempt(ctx)
+	return attempt.RunAt, scheduled, err
+}
+
+func (m *Manager) nextScheduledAttempt(ctx context.Context) (scheduledAttempt, bool, error) {
 	m.mu.RLock()
 	settings := cloneSettings(m.settings)
 	baseline := m.baseline
 	m.mu.RUnlock()
 	if !settings.Config.Enabled {
-		return time.Time{}, false, nil
+		return scheduledAttempt{}, false, nil
 	}
 	latest, ok, err := m.store.LatestAdmissionRun(ctx, settings.ProjectID)
 	if err != nil {
-		return time.Time{}, false, err
+		return scheduledAttempt{}, false, err
+	}
+	if ok && resumableAdmissionRun(latest) {
+		runAt := latest.ResumeAt
+		if now := m.now(); runAt.Before(now) {
+			runAt = now
+		}
+		return scheduledAttempt{RunAt: runAt, ScheduledFor: latest.ScheduledFor}, true, nil
 	}
 	if ok && latest.CompletedAt.After(baseline) {
 		baseline = latest.CompletedAt
 	}
 	schedule, err := cron.ParseStandard(settings.Config.Schedule)
 	if err != nil {
-		return time.Time{}, false, err
+		return scheduledAttempt{}, false, err
 	}
-	return schedule.Next(baseline), true, nil
+	next := schedule.Next(baseline)
+	return scheduledAttempt{RunAt: next, ScheduledFor: next}, true, nil
+}
+
+func (m *Manager) resumingScheduledRun(ctx context.Context, projectID string, scheduledFor time.Time) (bool, error) {
+	latest, ok, err := m.store.LatestAdmissionRun(ctx, projectID)
+	if err != nil || !ok {
+		return false, err
+	}
+	return resumableAdmissionRun(latest) && latest.ScheduledFor.Equal(scheduledFor) && !m.now().Before(latest.ResumeAt), nil
+}
+
+func resumableAdmissionRun(run admissionmodel.RunRecord) bool {
+	return run.Outcome == "deferred" && run.DeferredReason == connector.LocalDeferralReasonRESTFanoutCap && !run.ResumeAt.IsZero()
 }
 
 func acquireCapacity(ctx context.Context, settings Settings, now time.Time) (func() error, bool, string, error) {
@@ -2348,6 +2401,7 @@ func (m *Manager) logScheduledCompletion(ctx context.Context, result Result) {
 		"truncated", len(result.Truncated) > 0,
 		"truncations", result.Truncated,
 		"deferred_reason", result.DeferredReason,
+		"resume_at", result.ResumeAt,
 		"proposal_reason", result.ProposalReason,
 	)
 }

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -327,9 +327,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		Outcome:      "completed",
 	}
 	defer func() {
-		localDeferred := false
 		if deferral, ok := connector.ErrorLocalDeferral(runErr); ok {
-			localDeferred = true
 			result.DeferredReason = deferral.Reason
 			if scheduled && deferral.RetryAfter > 0 {
 				result.ResumeAt = m.now().UTC().Add(deferral.RetryAfter)
@@ -337,6 +335,10 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 			runErr = nil
 		}
 		runErr = errors.Join(runErr, cleanupErr)
+		if cleanupErr != nil {
+			result.DeferredReason = ""
+			result.ResumeAt = time.Time{}
+		}
 		record.CompletedAt = m.now().UTC()
 		record.CandidatesFound = result.CandidatesFound
 		record.Candidates = result.Candidates
@@ -358,7 +360,7 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, scheduledFor t
 		if result.DeferredReason != "" {
 			record.Outcome = "deferred"
 		}
-		if runErr != nil && !localDeferred {
+		if runErr != nil {
 			record.Outcome = "failed"
 		}
 		if runErr != nil {
@@ -1199,11 +1201,7 @@ func (m *Manager) executeEvaluations(
 	if len(evaluations) != len(candidates) {
 		return result, fmt.Errorf("%w: got %d evaluations for %d candidates", ErrInvalidOutput, len(evaluations), len(candidates))
 	}
-	ids := make([]string, 0, len(candidates))
 	candidateByID := issueMap(candidates)
-	for _, candidate := range candidates {
-		ids = append(ids, candidate.ID)
-	}
 	evaluationByID := make(map[string]AgentEvaluation, len(evaluations))
 	for _, evaluation := range evaluations {
 		issueID := strings.TrimSpace(evaluation.IssueID)
@@ -1246,44 +1244,66 @@ func (m *Manager) executeEvaluations(
 		}
 		evaluationByID[issueID] = evaluation
 	}
-	fresh, err := settings.Issues.FetchIssueStatesByIDs(ctx, ids)
+	open, err := m.store.CountOpenAdmissionProposals(ctx, settings.ProjectID)
 	if err != nil {
-		return result, fmt.Errorf("revalidate backlog admission candidates: %w", err)
+		return result, err
 	}
-	type evaluationPlan struct {
-		issue          connector.Issue
-		stale          bool
-		classification *admissionDeclineClassification
-		proposal       *admissionmodel.Proposal
-	}
-	freshByID := issueMap(fresh)
-	plans := make([]evaluationPlan, 0, len(candidates))
-	proposalCount := 0
 	for _, original := range candidates {
 		issueID := strings.TrimSpace(original.ID)
 		evaluation := evaluationByID[issueID]
-		current, currentFound := freshByID[issueID]
+		fresh, err := settings.Issues.FetchIssueStatesByIDs(ctx, []string{issueID})
+		if err != nil {
+			return result, fmt.Errorf("revalidate backlog admission candidate %s: %w", original.Identifier, err)
+		}
+		current, currentFound := issueMap(fresh)[issueID]
 		if !currentFound || issueFingerprint(original) != issueFingerprint(current) ||
 			!eligibleCandidate(current, settings.Config, settings.TerminalStates) {
-			plans = append(plans, evaluationPlan{issue: original, stale: true})
+			result.Skipped["stale_or_ineligible"]++
 			continue
 		}
-		if classification, declined := classifyNonDeliverable(current); declined {
-			plans = append(plans, evaluationPlan{issue: current, classification: &classification})
-			continue
-		}
-		if evaluation.Disposition == admissionDispositionDeclined {
+		var classification *admissionDeclineClassification
+		if declineClassification, declined := classifyNonDeliverable(current); declined {
+			classification = &declineClassification
+		} else if evaluation.Disposition == admissionDispositionDeclined {
 			failed := evaluation.Findings[0]
 			confidence := *evaluation.Confidence
-			classification := admissionDeclineClassification{
+			declineClassification := admissionDeclineClassification{
 				reason:          admissionDeclineCriteriaNotMet,
 				detail:          failed.Rationale,
 				confidence:      &confidence,
 				failedDimension: failed.Dimension,
 				failedCriterion: failed.CriterionQuote,
 			}
-			plans = append(plans, evaluationPlan{issue: current, classification: &classification})
+			classification = &declineClassification
+		}
+		if classification != nil {
+			decline, created, err := m.createAdmissionDecline(ctx, settings, current, *classification, at)
+			if err != nil {
+				return result, err
+			}
+			if classification.reason == admissionDeclineCriteriaNotMet {
+				result.Skipped[admissionDeclineCriteriaNotMet]++
+				continue
+			}
+			commented, err := m.ensureAdmissionDeclineComment(
+				ctx,
+				settings.Issues,
+				current,
+				decline,
+				created,
+				commentsRemaining > 0,
+			)
+			if err != nil {
+				return result, err
+			}
+			if commented {
+				commentsRemaining--
+			}
+			result.Skipped["non_deliverable"]++
 			continue
+		}
+		if open >= settings.Config.MaxOpenProposals {
+			return result, errors.New("backlog admission proposal capacity changed during evaluation")
 		}
 		proposal := admissionmodel.Proposal{
 			ID:                proposalID(settings.ProjectID, current.ID, issueFingerprint(current), at),
@@ -1303,48 +1323,6 @@ func (m *Manager) executeEvaluations(
 			CreatedAt:         at,
 			ExpiresAt:         at.AddDate(0, 0, settings.Config.ProposalExpiryDays),
 		}
-		plans = append(plans, evaluationPlan{issue: current, proposal: &proposal})
-		proposalCount++
-	}
-	open, err := m.store.CountOpenAdmissionProposals(ctx, settings.ProjectID)
-	if err != nil {
-		return result, err
-	}
-	if open+proposalCount > settings.Config.MaxOpenProposals {
-		return result, errors.New("backlog admission proposal capacity changed during evaluation")
-	}
-	for _, plan := range plans {
-		if plan.stale {
-			result.Skipped["stale_or_ineligible"]++
-			continue
-		}
-		if plan.classification != nil {
-			decline, created, err := m.createAdmissionDecline(ctx, settings, plan.issue, *plan.classification, at)
-			if err != nil {
-				return result, err
-			}
-			if plan.classification.reason == admissionDeclineCriteriaNotMet {
-				result.Skipped[admissionDeclineCriteriaNotMet]++
-				continue
-			}
-			commented, err := m.ensureAdmissionDeclineComment(
-				ctx,
-				settings.Issues,
-				plan.issue,
-				decline,
-				created,
-				commentsRemaining > 0,
-			)
-			if err != nil {
-				return result, err
-			}
-			if commented {
-				commentsRemaining--
-			}
-			result.Skipped["non_deliverable"]++
-			continue
-		}
-		proposal := *plan.proposal
 		created, err := m.store.CreateAdmissionProposal(ctx, proposal)
 		if err != nil {
 			return result, err
@@ -1353,18 +1331,19 @@ func (m *Manager) executeEvaluations(
 			result.Skipped["unchanged_open_proposal"]++
 			continue
 		}
+		open++
 		result.Proposals = append(result.Proposals, proposal)
 		if commentsRemaining > 0 {
-			if err := m.commentProposal(ctx, settings, proposal, plan.issue); err != nil {
+			if err := m.commentProposal(ctx, settings, proposal, current); err != nil {
 				return result, err
 			}
 			commentsRemaining--
 		}
-		if autoAdmitsRemaining > 0 && autoAdmitProposal(settings.Config, settings.Criteria, proposal, plan.issue.Labels) {
+		if autoAdmitsRemaining > 0 && autoAdmitProposal(settings.Config, settings.Criteria, proposal, current.Labels) {
 			if err := m.admitProposal(
 				ctx,
 				settings,
-				plan.issue,
+				current,
 				proposal,
 				automaticAdmissionDecision(settings.Issues, proposal, at),
 			); err != nil {

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -1993,6 +1993,108 @@ func TestManagerScheduledFanoutDeferralResumesWithoutDuplicateAdmission(t *testi
 	}
 }
 
+func TestManagerScheduledEvaluationFanoutDeferralCheckpointsBeforeResume(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	current := now
+	tracker := memory.New(memory.Config{
+		Issues: []connector.Issue{
+			admissionIssueFixture("issue-1", "DD-1", 1, now),
+			admissionIssueFixture("issue-2", "DD-2", 2, now),
+		},
+		Stateful: true,
+		Now:      func() time.Time { return current },
+	})
+	capped := &fanoutCappedAdmissionIssueStore{IssueStore: tracker, maxRequests: 1}
+	backend := openManagerTestStore(t)
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(capped, agent)
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return current })
+
+	attempt, scheduled, err := manager.nextScheduledAttempt(t.Context())
+	if err != nil || !scheduled {
+		t.Fatalf("nextScheduledAttempt() = %#v, %t, %v", attempt, scheduled, err)
+	}
+	current = attempt.ScheduledFor
+	partial, err := manager.run(t.Context(), attempt.ScheduledFor, true)
+	if err != nil {
+		t.Fatalf("scheduled run error = %v", err)
+	}
+	wantResumeAt := current.Add(30 * time.Second)
+	if partial.DeferredReason != "github_rest_fanout_cap" || !partial.ResumeAt.Equal(wantResumeAt) || len(partial.Proposals) != 1 {
+		t.Fatalf("partial result = %#v, want one checkpointed proposal and resume at %s", partial, wantResumeAt)
+	}
+	if capped.deferrals != 1 || capped.deferredScope != admissionRESTFanoutScope+"_evaluation" {
+		t.Fatalf("evaluation deferrals = %d scope = %q", capped.deferrals, capped.deferredScope)
+	}
+	firstProposalID := partial.Proposals[0].IssueID
+
+	restartedSettings := admissionTestSettings(tracker, agent)
+	restarted := newAdmissionTestManager(t, restartedSettings, backend, func() time.Time { return current })
+	resumedAttempt, scheduled, err := restarted.nextScheduledAttempt(t.Context())
+	if err != nil || !scheduled || !resumedAttempt.RunAt.Equal(wantResumeAt) ||
+		!resumedAttempt.ScheduledFor.Equal(attempt.ScheduledFor) {
+		t.Fatalf("resumed nextScheduledAttempt() = %#v, %t, %v", resumedAttempt, scheduled, err)
+	}
+	current = wantResumeAt
+	completed, err := restarted.run(t.Context(), resumedAttempt.ScheduledFor, true)
+	if err != nil || completed.DeferredReason != "" || !completed.ResumeAt.IsZero() || len(completed.Proposals) != 1 {
+		t.Fatalf("resumed run = %#v, %v", completed, err)
+	}
+	if agent.calls != 2 || len(agent.candidateIDs) != 2 || len(agent.candidateIDs[0]) != 2 || len(agent.candidateIDs[1]) != 1 {
+		t.Fatalf("runner calls = %d candidates = %#v", agent.calls, agent.candidateIDs)
+	}
+	if agent.candidateIDs[1][0] == firstProposalID {
+		t.Fatalf("resumed candidate = %q, want candidate not already checkpointed", agent.candidateIDs[1][0])
+	}
+	open, err := backend.OpenAdmissionProposals(t.Context(), settings.ProjectID, 0)
+	if err != nil || len(open) != 2 {
+		t.Fatalf("OpenAdmissionProposals() = %#v, %v, want two unique proposals", open, err)
+	}
+	latest, found, err := backend.LatestAdmissionRun(t.Context(), settings.ProjectID)
+	if err != nil || !found || latest.Outcome != "completed" ||
+		!latest.ScheduledFor.Equal(attempt.ScheduledFor) || !latest.ResumeAt.IsZero() {
+		t.Fatalf("LatestAdmissionRun() = %#v, %t, %v", latest, found, err)
+	}
+}
+
+func TestManagerCleanupFailureOverridesScheduledFanoutDeferral(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	current := now
+	tracker := memory.New(memory.Config{
+		Issues: []connector.Issue{
+			admissionIssueFixture("issue-1", "DD-1", 1, now),
+			admissionIssueFixture("issue-2", "DD-2", 2, now),
+		},
+		Stateful: true,
+		Now:      func() time.Time { return current },
+	})
+	capped := &fanoutCappedAdmissionIssueStore{IssueStore: tracker, maxRequests: 1}
+	backend := openManagerTestStore(t)
+	releaseErr := errors.New("release admission capacity")
+	scheduler := &capacityScheduler{releaseErr: releaseErr}
+	settings := admissionTestSettings(capped, &scriptedAdmissionRunner{propose: proposeEveryCandidate})
+	settings.Scheduler = scheduler
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return current })
+
+	attempt, scheduled, err := manager.nextScheduledAttempt(t.Context())
+	if err != nil || !scheduled {
+		t.Fatalf("nextScheduledAttempt() = %#v, %t, %v", attempt, scheduled, err)
+	}
+	current = attempt.ScheduledFor
+	result, err := manager.run(t.Context(), attempt.ScheduledFor, true)
+	if !errors.Is(err, releaseErr) {
+		t.Fatalf("scheduled run error = %v, want %v", err, releaseErr)
+	}
+	if result.DeferredReason != "" || !result.ResumeAt.IsZero() || scheduler.releases != 1 {
+		t.Fatalf("result = %#v releases = %d, want failed non-resumable cleanup", result, scheduler.releases)
+	}
+	latest, found, err := backend.LatestAdmissionRun(t.Context(), settings.ProjectID)
+	if err != nil || !found || latest.Outcome != "failed" || latest.DeferredReason != "" ||
+		!latest.ResumeAt.IsZero() || !strings.Contains(latest.Error, releaseErr.Error()) {
+		t.Fatalf("LatestAdmissionRun() = %#v, %t, %v", latest, found, err)
+	}
+}
+
 func TestAcquireCapacityReleaseClearsDerivedAdmissionReservation(t *testing.T) {
 	t.Parallel()
 
@@ -3349,6 +3451,29 @@ type deferringAdmissionIssueStore struct {
 	commentCalls     int
 	deferred         bool
 	deferredScope    string
+}
+
+type fanoutCappedAdmissionIssueStore struct {
+	IssueStore
+	maxRequests   int64
+	deferrals     int
+	deferredScope string
+}
+
+func (s *fanoutCappedAdmissionIssueStore) FetchIssueStatesByIDs(
+	ctx context.Context,
+	issueIDs []string,
+) ([]connector.Issue, error) {
+	if budget, ok := connector.RESTFanoutBudgetFromContext(ctx); ok {
+		for range issueIDs {
+			if _, allowed := budget.Reserve(s.maxRequests, 1); !allowed {
+				s.deferrals++
+				s.deferredScope = budget.Scope()
+				return nil, admissionFanoutDeferralError{scope: s.deferredScope}
+			}
+		}
+	}
+	return s.IssueStore.FetchIssueStatesByIDs(ctx, issueIDs)
 }
 
 func (s *deferringAdmissionIssueStore) FetchIssueComments(

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -552,6 +552,7 @@ func TestManagerLogsScheduledAdmissionScan(t *testing.T) {
 		result         Result
 		wantTruncated  bool
 		wantTruncation int
+		wantResumeAt   time.Time
 	}{
 		{
 			name: "exhausted scan",
@@ -571,6 +572,16 @@ func TestManagerLogsScheduledAdmissionScan(t *testing.T) {
 			wantTruncated:  true,
 			wantTruncation: 1,
 		},
+		{
+			name: "fanout deferred",
+			result: Result{
+				ProjectID:      "pyroapex",
+				DeferredReason: connector.LocalDeferralReasonRESTFanoutCap,
+				ResumeAt:       time.Date(2026, 9, 4, 15, 0, 30, 0, time.UTC),
+				Truncated:      map[string]int{},
+			},
+			wantResumeAt: time.Date(2026, 9, 4, 15, 0, 30, 0, time.UTC),
+		},
 	}
 
 	for _, test := range tests {
@@ -587,6 +598,7 @@ func TestManagerLogsScheduledAdmissionScan(t *testing.T) {
 				CandidatesFound int            `json:"candidates_found"`
 				Truncated       bool           `json:"truncated"`
 				Truncations     map[string]int `json:"truncations"`
+				ResumeAt        time.Time      `json:"resume_at"`
 			}
 			if err := json.Unmarshal(output.Bytes(), &record); err != nil {
 				t.Fatalf("decode log record: %v", err)
@@ -595,7 +607,8 @@ func TestManagerLogsScheduledAdmissionScan(t *testing.T) {
 				record.ItemsRead != test.result.ItemsRead ||
 				record.CandidatesFound != test.result.CandidatesFound ||
 				record.Truncated != test.wantTruncated ||
-				record.Truncations["candidate_reader"] != test.wantTruncation {
+				record.Truncations["candidate_reader"] != test.wantTruncation ||
+				!record.ResumeAt.Equal(test.wantResumeAt) {
 				t.Fatalf("log record = %#v", record)
 			}
 		})
@@ -1893,6 +1906,90 @@ func TestManagerDefersForCapacityAndBudget(t *testing.T) {
 				t.Fatalf("result = %#v, runner calls = %d", result, agent.calls)
 			}
 		})
+	}
+}
+
+func TestManagerScheduledFanoutDeferralResumesWithoutDuplicateAdmission(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	current := now
+	issues := []connector.Issue{
+		admissionIssueFixture("issue-1", "DD-1", 1, now),
+		admissionIssueFixture("issue-2", "DD-2", 2, now),
+	}
+	tracker := memory.New(memory.Config{
+		Issues:   issues,
+		Stateful: true,
+		Now:      func() time.Time { return current },
+	})
+	backend := openManagerTestStore(t)
+	agent := &scriptedAdmissionRunner{propose: proposeEveryCandidate}
+	settings := admissionTestSettings(tracker, agent)
+	manager := newAdmissionTestManager(t, settings, backend, func() time.Time { return current })
+
+	initial, err := manager.RunOnce(t.Context())
+	if err != nil || len(initial.Proposals) != 2 {
+		t.Fatalf("initial RunOnce() = %#v, %v, want two proposals", initial, err)
+	}
+	open, err := backend.OpenAdmissionProposals(t.Context(), settings.ProjectID, 0)
+	if err != nil || len(open) != 2 {
+		t.Fatalf("OpenAdmissionProposals() = %#v, %v, want two proposals", open, err)
+	}
+	current = now.Add(time.Minute)
+	for _, proposal := range open {
+		if err := tracker.CreateComment(t.Context(), proposal.IssueID, admissionAcceptCommand(proposal.ID)); err != nil {
+			t.Fatalf("CreateComment(%s) error = %v", proposal.IssueID, err)
+		}
+	}
+
+	deferring := &deferringAdmissionIssueStore{
+		IssueStore:       tracker,
+		comments:         tracker,
+		deferCommentCall: 2,
+	}
+	settings.Issues = deferring
+	manager = newAdmissionTestManager(t, settings, backend, func() time.Time { return current })
+	attempt, scheduled, err := manager.nextScheduledAttempt(t.Context())
+	if err != nil || !scheduled {
+		t.Fatalf("nextScheduledAttempt() = %#v, %t, %v", attempt, scheduled, err)
+	}
+	current = attempt.ScheduledFor
+	partial, err := manager.run(t.Context(), attempt.ScheduledFor, true)
+	if err != nil {
+		t.Fatalf("scheduled run error = %v", err)
+	}
+	wantResumeAt := current.Add(30 * time.Second)
+	if partial.DeferredReason != "github_rest_fanout_cap" || !partial.ResumeAt.Equal(wantResumeAt) {
+		t.Fatalf("partial result = %#v, want durable fanout deferral at %s", partial, wantResumeAt)
+	}
+	if deferring.deferredScope != admissionRESTFanoutScope+"_reconciliation" {
+		t.Fatalf("deferral scope = %q, want reconciliation budget", deferring.deferredScope)
+	}
+	if got := countAdmissionStateUpdates(tracker.Events(), settings.Config.TargetState); got != 1 {
+		t.Fatalf("target state updates after partial run = %d, want 1", got)
+	}
+
+	restartedSettings := admissionTestSettings(tracker, agent)
+	restarted := newAdmissionTestManager(t, restartedSettings, backend, func() time.Time { return current })
+	resumedAttempt, scheduled, err := restarted.nextScheduledAttempt(t.Context())
+	if err != nil || !scheduled || !resumedAttempt.RunAt.Equal(wantResumeAt) ||
+		!resumedAttempt.ScheduledFor.Equal(attempt.ScheduledFor) {
+		t.Fatalf("resumed nextScheduledAttempt() = %#v, %t, %v", resumedAttempt, scheduled, err)
+	}
+	current = wantResumeAt
+	completed, err := restarted.run(t.Context(), resumedAttempt.ScheduledFor, true)
+	if err != nil || completed.DeferredReason != "" || !completed.ResumeAt.IsZero() {
+		t.Fatalf("resumed run = %#v, %v", completed, err)
+	}
+	if got := countAdmissionStateUpdates(tracker.Events(), settings.Config.TargetState); got != 2 {
+		t.Fatalf("target state updates after resume = %d, want 2", got)
+	}
+	if agent.calls != 1 {
+		t.Fatalf("runner calls = %d, want original proposal run only", agent.calls)
+	}
+	latest, found, err := backend.LatestAdmissionRun(t.Context(), settings.ProjectID)
+	if err != nil || !found || latest.Outcome != "completed" ||
+		!latest.ScheduledFor.Equal(attempt.ScheduledFor) || !latest.ResumeAt.IsZero() {
+		t.Fatalf("LatestAdmissionRun() = %#v, %t, %v", latest, found, err)
 	}
 }
 
@@ -3245,6 +3342,46 @@ type scriptedAdmissionRunner struct {
 	candidateIDs [][]string
 }
 
+type deferringAdmissionIssueStore struct {
+	IssueStore
+	comments         connector.IssueCommentReader
+	deferCommentCall int
+	commentCalls     int
+	deferred         bool
+	deferredScope    string
+}
+
+func (s *deferringAdmissionIssueStore) FetchIssueComments(
+	ctx context.Context,
+	issue connector.Issue,
+) ([]connector.IssueComment, error) {
+	s.commentCalls++
+	if !s.deferred && s.commentCalls == s.deferCommentCall {
+		s.deferred = true
+		if budget, ok := connector.RESTFanoutBudgetFromContext(ctx); ok {
+			s.deferredScope = budget.Scope()
+		}
+		return nil, admissionFanoutDeferralError{scope: s.deferredScope}
+	}
+	return s.comments.FetchIssueComments(ctx, issue)
+}
+
+type admissionFanoutDeferralError struct {
+	scope string
+}
+
+func (e admissionFanoutDeferralError) Error() string {
+	return "github REST fanout deferred"
+}
+
+func (e admissionFanoutDeferralError) LocalDeferral() connector.LocalDeferral {
+	return connector.LocalDeferral{
+		Reason:     "github_rest_fanout_cap",
+		Scope:      e.scope,
+		RetryAfter: 30 * time.Second,
+	}
+}
+
 type staticAdmissionRunner struct {
 	output string
 }
@@ -3716,6 +3853,16 @@ func admissionIssueFixture(id string, identifier string, priority int, createdAt
 	issue.Priority = &priority
 	issue.CreatedAt = &createdAt
 	return issue
+}
+
+func countAdmissionStateUpdates(events []memory.Event, state string) int {
+	count := 0
+	for _, event := range events {
+		if event.Kind == memory.EventKindStateUpdate && event.State == state {
+			count++
+		}
+	}
+	return count
 }
 
 func openManagerTestStore(t *testing.T) store.Store {

--- a/internal/admission/model/model.go
+++ b/internal/admission/model/model.go
@@ -69,6 +69,7 @@ type RunRecord struct {
 	CompletedAt     time.Time
 	Outcome         string
 	DeferredReason  string
+	ResumeAt        time.Time
 	ProposalReason  string
 	CandidatesFound int
 	Candidates      int

--- a/internal/connector/deferral.go
+++ b/internal/connector/deferral.go
@@ -1,0 +1,85 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+const LocalDeferralReasonRESTFanoutCap = "github_rest_fanout_cap"
+
+type LocalDeferral struct {
+	Reason     string
+	Scope      string
+	RetryAfter time.Duration
+}
+
+type LocalDeferralReporter interface {
+	LocalDeferral() LocalDeferral
+}
+
+func ErrorLocalDeferral(err error) (LocalDeferral, bool) {
+	var reporter LocalDeferralReporter
+	if !errors.As(err, &reporter) || reporter == nil {
+		return LocalDeferral{}, false
+	}
+	deferral := reporter.LocalDeferral()
+	deferral.Reason = strings.TrimSpace(deferral.Reason)
+	deferral.Scope = strings.TrimSpace(deferral.Scope)
+	return deferral, deferral.Reason != ""
+}
+
+type restFanoutBudgetContextKey struct{}
+
+type RESTFanoutBudget struct {
+	scope string
+	mu    sync.Mutex
+	units int64
+}
+
+func WithRESTFanoutBudget(ctx context.Context, scope string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, restFanoutBudgetContextKey{}, &RESTFanoutBudget{scope: strings.TrimSpace(scope)})
+}
+
+func RESTFanoutBudgetFromContext(ctx context.Context) (*RESTFanoutBudget, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	budget, ok := ctx.Value(restFanoutBudgetContextKey{}).(*RESTFanoutBudget)
+	return budget, ok && budget != nil
+}
+
+func (b *RESTFanoutBudget) Scope() string {
+	if b == nil {
+		return ""
+	}
+	return b.scope
+}
+
+func (b *RESTFanoutBudget) Reserve(maxUnits int64, requestUnits int64) (int64, bool) {
+	if b == nil {
+		return 0, false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	used := b.units
+	if maxUnits > 0 && used+requestUnits > maxUnits {
+		return used, false
+	}
+	b.units += requestUnits
+	return used, true
+}
+
+func (b *RESTFanoutBudget) Add(units int64) {
+	if b == nil || units == 0 {
+		return
+	}
+	b.mu.Lock()
+	b.units += units
+	b.mu.Unlock()
+}

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -282,8 +282,8 @@ func TestFactoryGitHubConnectorUsesConfiguredLogger(t *testing.T) {
 		t.Fatalf("FetchStatusDrift() first error = %v", err)
 	}
 	_, err = driftReader.FetchStatusDrift(context.Background())
-	if !errors.Is(err, githubconnector.ErrRESTBudgetReserved) {
-		t.Fatalf("FetchStatusDrift() error = %v, want ErrRESTBudgetReserved", err)
+	if !errors.Is(err, githubconnector.ErrRESTFanoutDeferred) {
+		t.Fatalf("FetchStatusDrift() error = %v, want ErrRESTFanoutDeferred", err)
 	}
 	if strings.Contains(defaultLogs.String(), "github rest budget preserved") {
 		t.Fatalf("default logger received connector warning:\n%s", defaultLogs.String())

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2030,15 +2030,15 @@ func TestConnectorFetchCandidateIssuesMarksBranchPullRequestHydrationUnavailable
 		}
 	}
 	usage := c.client.FlushRESTRateLimitUsage()
-	if !usage.RateLimited {
-		t.Fatalf("RESTRateLimitUsage.RateLimited = false, want reserved budget throttle")
+	if usage.RateLimited || !usage.ReserveHeld || usage.FanoutDeferred {
+		t.Fatalf("RESTRateLimitUsage = %#v, want reserve-floor hold only", usage)
 	}
 	if got := restEndpointUsageCount(usage.Requests, "pull requests"); got != 1 {
 		t.Fatalf("pull requests usage count = %d, want synthetic throttle; usage = %#v", got, usage.Requests)
 	}
 }
 
-func TestConnectorAttachPullRequestsRotatesAfterRESTBudgetReservation(t *testing.T) {
+func TestConnectorAttachPullRequestsRotatesAfterRESTFanoutDeferral(t *testing.T) {
 	t.Parallel()
 
 	var mu sync.Mutex
@@ -2090,8 +2090,8 @@ func TestConnectorAttachPullRequestsRotatesAfterRESTBudgetReservation(t *testing
 	if first[0].PullRequest == nil || first[0].PullRequest.HydrationUnavailableReason != "" {
 		t.Fatalf("first pass issue 1 PullRequest = %#v, want hydrated", first[0].PullRequest)
 	}
-	if first[1].PullRequest == nil || first[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
-		t.Fatalf("first pass issue 2 PullRequest = %#v, want budget reservation", first[1].PullRequest)
+	if first[1].PullRequest == nil || first[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTFanoutDeferred {
+		t.Fatalf("first pass issue 2 PullRequest = %#v, want fanout deferral", first[1].PullRequest)
 	}
 	c.FlushRESTRateLimitUsage()
 
@@ -2102,8 +2102,8 @@ func TestConnectorAttachPullRequestsRotatesAfterRESTBudgetReservation(t *testing
 	if second[1].PullRequest == nil || second[1].PullRequest.HydrationUnavailableReason != "" {
 		t.Fatalf("second pass issue 2 PullRequest = %#v, want rotated hydration", second[1].PullRequest)
 	}
-	if second[0].PullRequest == nil || second[0].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
-		t.Fatalf("second pass issue 1 PullRequest = %#v, want rotated budget reservation", second[0].PullRequest)
+	if second[0].PullRequest == nil || second[0].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTFanoutDeferred {
+		t.Fatalf("second pass issue 1 PullRequest = %#v, want rotated fanout deferral", second[0].PullRequest)
 	}
 
 	mu.Lock()
@@ -2167,8 +2167,8 @@ func TestConnectorAttachPullRequestsPrioritizesSkippedBranchCandidate(t *testing
 	if err := c.attachPullRequests(context.Background(), first); err != nil {
 		t.Fatalf("attachPullRequests() first error = %v", err)
 	}
-	if first[1].PullRequest == nil || first[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
-		t.Fatalf("first pass branch issue PullRequest = %#v, want budget reservation", first[1].PullRequest)
+	if first[1].PullRequest == nil || first[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTFanoutDeferred {
+		t.Fatalf("first pass branch issue PullRequest = %#v, want fanout deferral", first[1].PullRequest)
 	}
 	c.FlushRESTRateLimitUsage()
 
@@ -2179,8 +2179,8 @@ func TestConnectorAttachPullRequestsPrioritizesSkippedBranchCandidate(t *testing
 	if second[1].PullRequest == nil || second[1].PullRequest.HydrationUnavailableReason != "" || second[1].PullRequest.Number != 202 {
 		t.Fatalf("second pass branch issue PullRequest = %#v, want prioritized hydration", second[1].PullRequest)
 	}
-	if second[0].PullRequest == nil || second[0].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
-		t.Fatalf("second pass linked issue PullRequest = %#v, want rotated budget reservation", second[0].PullRequest)
+	if second[0].PullRequest == nil || second[0].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTFanoutDeferred {
+		t.Fatalf("second pass linked issue PullRequest = %#v, want rotated fanout deferral", second[0].PullRequest)
 	}
 
 	mu.Lock()
@@ -5749,8 +5749,8 @@ func TestConnectorHydratePullRequestIncludesWorkflowAndAnnotationsInRESTFanoutCa
 	if err != nil {
 		t.Fatalf("HydratePullRequest() error = %v", err)
 	}
-	if got.PullRequest == nil || got.PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
-		t.Fatalf("PullRequest = %#v, want REST budget reservation", got.PullRequest)
+	if got.PullRequest == nil || got.PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTFanoutDeferred {
+		t.Fatalf("PullRequest = %#v, want REST fanout deferral", got.PullRequest)
 	}
 	if requests := server.requests(); len(requests) != 4 {
 		t.Fatalf("outbound REST requests = %d, want fanout cap 4; requests = %#v", len(requests), requests)

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -1885,7 +1885,13 @@ func sortedRESTEndpointUsages(usages map[string]connector.RESTEndpointUsage) []c
 		if out[i].CredentialIdentity != out[j].CredentialIdentity {
 			return out[i].CredentialIdentity < out[j].CredentialIdentity
 		}
-		return out[i].EndpointFamily < out[j].EndpointFamily
+		if out[i].EndpointFamily != out[j].EndpointFamily {
+			return out[i].EndpointFamily < out[j].EndpointFamily
+		}
+		if out[i].BudgetScope != out[j].BudgetScope {
+			return out[i].BudgetScope < out[j].BudgetScope
+		}
+		return out[i].BudgetGate < out[j].BudgetGate
 	})
 	return out
 }

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -32,6 +32,7 @@ const (
 	restFanoutCostUnitsPerRequest       = int64(4)
 	restConditionalFanoutCostUnits      = int64(1)
 	restRateLimitResetSkew              = 5 * time.Second
+	restFanoutDeferralRetry             = 30 * time.Second
 	restBudgetGateFanoutCap             = "fanout_cap"
 	restBudgetGateReserve               = "reserve"
 	restDivergenceMinUnexplained        = int64(10)
@@ -82,6 +83,8 @@ type Client struct {
 	restDivergences        *restDivergenceRegistry
 	restRequests           map[string]connector.RESTEndpointUsage
 	restFanoutUnits        int64
+	restReserveHeld        bool
+	restFanoutDeferred     bool
 	restCache              map[string]restCacheEntry
 	conditionalRequests    bool
 	restBackoffUntil       time.Time
@@ -302,7 +305,7 @@ func (c *Client) restTextWithTokenRefresh(ctx context.Context, path, accept stri
 	if err := c.restBackoffError(backoffKey, now); err != nil {
 		return "", false, err
 	}
-	if err := c.restBudgetPolicyError(credentialIdentity, http.MethodGet, path, false, now); err != nil {
+	if err := c.restBudgetPolicyError(ctx, credentialIdentity, http.MethodGet, path, false, now); err != nil {
 		return "", false, err
 	}
 
@@ -466,8 +469,8 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		)
 		return nil, err
 	}
-	if err := c.restBudgetPolicyError(credentialIdentity, method, path, conditional, now); err != nil {
-		c.logger.DebugContext(ctx, "github rest budget reserved",
+	if err := c.restBudgetPolicyError(ctx, credentialIdentity, method, path, conditional, now); err != nil {
+		c.logger.DebugContext(ctx, "github rest request deferred",
 			"method", strings.ToUpper(strings.TrimSpace(method)),
 			"path", path,
 			"endpoint_family", restEndpointFamily(method, path),
@@ -768,12 +771,14 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 		}
 	}
 	usage := connector.RESTRateLimitUsage{
-		RateLimit:    rateLimit,
-		HasRateLimit: c.hasRestRateLimit,
-		Requests:     sortedRESTEndpointUsages(c.restRequests),
-		Budgets:      sortedRESTRateLimitBudgets(c.restBudgets),
-		Divergences:  c.restDivergences.snapshots(c.restDivergenceKeys),
-		BackoffUntil: backoffUntil,
+		RateLimit:      rateLimit,
+		HasRateLimit:   c.hasRestRateLimit,
+		Requests:       sortedRESTEndpointUsages(c.restRequests),
+		Budgets:        sortedRESTRateLimitBudgets(c.restBudgets),
+		Divergences:    c.restDivergences.snapshots(c.restDivergenceKeys),
+		BackoffUntil:   backoffUntil,
+		ReserveHeld:    c.restReserveHeld,
+		FanoutDeferred: c.restFanoutDeferred,
 	}
 	for _, request := range usage.Requests {
 		usage.TotalRequests += request.Count
@@ -786,6 +791,8 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 	}
 	c.restRequests = nil
 	c.restFanoutUnits = 0
+	c.restReserveHeld = false
+	c.restFanoutDeferred = false
 	c.restRateLimitStatus = false
 	return usage
 }
@@ -806,10 +813,12 @@ func (c *Client) RESTRateLimitStatus() connector.RESTRateLimitUsage {
 		}
 	}
 	usage := connector.RESTRateLimitUsage{
-		RateLimit:    rateLimit,
-		HasRateLimit: c.hasRestRateLimit,
-		BackoffUntil: backoffUntil,
-		RateLimited:  c.restRateLimitStatus || backoffUntil.After(now),
+		RateLimit:      rateLimit,
+		HasRateLimit:   c.hasRestRateLimit,
+		BackoffUntil:   backoffUntil,
+		RateLimited:    c.restRateLimitStatus || backoffUntil.After(now),
+		ReserveHeld:    c.restReserveHeld,
+		FanoutDeferred: c.restFanoutDeferred,
 	}
 	return usage
 }
@@ -856,7 +865,7 @@ func normalizeRESTBudgetPolicy(policy RESTBudgetPolicy) RESTBudgetPolicy {
 	return policy
 }
 
-func (c *Client) restBudgetPolicyError(credentialIdentity string, method string, path string, conditional bool, now time.Time) error {
+func (c *Client) restBudgetPolicyError(ctx context.Context, credentialIdentity string, method string, path string, conditional bool, now time.Time) error {
 	family := restEndpointFamily(method, path)
 	if !restFanoutEndpointFamily(family) {
 		return nil
@@ -870,13 +879,38 @@ func (c *Client) restBudgetPolicyError(credentialIdentity string, method string,
 	if conditional {
 		requestCost = restConditionalFanoutCostUnits
 	}
-	if c.restPolicy.FanoutMaxRequests > 0 &&
-		c.restFanoutUnits+requestCost > c.restPolicy.FanoutMaxRequests*restFanoutCostUnitsPerRequest {
-		c.recordRESTBudgetThrottleLocked(credentialIdentity, method, path, family, restBudgetGateFanoutCap, rateLimit, hasRateLimit, now)
-		return &StatusError{
-			StatusCode: http.StatusTooManyRequests,
-			Body:       "REST fanout request cap reached for " + family,
-			Err:        ErrRESTBudgetReserved,
+	budget, scoped := connector.RESTFanoutBudgetFromContext(ctx)
+	budgetScope := "refresh"
+	fanoutUnits := c.restFanoutUnits
+	reservedScoped := false
+	if scoped {
+		budgetScope = budget.Scope()
+	}
+	if c.restPolicy.FanoutMaxRequests > 0 {
+		maxUnits := c.restPolicy.FanoutMaxRequests * restFanoutCostUnitsPerRequest
+		if scoped {
+			var allowed bool
+			fanoutUnits, allowed = budget.Reserve(maxUnits, requestCost)
+			if !allowed {
+				c.recordRESTBudgetThrottleLocked(credentialIdentity, method, path, family, budgetScope, restBudgetGateFanoutCap, fanoutUnits, rateLimit, hasRateLimit, now)
+				return &RESTFanoutDeferralError{
+					EndpointFamily: family,
+					BudgetScope:    budgetScope,
+					FanoutCount:    float64(fanoutUnits) / float64(restFanoutCostUnitsPerRequest),
+					FanoutCap:      c.restPolicy.FanoutMaxRequests,
+					RetryAfter:     restFanoutDeferralRetry,
+				}
+			}
+			reservedScoped = true
+		} else if fanoutUnits+requestCost > maxUnits {
+			c.recordRESTBudgetThrottleLocked(credentialIdentity, method, path, family, budgetScope, restBudgetGateFanoutCap, fanoutUnits, rateLimit, hasRateLimit, now)
+			return &RESTFanoutDeferralError{
+				EndpointFamily: family,
+				BudgetScope:    budgetScope,
+				FanoutCount:    float64(fanoutUnits) / float64(restFanoutCostUnitsPerRequest),
+				FanoutCap:      c.restPolicy.FanoutMaxRequests,
+				RetryAfter:     restFanoutDeferralRetry,
+			}
 		}
 	}
 	if c.restPolicy.MinRemainingReserve > 0 &&
@@ -885,14 +919,19 @@ func (c *Client) restBudgetPolicyError(credentialIdentity string, method string,
 		rateLimit.Limit > 0 &&
 		!restRateLimitSnapshotExpired(rateLimit, now) &&
 		rateLimit.Remaining <= c.restPolicy.MinRemainingReserve {
-		c.recordRESTBudgetThrottleLocked(credentialIdentity, method, path, family, restBudgetGateReserve, rateLimit, hasRateLimit, now)
+		if reservedScoped {
+			budget.Add(-requestCost)
+		}
+		c.recordRESTBudgetThrottleLocked(credentialIdentity, method, path, family, budgetScope, restBudgetGateReserve, fanoutUnits, rateLimit, hasRateLimit, now)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       "REST remaining budget is reserved for shared GitHub work",
 			Err:        ErrRESTBudgetReserved,
 		}
 	}
-	c.restFanoutUnits += requestCost
+	if !scoped {
+		c.restFanoutUnits += requestCost
+	}
 	return nil
 }
 
@@ -913,8 +952,8 @@ func (c *Client) restRateLimitForResourceLocked(resource string) (connector.REST
 	return connector.RESTRateLimit{}, false
 }
 
-func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, method string, path string, family string, branch string, rateLimit connector.RESTRateLimit, hasRateLimit bool, now time.Time) {
-	fanoutCount := float64(c.restFanoutUnits) / float64(restFanoutCostUnitsPerRequest)
+func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, method string, path string, family string, budgetScope string, branch string, fanoutUnits int64, rateLimit connector.RESTRateLimit, hasRateLimit bool, now time.Time) {
+	fanoutCount := float64(fanoutUnits) / float64(restFanoutCostUnitsPerRequest)
 	snapshotAge := "unknown"
 	if !rateLimit.UpdatedAt.IsZero() {
 		age := now.Sub(rateLimit.UpdatedAt)
@@ -926,13 +965,13 @@ func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, metho
 	if c.restRequests == nil {
 		c.restRequests = make(map[string]connector.RESTEndpointUsage)
 	}
-	requestKey := restCredentialFamilyKey(credentialIdentity, family)
+	requestKey := restCredentialFamilyKey(credentialIdentity, family) + "\x00" + budgetScope
 	request := c.restRequests[requestKey]
 	request.CredentialIdentity = credentialIdentity
 	request.EndpointFamily = family
+	request.BudgetScope = budgetScope
+	request.BudgetGate = branch
 	request.Count++
-	request.RateLimited = true
-	request.LastStatus = http.StatusTooManyRequests
 	if hasRateLimit {
 		request.Limit = rateLimit.Limit
 		request.Used = rateLimit.Used
@@ -942,11 +981,19 @@ func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, metho
 		request.RetryAfter = rateLimit.RetryAfter
 	}
 	c.restRequests[requestKey] = request
+	message := "github rest reserve floor held"
+	if branch == restBudgetGateFanoutCap {
+		message = "github rest fanout deferred"
+		c.restFanoutDeferred = true
+	} else {
+		c.restReserveHeld = true
+	}
 	c.logger.Warn(
-		"github rest budget preserved",
+		message,
 		"method", strings.ToUpper(strings.TrimSpace(method)),
 		"path", path,
 		"endpoint_family", family,
+		"budget_scope", budgetScope,
 		"credential_identity", credentialIdentity,
 		"resource", rateLimit.Resource,
 		"remaining", rateLimit.Remaining,
@@ -994,6 +1041,11 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 	resourceHeader := strings.TrimSpace(headers.Get("X-RateLimit-Resource"))
 	resource := restRateLimitResourceName(resourceHeader, family)
 	sharedBackoff := rateLimited && (restShouldApplySharedBackoff(family, remaining, hasRemaining) || !headerRateLimited)
+	fanoutBudget, _ := connector.RESTFanoutBudgetFromContext(ctx)
+	budgetScope := "refresh"
+	if fanoutBudget != nil {
+		budgetScope = fanoutBudget.Scope()
+	}
 
 	var resetAt time.Time
 	if hasReset {
@@ -1078,10 +1130,11 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 	if c.restRequests == nil {
 		c.restRequests = make(map[string]connector.RESTEndpointUsage)
 	}
-	requestKey := restCredentialFamilyKey(credentialIdentity, family)
+	requestKey := restCredentialFamilyKey(credentialIdentity, family) + "\x00" + budgetScope
 	request := c.restRequests[requestKey]
 	request.CredentialIdentity = credentialIdentity
 	request.EndpointFamily = family
+	request.BudgetScope = budgetScope
 	request.Count++
 	if conditional {
 		request.Conditional++
@@ -1091,7 +1144,12 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 	} else {
 		request.Billable++
 		if conditional && restFanoutEndpointFamily(family) {
-			c.restFanoutUnits += restFanoutCostUnitsPerRequest - restConditionalFanoutCostUnits
+			additionalCost := restFanoutCostUnitsPerRequest - restConditionalFanoutCostUnits
+			if fanoutBudget != nil {
+				fanoutBudget.Add(additionalCost)
+			} else {
+				c.restFanoutUnits += additionalCost
+			}
 		}
 	}
 	request.LastStatus = status
@@ -2186,6 +2244,8 @@ func restBackoffReason(err error) string {
 		}
 	}
 	switch {
+	case errors.Is(err, ErrRESTFanoutDeferred):
+		return "github_rest_fanout_cap"
 	case errors.Is(err, ErrRESTBudgetReserved):
 		return "rest_budget_reserved"
 	case errors.Is(err, ErrRateLimited):

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -1236,6 +1236,44 @@ func TestClientRESTFanoutBudgetsIsolateProjectOperations(t *testing.T) {
 	}
 }
 
+func TestSortedRESTEndpointUsagesUsesBudgetTieBreakers(t *testing.T) {
+	tests := []struct {
+		name   string
+		usages map[string]connector.RESTEndpointUsage
+		want   string
+	}{
+		{
+			name: "budget scope",
+			usages: map[string]connector.RESTEndpointUsage{
+				"second": {CredentialIdentity: "credential", EndpointFamily: "issues", BudgetScope: "refresh"},
+				"first":  {CredentialIdentity: "credential", EndpointFamily: "issues", BudgetScope: "admission"},
+			},
+			want: "admission/|refresh/",
+		},
+		{
+			name: "budget gate",
+			usages: map[string]connector.RESTEndpointUsage{
+				"second": {CredentialIdentity: "credential", EndpointFamily: "issues", BudgetScope: "admission", BudgetGate: "reserve"},
+				"first":  {CredentialIdentity: "credential", EndpointFamily: "issues", BudgetScope: "admission", BudgetGate: "fanout_cap"},
+			},
+			want: "admission/fanout_cap|admission/reserve",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sortedRESTEndpointUsages(tt.usages)
+			keys := make([]string, 0, len(got))
+			for _, usage := range got {
+				keys = append(keys, usage.BudgetScope+"/"+usage.BudgetGate)
+			}
+			if joined := strings.Join(keys, "|"); joined != tt.want {
+				t.Fatalf("sorted budget keys = %q, want %q", joined, tt.want)
+			}
+		})
+	}
+}
+
 func TestClientRESTCountsRepositoryIssuesAsFanout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -1157,16 +1157,16 @@ func TestClientRESTStopsFanoutAtRequestCap(t *testing.T) {
 		t.Fatalf("REST() pull requests error = %v", err)
 	}
 	err = client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/commits/abc/check-runs", nil, nil)
-	if !errors.Is(err, ErrRESTBudgetReserved) {
-		t.Fatalf("REST() capped fanout error = %v, want ErrRESTBudgetReserved", err)
+	if !errors.Is(err, ErrRESTFanoutDeferred) {
+		t.Fatalf("REST() capped fanout error = %v, want ErrRESTFanoutDeferred", err)
 	}
 	if calls.Load() != 1 {
 		t.Fatalf("REST calls = %d, want only first request sent", calls.Load())
 	}
 
 	usage := client.FlushRESTRateLimitUsage()
-	if usage.TotalRequests != 2 || !usage.RateLimited {
-		t.Fatalf("FlushRESTRateLimitUsage() totals = requests %d rate_limited %v, want 2 true", usage.TotalRequests, usage.RateLimited)
+	if usage.TotalRequests != 2 || usage.RateLimited || !usage.FanoutDeferred || usage.ReserveHeld {
+		t.Fatalf("FlushRESTRateLimitUsage() = %#v, want local fanout deferral only", usage)
 	}
 	if got := restEndpointUsageCount(usage.Requests, "pull requests"); got != 1 {
 		t.Fatalf("pull requests usage count = %d, want 1; usage = %#v", got, usage.Requests)
@@ -1174,10 +1174,65 @@ func TestClientRESTStopsFanoutAtRequestCap(t *testing.T) {
 	if got := restEndpointUsageCount(usage.Requests, "check runs"); got != 1 {
 		t.Fatalf("check runs usage count = %d, want throttled synthetic request; usage = %#v", got, usage.Requests)
 	}
-	for _, want := range []string{"gate_branch=fanout_cap", "fanout_count=1", "snapshot_age="} {
+	for _, want := range []string{`msg="github rest fanout deferred"`, "gate_branch=fanout_cap", "budget_scope=refresh", "fanout_count=1", "snapshot_age="} {
 		if !strings.Contains(logs.String(), want) {
 			t.Fatalf("throttle log missing %q:\n%s", want, logs.String())
 		}
+	}
+}
+
+func TestClientRESTFanoutBudgetsIsolateProjectOperations(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Used", "390")
+		w.Header().Set("X-RateLimit-Remaining", "4610")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+		RESTPolicy:  RESTBudgetPolicy{FanoutMaxRequests: 1},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	hydration := connector.WithRESTFanoutBudget(context.Background(), "fastestbanners_dependency_hydration")
+	if err := client.REST(hydration, http.MethodGet, "/repos/fastestbanners/app/issues/1/dependencies/blocked_by", nil, nil); err != nil {
+		t.Fatalf("dependency hydration error = %v", err)
+	}
+	err = client.REST(hydration, http.MethodGet, "/repos/fastestbanners/app/issues/2/dependencies/blocked_by", nil, nil)
+	if !errors.Is(err, ErrRESTFanoutDeferred) {
+		t.Fatalf("dependency hydration cap error = %v, want ErrRESTFanoutDeferred", err)
+	}
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) {
+		t.Fatalf("dependency hydration cap error = %#v, want no HTTP status", statusErr)
+	}
+	deferral, ok := connector.ErrorLocalDeferral(err)
+	if !ok || deferral.Reason != "github_rest_fanout_cap" || deferral.Scope != "fastestbanners_dependency_hydration" || deferral.RetryAfter != restFanoutDeferralRetry {
+		t.Fatalf("ErrorLocalDeferral() = %#v, %t", deferral, ok)
+	}
+
+	admission := connector.WithRESTFanoutBudget(context.Background(), "leadpipe_backlog_admission")
+	if err := client.REST(admission, http.MethodGet, "/repos/leadpipe/app/issues?state=open", nil, nil); err != nil {
+		t.Fatalf("independently budgeted admission error = %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("outbound REST calls = %d, want hydration plus admission", calls.Load())
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+	if usage.RateLimited || usage.ReserveHeld || !usage.FanoutDeferred || usage.RateLimit.Remaining != 4610 {
+		t.Fatalf("FlushRESTRateLimitUsage() = %#v, want healthy provider plus local deferral", usage)
 	}
 }
 
@@ -1216,8 +1271,8 @@ func TestClientRESTCountsRepositoryIssuesAsFanout(t *testing.T) {
 		t.Fatalf("REST() repository issues error = %v", err)
 	}
 	err = client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/pulls?state=all", nil, nil)
-	if !errors.Is(err, ErrRESTBudgetReserved) {
-		t.Fatalf("REST() capped fanout error = %v, want ErrRESTBudgetReserved", err)
+	if !errors.Is(err, ErrRESTFanoutDeferred) {
+		t.Fatalf("REST() capped fanout error = %v, want ErrRESTFanoutDeferred", err)
 	}
 	if calls.Load() != 1 {
 		t.Fatalf("REST calls = %d, want only repository issues request sent", calls.Load())

--- a/internal/connector/github/conditional_test.go
+++ b/internal/connector/github/conditional_test.go
@@ -103,8 +103,8 @@ func TestClientRESTConditionalRequestsReserveConservativeFanoutCost(t *testing.T
 		if index < 4 && err != nil {
 			t.Fatalf("conditional REST() request %d error = %v", index+1, err)
 		}
-		if index == 4 && !errors.Is(err, ErrRESTBudgetReserved) {
-			t.Fatalf("conditional REST() request 5 error = %v, want ErrRESTBudgetReserved", err)
+		if index == 4 && !errors.Is(err, ErrRESTFanoutDeferred) {
+			t.Fatalf("conditional REST() request 5 error = %v, want ErrRESTFanoutDeferred", err)
 		}
 	}
 	if calls.Load() != 4 {

--- a/internal/connector/github/errors.go
+++ b/internal/connector/github/errors.go
@@ -35,6 +35,7 @@ var (
 	ErrProjectNotFound             = errors.New("github project not found")
 	ErrRateLimited                 = connector.NewRetryableError("github rate limited")
 	ErrResourceExhausted           = fmt.Errorf("github resource exhausted: %w", connector.ErrResourceExhausted)
+	ErrRESTFanoutDeferred          = connector.NewRetryableError("github rest fanout deferred")
 	ErrRESTBudgetReserved          = connector.NewRetryableError("github rest budget reserved")
 	ErrStatusFieldNotFound         = errors.New("github status field not found")
 	ErrStatusOptionNotFound        = errors.New("github status option not found")
@@ -82,6 +83,36 @@ type StatusError struct {
 	RateLimitKind string
 	RetryAfter    time.Duration
 	ResetAt       time.Time
+}
+
+type RESTFanoutDeferralError struct {
+	EndpointFamily string
+	BudgetScope    string
+	FanoutCount    float64
+	FanoutCap      int64
+	RetryAfter     time.Duration
+}
+
+func (e *RESTFanoutDeferralError) Error() string {
+	if e == nil {
+		return ErrRESTFanoutDeferred.Error()
+	}
+	return fmt.Sprintf("%s: endpoint family %s reached request cap %d", ErrRESTFanoutDeferred, strings.TrimSpace(e.EndpointFamily), e.FanoutCap)
+}
+
+func (e *RESTFanoutDeferralError) Unwrap() error {
+	return ErrRESTFanoutDeferred
+}
+
+func (e *RESTFanoutDeferralError) LocalDeferral() connector.LocalDeferral {
+	if e == nil {
+		return connector.LocalDeferral{}
+	}
+	return connector.LocalDeferral{
+		Reason:     connector.LocalDeferralReasonRESTFanoutCap,
+		Scope:      e.BudgetScope,
+		RetryAfter: e.RetryAfter,
+	}
 }
 
 func (e *StatusError) Error() string {

--- a/internal/connector/github/issue_dependencies.go
+++ b/internal/connector/github/issue_dependencies.go
@@ -301,7 +301,7 @@ func (c *Connector) handleNativeDependencyWriteError(ctx context.Context, repo s
 }
 
 func nativeDependencyRetryableError(err error) bool {
-	return errors.Is(err, ErrRateLimited) || errors.Is(err, ErrRESTBudgetReserved)
+	return errors.Is(err, ErrRateLimited) || restFanoutOrReserveDeferred(err)
 }
 
 func nativeDependencyUnavailableError(err error) bool {

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -154,7 +154,7 @@ func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequ
 }
 
 func pullRequestHydrationThrottleError(err error) bool {
-	return errors.Is(err, ErrRateLimited) || errors.Is(err, ErrRESTBudgetReserved)
+	return errors.Is(err, ErrRateLimited) || restFanoutOrReserveDeferred(err)
 }
 
 func (c *Connector) logStaleSuccessfulCheckRuns(ctx context.Context, repo pullRequestRepo, sha string, checks []connector.PullRequestCheck) {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -180,7 +180,7 @@ func (c *Connector) attachBranchPullRequests(
 	if err != nil {
 		if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
 			cursor := ""
-			if errors.Is(err, ErrRESTBudgetReserved) {
+			if restFanoutOrReserveDeferred(err) {
 				cursor = firstUnattachedBranchPullRequestCandidate(issues, candidates)
 			}
 			markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
@@ -254,7 +254,7 @@ func (c *Connector) attachPullRequestMergeStates(ctx context.Context, issues []c
 	for _, repo := range repos {
 		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
 		if err != nil {
-			if errors.Is(err, ErrRESTBudgetReserved) {
+			if restFanoutOrReserveDeferred(err) {
 				continue
 			}
 			return err
@@ -698,7 +698,7 @@ func (c *Connector) attachLinkedPullRequests(
 		}
 		hydration := hydrations[hydrationIndex]
 		if hydration.state.Reason != "" {
-			if hydration.state.Reason == connector.PullRequestHydrationReasonRESTBudgetReserved && nextCursor == "" {
+			if pullRequestHydrationBudgetDeferred(hydration.state.Reason) && nextCursor == "" {
 				nextCursor = candidate.Identifier
 			}
 			if hydration.pullRequest.Number <= 0 {
@@ -786,7 +786,7 @@ func (c *Connector) attachMatchingPullRequests(
 						hydrated[pullRequest.Number] = pullRequest
 						attachPullRequestToIssue(&issues[candidate.Index], repo, pullRequest)
 						markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
-						if errors.Is(err, ErrRESTBudgetReserved) {
+						if restFanoutOrReserveDeferred(err) {
 							return candidate.Identifier, nil
 						}
 						return "", nil
@@ -799,7 +799,7 @@ func (c *Connector) attachMatchingPullRequests(
 						hydrated[pullRequest.Number] = hydratedPullRequest
 						attachPullRequestToIssue(&issues[candidate.Index], repo, hydratedPullRequest)
 						markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
-						if errors.Is(err, ErrRESTBudgetReserved) {
+						if restFanoutOrReserveDeferred(err) {
 							return candidate.Identifier, nil
 						}
 						return "", nil
@@ -989,6 +989,8 @@ func (c *Connector) currentPullRequestHydrationState(repo pullRequestRepo) (pull
 
 func (c *Connector) pullRequestHydrationStateForError(repo pullRequestRepo, err error) pullRequestHydrationState {
 	switch {
+	case errors.Is(err, ErrRESTFanoutDeferred):
+		return pullRequestHydrationState{Reason: connector.PullRequestHydrationReasonRESTFanoutDeferred}
 	case errors.Is(err, ErrRESTBudgetReserved):
 		return pullRequestHydrationState{Reason: connector.PullRequestHydrationReasonRESTBudgetReserved}
 	case errors.Is(err, ErrRateLimited):
@@ -1008,6 +1010,14 @@ func (c *Connector) pullRequestHydrationStateForError(repo pullRequestRepo, err 
 	default:
 		return pullRequestHydrationState{}
 	}
+}
+
+func restFanoutOrReserveDeferred(err error) bool {
+	return errors.Is(err, ErrRESTFanoutDeferred) || errors.Is(err, ErrRESTBudgetReserved)
+}
+
+func pullRequestHydrationBudgetDeferred(reason string) bool {
+	return reason == connector.PullRequestHydrationReasonRESTFanoutDeferred || reason == connector.PullRequestHydrationReasonRESTBudgetReserved
 }
 
 func (c *Connector) tripPullRequestHydrationCircuit(repo pullRequestRepo, retryAfter time.Duration) pullRequestHydrationState {

--- a/internal/connector/github/pull_requests_concurrency_test.go
+++ b/internal/connector/github/pull_requests_concurrency_test.go
@@ -261,7 +261,7 @@ func TestConnectorFiniteFanoutPreservesPriorityWithPaginatedHydration(t *testing
 	if issues[0].PullRequest == nil || issues[0].PullRequest.HydrationUnavailableReason != "" {
 		t.Fatalf("priority PullRequest = %#v, want complete hydration", issues[0].PullRequest)
 	}
-	if issues[1].PullRequest == nil || issues[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTBudgetReserved {
+	if issues[1].PullRequest == nil || issues[1].PullRequest.HydrationUnavailableReason != connector.PullRequestHydrationReasonRESTFanoutDeferred {
 		t.Fatalf("tail PullRequest = %#v, want deferred hydration", issues[1].PullRequest)
 	}
 }

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -155,6 +155,7 @@ const (
 	PullRequestHydrationReasonRateLimited         = "rate_limited"
 	PullRequestHydrationReasonSecondaryThrottled  = "secondary_throttled"
 	PullRequestHydrationReasonPrimaryExhausted    = "primary_exhausted"
+	PullRequestHydrationReasonRESTFanoutDeferred  = "rest_fanout_deferred"
 	PullRequestHydrationReasonRESTBudgetReserved  = "rest_budget_reserved"
 	PullRequestHydrationReasonChecksUnavailable   = "checks_unavailable"
 	PullRequestHydrationReasonStaleCachedPullData = "stale_cached_pull_request"

--- a/internal/connector/ratelimit.go
+++ b/internal/connector/ratelimit.go
@@ -66,6 +66,8 @@ type RESTRateLimit struct {
 type RESTEndpointUsage struct {
 	CredentialIdentity string
 	EndpointFamily     string
+	BudgetScope        string
+	BudgetGate         string
 	Count              int64
 	Conditional        int64
 	NotModified        int64
@@ -116,6 +118,8 @@ type RESTRateLimitUsage struct {
 	NotModifiedRequests int64
 	BillableRequests    int64
 	RateLimited         bool
+	ReserveHeld         bool
+	FanoutDeferred      bool
 	BackoffUntil        time.Time
 }
 

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -496,6 +496,32 @@ func TestRESTUsageSummaryPresence(t *testing.T) {
 	}
 }
 
+func TestRESTUsageSummaryPreservesLocalDeferralClassification(t *testing.T) {
+	t.Parallel()
+
+	usage := restUsageSummary(connector.RESTRateLimitUsage{
+		HasRateLimit:   true,
+		FanoutDeferred: true,
+		Requests: []connector.RESTEndpointUsage{{
+			EndpointFamily: "issue comments",
+			BudgetScope:    "backlog_admission_reconciliation",
+			BudgetGate:     "fanout_cap",
+			Count:          1,
+			RetryAfter:     30 * time.Second,
+		}},
+		TotalRequests: 1,
+	})
+	if usage == nil || usage.RateLimited || !usage.FanoutDeferred || usage.ReserveHeld {
+		t.Fatalf("restUsageSummary() = %#v, want fanout-only local deferral", usage)
+	}
+	if len(usage.Contributors) != 1 ||
+		usage.Contributors[0].BudgetScope != "backlog_admission_reconciliation" ||
+		usage.Contributors[0].BudgetGate != "fanout_cap" ||
+		usage.Contributors[0].LastStatus != 0 {
+		t.Fatalf("contributors = %#v, want typed local fanout gate without HTTP status", usage.Contributors)
+	}
+}
+
 func TestReplaceRESTConsumerBudgetsPreservesWorkerBudget(t *testing.T) {
 	t.Parallel()
 
@@ -1714,6 +1740,39 @@ func TestGitHubRESTLookupBackoffUsesRESTProbe(t *testing.T) {
 	}
 	if tracker.restProbeCalls != 2 || tracker.probeCalls != 0 {
 		t.Fatalf("probe calls = REST %d GraphQL %d, want REST 2 GraphQL 0", tracker.restProbeCalls, tracker.probeCalls)
+	}
+}
+
+func TestGitHubRESTFanoutDeferralDoesNotStartLookupBackoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 9, 0, 0, 0, time.UTC)
+	resetAt := now.Add(time.Hour)
+	cfg := normalizeConfig(Config{
+		Project:              scheduler.ProjectCandidate{ID: "leadpipe"},
+		MaxConcurrentAgents:  4,
+		GitHubRESTMinReserve: 1000,
+	})
+	tracker := &rateLimitConnector{
+		restStatus: connector.RESTRateLimitUsage{
+			HasRateLimit:   true,
+			FanoutDeferred: true,
+			RateLimit: connector.RESTRateLimit{
+				Limit:     5000,
+				Used:      390,
+				Remaining: 4610,
+				ResetAt:   resetAt,
+			},
+		},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+	state := newState(cfg)
+
+	if orch.githubLookupBackoffGate(t.Context(), &state, now) {
+		t.Fatal("githubLookupBackoffGate() = true for a local fanout deferral")
+	}
+	if _, _, active := githubLookupBackoff(state.BackendOutages); active {
+		t.Fatalf("BackendOutages = %#v, want no provider lookup backoff", state.BackendOutages)
 	}
 }
 

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -125,6 +125,8 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 		NotModifiedRequests: usage.NotModifiedRequests,
 		BillableRequests:    usage.BillableRequests,
 		RateLimited:         usage.RateLimited,
+		ReserveHeld:         usage.ReserveHeld,
+		FanoutDeferred:      usage.FanoutDeferred,
 		Contributors:        make([]telemetry.RESTUsageContributor, 0, len(usage.Requests)),
 		Divergences:         make([]telemetry.RESTUsageDivergence, 0, len(usage.Divergences)),
 	}
@@ -137,6 +139,8 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 			Consumer:           telemetry.RESTConsumerOrchestrator,
 			CredentialIdentity: request.CredentialIdentity,
 			EndpointFamily:     request.EndpointFamily,
+			BudgetScope:        request.BudgetScope,
+			BudgetGate:         request.BudgetGate,
 			Count:              request.Count,
 			Conditional:        request.Conditional,
 			NotModified:        request.NotModified,
@@ -264,12 +268,16 @@ func (o *Orchestrator) logRESTRateLimitCycle(cycle restRateLimitCycle) {
 	billableRequests := int64(0)
 	notModifiedRequests := int64(0)
 	rateLimited := false
+	reserveHeld := false
+	fanoutDeferred := false
 	var contributors []telemetry.RESTUsageContributor
 	if cycle.Usage != nil {
 		totalRequests = cycle.Usage.TotalRequests
 		billableRequests = cycle.Usage.BillableRequests
 		notModifiedRequests = cycle.Usage.NotModifiedRequests
 		rateLimited = cycle.Usage.RateLimited
+		reserveHeld = cycle.Usage.ReserveHeld
+		fanoutDeferred = cycle.Usage.FanoutDeferred
 		contributors = cycle.Usage.Contributors
 	}
 
@@ -280,6 +288,8 @@ func (o *Orchestrator) logRESTRateLimitCycle(cycle restRateLimitCycle) {
 		"billable_request_count", billableRequests,
 		"not_modified_request_count", notModifiedRequests,
 		"rate_limited", rateLimited,
+		"reserve_held", reserveHeld,
+		"fanout_deferred", fanoutDeferred,
 		"remaining", cycle.Bucket.Remaining,
 		"limit", cycle.Bucket.Limit,
 		"reset_at", resetAt,

--- a/internal/store/admission.go
+++ b/internal/store/admission.go
@@ -904,18 +904,23 @@ func (s *sqliteStore) RecordAdmissionRun(ctx context.Context, record admissionmo
 	if err != nil {
 		return fmt.Errorf("encoding backlog admission issues: %w", err)
 	}
+	resumeAt, err := optionalTimestamp("resume_at", record.ResumeAt)
+	if err != nil {
+		return err
+	}
 	_, err = s.db.ExecContext(ctx, `
 INSERT INTO backlog_admission_runs (
-  project_id, scheduled_for, started_at, completed_at, outcome, deferred_reason, proposal_reason,
+  project_id, scheduled_for, started_at, completed_at, outcome, deferred_reason, resume_at, proposal_reason,
   candidates_found_count, candidates_count, proposed_count, skipped_json,
   truncated_json, issues_json, error
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strings.TrimSpace(record.ProjectID),
 		scheduledFor,
 		startedAt,
 		completedAt,
 		strings.TrimSpace(record.Outcome),
 		nullString(record.DeferredReason),
+		resumeAt,
 		nullString(record.ProposalReason),
 		nonNegative(int64(record.CandidatesFound)),
 		nonNegative(int64(record.Candidates)),
@@ -934,7 +939,7 @@ INSERT INTO backlog_admission_runs (
 func (s *sqliteStore) LatestAdmissionRun(ctx context.Context, projectID string) (admissionmodel.RunRecord, bool, error) {
 	row := s.db.QueryRowContext(ctx, `
 SELECT project_id, scheduled_for, started_at, completed_at, outcome,
-       COALESCE(deferred_reason, ''), COALESCE(proposal_reason, ''), candidates_found_count, candidates_count,
+       COALESCE(deferred_reason, ''), COALESCE(resume_at, ''), COALESCE(proposal_reason, ''), candidates_found_count, candidates_count,
        proposed_count, skipped_json, truncated_json, issues_json, COALESCE(error, '')
 FROM backlog_admission_runs
 WHERE project_id = ?
@@ -956,7 +961,7 @@ func (s *sqliteStore) RecentAdmissionRuns(ctx context.Context, projectID string,
 	}
 	rows, err := s.db.QueryContext(ctx, `
 SELECT project_id, scheduled_for, started_at, completed_at, outcome,
-       COALESCE(deferred_reason, ''), COALESCE(proposal_reason, ''), candidates_found_count, candidates_count,
+       COALESCE(deferred_reason, ''), COALESCE(resume_at, ''), COALESCE(proposal_reason, ''), candidates_found_count, candidates_count,
        proposed_count, skipped_json, truncated_json, issues_json, COALESCE(error, '')
 FROM backlog_admission_runs
 WHERE project_id = ?
@@ -1180,6 +1185,7 @@ func scanAdmissionRun(scan admissionScan) (admissionmodel.RunRecord, error) {
 	var scheduledFor string
 	var startedAt string
 	var completedAt string
+	var resumeAt string
 	var skippedJSON string
 	var truncatedJSON string
 	var issuesJSON string
@@ -1190,6 +1196,7 @@ func scanAdmissionRun(scan admissionScan) (admissionmodel.RunRecord, error) {
 		&completedAt,
 		&record.Outcome,
 		&record.DeferredReason,
+		&resumeAt,
 		&record.ProposalReason,
 		&record.CandidatesFound,
 		&record.Candidates,
@@ -1212,6 +1219,9 @@ func scanAdmissionRun(scan admissionScan) (admissionmodel.RunRecord, error) {
 		return admissionmodel.RunRecord{}, err
 	}
 	if record.CompletedAt, err = parseTimestamp("completed_at", completedAt); err != nil {
+		return admissionmodel.RunRecord{}, err
+	}
+	if record.ResumeAt, err = parseAdmissionOptionalTimestamp("resume_at", resumeAt); err != nil {
 		return admissionmodel.RunRecord{}, err
 	}
 	if err := json.Unmarshal([]byte(skippedJSON), &record.Skipped); err != nil {

--- a/internal/store/admission_test.go
+++ b/internal/store/admission_test.go
@@ -186,7 +186,9 @@ func TestAdmissionProposalExpiryAndRunLedger(t *testing.T) {
 		ScheduledFor:    now,
 		StartedAt:       now.Add(time.Minute),
 		CompletedAt:     now.Add(2 * time.Minute),
-		Outcome:         "completed",
+		Outcome:         "deferred",
+		DeferredReason:  "github_rest_fanout_cap",
+		ResumeAt:        now.Add(3 * time.Minute),
 		ProposalReason:  "criteria_not_met",
 		CandidatesFound: 4,
 		Candidates:      2,
@@ -208,6 +210,8 @@ func TestAdmissionProposalExpiryAndRunLedger(t *testing.T) {
 		t.Fatalf("LatestAdmissionRun() = %#v, %t, %v", got, ok, err)
 	}
 	if got.CandidatesFound != 4 || got.Candidates != 2 || got.Proposed != 1 ||
+		got.Outcome != "deferred" || got.DeferredReason != "github_rest_fanout_cap" ||
+		!got.ResumeAt.Equal(record.ResumeAt) ||
 		got.ProposalReason != "criteria_not_met" ||
 		got.Skipped["author"] != 1 || got.Truncated["candidates"] != 1 ||
 		len(got.Issues) != 1 || got.Issues[0].ProposalID != "proposal-expiring" {

--- a/internal/store/migrations/00052_add_admission_run_resume.sql
+++ b/internal/store/migrations/00052_add_admission_run_resume.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE backlog_admission_runs ADD COLUMN resume_at TEXT;
+
+-- +goose Down
+ALTER TABLE backlog_admission_runs DROP COLUMN resume_at;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -121,6 +121,7 @@ type BacklogAdmissionRun struct {
 	IssuesJson           string         `json:"issues_json"`
 	Error                sql.NullString `json:"error"`
 	ProposalReason       sql.NullString `json:"proposal_reason"`
+	ResumeAt             sql.NullString `json:"resume_at"`
 }
 
 type BudgetOverride struct {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1571,6 +1571,8 @@ type RESTUsage struct {
 	NotModifiedRequests int64                  `json:"not_modified_requests,omitempty"`
 	BillableRequests    int64                  `json:"billable_requests,omitempty"`
 	RateLimited         bool                   `json:"rate_limited,omitempty"`
+	ReserveHeld         bool                   `json:"reserve_held,omitempty"`
+	FanoutDeferred      bool                   `json:"fanout_deferred,omitempty"`
 	BackoffUntil        *time.Time             `json:"backoff_until,omitempty"`
 	Contributors        []RESTUsageContributor `json:"contributors,omitempty"`
 	Divergences         []RESTUsageDivergence  `json:"divergences,omitempty"`
@@ -1600,6 +1602,8 @@ type RESTUsageContributor struct {
 	Consumer           string     `json:"consumer,omitempty"`
 	CredentialIdentity string     `json:"credential_identity,omitempty"`
 	EndpointFamily     string     `json:"endpoint_family"`
+	BudgetScope        string     `json:"budget_scope,omitempty"`
+	BudgetGate         string     `json:"budget_gate,omitempty"`
 	Count              int64      `json:"count"`
 	Conditional        int64      `json:"conditional,omitempty"`
 	NotModified        int64      `json:"not_modified,omitempty"`

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -415,11 +415,11 @@ templ GitHubAPIHealthDetails(snapshot telemetry.Snapshot) {
 				</div>
 			}
 		</section>
-		<section class="dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5" aria-label="GitHub endpoint backoff details">
+		<section class="dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5" aria-label="GitHub REST endpoint details">
 			<div class="flex min-w-0 items-start justify-between gap-3">
 				<div class="min-w-0">
 					<h3 class="text-sm font-semibold text-text">Affected endpoints</h3>
-					<p class="text-sm text-sec">Endpoint families currently paused by secondary REST throttling.</p>
+					<p class="text-sm text-sec">Endpoint families affected by provider throttles or local REST gates.</p>
 				</div>
 				<span class="shrink-0 rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec">{ formatInt(int64(len(gitHubAPIHealth(snapshot).Endpoints))) }</span>
 			</div>

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -8197,6 +8197,12 @@ func restContributorStatus(contributor telemetry.RESTUsageContributor) string {
 	if contributor.RateLimited {
 		return "rate limited"
 	}
+	if contributor.BudgetGate == "fanout_cap" {
+		return "fanout deferred"
+	}
+	if contributor.BudgetGate == "reserve" {
+		return "reserve held"
+	}
 	if contributor.LastStatus > 0 {
 		return formatInt(int64(contributor.LastStatus))
 	}
@@ -8251,6 +8257,13 @@ func gitHubAPIHealth(snapshot telemetry.Snapshot) gitHubAPIHealthView {
 		view.Detail = "GitHub secondary endpoint throttle is active for " + families + ". " + primaryContext + ". " + retrySentence + "."
 		return view
 	}
+	if localDeferral := gitHubAPILocalRESTDeferral(snapshot.RateLimits); localDeferral != "" {
+		view.State = gitHubAPIHealthStateWarning
+		view.Label = localDeferral
+		view.Summary = gitHubAPIRESTPrimaryContext(snapshot.RateLimits) + "."
+		view.Detail = gitHubAPILocalRESTDeferralDetail(snapshot.RateLimits)
+		return view
+	}
 	if gitHubAPITrackerDegraded(snapshot) {
 		view.State = gitHubAPIHealthStateWarning
 		view.Label = "GitHub tracker degraded"
@@ -8286,6 +8299,37 @@ func gitHubAPIHealth(snapshot telemetry.Snapshot) gitHubAPIHealthView {
 	view.Summary = primarySummary
 	view.Detail = gitHubAPIHealthyDetail(snapshot)
 	return view
+}
+
+func gitHubAPILocalRESTDeferral(limits *telemetry.RateLimits) string {
+	if limits == nil || limits.RESTUsage == nil {
+		return ""
+	}
+	switch {
+	case limits.RESTUsage.FanoutDeferred && limits.RESTUsage.ReserveHeld:
+		return "GitHub REST local deferrals active"
+	case limits.RESTUsage.FanoutDeferred:
+		return "GitHub REST fanout deferred"
+	case limits.RESTUsage.ReserveHeld:
+		return "GitHub REST reserve held"
+	default:
+		return ""
+	}
+}
+
+func gitHubAPILocalRESTDeferralDetail(limits *telemetry.RateLimits) string {
+	primary := gitHubAPIRESTPrimaryContext(limits)
+	if limits == nil || limits.RESTUsage == nil {
+		return primary + "."
+	}
+	switch {
+	case limits.RESTUsage.FanoutDeferred && limits.RESTUsage.ReserveHeld:
+		return "Internal REST fanout capacity and the provider quota reserve floor deferred local work. " + primary + "."
+	case limits.RESTUsage.FanoutDeferred:
+		return "The internal REST fanout cap deferred local work without a provider rate-limit response. " + primary + "."
+	default:
+		return "The provider quota reserve floor deferred local work before exhaustion. " + primary + "."
+	}
 }
 
 func gitHubAPITrackerDegraded(snapshot telemetry.Snapshot) bool {
@@ -8541,6 +8585,9 @@ func gitHubAPIContributorBackedOff(snapshot telemetry.Snapshot, contributor tele
 }
 
 func gitHubAPIContributorHasBackoffSignal(contributor telemetry.RESTUsageContributor) bool {
+	if contributor.BudgetGate != "" {
+		return false
+	}
 	return contributor.RateLimited || contributor.LastStatus == httpStatusTooManyRequests || contributor.RetryAfterMS > 0
 }
 
@@ -8820,7 +8867,7 @@ func gitHubAPIHealthEndpointRows(snapshot telemetry.Snapshot) []gitHubAPIHealthE
 	usage := snapshot.RateLimits.RESTUsage
 	rows := make([]gitHubAPIHealthEndpointRow, 0, len(usage.Contributors))
 	for _, contributor := range usage.Contributors {
-		if !gitHubAPIContributorBackedOff(snapshot, contributor, usage.BackoffUntil) {
+		if !gitHubAPIContributorBackedOff(snapshot, contributor, usage.BackoffUntil) && contributor.BudgetGate == "" {
 			continue
 		}
 		rows = append(rows, gitHubAPIHealthEndpointRow{
@@ -8837,13 +8884,19 @@ func gitHubAPIHealthEndpointRows(snapshot telemetry.Snapshot) []gitHubAPIHealthE
 
 func gitHubAPIEndpointFamily(contributor telemetry.RESTUsageContributor) string {
 	family := strings.TrimSpace(contributor.EndpointFamily)
-	if family != "" {
-		return family
+	if family == "" {
+		family = "REST endpoints"
 	}
-	return "REST endpoints"
+	if scope := strings.TrimSpace(contributor.BudgetScope); scope != "" {
+		return scope + ": " + family
+	}
+	return family
 }
 
 func gitHubAPIEndpointStatus(contributor telemetry.RESTUsageContributor) string {
+	if contributor.BudgetGate != "" {
+		return restContributorStatus(contributor)
+	}
 	if contributor.LastStatus > 0 {
 		return formatInt(int64(contributor.LastStatus))
 	}

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -434,6 +434,59 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 			wantSummaryPart: "REST primary: 4,878 remaining / 5,000 total (122 used)",
 		},
 		{
+			name: "internal fanout deferral preserves healthy provider quota",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4610, Used: 390, Limit: 5000, ResetAt: &resetAt},
+					GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 4880, Used: 120, Limit: 5000, ResetAt: &resetAt},
+					RESTUsage: &telemetry.RESTUsage{
+						FanoutDeferred: true,
+						Contributors: []telemetry.RESTUsageContributor{{
+							EndpointFamily: "issue dependencies",
+							BudgetScope:    "backlog_admission_reconciliation",
+							BudgetGate:     "fanout_cap",
+							Count:          80,
+							RetryAfterMS:   (30 * time.Second).Milliseconds(),
+						}},
+					},
+				},
+			},
+			wantState:       gitHubAPIHealthStateWarning,
+			wantLabel:       "GitHub REST fanout deferred",
+			wantSummaryPart: "Primary REST quota is healthy: 4,610/5,000 remaining",
+			wantDetailParts: []string{
+				"internal REST fanout cap deferred local work",
+				"without a provider rate-limit response",
+			},
+		},
+		{
+			name: "reserve hold is distinct from provider exhaustion",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST:    &telemetry.RateLimitBucket{Remaining: 1250, Used: 3750, Limit: 5000, ResetAt: &resetAt},
+					GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 4880, Used: 120, Limit: 5000, ResetAt: &resetAt},
+					RESTUsage: &telemetry.RESTUsage{
+						ReserveHeld: true,
+						Contributors: []telemetry.RESTUsageContributor{{
+							EndpointFamily: "issue comments",
+							BudgetScope:    "backlog_admission_reconciliation",
+							BudgetGate:     "reserve",
+							Count:          1,
+						}},
+					},
+				},
+			},
+			wantState:       gitHubAPIHealthStateWarning,
+			wantLabel:       "GitHub REST reserve held",
+			wantSummaryPart: "Primary REST quota is healthy: 1,250/5,000 remaining",
+			wantDetailParts: []string{
+				"provider quota reserve floor deferred local work",
+				"before exhaustion",
+			},
+		},
+		{
 			name: "never observed graphql stays at rest",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,
@@ -737,6 +790,48 @@ func TestRESTBudgetContributorRowsPreserveCredentialAndEndpointWindows(t *testin
 	}
 	if got := restBudgetCredentialCount(limits); got != 2 {
 		t.Fatalf("restBudgetCredentialCount() = %d, want 2", got)
+	}
+}
+
+func TestRESTContributorStatusDistinguishesProviderAndLocalGates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contributor telemetry.RESTUsageContributor
+		want        string
+	}{
+		{name: "provider rate limit", contributor: telemetry.RESTUsageContributor{RateLimited: true, LastStatus: 429}, want: "rate limited"},
+		{name: "fanout cap", contributor: telemetry.RESTUsageContributor{BudgetGate: "fanout_cap"}, want: "fanout deferred"},
+		{name: "reserve floor", contributor: telemetry.RESTUsageContributor{BudgetGate: "reserve"}, want: "reserve held"},
+		{name: "provider response", contributor: telemetry.RESTUsageContributor{LastStatus: 200}, want: "200"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := restContributorStatus(tt.contributor); got != tt.want {
+				t.Fatalf("restContributorStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 9, 4, 9, 0, 0, 0, time.UTC),
+		RateLimits: &telemetry.RateLimits{RESTUsage: &telemetry.RESTUsage{
+			FanoutDeferred: true,
+			Contributors: []telemetry.RESTUsageContributor{{
+				EndpointFamily: "issue comments",
+				BudgetScope:    "backlog_admission_reconciliation",
+				BudgetGate:     "fanout_cap",
+				Count:          1,
+				RetryAfterMS:   (30 * time.Second).Milliseconds(),
+			}},
+		}},
+	}
+	rows := gitHubAPIHealthEndpointRows(snapshot)
+	if len(rows) != 1 || rows[0].Status != "fanout deferred" ||
+		rows[0].EndpointFamily != "backlog_admission_reconciliation: issue comments" {
+		t.Fatalf("gitHubAPIHealthEndpointRows() = %#v", rows)
 	}
 }
 

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -2024,7 +2024,7 @@ func GitHubAPIHealthDetails(snapshot telemetry.Snapshot) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "</section><section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"GitHub endpoint backoff details\"><div class=\"flex min-w-0 items-start justify-between gap-3\"><div class=\"min-w-0\"><h3 class=\"text-sm font-semibold text-text\">Affected endpoints</h3><p class=\"text-sm text-sec\">Endpoint families currently paused by secondary REST throttling.</p></div><span class=\"shrink-0 rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "</section><section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"GitHub REST endpoint details\"><div class=\"flex min-w-0 items-start justify-between gap-3\"><div class=\"min-w-0\"><h3 class=\"text-sm font-semibold text-text\">Affected endpoints</h3><p class=\"text-sm text-sec\">Endpoint families affected by provider throttles or local REST gates.</p></div><span class=\"shrink-0 rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- classify internal GitHub REST fanout exhaustion as a typed local deferral instead of a provider 429
- isolate refresh and scheduled-admission request budgets, then durably resume the original scheduled occurrence without duplicate proposals
- distinguish provider throttles, reserve-floor holds, and local fanout gates in logs, telemetry, health UI, and operator documentation

Fixes #2142

## UI Surface Contract

- [x] N/A for high-impact layout/density tradeoffs; this is an issue-authorized health-diagnostic copy change only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Verified the seeded fanout-deferral state in an isolated browser preview: provider quota remained healthy, no provider backoff appeared, and the affected endpoint was labeled as locally deferred.

## Test Plan

- [x] Focused admission, connector, GitHub, store, orchestrator, and web-template tests
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`
- [x] `PATH="$TMPDIR/issue-2142-lint-bin:$PATH" GOTOOLCHAIN=go1.26.6 GOMAXPROCS=4 make check`
