### PR TITLE
fix(scheduler): bound cross-project starvation

### DIFF
--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -90,6 +90,23 @@ Project weights are relative scheduling weights. Higher weights receive a
 larger dispatch share in weighted and fair-share scheduling modes. Project
 priority is a rank: `0` is highest and `4` is lowest.
 
+Lifecycle-state priority is preferred within each pool. In `weighted`,
+`fair_share`, and `round_robin` pools, a ready project bypassed by one
+higher-priority lane dispatch becomes rescue-eligible. Rescue-eligible projects
+receive reservations before another priority-only reservation, while the
+pool's configured project scheduler chooses among equally eligible projects.
+With `R` continuously ready projects, a project receives a reservation within
+at most `R` dispatch opportunities after its first higher-lane bypass. The
+`strict` scheduler does not apply this bound and can intentionally starve lower
+project or lifecycle priorities.
+
+Readiness remains eligible for bypass accounting while a project scans its
+current candidates and is cleared when that scan finds no demand. Dispatch
+stall age survives restarts and refusal-reason changes by using the later of
+the project's last successful selection and its oldest current candidate's
+lane-entry time. A newly ready project therefore does not inherit idle time
+from an older selection.
+
 `global.agent_pools` defines independent agent-capacity partitions. Each
 project belongs to exactly one pool through `projects[].pool`. A project with
 no `pool` uses the implicit `default` pool, whose capacity is

