### PR TITLE
fix(notify): isolate webhook transports

### DIFF
--- a/.detent/skills/deterministic-http-transport-cleanup-testing.md
+++ b/.detent/skills/deterministic-http-transport-cleanup-testing.md
@@ -1,0 +1,15 @@
+---
+name: deterministic-http-transport-cleanup-testing
+description: "Reproduce HTTP client failures caused by concurrent test-server cleanup closing a shared process-wide transport."
+when_to_use: "Use when parallel Go HTTP tests intermittently fail with transport lifecycle errors such as `http: CloseIdleConnections called` while another `httptest.Server` is closing."
+---
+
+# Test shared HTTP transport cleanup deterministically
+
+- Verify the active Go toolchain's `httptest.Server.Close` implementation before assigning causality. It may call `http.DefaultTransport.CloseIdleConnections`, so separate `http.Client` values with nil transports still share lifecycle state.
+- Replace `http.DefaultTransport` in one non-parallel top-level test with a close-sensitive `http.RoundTripper`. Have `RoundTrip` signal that delivery started, wait for `CloseIdleConnections`, and then return the recorded transport error. Restore the original transport with test cleanup before parallel tests resume.
+- Use a separate `httptest.Server` solely to invoke the real cleanup path. Coordinate delivery and cleanup with channels and `sync.Once`; do not use sleeps to widen the race.
+- Arrange the readiness signal so both implementations progress: the close-sensitive transport signals it when the buggy client uses the process default, while the target server handler signals it when an isolated client reaches the server. This lets the unchanged test fail with the observed error before the fix and complete without timing assumptions afterward.
+- Assert the ownership invariant separately by constructing two clients and verifying both transports are non-nil and distinct.
+- Isolate lifecycle state by cloning the standard `*http.Transport` for each client. If the process default can be a custom `RoundTripper`, use an independent standard-settings fallback rather than silently sharing the custom transport.
+- Prove the regression red against the old constructor, then repeat the focused test, the affected package with a high `-count`, the focused package under `-race`, and the repository validation gate.

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -7,12 +7,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 )
 
 const defaultWebhookTimeout = 5 * time.Second
+
+const (
+	defaultWebhookDialTimeout     = 30 * time.Second
+	defaultWebhookDialKeepAlive   = 30 * time.Second
+	defaultWebhookIdleConnTimeout = 90 * time.Second
+)
 
 type WebhookConfig struct {
 	URL       string
@@ -44,8 +51,31 @@ func NewWebhook(cfg WebhookConfig) (*Webhook, error) {
 		url:       cfg.URL,
 		headers:   cloneHeaders(cfg.Headers),
 		userAgent: strings.TrimSpace(cfg.UserAgent),
-		client:    &http.Client{Timeout: cfg.Timeout},
+		client: &http.Client{
+			Timeout:   cfg.Timeout,
+			Transport: newWebhookTransport(),
+		},
 	}, nil
+}
+
+func newWebhookTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   defaultWebhookDialTimeout,
+		KeepAlive: defaultWebhookDialKeepAlive,
+	}
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       defaultWebhookIdleConnTimeout,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: time.Second,
+	}
 }
 
 func (w *Webhook) Send(ctx context.Context, payload any) error {

--- a/internal/notify/webhook_test.go
+++ b/internal/notify/webhook_test.go
@@ -2,9 +2,11 @@ package notify
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -79,4 +81,90 @@ func TestWebhookErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWebhookTransportIsolation(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{name: "separate webhooks", test: testSeparateWebhookTransports},
+		{name: "concurrent server cleanup", test: testConcurrentServerCleanup},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.test)
+	}
+}
+
+func testSeparateWebhookTransports(t *testing.T) {
+	first, err := NewWebhook(WebhookConfig{URL: "http://example.com"})
+	if err != nil {
+		t.Fatalf("NewWebhook() first error = %v", err)
+	}
+	second, err := NewWebhook(WebhookConfig{URL: "http://example.com"})
+	if err != nil {
+		t.Fatalf("NewWebhook() second error = %v", err)
+	}
+	if first.client.Transport == nil {
+		t.Fatal("first transport is nil, want dedicated transport")
+	}
+	if first.client.Transport == second.client.Transport {
+		t.Fatal("webhook transports are shared, want dedicated transports")
+	}
+}
+
+func testConcurrentServerCleanup(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	deliveryStarted := make(chan struct{})
+	cleanupTransport := &closeSensitiveTransport{
+		deliveryStarted: deliveryStarted,
+		closed:          make(chan struct{}),
+	}
+	http.DefaultTransport = cleanupTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	releaseDelivery := make(chan struct{})
+	deliveryServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		close(deliveryStarted)
+		<-releaseDelivery
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(deliveryServer.Close)
+	cleanupServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	webhook, err := NewWebhook(WebhookConfig{URL: deliveryServer.URL, Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewWebhook() error = %v", err)
+	}
+	sendResult := make(chan error, 1)
+	go func() {
+		sendResult <- webhook.Send(t.Context(), struct{}{})
+	}()
+
+	<-deliveryStarted
+	cleanupServer.Close()
+	close(releaseDelivery)
+	if err := <-sendResult; err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+}
+
+type closeSensitiveTransport struct {
+	deliveryStarted chan struct{}
+	closed          chan struct{}
+	startOnce       sync.Once
+	closeOnce       sync.Once
+}
+
+func (t *closeSensitiveTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	t.startOnce.Do(func() { close(t.deliveryStarted) })
+	<-t.closed
+	return nil, errors.New("http: CloseIdleConnections called")
+}
+
+func (t *closeSensitiveTransport) CloseIdleConnections() {
+	t.closeOnce.Do(func() { close(t.closed) })
 }


### PR DESCRIPTION
## Summary

- give each webhook client a dedicated clone of the default HTTP transport
- preserve standard transport behavior when the process default is custom
- reproduce concurrent `httptest.Server.Close` transport disruption deterministically
- draft a reusable deterministic transport-cleanup testing skill

Fixes #2157

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (No visual changes.)

## Test Plan

- [x] `go test ./internal/notify -run '^TestWebhookTransportIsolation$' -count=20`
- [x] `go test ./internal/notify -count=100`
- [x] `go test -race ./internal/notify -count=20`
- [x] `PATH="$TMPDIR/go-bin:$PATH" GOTOOLCHAIN=go1.26.6 make check` (twice; before and after skill draft)