### PR TITLE
test(runner): stabilize no-progress completion

### DIFF
--- a/internal/runner/session_brake_test.go
+++ b/internal/runner/session_brake_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
-const sessionBrakeTestWaitTimeout = 10 * time.Second
+const (
+	sessionBrakeTestWaitTimeout        = 10 * time.Second
+	sessionBrakeCompletionGuardTimeout = time.Minute
+)
 
 func TestRunnerStopsSessionBeyondMaxTurns(t *testing.T) {
 	t.Parallel()
@@ -150,8 +153,7 @@ func TestRunnerStopsSessionAfterNoProgressBeforeCompletion(t *testing.T) {
 		t.Fatalf("NewRunner() error = %v", err)
 	}
 
-	resultCh := make(chan RunResult, 1)
-	errCh := make(chan error, 1)
+	completionCh := make(chan sessionRunCompletion, 1)
 	go func() {
 		result, runErr := runner.Run(t.Context(), RunRequest{
 			Issue: connector.Issue{
@@ -164,8 +166,7 @@ func TestRunnerStopsSessionAfterNoProgressBeforeCompletion(t *testing.T) {
 				return "unchanged-workpad", nil
 			},
 		})
-		resultCh <- result
-		errCh <- runErr
+		completionCh <- sessionRunCompletion{result: result, err: runErr}
 	}()
 
 	waitSessionSignal(t, probeCalls, "initial progress probe")
@@ -175,18 +176,13 @@ func TestRunnerStopsSessionAfterNoProgressBeforeCompletion(t *testing.T) {
 	waitSessionSignal(t, probeCalls, "expiration progress probe")
 	waitSessionSignal(t, backend.stopped, "agent backend cancellation")
 
-	var result RunResult
+	var completion sessionRunCompletion
 	select {
-	case result = <-resultCh:
-	case <-time.After(sessionBrakeTestWaitTimeout):
-		t.Fatal("timed out waiting for no-progress result")
+	case completion = <-completionCh:
+	case <-time.After(sessionBrakeCompletionGuardTimeout):
+		t.Fatal("timed out waiting for no-progress completion")
 	}
-	var runErr error
-	select {
-	case runErr = <-errCh:
-	case <-time.After(sessionBrakeTestWaitTimeout):
-		t.Fatal("timed out waiting for no-progress error")
-	}
+	result, runErr := completion.result, completion.err
 	if !errors.Is(runErr, ErrSessionNoProgress) {
 		t.Fatalf("Run() error = %v, want ErrSessionNoProgress", runErr)
 	}
@@ -206,6 +202,11 @@ func TestRunnerStopsSessionAfterNoProgressBeforeCompletion(t *testing.T) {
 	if !workspaceBackend.afterRun {
 		t.Fatal("AfterRun() was not called")
 	}
+}
+
+type sessionRunCompletion struct {
+	result RunResult
+	err    error
 }
 
 func TestRunnerWorkpadProgressResetsNoProgressHeartbeat(t *testing.T) {


### PR DESCRIPTION
## Summary

- synchronize the no-progress runner result and error through one completion signal after backend cancellation
- retain a one-minute wall-clock guard only for deadlock detection
- preserve assertions for brake details, final state, session persistence, and workspace cleanup

Fixes #2151

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test -race ./internal/runner -run '^TestRunnerStopsSessionAfterNoProgressBeforeCompletion$' -count=10`
- [x] `make check`