--- a/internal/orchestrator/dispatch_status.go
+++ b/internal/orchestrator/dispatch_status.go
@@ -137,14 +137,50 @@ func projectDispatchStatusFromCycle(
 	if mixedWaitReasonDetail {
 		status.WaitReason = schedulerDecisionWaitReason(commonWaitReasonCode)
 	}
-	if previous.CandidateFingerprint == status.CandidateFingerprint &&
-		dispatchStatusWaitReasonMatches(previous, status) &&
-		previous.AllSkippedSince != nil && !previous.AllSkippedSince.IsZero() {
-		status.AllSkippedSince = cloneTimePointer(previous.AllSkippedSince)
-	} else {
-		status.AllSkippedSince = &now
+	allSkippedSince := now
+	continuousStarvation := previous.CandidateCount > 0 &&
+		previous.SelectedCount == 0 &&
+		previous.SkippedCount == previous.CandidateCount
+	matchingRefusalWindow := previous.CandidateFingerprint == status.CandidateFingerprint &&
+		dispatchStatusWaitReasonMatches(previous, status)
+	if continuousStarvation || matchingRefusalWindow {
+		if previous.AllSkippedSince != nil && !previous.AllSkippedSince.IsZero() && previous.AllSkippedSince.Before(allSkippedSince) {
+			allSkippedSince = *previous.AllSkippedSince
+		}
 	}
+	if candidateReadySince, ok := dispatchCandidateReadySince(candidates, identities, now); ok {
+		if previous.LastSelectedAt != nil &&
+			!previous.LastSelectedAt.IsZero() &&
+			previous.LastSelectedAt.After(candidateReadySince) &&
+			!previous.LastSelectedAt.After(now) {
+			candidateReadySince = *previous.LastSelectedAt
+		}
+		if candidateReadySince.Before(allSkippedSince) {
+			allSkippedSince = candidateReadySince
+		}
+	}
+	status.AllSkippedSince = &allSkippedSince
 	return status
+}
+
+func dispatchCandidateReadySince(candidates []connector.Issue, identities []string, now time.Time) (time.Time, bool) {
+	tracked := make(map[string]struct{}, len(identities))
+	for _, identity := range identities {
+		tracked[identity] = struct{}{}
+	}
+	readySince := time.Time{}
+	for _, candidate := range candidates {
+		if _, ok := tracked[workflowIssueIdentityKey(candidate)]; !ok ||
+			candidate.StageUpdatedAt == nil ||
+			candidate.StageUpdatedAt.IsZero() ||
+			candidate.StageUpdatedAt.After(now) {
+			continue
+		}
+		if readySince.IsZero() || candidate.StageUpdatedAt.Before(readySince) {
+			readySince = candidate.StageUpdatedAt.UTC()
+		}
+	}
+	return readySince, !readySince.IsZero()
 }
 
 func dispatchStatusWaitReasonMatches(previous store.ProjectDispatchStatus, current store.ProjectDispatchStatus) bool {

--- a/internal/orchestrator/dispatch_status_test.go
+++ b/internal/orchestrator/dispatch_status_test.go
@@ -224,6 +224,80 @@ func TestProjectDispatchStatusMixedProjects(t *testing.T) {
 	}
 }
 
+func TestDispatchStatusSnapshotUsesLastSelectionForStarvationAge(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 18, 41, 0, 0, time.UTC)
+	lastSelectedAt := now.Add(-48 * time.Hour)
+	allSkippedSince := now.Add(-30 * time.Minute)
+	candidate := dispatchTestIssue("todo", "Todo")
+	candidate.StageUpdatedAt = dispatchStatusTimePointer(now.Add(-72 * time.Hour))
+	previous := store.ProjectDispatchStatus{
+		ProjectID:       "pyroapex",
+		CandidateCount:  1,
+		SkippedCount:    1,
+		WaitReason:      "global capacity full",
+		WaitReasonCode:  "global_capacity_full",
+		AllSkippedSince: &allSkippedSince,
+		LastSelectedAt:  &lastSelectedAt,
+	}
+	status := projectDispatchStatusFromCycle(
+		previous,
+		"pyroapex",
+		[]connector.Issue{candidate},
+		[]dispatchPlanDecision{{Issue: candidate, SkipReason: "reserved_for_higher_priority_state"}},
+		nil,
+		now,
+	)
+
+	got := dispatchStatusSnapshot(status, 2*time.Hour, now)
+	if status.AllSkippedSince == nil || !status.AllSkippedSince.Equal(lastSelectedAt) {
+		t.Fatalf("AllSkippedSince = %#v, want durable last selection %s", status.AllSkippedSince, lastSelectedAt)
+	}
+	if !got.Stalled {
+		t.Fatalf("Stalled = false, want true after %s without a selection", now.Sub(lastSelectedAt))
+	}
+	if got.StallDurationSeconds != int64(48*time.Hour/time.Second) {
+		t.Fatalf("StallDurationSeconds = %d, want %d", got.StallDurationSeconds, int64(48*time.Hour/time.Second))
+	}
+}
+
+func TestDispatchStatusSnapshotDoesNotCountIdleTimeAsStarvation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 18, 41, 0, 0, time.UTC)
+	lastSelectedAt := now.Add(-48 * time.Hour)
+	candidate := dispatchTestIssue("todo", "Todo")
+	status := projectDispatchStatusFromCycle(
+		store.ProjectDispatchStatus{ProjectID: "pyroapex", LastSelectedAt: &lastSelectedAt},
+		"pyroapex",
+		[]connector.Issue{candidate},
+		[]dispatchPlanDecision{{Issue: candidate, SkipReason: "reserved_for_higher_priority_state"}},
+		nil,
+		now,
+	)
+
+	got := dispatchStatusSnapshot(status, 2*time.Hour, now)
+	if got.Stalled {
+		t.Fatal("Stalled = true, want false for newly waiting work after an idle interval")
+	}
+	if status.AllSkippedSince == nil || !status.AllSkippedSince.Equal(now) {
+		t.Fatalf("AllSkippedSince = %#v, want current refusal time %s", status.AllSkippedSince, now)
+	}
+
+	status = projectDispatchStatusFromCycle(
+		status,
+		"pyroapex",
+		[]connector.Issue{candidate},
+		[]dispatchPlanDecision{{Issue: candidate, SkipReason: "reserved_for_higher_priority_state"}},
+		nil,
+		now.Add(time.Minute),
+	)
+	if status.AllSkippedSince == nil || !status.AllSkippedSince.Equal(now) {
+		t.Fatalf("second AllSkippedSince = %#v, want refusal window start %s", status.AllSkippedSince, now)
+	}
+}
+
 func dispatchStatusOutcomes(issue connector.Issue, outcome dispatchIssueOutcome) map[string]dispatchIssueOutcome {
 	return map[string]dispatchIssueOutcome{workflowIssueIdentityKey(issue): outcome}
 }

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	maxPriorityLaneBypasses                            = 1
 	DispatchGateReasonGranted                          = "granted"
 	DispatchGateReasonGlobalCapacityFull               = "global_capacity_full"
 	DispatchGateReasonOutsideActiveWindow              = "outside_active_window"
