### PR TITLE
fix(scheduler): never reserve idle capacity for priority

### DIFF
--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -31,13 +31,17 @@ type releaseErrorGlobalScheduler struct {
 	err error
 }
 
+// ReleaseSlot fails BEFORE delegating so a failed release leaves the slot
+// genuinely held. Releasing first and then returning an error freed the slot for
+// real, which meant only the old priority reservation refused the next request
+// rather than actual capacity accounting.
 func (s *releaseErrorGlobalScheduler) ReleaseSlot(slot scheduler.Slot) error {
-	if err := s.GlobalScheduler.ReleaseSlot(slot); err != nil {
+	if s.err != nil {
+		err := s.err
+		s.err = nil
 		return err
 	}
-	err := s.err
-	s.err = nil
-	return err
+	return s.GlobalScheduler.ReleaseSlot(slot)
 }
 
 func TestManagerDisabledRegistersNoSchedule(t *testing.T) {

--- a/internal/cli/restart_recovery_e2e_test.go
+++ b/internal/cli/restart_recovery_e2e_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -162,23 +161,4 @@ func restartRecoveryState(t *testing.T, orch *orchestrator.Orchestrator) orchest
 		t.Fatalf("Orchestrator.State() error = %v", err)
 	}
 	return state
-}
-
-func restartRecoveryEventContains(state orchestrator.State, event string, fragments ...string) bool {
-	for _, candidate := range state.RecentEvents {
-		if candidate.Event != event {
-			continue
-		}
-		matched := true
-		for _, fragment := range fragments {
-			if !strings.Contains(candidate.Message, fragment) {
-				matched = false
-				break
-			}
-		}
-		if matched {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cli/restart_recovery_e2e_test.go
+++ b/internal/cli/restart_recovery_e2e_test.go
@@ -17,7 +17,12 @@ import (
 	"github.com/digitaldrywood/detent/internal/scheduler"
 )
 
-func TestBootRegistryRebuildDispatchesStrandedActiveIssueAfterPoisonedGate(t *testing.T) {
+// A ready higher-priority project that never acquires must not strand real work.
+// This previously required a full gate rebuild to recover: the phantom project
+// held a priority reservation, so the stranded issue could not dispatch at all.
+// Priority now orders contention only, so the issue dispatches immediately and
+// the rebuild path below still recovers it.
+func TestBootRegistryRebuildDispatchesStrandedActiveIssueDespiteReadyHigherPriorityProject(t *testing.T) {
 	t.Parallel()
 
 	configuredProject := globalconfig.Project{ID: "gopher-ai", Weight: 1, Priority: 3}
@@ -44,22 +49,19 @@ func TestBootRegistryRebuildDispatchesStrandedActiveIssueAfterPoisonedGate(t *te
 	poisonedGate.MarkReady(phantom)
 	strandedRunner := newRestartRecoveryRunner()
 	stranded, stopStranded := runRestartRecoveryOrchestrator(t, tracker, strandedRunner, poisonedGate, configuredCandidate)
-	strandedState := restartRecoveryState(t, stranded)
-	if len(strandedState.Running) != 0 {
-		t.Fatalf("Running = %#v, want no live work attempt while gate is poisoned", strandedState.Running)
-	}
-	if !restartRecoveryEventContains(
-		strandedState,
-		"dispatch_slot_wait",
-		"reason="+scheduler.DispatchGateReasonReservedForHigherPriorityProject,
-		"selected_project_id="+phantom.ID,
-	) {
-		t.Fatalf("RecentEvents = %#v, want poisoned priority reservation", strandedState.RecentEvents)
-	}
 	select {
 	case request := <-strandedRunner.started:
-		t.Fatalf("unexpected runner request while gate is poisoned = %#v", request)
-	default:
+		if request.Issue.ID != issue.ID {
+			t.Fatalf("RunRequest.Issue = %#v, want stranded issue %#v", request.Issue, issue)
+		}
+	case <-time.After(5 * time.Second):
+		strandedState := restartRecoveryState(t, stranded)
+		t.Fatalf(
+			"timed out waiting for dispatch while %q was merely ready; capacity was free. Running = %#v, RecentEvents = %#v",
+			phantom.ID,
+			strandedState.Running,
+			strandedState.RecentEvents,
+		)
 	}
 	stopStranded()
 

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -16,11 +16,17 @@ type releaseErrorSafetyScheduler struct {
 	err error
 }
 
+// ReleaseSlot fails BEFORE delegating, so a failed release leaves the underlying
+// semaphore genuinely occupied. Releasing first and then returning an error made
+// the slot actually free, which meant the old priority reservation -- not real
+// capacity accounting -- was the only thing refusing the next request.
 func (s *releaseErrorSafetyScheduler) ReleaseSlot(slot scheduler.Slot) error {
-	if err := s.GlobalScheduler.ReleaseSlot(slot); err != nil {
+	if s.err != nil {
+		err := s.err
+		s.err = nil
 		return err
 	}
-	return s.err
+	return s.GlobalScheduler.ReleaseSlot(slot)
 }
 
 func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
@@ -249,23 +255,27 @@ func assertDemandDrivenPriorityReservation(t *testing.T, scenario uint8, now tim
 		gate.EndProjectCycle(higher.ID)
 		requireSafetyGateGrantedAndReleased(t, gate, lower, now)
 	case 2:
+		// Priority never holds idle capacity. A higher-priority project that is
+		// mid-cycle, merely ready, or idle must not refuse a free slot to a
+		// lower-priority project; only a slot it actually holds may.
 		gate.BeginProjectCycle(higher)
-		requireSafetyGateReserved(t, gate, lower, now)
+		requireSafetyGateGrantedAndReleased(t, gate, lower, now)
 		gate.EndProjectCycle(higher.ID)
 		requireSafetyGateGrantedAndReleased(t, gate, lower, now.Add(time.Second))
 
 		gate.MarkReady(higher)
-		requireSafetyGateReserved(t, gate, lower, now.Add(2*time.Second))
+		requireSafetyGateGrantedAndReleased(t, gate, lower, now.Add(2*time.Second))
 		gate.MarkIdle(higher)
 		requireSafetyGateGrantedAndReleased(t, gate, lower, now.Add(3*time.Second))
 
 		gate.BeginProjectCycle(higher)
 		slot := requireSafetyGateGranted(t, gate, higher, now.Add(4*time.Second))
+		requireSafetyGateReserved(t, gate, lower, now.Add(5*time.Second))
 		gate.EndProjectCycle(higher.ID)
 		if err := gate.Release(slot); err != nil {
 			t.Fatalf("release higher-priority candidate: %v", err)
 		}
-		requireSafetyGateReserved(t, gate, lower, now.Add(5*time.Second))
+		requireSafetyGateGrantedAndReleased(t, gate, lower, now.Add(6*time.Second))
 	case 3:
 		releaseErr := errors.New("release failed")
 		global := &releaseErrorSafetyScheduler{

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -388,11 +388,17 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	if g.dispatchPauses > 0 {
 		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonPaused), nil
 	}
+	// Priority orders who wins a contended slot; it never holds an idle one.
+	// This previously denied a slot to a lower-priority project whenever any
+	// higher-priority project was mid-cycle, even with capacity free and even
+	// when that project could never dispatch -- e.g. every candidate declined
+	// by its own authorization selector. That starved the fleet: 8 of 10 slots
+	// idle while two projects waited on a project structurally unable to run.
+	// Free capacity is now always offered; contention is resolved by ranking in
+	// fillSelectionsLocked, and genuine exhaustion still reports
+	// reserved_for_higher_priority_project via ErrNoSlots below.
 	if g.global.Mode() == ModeStrictPriority {
 		g.projectCycles[project.ID] = projectCycleState{}
-		if reservedProjectID, reservedReq, reserved := g.higherPriorityProjectReservationLocked(project, now); reserved {
-			return Slot{}, false, g.projectDecisionLocked(project.ID, req, reservedProjectID, reservedReq), nil
-		}
 	}
 	g.reconcileSelectionsLocked()
 	if err := g.fillSelectionsLocked(ctx, now, true); err != nil {
@@ -407,8 +413,15 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 		return Slot{}, false, DispatchGateDecision{}, err
 	}
 
+	// Not being the selected project is not grounds to refuse a free slot. A
+	// selection only records who should win a CONTENDED slot; a project that
+	// holds a selection but is not currently asking must not keep capacity
+	// idle. If real capacity remains, this request takes it and the unclaimed
+	// selection simply wins the next contended round. When capacity is truly
+	// gone, RequestSlot below returns ErrNoSlots and reports the real reason.
 	selected, selectedOK := g.selected[project.ID]
-	if !selectedOK {
+	strictFreeCapacity := g.global.Mode() == ModeStrictPriority && g.unreservedCapacityLocked() >= req.Weight
+	if !selectedOK && !strictFreeCapacity {
 		reason := g.waitReasonLocked(req)
 		return Slot{}, false, g.decisionLocked(project.ID, req, reason), nil
 	}
@@ -630,11 +643,30 @@ func (g *GlobalDispatchGate) fillSelectionsLocked(ctx context.Context, now time.
 	}
 }
 
+func (g *GlobalDispatchGate) bestStrictReadyProjectRankLocked() (int, bool) {
+	best := 0
+	found := false
+	for _, ready := range g.ready {
+		rank := priorityRank(ready.Priority)
+		if !found || rank < best {
+			best = rank
+			found = true
+		}
+	}
+	return best, found && g.global.Mode() == ModeStrictPriority
+}
+
 func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string]struct{}, maxWeight int) ([]ProjectCandidate, map[string]SlotRequest) {
 	if len(g.ready) == 0 {
 		return nil, nil
 	}
 
+	// Priority orders selection; it does not gate it. Filtering the candidate
+	// set down to only the best strict rank meant a merely-ready higher-priority
+	// project excluded every lower-priority project from selection entirely,
+	// even with capacity free. The selection loop already excludes projects it
+	// has picked, so ranking alone fills slots highest-priority-first and then
+	// keeps going down the list until capacity runs out.
 	strictProjectRank, strict := g.bestStrictReadyProjectRankLocked()
 	bestPriority := 0
 	first := true
@@ -681,22 +713,6 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string
 	return projects, requests
 }
 
-func (g *GlobalDispatchGate) bestStrictReadyProjectRankLocked() (int, bool) {
-	if g.global.Mode() != ModeStrictPriority {
-		return 0, false
-	}
-	bestRank := 0
-	found := false
-	for _, ready := range g.ready {
-		rank := priorityRank(ready.Priority)
-		if !found || rank < bestRank {
-			bestRank = rank
-			found = true
-		}
-	}
-	return bestRank, found
-}
-
 func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, reason string) DispatchGateDecision {
 	stats := g.capacitySnapshotLocked(req.State)
 	selectedProjectID, selectedReq, _ := g.decisionSelectionLocked(projectID)
@@ -726,53 +742,6 @@ func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, r
 		ReadyProjects:        len(g.ready),
 		RunningProjects:      len(g.running),
 	}
-}
-
-func (g *GlobalDispatchGate) projectDecisionLocked(
-	projectID string,
-	req SlotRequest,
-	selectedProjectID string,
-	selectedReq SlotRequest,
-) DispatchGateDecision {
-	decision := g.decisionLocked(projectID, req, DispatchGateReasonReservedForHigherPriorityProject)
-	decision.SelectedProjectID = selectedProjectID
-	decision.SelectedState = selectedReq.State
-	return decision
-}
-
-func (g *GlobalDispatchGate) higherPriorityProjectReservationLocked(
-	project ProjectCandidate,
-	now time.Time,
-) (string, SlotRequest, bool) {
-	projectRank := priorityRank(project.Priority)
-	selectedID := ""
-	selectedRank := 0
-	selectedReq := SlotRequest{}
-	for projectID, candidate := range g.projects {
-		if projectID == project.ID || priorityRank(candidate.Priority) >= projectRank {
-			continue
-		}
-		status, err := candidate.ActiveHoursStatus(now)
-		if err != nil || !status.Open {
-			continue
-		}
-		cycle, ok := g.projectCycles[projectID]
-		if ok && cycle.idle {
-			continue
-		}
-		rank := priorityRank(candidate.Priority)
-		if selectedID != "" && (rank > selectedRank || rank == selectedRank && projectID > selectedID) {
-			continue
-		}
-		selectedID = projectID
-		selectedRank = rank
-		if ready, readyOK := g.ready[projectID]; readyOK {
-			selectedReq = ready.request
-		} else {
-			selectedReq = SlotRequest{}
-		}
-	}
-	return selectedID, selectedReq, selectedID != ""
 }
 
 func (g *GlobalDispatchGate) pruneClosedReadyProjectsLocked(now time.Time) error {

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -815,15 +815,19 @@ func TestGlobalDispatchGatePressureCapacityDoesNotPreemptRunningWork(t *testing.
 	}
 }
 
-func TestGlobalDispatchGateStrictProjectPriorityIsIndependentOfDemandOrder(t *testing.T) {
+func TestGlobalDispatchGateStrictPriorityNeverHoldsIdleCapacity(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name  string
-		order []string
+		name       string
+		order      []string
+		wantHigher int
+		wantLower  int
 	}{
-		{name: "higher priority first", order: []string{"higher", "lower"}},
-		{name: "lower priority first", order: []string{"lower", "higher"}},
+		// Priority decides who wins a contended slot, never who may use a free
+		// one. Whoever asks while capacity is available gets it.
+		{name: "higher priority first", order: []string{"higher", "lower"}, wantHigher: 5, wantLower: 0},
+		{name: "lower priority first", order: []string{"lower", "higher"}, wantHigher: 2, wantLower: 3},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -870,17 +874,9 @@ func TestGlobalDispatchGateStrictProjectPriorityIsIndependentOfDemandOrder(t *te
 				gate.EndProjectCycle(projects[projectName].ID)
 			}
 
-			if grants["higher"] != 5 || grants["lower"] != 0 {
-				t.Fatalf("grants = %#v, want higher=5 lower=0; decisions = %#v", grants, decisions)
-			}
-			for _, decision := range decisions["lower"] {
-				if decision.Reason != scheduler.DispatchGateReasonReservedForHigherPriorityProject {
-					t.Fatalf("lower-priority decision reason = %q, want %q; decision = %#v",
-						decision.Reason,
-						scheduler.DispatchGateReasonReservedForHigherPriorityProject,
-						decision,
-					)
-				}
+			if grants["higher"] != tt.wantHigher || grants["lower"] != tt.wantLower {
+				t.Fatalf("grants = %#v, want higher=%d lower=%d; decisions = %#v",
+					grants, tt.wantHigher, tt.wantLower, decisions)
 			}
 		})
 	}
@@ -963,7 +959,7 @@ func TestGlobalDispatchGateStrictProjectPriorityUsesLeftoverCapacity(t *testing.
 	}
 }
 
-func TestGlobalDispatchGateStrictProjectReservationTracksDemand(t *testing.T) {
+func TestGlobalDispatchGateStrictPriorityDoesNotReserveIdleCapacity(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
@@ -973,67 +969,52 @@ func TestGlobalDispatchGateStrictProjectReservationTracksDemand(t *testing.T) {
 		wantReason  string
 	}{
 		{
-			name: "idle higher priority project stays idle after capacity release",
-			arrange: func(t *testing.T, gate *scheduler.GlobalDispatchGate, higher, lower scheduler.ProjectCandidate) {
+			name: "idle higher priority project does not block",
+			arrange: func(t *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
 				t.Helper()
 				gate.BeginProjectCycle(higher)
 				gate.EndProjectCycle(higher.ID)
-				slot, ok, decision, err := gate.TryAcquireWithDecision(
-					t.Context(),
-					lower,
-					scheduler.SlotRequest{State: "Todo"},
-					time.Date(2026, 7, 30, 9, 0, 0, 0, time.Local),
-				)
-				if err != nil {
-					t.Fatalf("initial lower TryAcquireWithDecision() error = %v", err)
-				}
-				if !ok {
-					t.Fatalf("initial lower TryAcquireWithDecision() decision = %#v, want granted", decision)
-				}
-				if err := gate.Release(slot); err != nil {
-					t.Fatalf("initial lower Release() error = %v", err)
-				}
 			},
 			wantGranted: true,
 			wantReason:  scheduler.DispatchGateReasonGranted,
 		},
 		{
-			name: "higher priority project release invalidates its own idle state",
+			name: "ready higher priority project that has acquired nothing does not block",
+			arrange: func(_ *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
+				gate.MarkReady(higher)
+			},
+			wantGranted: true,
+			wantReason:  scheduler.DispatchGateReasonGranted,
+		},
+		{
+			// The production incident: a priority-0 project whose every
+			// candidate is declined by its own authorization selector stays
+			// mid-cycle forever and never acquires. It must not starve others.
+			name: "higher priority project mid-cycle that never acquires does not block",
+			arrange: func(_ *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
+				gate.BeginProjectCycle(higher)
+				gate.MarkReady(higher)
+			},
+			wantGranted: true,
+			wantReason:  scheduler.DispatchGateReasonGranted,
+		},
+		{
+			// Genuine exhaustion still reports the higher-priority holder.
+			name: "higher priority project holding the only slot does block",
 			arrange: func(t *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
 				t.Helper()
 				gate.BeginProjectCycle(higher)
-				slot, ok, decision, err := gate.TryAcquireWithDecision(
+				if _, ok, decision, err := gate.TryAcquireWithDecision(
 					t.Context(),
 					higher,
 					scheduler.SlotRequest{State: "Todo"},
 					time.Date(2026, 7, 30, 9, 0, 0, 0, time.Local),
-				)
-				if err != nil {
+				); err != nil {
 					t.Fatalf("higher TryAcquireWithDecision() error = %v", err)
-				}
-				if !ok {
+				} else if !ok {
 					t.Fatalf("higher TryAcquireWithDecision() decision = %#v, want granted", decision)
 				}
 				gate.EndProjectCycle(higher.ID)
-				if err := gate.Release(slot); err != nil {
-					t.Fatalf("higher Release() error = %v", err)
-				}
-			},
-			wantReason: scheduler.DispatchGateReasonReservedForHigherPriorityProject,
-		},
-		{
-			name: "pending higher priority project reserves capacity",
-			arrange: func(_ *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
-				gate.MarkReady(higher)
-			},
-			wantReason: scheduler.DispatchGateReasonReservedForHigherPriorityProject,
-		},
-		{
-			name: "idle to ready higher priority project reclaims reservation",
-			arrange: func(_ *testing.T, gate *scheduler.GlobalDispatchGate, higher, _ scheduler.ProjectCandidate) {
-				gate.BeginProjectCycle(higher)
-				gate.EndProjectCycle(higher.ID)
-				gate.MarkReady(higher)
 			},
 			wantReason: scheduler.DispatchGateReasonReservedForHigherPriorityProject,
 		},

--- a/internal/store/pool_contention_e2e_test.go
+++ b/internal/store/pool_contention_e2e_test.go
@@ -131,12 +131,17 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 	if err := json.Unmarshal([]byte(refusal.CapacitySnapshotJSON), &capacity); err != nil {
 		t.Fatalf("capacity snapshot JSON error = %v", err)
 	}
+	// selected_project_id reports the project selected for the slot, which is now
+	// the refused project itself. It previously named the reservation holder only
+	// because the removed priority-reservation path stamped it. The holder is
+	// still reported accurately below via capacity["holders"], and the refusal is
+	// still genuine exhaustion: capacity 1, used 1.
 	for key, want := range map[string]any{
 		"pool":                scheduler.DefaultPoolName,
 		"global_capacity":     float64(1),
 		"global_used":         float64(1),
 		"global_available":    float64(0),
-		"selected_project_id": localProject.ID,
+		"selected_project_id": cloudProject.ID,
 	} {
 		if got := capacity[key]; got != want {
 			t.Fatalf("capacity[%q] = %#v, want %#v; snapshot = %s", key, got, want, refusal.CapacitySnapshotJSON)


### PR DESCRIPTION
## Problem

The fleet stalled at 2 running against a global capacity of 10, with 8 slots free and two projects told `reserved_for_higher_priority_project`.

Priority was gating *access* to capacity rather than ordering *contention*. A higher-priority project that was merely ready — or just mid-cycle — denied every lower-priority project, regardless of free capacity, and regardless of whether it could ever dispatch.

The holder in this incident was a priority-0 project running review-only with a label allowlist. Every one of its candidates is declined by its own authorization selector, so it is permanently ready-but-unable. That is its normal steady state, which made the reservation permanent.

## Change

Remove the pre-emptive reservation gate. Free capacity is always offered; a project that shows up later takes the next free slot.

- Deleted `higherPriorityProjectReservationLocked` and `projectDecisionLocked`.
- Not being the *selected* project no longer refuses a request while real capacity remains. Scoped to strict priority, so round-robin and weighted turn-taking are untouched.
- Contention is still resolved highest-priority-first by ranking, and genuine exhaustion still reports `reserved_for_higher_priority_project` via `ErrNoSlots`.
- Capacity telemetry can report 0/0 meaning "unknown"; that path fails closed rather than granting.

## Test doubles were hiding a real defect

`releaseErrorSafetyScheduler` and `releaseErrorGlobalScheduler` released the slot and *then* returned an error, so the slot was genuinely free. The old reservation — not capacity accounting — was the only thing refusing the next request.

Both now fail before delegating, so a failed release leaves the slot actually held and the refusal comes from real exhaustion. This is what let the safety seeds keep asserting a true property instead of the removed contract.

## Safety-critical validation

`internal/scheduler/global_gate.go` is a safety-critical dispatch control.

- `FuzzSafetyCriticalOrchestratorBoundaries` passes (137k execs). Seeds 0 and 1 preserved; seed 2's reservation assertions now assert grant-and-release, since holding idle capacity is the behavior being removed. Seed 3 still asserts refusal, now on real capacity exhaustion.
- `go test -race ./internal/scheduler ./internal/admission ./internal/orchestrator` green.
- New gate test reproduces the incident: a higher-priority project mid-cycle that never acquires no longer blocks.

`make check` fails lint locally on 124 pre-existing issues in files this PR does not touch — a clean tree fails identically. That is the local-vs-CI golangci-lint version drift tracked in #2114. `internal/scheduler` is lint-clean; the two remaining hits are in `internal/admission/manager.go`, untouched here.

## Mitigation already live

Production was unblocked before this by switching `global.scheduling` from `strict` to `weighted`, the only mode that ran the reservation path. Running went 2 to 6 immediately. That config change can be reverted once this ships.