@@ -80,7 +81,8 @@ type selectedProjectSlot struct {
 }
 
 type projectCycleState struct {
-	idle bool
+	idle           bool
+	observedDemand bool
 }
 
 type GlobalDispatchGate struct {
@@ -88,14 +90,15 @@ type GlobalDispatchGate struct {
 	global   GlobalScheduler
 	admit    *poolCapacityAdmission
 
-	mu             sync.Mutex
-	ready          map[string]readyProjectSlot
-	running        map[uint64]runningProjectSlot
-	selected       map[string]selectedProjectSlot
-	projects       map[string]ProjectCandidate
-	pausedProjects map[string]struct{}
-	projectCycles  map[string]projectCycleState
-	dispatchPauses int
+	mu               sync.Mutex
+	ready            map[string]readyProjectSlot
+	running          map[uint64]runningProjectSlot
+	selected         map[string]selectedProjectSlot
+	projects         map[string]ProjectCandidate
+	pausedProjects   map[string]struct{}
+	projectCycles    map[string]projectCycleState
+	priorityBypasses map[string]int
+	dispatchPauses   int
 }
 
 func NewGlobalDispatchGate(global GlobalScheduler, projects ...ProjectCandidate) *GlobalDispatchGate {
@@ -104,14 +107,15 @@ func NewGlobalDispatchGate(global GlobalScheduler, projects ...ProjectCandidate)
 
 func newGlobalDispatchGate(poolName string, global GlobalScheduler, projects ...ProjectCandidate) *GlobalDispatchGate {
 	gate := &GlobalDispatchGate{
-		poolName:       normalizePoolName(poolName),
-		global:         global,
-		ready:          map[string]readyProjectSlot{},
-		running:        map[uint64]runningProjectSlot{},
-		selected:       map[string]selectedProjectSlot{},
-		projects:       map[string]ProjectCandidate{},
-		pausedProjects: map[string]struct{}{},
-		projectCycles:  map[string]projectCycleState{},
+		poolName:         normalizePoolName(poolName),
+		global:           global,
+		ready:            map[string]readyProjectSlot{},
+		running:          map[uint64]runningProjectSlot{},
+		selected:         map[string]selectedProjectSlot{},
+		projects:         map[string]ProjectCandidate{},
+		pausedProjects:   map[string]struct{}{},
+		projectCycles:    map[string]projectCycleState{},
+		priorityBypasses: map[string]int{},
 	}
 	gate.SetProjects(projects)
 	return gate
@@ -174,6 +178,7 @@ func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
 			delete(g.ready, project.ID)
 			delete(g.selected, project.ID)
 			delete(g.projectCycles, project.ID)
+			delete(g.priorityBypasses, project.ID)
 			continue
 		}
 		next[project.ID] = project
@@ -185,6 +190,7 @@ func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
 		delete(g.ready, projectID)
 		delete(g.selected, projectID)
 		delete(g.projectCycles, projectID)
+		delete(g.priorityBypasses, projectID)
 	}
 	for projectID := range g.projectCycles {
 		if _, ok := next[projectID]; !ok {
@@ -231,6 +237,7 @@ func (g *GlobalDispatchGate) Reconfigure(cfg Config) error {
 	clear(g.selected)
 	if previousMode != g.global.Mode() {
 		clear(g.projectCycles)
+		clear(g.priorityBypasses)
 	}
 	return nil
 }
@@ -249,21 +256,24 @@ func (g *GlobalDispatchGate) BeginProjectCycle(project ProjectCandidate) {
 	if _, paused := g.pausedProjects[project.ID]; paused {
 		delete(g.ready, project.ID)
 		delete(g.selected, project.ID)
+		delete(g.priorityBypasses, project.ID)
 		g.projectCycles[project.ID] = projectCycleState{idle: true}
 		return
 	}
 
 	g.projects[project.ID] = project
-	delete(g.ready, project.ID)
 	delete(g.selected, project.ID)
-	g.projectCycles[project.ID] = projectCycleState{}
-	if g.global.Mode() != ModeStrictPriority {
-		delete(g.projectCycles, project.ID)
+	if g.global.Mode() == ModeStrictPriority {
+		delete(g.ready, project.ID)
+	} else if ready, readyOK := g.ready[project.ID]; readyOK {
+		ready.ProjectCandidate = project
+		g.ready[project.ID] = ready
 	}
+	g.projectCycles[project.ID] = projectCycleState{}
 }
 
 func (g *GlobalDispatchGate) EndProjectCycle(projectID string) {
-	if g == nil || g.global == nil || g.global.Mode() != ModeStrictPriority {
+	if g == nil || g.global == nil {
 		return
 	}
 	projectID = normalizeProjectID(projectID)
@@ -274,8 +284,21 @@ func (g *GlobalDispatchGate) EndProjectCycle(projectID string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	cycle, cycleOK := g.projectCycles[projectID]
 	_, waiting := g.ready[projectID]
-	g.projectCycles[projectID] = projectCycleState{idle: !waiting}
+	if g.global.Mode() == ModeStrictPriority {
+		g.projectCycles[projectID] = projectCycleState{idle: !waiting}
+	} else {
+		if cycleOK && !cycle.observedDemand {
+			delete(g.ready, projectID)
+			delete(g.selected, projectID)
+			waiting = false
+		}
+		delete(g.projectCycles, projectID)
+	}
+	if !waiting {
+		delete(g.priorityBypasses, projectID)
+	}
 }
 
 func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
@@ -292,6 +315,7 @@ func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
 	if _, paused := g.pausedProjects[project.ID]; paused {
 		delete(g.ready, project.ID)
 		delete(g.selected, project.ID)
+		delete(g.priorityBypasses, project.ID)
 		g.projectCycles[project.ID] = projectCycleState{idle: true}
 		return
 	}
@@ -300,6 +324,7 @@ func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
 	ready := g.ready[project.ID]
 	ready.ProjectCandidate = project
 	g.ready[project.ID] = ready
+	g.observeProjectCycleDemandLocked(project.ID)
 	if g.global.Mode() == ModeStrictPriority {
 		g.projectCycles[project.ID] = projectCycleState{}
 	}
@@ -319,6 +344,7 @@ func (g *GlobalDispatchGate) MarkIdle(project ProjectCandidate) {
 
 	delete(g.ready, projectID)
 	delete(g.selected, projectID)
+	delete(g.priorityBypasses, projectID)
 	if g.global != nil && g.global.Mode() == ModeStrictPriority {
 		g.projectCycles[projectID] = projectCycleState{idle: true}
 	}
@@ -369,6 +395,7 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	if _, paused := g.pausedProjects[project.ID]; paused {
 		delete(g.ready, project.ID)
 		delete(g.selected, project.ID)
+		delete(g.priorityBypasses, project.ID)
 		g.projectCycles[project.ID] = projectCycleState{idle: true}
 		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonPaused), nil
 	}
@@ -381,10 +408,15 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	if !status.Open {
 		delete(g.ready, project.ID)
 		delete(g.selected, project.ID)
+		delete(g.priorityBypasses, project.ID)
 		g.projectCycles[project.ID] = projectCycleState{idle: true}
 		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonOutsideActiveWindow), nil
 	}
-	g.ready[project.ID] = readyProjectSlot{ProjectCandidate: project, request: req}
+	ready := g.ready[project.ID]
+	ready.ProjectCandidate = project
+	ready.request = req
+	g.ready[project.ID] = ready
+	g.observeProjectCycleDemandLocked(project.ID)
 	if g.dispatchPauses > 0 {
 		return Slot{}, false, g.decisionLocked(project.ID, req, DispatchGateReasonPaused), nil
 	}
@@ -464,6 +496,7 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	if g.admit != nil {
 		g.admit.complete(g.capacitySnapshotLocked("").globalUsed)
 	}
+	g.recordPriorityLaneDispatchLocked(project.ID, req.Priority)
 
 	decision := g.decisionLocked(project.ID, req, DispatchGateReasonGranted)
 	delete(g.ready, project.ID)
@@ -478,6 +511,16 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 		slot: slot,
 	}
 	return slot, true, decision, nil
+}
+
+func (g *GlobalDispatchGate) observeProjectCycleDemandLocked(projectID string) {
+	cycle, ok := g.projectCycles[projectID]
+	if !ok {
+		return
+	}
+	cycle.observedDemand = true
+	cycle.idle = false
+	g.projectCycles[projectID] = cycle
 }
 
 func (g *GlobalDispatchGate) preemptionWeightLocked(preemptions []RunningProject) int {
@@ -583,6 +626,16 @@ func (g *GlobalDispatchGate) reconcileSelectionsLocked() {
 		selected.request = ready.request
 		g.selected[projectID] = selected
 	}
+	if g.global.Mode() != ModeStrictPriority && g.hasPriorityRescueReadyLocked() {
+		if g.hasUnselectedPriorityRescueReadyLocked() {
+			for projectID := range g.selected {
+				if g.priorityBypasses[projectID] < maxPriorityLaneBypasses {
+					delete(g.selected, projectID)
+				}
+			}
+		}
+		return
+	}
 
 	bestPriority, ok := g.bestReadyPriorityLocked()
 	if !ok {
@@ -668,6 +721,7 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string
 	// has picked, so ranking alone fills slots highest-priority-first and then
 	// keeps going down the list until capacity runs out.
 	strictProjectRank, strict := g.bestStrictReadyProjectRankLocked()
+	priorityRescue := false
 	bestPriority := 0
 	first := true
 	for _, ready := range g.ready {
@@ -679,6 +733,9 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string
 		}
 		if maxWeight >= 0 && ready.request.Weight > maxWeight {
 			continue
+		}
+		if !strict && g.priorityBypasses[ready.ID] >= maxPriorityLaneBypasses {
+			priorityRescue = true
 		}
 		if first || ready.request.Priority < bestPriority {
 			bestPriority = ready.request.Priority
@@ -701,7 +758,10 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string
 		if maxWeight >= 0 && ready.request.Weight > maxWeight {
 			continue
 		}
-		if ready.request.Priority != bestPriority {
+		if priorityRescue && g.priorityBypasses[ready.ID] < maxPriorityLaneBypasses {
+			continue
+		}
+		if !priorityRescue && ready.request.Priority != bestPriority {
 			continue
 		}
 		projects = append(projects, ready.ProjectCandidate)
@@ -755,9 +815,49 @@ func (g *GlobalDispatchGate) pruneClosedReadyProjectsLocked(now time.Time) error
 		}
 		delete(g.ready, projectID)
 		delete(g.selected, projectID)
+		delete(g.priorityBypasses, projectID)
 		g.projectCycles[projectID] = projectCycleState{idle: true}
 	}
 	return nil
+}
+
+func (g *GlobalDispatchGate) recordPriorityLaneDispatchLocked(projectID string, priority int) {
+	delete(g.priorityBypasses, projectID)
+	if g.global.Mode() == ModeStrictPriority {
+		return
+	}
+	for waitingID, ready := range g.ready {
+		if waitingID == projectID || ready.request.Priority <= priority {
+			continue
+		}
+		if _, selected := g.selected[waitingID]; selected {
+			continue
+		}
+		if g.priorityBypasses[waitingID] < maxPriorityLaneBypasses {
+			g.priorityBypasses[waitingID]++
+		}
+	}
+}
+
+func (g *GlobalDispatchGate) hasPriorityRescueReadyLocked() bool {
+	for projectID := range g.ready {
+		if g.priorityBypasses[projectID] >= maxPriorityLaneBypasses {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *GlobalDispatchGate) hasUnselectedPriorityRescueReadyLocked() bool {
+	for projectID := range g.ready {
+		if g.priorityBypasses[projectID] < maxPriorityLaneBypasses {
+			continue
+		}
+		if _, selected := g.selected[projectID]; !selected {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *GlobalDispatchGate) hasHigherPriorityRunningProjectLocked(project ProjectCandidate) bool {

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -497,6 +497,237 @@ func TestGlobalDispatchGateReselectsHigherPriorityWaitingLane(t *testing.T) {
 	}
 }
 
+func TestGlobalDispatchGateBoundsCrossProjectLaneStarvation(t *testing.T) {
+	t.Parallel()
+
+	modes := []struct {
+		name         string
+		newScheduler func(int) scheduler.GlobalScheduler
+		wantProgress bool
+	}{
+		{
+			name: "weighted",
+			newScheduler: func(capacity int) scheduler.GlobalScheduler {
+				return scheduler.NewWeightedFair(scheduler.Config{Capacity: capacity})
+			},
+			wantProgress: true,
+		},
+		{
+			name: "fair share",
+			newScheduler: func(capacity int) scheduler.GlobalScheduler {
+				return scheduler.NewFairShare(scheduler.Config{Capacity: capacity, FairShareStore: &fairShareStore{}})
+			},
+			wantProgress: true,
+		},
+		{
+			name: "round robin",
+			newScheduler: func(capacity int) scheduler.GlobalScheduler {
+				return scheduler.NewRoundRobin(scheduler.Config{Capacity: capacity})
+			},
+			wantProgress: true,
+		},
+		{
+			name: "strict priority",
+			newScheduler: func(capacity int) scheduler.GlobalScheduler {
+				return scheduler.NewStrictPriority(scheduler.Config{Capacity: capacity})
+			},
+		},
+	}
+	capacities := []struct {
+		name  string
+		value int
+	}{
+		{name: "capacity one", value: 1},
+		{name: "capacity two", value: 2},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			t.Parallel()
+			for _, capacity := range capacities {
+				t.Run(capacity.name, func(t *testing.T) {
+					t.Parallel()
+					now := time.Date(2026, 9, 4, 18, 41, 0, 0, time.UTC)
+					busy := scheduler.ProjectCandidate{ID: "busy", Weight: 1}
+					todo := scheduler.ProjectCandidate{ID: "todo", Weight: 1}
+					gate := scheduler.NewGlobalDispatchGate(mode.newScheduler(capacity.value), busy, todo)
+					tryAcquire := func(
+						project scheduler.ProjectCandidate,
+						request scheduler.SlotRequest,
+						at time.Time,
+					) (scheduler.Slot, bool, scheduler.DispatchGateDecision, error) {
+						gate.BeginProjectCycle(project)
+						slot, granted, decision, err := gate.TryAcquireWithDecision(t.Context(), project, request, at)
+						gate.EndProjectCycle(project.ID)
+						return slot, granted, decision, err
+					}
+					running := make([]scheduler.Slot, 0, capacity.value)
+					for index := range capacity.value {
+						slot, granted, decision, err := tryAcquire(
+							busy,
+							scheduler.SlotRequest{State: "Merging", Priority: 0},
+							now.Add(time.Duration(index)*time.Second),
+						)
+						if err != nil || !granted {
+							t.Fatalf("initial busy acquisition %d = %t, %#v, %v; want grant", index, granted, decision, err)
+						}
+						running = append(running, slot)
+					}
+					t.Cleanup(func() {
+						for _, slot := range running {
+							if err := gate.Release(slot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+								t.Fatalf("Release() error = %v", err)
+							}
+						}
+					})
+
+					if _, granted, _, err := tryAcquire(
+						todo,
+						scheduler.SlotRequest{State: "Todo", Priority: 2},
+						now.Add(10*time.Second),
+					); err != nil || granted {
+						t.Fatalf("initial Todo acquisition = %t, %v; want capacity refusal", granted, err)
+					}
+
+					progressed := false
+					for attempt := range 4 {
+						attemptAt := now.Add(time.Duration(20+attempt*10) * time.Second)
+						if _, granted, _, err := tryAcquire(
+							busy,
+							scheduler.SlotRequest{State: "Merging", Priority: 0},
+							attemptAt,
+						); err != nil || granted {
+							t.Fatalf("busy reservation %d = %t, %v; want full-pool refusal", attempt, granted, err)
+						}
+						if err := gate.Release(running[0]); err != nil {
+							t.Fatalf("release busy slot %d error = %v", attempt, err)
+						}
+						running = running[1:]
+
+						todoSlot, granted, _, err := tryAcquire(
+							todo,
+							scheduler.SlotRequest{State: "Todo", Priority: 2},
+							attemptAt.Add(time.Second),
+						)
+						if err != nil {
+							t.Fatalf("Todo acquisition %d error = %v", attempt, err)
+						}
+						if granted {
+							progressed = true
+							running = append(running, todoSlot)
+							break
+						}
+
+						busySlot, granted, decision, err := tryAcquire(
+							busy,
+							scheduler.SlotRequest{State: "Merging", Priority: 0},
+							attemptAt.Add(2*time.Second),
+						)
+						if err != nil || !granted {
+							t.Fatalf("busy acquisition %d = %t, %#v, %v; want grant", attempt, granted, decision, err)
+						}
+						running = append(running, busySlot)
+					}
+
+					if progressed != mode.wantProgress {
+						t.Fatalf("Todo progress = %t, want %t after bounded dispatch opportunities", progressed, mode.wantProgress)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestGlobalDispatchGateCountsPriorityBypassDuringReadyProjectScan(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name         string
+		newScheduler func(scheduler.Config) scheduler.GlobalScheduler
+	}{
+		{name: "weighted", newScheduler: scheduler.NewWeightedFair},
+		{name: "fair share", newScheduler: func(cfg scheduler.Config) scheduler.GlobalScheduler {
+			cfg.FairShareStore = &fairShareStore{}
+			return scheduler.NewFairShare(cfg)
+		}},
+		{name: "round robin", newScheduler: scheduler.NewRoundRobin},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 9, 4, 18, 41, 0, 0, time.UTC)
+			busy := scheduler.ProjectCandidate{ID: "busy", Weight: 1}
+			todo := scheduler.ProjectCandidate{ID: "todo", Weight: 1}
+			gate := scheduler.NewGlobalDispatchGate(tt.newScheduler(scheduler.Config{Capacity: 1}), busy, todo)
+
+			busySlot, granted, decision, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				busy,
+				scheduler.SlotRequest{State: "Merging", Priority: 0},
+				now,
+			)
+			if err != nil || !granted {
+				t.Fatalf("initial busy acquisition = %t, %#v, %v; want grant", granted, decision, err)
+			}
+
+			gate.BeginProjectCycle(todo)
+			if _, granted, _, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				todo,
+				scheduler.SlotRequest{State: "Todo", Priority: 2},
+				now.Add(time.Second),
+			); err != nil || granted {
+				t.Fatalf("initial Todo acquisition = %t, %v; want capacity refusal", granted, err)
+			}
+			gate.EndProjectCycle(todo.ID)
+
+			gate.BeginProjectCycle(todo)
+			if err := gate.Release(busySlot); err != nil {
+				t.Fatalf("initial busy Release() error = %v", err)
+			}
+			gate.BeginProjectCycle(busy)
+			busySlot, granted, decision, err = gate.TryAcquireWithDecision(
+				t.Context(),
+				busy,
+				scheduler.SlotRequest{State: "Merging", Priority: 0},
+				now.Add(2*time.Second),
+			)
+			gate.EndProjectCycle(busy.ID)
+			if err != nil || !granted {
+				t.Fatalf("bypassing busy acquisition = %t, %#v, %v; want grant", granted, decision, err)
+			}
+
+			gate.BeginProjectCycle(busy)
+			if _, granted, _, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				busy,
+				scheduler.SlotRequest{State: "Merging", Priority: 0},
+				now.Add(3*time.Second),
+			); err != nil || granted {
+				t.Fatalf("pending busy acquisition = %t, %v; want capacity refusal", granted, err)
+			}
+			gate.EndProjectCycle(busy.ID)
+			if err := gate.Release(busySlot); err != nil {
+				t.Fatalf("bypassing busy Release() error = %v", err)
+			}
+
+			todoSlot, granted, decision, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				todo,
+				scheduler.SlotRequest{State: "Todo", Priority: 2},
+				now.Add(4*time.Second),
+			)
+			gate.EndProjectCycle(todo.ID)
+			if err != nil || !granted {
+				t.Fatalf("rescued Todo acquisition = %t, %#v, %v; want grant", granted, decision, err)
+			}
+			if err := gate.Release(todoSlot); err != nil {
+				t.Fatalf("Todo Release() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestGlobalDispatchGateUsesUnreservedCapacityBehindPendingHigherPriorityLane(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Continuously busy Merging/Rework projects could exclude another project's Todo queue indefinitely. Non-strict pools now make a ready project rescue-eligible after one higher-lane bypass and reserve capacity using the configured project scheduler. Readiness remains visible during concurrent project scans; strict-priority admission keeps its existing behavior.

Dispatch-stall telemetry uses durable selection and candidate lane-entry times, preserving starvation age across refusal-window resets without counting prior idle time. `docs/multi-project.md` documents the reservation bound.

Fixes #2165

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual layout or template changes.

## Test Plan

- [x] `PATH="$TMPDIR/golangci-2165:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] Focused scheduler and orchestrator regressions: weighted, fair-share, round-robin, and strict modes at capacities one and two; interleaved project scans; durable starvation age and idle intervals.
- [x] `env -u DETENT_API_TOKEN GOTOOLCHAIN=go1.26.6 go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s` — seven seeds and 146,777 executions passed.
- [x] Both automated review findings fixed and review threads resolved.
- [x] Aggregate coverage 78.9%; scheduler package 91.0%; `global_gate.go` exact-file coverage 90.58%, meeting its 90% safety floor.
- [x] All 11 checks passed on `0831e36b` in [CI run 33921021386](https://github.com/digitaldrywood/detent/actions/runs/33921021386).
