### PR TITLE
fix(web): keep project state reads responsive

### DIFF
--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -59,6 +59,7 @@ func classifyStateReadError(err error) error {
 func writeStatePretty(writer io.Writer, state DashboardState) error {
 	status := stateString(state.field("status"))
 	refreshStatus := stateNestedString(state.field("refresh"), "status")
+	enrichmentStatus := stateNestedString(state.field("enrichment"), "status")
 	errorCode := stateNestedString(state.field("error"), "code")
 	if status == "" && errorCode != "" {
 		status = "degraded"
@@ -66,7 +67,7 @@ func writeStatePretty(writer io.Writer, state DashboardState) error {
 	if status == "" {
 		status = "unknown"
 	}
-	degraded := refreshStatus == "degraded" || errorCode != "" || stateRefreshSourceDegraded(state.field("refresh"))
+	degraded := refreshStatus == "degraded" || enrichmentStatus == "pending" || enrichmentStatus == "omitted" || errorCode != "" || stateRefreshSourceDegraded(state.field("refresh"))
 
 	lines := []string{
 		"Status: " + status,
@@ -75,6 +76,15 @@ func writeStatePretty(writer io.Writer, state DashboardState) error {
 	}
 	if refreshStatus != "" {
 		lines = append(lines, "Refresh status: "+refreshStatus)
+	}
+	if enrichmentStatus != "" {
+		lines = append(lines, "Enrichment status: "+enrichmentStatus)
+	}
+	if completedAt := stateNestedString(state.field("enrichment"), "completed_snapshot_generated_at"); completedAt != "" {
+		lines = append(lines, "Enrichment completed snapshot: "+completedAt)
+	}
+	if reason := stateNestedString(state.field("enrichment"), "degraded_reason"); reason != "" {
+		lines = append(lines, "Enrichment reason: "+reason)
 	}
 	if refreshedAt := stateNestedString(state.field("refresh"), "last_refresh_at"); refreshedAt != "" {
 		lines = append(lines, "Last refresh: "+refreshedAt)

--- a/internal/cli/state_test.go
+++ b/internal/cli/state_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -212,7 +213,7 @@ func TestStateCommandOutput(t *testing.T) {
 		wantJSONBuild bool
 	}{
 		{name: "JSON projection", args: []string{"--project", "detent"}, wantJSONBuild: true},
-		{name: "pretty projection", stdoutTTY: true, args: []string{"--project", "detent"}, wantPretty: []string{"Status: running", "Generated at: 2026-08-08T03:00:00Z", "Degraded: true", "Refresh status: degraded", "Running: 2", "Ready: 3", "Waiting: 4", "Blocked: 1", "Memory PSI some avg60: 0% / 10% threshold (admitting)", "I/O PSI full avg10: 63.64% / 5% threshold (limited to 1 agent for 5m0s)", "CPU PSI some avg10: 91.2% / 80% threshold (holding dispatch)", "Truncated: false"}},
+		{name: "pretty projection", stdoutTTY: true, args: []string{"--project", "detent"}, wantPretty: []string{"Status: running", "Generated at: 2026-08-08T03:00:00Z", "Degraded: true", "Refresh status: degraded", "Enrichment status: ready", "Enrichment completed snapshot: 2026-08-08T03:00:00Z", "Running: 2", "Ready: 3", "Waiting: 4", "Blocked: 1", "Memory PSI some avg60: 0% / 10% threshold (admitting)", "I/O PSI full avg10: 63.64% / 5% threshold (limited to 1 agent for 5m0s)", "CPU PSI some avg10: 91.2% / 80% threshold (holding dispatch)", "Truncated: false"}},
 	}
 
 	for _, tt := range tests {
@@ -269,7 +270,7 @@ func TestStateCommandOutput(t *testing.T) {
 			if err := json.Unmarshal(stdout.Bytes(), &object); err != nil {
 				t.Fatalf("Unmarshal() error = %v; stdout = %s", err, stdout.String())
 			}
-			for _, key := range []string{"generated_at", "refresh", "running", "io_pressure", "cpu_pressure", "truncation"} {
+			for _, key := range []string{"generated_at", "refresh", "enrichment", "running", "io_pressure", "cpu_pressure", "truncation"} {
 				if _, ok := object[key]; !ok {
 					t.Fatalf("JSON output missing %q: %s", key, stdout.String())
 				}
@@ -281,6 +282,56 @@ func TestStateCommandOutput(t *testing.T) {
 				}
 				if instance["version"] != "v1.3.0" || instance["commit"] != "abcdef123456" {
 					t.Fatalf("instance = %#v, want running build", instance)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteStatePrettyReportsEnrichment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		enrichment map[string]any
+		degraded   bool
+		want       []string
+	}{
+		{
+			name:       "ready",
+			enrichment: map[string]any{"status": "ready", "completed_snapshot_generated_at": "2026-08-08T03:00:00Z"},
+			want:       []string{"Enrichment status: ready", "Enrichment completed snapshot: 2026-08-08T03:00:00Z"},
+		},
+		{
+			name:       "pending",
+			enrichment: map[string]any{"status": "pending", "completed_snapshot_generated_at": "2026-08-08T02:59:00Z", "degraded_reason": "refresh in progress"},
+			degraded:   true,
+			want:       []string{"Enrichment status: pending", "Enrichment completed snapshot: 2026-08-08T02:59:00Z", "Enrichment reason: refresh in progress"},
+		},
+		{
+			name:       "omitted",
+			enrichment: map[string]any{"status": "omitted", "degraded_reason": "no completed enrichment available"},
+			degraded:   true,
+			want:       []string{"Enrichment status: omitted", "Enrichment reason: no completed enrichment available"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := DashboardState{payload: map[string]any{
+				"generated_at": "2026-08-08T03:00:00Z",
+				"status":       "running",
+				"enrichment":   tt.enrichment,
+			}}
+			var output bytes.Buffer
+			if err := writeStatePretty(&output, state); err != nil {
+				t.Fatalf("writeStatePretty() error = %v", err)
+			}
+			for _, want := range append([]string{fmt.Sprintf("Degraded: %t", tt.degraded)}, tt.want...) {
+				if !strings.Contains(output.String(), want) {
+					t.Fatalf("output missing %q:\n%s", want, output.String())
 				}
 			}
 		})
@@ -343,6 +394,7 @@ func stateFixture() map[string]any {
 		"generated_at": "2026-08-08T03:00:00Z",
 		"status":       "running",
 		"instance":     map[string]any{"version": "v1.3.0", "commit": "abcdef123456"},
+		"enrichment":   map[string]any{"status": "ready", "completed_snapshot_generated_at": "2026-08-08T03:00:00Z"},
 		"refresh": map[string]any{
 			"status":              "degraded",
 			"last_refresh_at":     "2026-08-08T02:59:30Z",

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -29,7 +30,155 @@ const (
 	manualRefreshStatusID              = "manual-refresh-status"
 	gitHubAPIManualRefreshStatusID     = "github-api-manual-refresh-status"
 	manualRefreshStatusIDFormField     = "manual_refresh_status_id"
+	stateEndpointTargetLatency         = 500 * time.Millisecond
 )
+
+type stateEndpointKind string
+
+const (
+	stateEndpointFleet   stateEndpointKind = "fleet"
+	stateEndpointProject stateEndpointKind = "project"
+)
+
+type stateEndpointRecorder struct {
+	mu      sync.Mutex
+	fleet   stateEndpointObservation
+	project stateEndpointObservation
+}
+
+type stateEndpointObservation struct {
+	requestCount         uint64
+	inFlight             int64
+	lastLatency          time.Duration
+	maxLatency           time.Duration
+	slowRequestCount     uint64
+	timeoutCount         uint64
+	canceledRequestCount uint64
+	lastCompletedAt      time.Time
+	lastSlowAt           time.Time
+	lastTimeoutAt        time.Time
+	lastCanceledAt       time.Time
+	lastOutcome          string
+}
+
+type healthStateEndpoints struct {
+	Fleet   healthStateEndpoint `json:"fleet"`
+	Project healthStateEndpoint `json:"project"`
+}
+
+type healthStateEndpoint struct {
+	Status               string    `json:"status"`
+	TargetLatencyMS      int64     `json:"target_latency_ms"`
+	RequestCount         uint64    `json:"request_count"`
+	InFlight             int64     `json:"in_flight"`
+	LastLatencyMS        int64     `json:"last_latency_ms"`
+	MaxLatencyMS         int64     `json:"max_latency_ms"`
+	SlowRequestCount     uint64    `json:"slow_request_count"`
+	TimeoutCount         uint64    `json:"timeout_count"`
+	CanceledRequestCount uint64    `json:"canceled_request_count"`
+	LastOutcome          string    `json:"last_outcome"`
+	LastCompletedAt      time.Time `json:"last_completed_at,omitzero"`
+	LastSlowAt           time.Time `json:"last_slow_at,omitzero"`
+	LastTimeoutAt        time.Time `json:"last_timeout_at,omitzero"`
+	LastCanceledAt       time.Time `json:"last_canceled_at,omitzero"`
+}
+
+func newStateEndpointRecorder() *stateEndpointRecorder {
+	return &stateEndpointRecorder{}
+}
+
+func (r *stateEndpointRecorder) begin(kind stateEndpointKind) func(context.Context) {
+	if r == nil {
+		return func(context.Context) {}
+	}
+
+	startedAt := time.Now()
+	r.mu.Lock()
+	observation := r.observation(kind)
+	observation.requestCount++
+	observation.inFlight++
+	r.mu.Unlock()
+
+	return func(ctx context.Context) {
+		completedAt := time.Now().UTC()
+		latency := time.Since(startedAt)
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		observation := r.observation(kind)
+		observation.inFlight--
+		observation.lastLatency = latency
+		observation.lastCompletedAt = completedAt
+		if latency > observation.maxLatency {
+			observation.maxLatency = latency
+		}
+		if latency >= stateEndpointTargetLatency {
+			observation.slowRequestCount++
+			observation.lastSlowAt = completedAt
+		}
+		switch {
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			observation.timeoutCount++
+			observation.lastTimeoutAt = completedAt
+			observation.lastOutcome = "timeout"
+		case errors.Is(ctx.Err(), context.Canceled):
+			observation.canceledRequestCount++
+			observation.lastCanceledAt = completedAt
+			observation.lastOutcome = "canceled"
+		case latency >= stateEndpointTargetLatency:
+			observation.lastOutcome = "slow"
+		default:
+			observation.lastOutcome = "ok"
+		}
+	}
+}
+
+func (r *stateEndpointRecorder) observation(kind stateEndpointKind) *stateEndpointObservation {
+	if kind == stateEndpointProject {
+		return &r.project
+	}
+	return &r.fleet
+}
+
+func (r *stateEndpointRecorder) health() healthStateEndpoints {
+	if r == nil {
+		return healthStateEndpoints{
+			Fleet:   stateEndpointHealth(stateEndpointObservation{}),
+			Project: stateEndpointHealth(stateEndpointObservation{}),
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return healthStateEndpoints{
+		Fleet:   stateEndpointHealth(r.fleet),
+		Project: stateEndpointHealth(r.project),
+	}
+}
+
+func stateEndpointHealth(observation stateEndpointObservation) healthStateEndpoint {
+	status := "idle"
+	if observation.requestCount > 0 {
+		status = "ok"
+		if observation.lastOutcome == "timeout" || observation.lastOutcome == "slow" || (observation.lastOutcome == "canceled" && observation.lastLatency >= stateEndpointTargetLatency) {
+			status = "degraded"
+		}
+	}
+	return healthStateEndpoint{
+		Status:               status,
+		TargetLatencyMS:      stateEndpointTargetLatency.Milliseconds(),
+		RequestCount:         observation.requestCount,
+		InFlight:             observation.inFlight,
+		LastLatencyMS:        observation.lastLatency.Milliseconds(),
+		MaxLatencyMS:         observation.maxLatency.Milliseconds(),
+		SlowRequestCount:     observation.slowRequestCount,
+		TimeoutCount:         observation.timeoutCount,
+		CanceledRequestCount: observation.canceledRequestCount,
+		LastOutcome:          observation.lastOutcome,
+		LastCompletedAt:      observation.lastCompletedAt,
+		LastSlowAt:           observation.lastSlowAt,
+		LastTimeoutAt:        observation.lastTimeoutAt,
+		LastCanceledAt:       observation.lastCanceledAt,
+	}
+}
 
 type Refresher interface {
 	RequestRefresh(context.Context) (RefreshResponse, error)
@@ -62,6 +211,9 @@ type WorkAttemptRecovery interface {
 }
 
 func (s *Server) apiState(c echo.Context) error {
+	complete := s.stateEndpoints.begin(stateEndpointFleet)
+	defer func() { complete(c.Request().Context()) }()
+
 	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
 		return err
 	} else if ok {
@@ -76,12 +228,17 @@ func (s *Server) apiState(c echo.Context) error {
 	if !ok {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
+	var enrichment stateEnrichmentAPIResponse
 	if !snapshot.Shutdown.Draining {
-		snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
+		snapshot, enrichment = s.stateSnapshot(snapshot)
 		snapshot = s.withManualRefresh(snapshot)
+	} else {
+		enrichment = stateEnrichmentAPIResponse{Status: "omitted", DegradedReason: "enrichment omitted while draining"}
 	}
 
-	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now), now, s.instanceName(), s.build))
+	response := stateResponse(snapshot, generatedAt(snapshot, now), now, s.instanceName(), s.build)
+	response.Enrichment = enrichment
+	return c.JSON(http.StatusOK, response)
 }
 
 func (s *Server) apiProject(c echo.Context) error {
@@ -105,6 +262,9 @@ func projectAPIParam(c echo.Context, suffix string) (string, bool) {
 }
 
 func (s *Server) apiProjectState(c echo.Context, projectID string) error {
+	complete := s.stateEndpoints.begin(stateEndpointProject)
+	defer func() { complete(c.Request().Context()) }()
+
 	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
 		return err
 	} else if ok {
@@ -122,7 +282,12 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 	if !ok {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
-	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
+	var enrichment stateEnrichmentAPIResponse
+	if !snapshot.Shutdown.Draining {
+		snapshot, enrichment = s.stateSnapshot(snapshot)
+	} else {
+		enrichment = stateEnrichmentAPIResponse{Status: "omitted", DegradedReason: "enrichment omitted while draining"}
+	}
 	projects := s.cachedProjectSmallMultiples(snapshot)
 	project, ok := s.dashboardProject(projectID, projects, snapshot)
 	if !ok {
@@ -136,7 +301,35 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 	})
 	scopedSnapshot = s.withManualRefresh(scopedSnapshot)
 
-	return c.JSON(http.StatusOK, stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), now, s.instanceName(), s.build))
+	response := stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), now, s.instanceName(), s.build)
+	response.Enrichment = enrichment
+	return c.JSON(http.StatusOK, response)
+}
+
+func (s *Server) stateSnapshot(snapshot telemetry.Snapshot) (telemetry.Snapshot, stateEnrichmentAPIResponse) {
+	enriched, ok, completedAt, loading := s.snapshots.lookup(snapshot)
+	if ok {
+		return enriched, readyStateEnrichment(snapshot.GeneratedAt)
+	}
+
+	status := "omitted"
+	reason := "latest enrichment is not cached; slow enrichment is omitted"
+	if loading {
+		status = "pending"
+		reason = "latest enrichment is pending; slow enrichment is omitted"
+	}
+	return snapshot, stateEnrichmentAPIResponse{
+		Status:                       status,
+		CompletedSnapshotGeneratedAt: completedAt,
+		DegradedReason:               reason,
+	}
+}
+
+func readyStateEnrichment(generatedAt time.Time) stateEnrichmentAPIResponse {
+	return stateEnrichmentAPIResponse{
+		Status:                       "ready",
+		CompletedSnapshotGeneratedAt: generatedAt,
+	}
 }
 
 func (s *Server) apiTimeSeries(c echo.Context) error {
@@ -462,6 +655,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, observedA
 	return stateAPIResponse{
 		GeneratedAt:        generatedAt,
 		SnapshotAgeSeconds: snapshot.AgeSeconds(observedAt),
+		Enrichment:         readyStateEnrichment(snapshot.GeneratedAt),
 		Status:             runtimeStatus(snapshot),
 		Shutdown:           shutdownResponse(snapshot.Shutdown),
 		Update:             snapshot.Update,
@@ -1434,6 +1628,7 @@ func snapshotErrorResponse(generatedAt time.Time, code string, message string) s
 type stateAPIResponse struct {
 	GeneratedAt        time.Time                    `json:"generated_at"`
 	SnapshotAgeSeconds int64                        `json:"snapshot_age_seconds"`
+	Enrichment         stateEnrichmentAPIResponse   `json:"enrichment"`
 	Status             string                       `json:"status"`
 	Shutdown           shutdownAPIResponse          `json:"shutdown"`
 	Update             telemetry.Update             `json:"update,omitzero"`
@@ -1470,6 +1665,12 @@ type stateAPIResponse struct {
 	StalenessWarnings  []telemetry.StalenessWarning `json:"staleness_warnings,omitempty"`
 	CleanupFaults      []telemetry.CleanupFault     `json:"workspace_cleanup_failures,omitempty"`
 	Budget             budgetAPIResponse            `json:"budget"`
+}
+
+type stateEnrichmentAPIResponse struct {
+	Status                       string    `json:"status"`
+	CompletedSnapshotGeneratedAt time.Time `json:"completed_snapshot_generated_at,omitzero"`
+	DegradedReason               string    `json:"degraded_reason,omitempty"`
 }
 
 type shutdownAPIResponse struct {

--- a/internal/web/api_benchmark_test.go
+++ b/internal/web/api_benchmark_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
-const projectStatePerformanceDeadline = 2 * time.Second
+const projectStatePerformanceDeadline = 500 * time.Millisecond
 
 func BenchmarkProjectStateAPIWarmStoreChangingSnapshot(b *testing.B) {
 	server, snapshotHub, snapshot := newProjectStatePerformanceServer(b, 5000, 2600)

--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -57,16 +57,35 @@ func (s *Server) cachedEnrichedSnapshot(ctx context.Context, snapshot telemetry.
 }
 
 func (c *snapshotEnrichmentCache) get(snapshot telemetry.Snapshot) (telemetry.Snapshot, bool) {
+	enriched, cached, _, _ := c.lookup(snapshot)
+	return enriched, cached
+}
+
+func (c *snapshotEnrichmentCache) lookup(snapshot telemetry.Snapshot) (telemetry.Snapshot, bool, time.Time, bool) {
 	if c == nil {
-		return telemetry.Snapshot{}, false
+		return telemetry.Snapshot{}, false, time.Time{}, false
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if !c.cached || !reflect.DeepEqual(c.raw, snapshot) {
-		return telemetry.Snapshot{}, false
+	lastCompletedAt := time.Time{}
+	if c.cached {
+		lastCompletedAt = c.raw.GeneratedAt
 	}
-	return c.enriched, true
+	if !c.cached || !sameSnapshotForEnrichment(c.raw, snapshot) {
+		return telemetry.Snapshot{}, false, lastCompletedAt, c.loading
+	}
+	return c.enriched, true, lastCompletedAt, c.loading
+}
+
+func sameSnapshotForEnrichment(left telemetry.Snapshot, right telemetry.Snapshot) bool {
+	if left.Seq != right.Seq {
+		return false
+	}
+	if !left.GeneratedAt.Equal(right.GeneratedAt) {
+		return false
+	}
+	return reflect.DeepEqual(left, right)
 }
 
 func (c *snapshotEnrichmentCache) enrich(ctx context.Context, snapshot telemetry.Snapshot, enrich func(context.Context, telemetry.Snapshot) telemetry.Snapshot) telemetry.Snapshot {
@@ -76,7 +95,7 @@ func (c *snapshotEnrichmentCache) enrich(ctx context.Context, snapshot telemetry
 
 	c.mu.Lock()
 	for {
-		if c.cached && reflect.DeepEqual(c.raw, snapshot) {
+		if c.cached && sameSnapshotForEnrichment(c.raw, snapshot) {
 			enriched := c.enriched
 			c.mu.Unlock()
 			return enriched

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -1252,10 +1252,11 @@ components:
       enum: [available, live, last_known, expired, unavailable, corrupt]
     State:
       type: object
-      required: [generated_at, snapshot_age_seconds, status, shutdown, instance, projects, stats, board]
+      required: [generated_at, snapshot_age_seconds, enrichment, status, shutdown, instance, projects, stats, board]
       properties:
         generated_at: {type: string, format: date-time}
         snapshot_age_seconds: {type: integer, format: int64, minimum: 0}
+        enrichment: {$ref: "#/components/schemas/StateEnrichment"}
         status: {type: string, enum: [running, draining]}
         shutdown: {$ref: "#/components/schemas/GenericObject"}
         instance: {$ref: "#/components/schemas/GenericObject"}
@@ -1265,6 +1266,15 @@ components:
         stats: {$ref: "#/components/schemas/GenericObject"}
         board: {$ref: "#/components/schemas/GenericObject"}
       additionalProperties: true
+    StateEnrichment:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [ready, pending, omitted]
+        completed_snapshot_generated_at: {type: string, format: date-time}
+        degraded_reason: {type: string}
     TimeSeries:
       type: object
       description: Bucketed time-series response; metric arrays evolve additively.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -206,6 +206,7 @@ type Server struct {
 	assets              staticAssets
 	projects            *projectSmallMultipleRecorder
 	snapshots           *snapshotEnrichmentCache
+	stateEndpoints      *stateEndpointRecorder
 	spendRegressions    *spendRegressionMonitor
 	kanbanMutations     *kanbanstate.MutationTracker
 	kanbanRefreshes     *kanbanRefreshFeedbackTracker
@@ -336,6 +337,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		assets:              newStaticAssets(cfg.staticDir()),
 		projects:            newProjectSmallMultipleRecorder(),
 		snapshots:           newSnapshotEnrichmentCache(),
+		stateEndpoints:      newStateEndpointRecorder(),
 		spendRegressions:    newSpendRegressionMonitor(),
 		kanbanMutations:     kanbanstate.NewMutationTracker(),
 		kanbanRefreshes:     newKanbanRefreshFeedbackTracker(),
@@ -1261,6 +1263,7 @@ func (s *Server) health(c echo.Context) error {
 		checks["demo_clock"] = s.demo.clock
 	}
 	projectStatus, projectHealth := s.projectHealth()
+	stateEndpoints := s.stateEndpoints.health()
 	faultDispatchStalls := faultDispatchStatuses(dispatchStalls)
 	actionableBreakers := faultFailureBreakers(failureBreakers)
 	actionableOutages := faultBackendOutages(backendOutages)
@@ -1274,6 +1277,9 @@ func (s *Server) health(c echo.Context) error {
 			status = "needs_attention"
 		}
 		if pauseExitNeedsAttention(projectHealth) {
+			status = "needs_attention"
+		}
+		if stateEndpoints.Fleet.Status == "degraded" || stateEndpoints.Project.Status == "degraded" {
 			status = "needs_attention"
 		}
 	}
@@ -1320,6 +1326,7 @@ func (s *Server) health(c echo.Context) error {
 		AgentMemory:            agentMemory,
 		SnapshotGeneratedAt:    snapshotGeneratedAt,
 		SnapshotAgeSeconds:     snapshotAgeSeconds,
+		StateEndpoints:         stateEndpoints,
 		TickLiveness:           tickLiveness,
 		OrphanedAgentProcesses: orphanedProcesses,
 	})
@@ -1807,6 +1814,7 @@ type healthResponse struct {
 	AgentMemory            []healthAgentMemory              `json:"agent_memory"`
 	SnapshotGeneratedAt    time.Time                        `json:"snapshot_generated_at,omitzero"`
 	SnapshotAgeSeconds     int64                            `json:"snapshot_age_seconds"`
+	StateEndpoints         healthStateEndpoints             `json:"state_endpoints"`
 	TickLiveness           []telemetry.TickLiveness         `json:"tick_liveness"`
 	OrphanedAgentProcesses telemetry.OrphanedAgentProcesses `json:"orphaned_agent_processes"`
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6883,13 +6883,34 @@ func TestStateAPICachesEnrichmentQueries(t *testing.T) {
 				t.Fatalf("NewServer() error = %v", err)
 			}
 
-			requestJSON(t, server, http.MethodGet, tt.path, http.StatusOK)
-			requestJSON(t, server, http.MethodGet, tt.path, http.StatusOK)
-			if got := backend.workflowMetricsCalls.Load(); got != 6 {
-				t.Fatalf("WorkflowMetricsReport() calls = %d, want 6", got)
+			cold := requestJSON(t, server, http.MethodGet, tt.path, http.StatusOK)
+			if enrichment := cold["enrichment"].(map[string]any); enrichment["status"] != "omitted" {
+				t.Fatalf("cold enrichment = %#v, want omitted", enrichment)
 			}
-			if got := backend.budgetCostCalls.Load(); got != 1 {
-				t.Fatalf("BudgetCostEvents() calls = %d, want 1", got)
+			if got := backend.workflowMetricsCalls.Load(); got != 0 {
+				t.Fatalf("cold WorkflowMetricsReport() calls = %d, want 0", got)
+			}
+			if got := backend.budgetCostCalls.Load(); got != 0 {
+				t.Fatalf("cold BudgetCostEvents() calls = %d, want 0", got)
+			}
+
+			requestDashboardEnrichment(t, server)
+			workflowCalls := backend.workflowMetricsCalls.Load()
+			budgetCalls := backend.budgetCostCalls.Load()
+			if workflowCalls == 0 || budgetCalls == 0 {
+				t.Fatalf("dashboard enrichment calls = workflow %d, budget %d", workflowCalls, budgetCalls)
+			}
+			for range 2 {
+				cached := requestJSON(t, server, http.MethodGet, tt.path, http.StatusOK)
+				if enrichment := cached["enrichment"].(map[string]any); enrichment["status"] != "ready" {
+					t.Fatalf("cached enrichment = %#v, want ready", enrichment)
+				}
+			}
+			if got := backend.workflowMetricsCalls.Load(); got != workflowCalls {
+				t.Fatalf("cached WorkflowMetricsReport() calls = %d, want %d", got, workflowCalls)
+			}
+			if got := backend.budgetCostCalls.Load(); got != budgetCalls {
+				t.Fatalf("cached BudgetCostEvents() calls = %d, want %d", got, budgetCalls)
 			}
 		})
 	}
@@ -8240,6 +8261,214 @@ func TestAPIStateRespondsDuringDrainWithoutStoreEnrichment(t *testing.T) {
 	}
 }
 
+func TestProjectStateAPIRespondsDuringConcurrentRefreshAndStoreEnrichment(t *testing.T) {
+	t.Parallel()
+
+	const requestDeadline = 500 * time.Millisecond
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	var logs bytes.Buffer
+	deps := testDeps(t)
+	deps.Store = storeProbe{
+		cycleTimeReport: func(ctx context.Context) (store.CycleTimeReport, error) {
+			startedOnce.Do(func() { close(started) })
+			select {
+			case <-release:
+				return store.CycleTimeReport{}, nil
+			case <-ctx.Done():
+				return store.CycleTimeReport{}, ctx.Err()
+			}
+		},
+	}
+	generatedAt := time.Date(2026, 9, 4, 15, 4, 5, 0, time.UTC)
+	publish := func(index int) {
+		t.Helper()
+		if err := deps.Hub.Publish(telemetry.Snapshot{
+			GeneratedAt: generatedAt.Add(time.Duration(index) * time.Second),
+			Projects: []telemetry.ProjectSnapshot{{
+				Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+			}},
+		}); err != nil {
+			t.Fatalf("Publish(%d) error = %v", index, err)
+		}
+	}
+	publish(0)
+
+	server, err := web.NewServer(web.Config{
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	enrichmentResult := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		recorder := httptest.NewRecorder()
+		server.Handler().ServeHTTP(recorder, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/reports", nil))
+		enrichmentResult <- recorder
+	}()
+	select {
+	case <-started:
+	case <-time.After(requestDeadline):
+		t.Fatal("project state enrichment did not reach the blocked store query")
+	}
+
+	for index := 1; index <= 8; index++ {
+		publish(index)
+		result := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			result <- projectStateRequest(server, context.Background())
+		}()
+		select {
+		case recorder := <-result:
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("request %d status = %d, want %d; body = %s", index, recorder.Code, http.StatusOK, recorder.Body.String())
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("request %d Unmarshal() error = %v", index, err)
+			}
+			if payload["generated_at"] != generatedAt.Add(time.Duration(index)*time.Second).Format(time.RFC3339) {
+				t.Fatalf("request %d generated_at = %#v", index, payload["generated_at"])
+			}
+			enrichment, ok := payload["enrichment"].(map[string]any)
+			if !ok || enrichment["status"] != "pending" {
+				t.Fatalf("request %d enrichment = %#v, want pending", index, payload["enrichment"])
+			}
+		case <-time.After(requestDeadline):
+			t.Fatalf("request %d exceeded %s while enrichment was blocked", index, requestDeadline)
+		}
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	canceled := projectStateRequest(server, canceledCtx)
+	if canceled.Code != http.StatusOK {
+		t.Fatalf("canceled request status = %d, want %d; body = %s", canceled.Code, http.StatusOK, canceled.Body.String())
+	}
+	if strings.Contains(logs.String(), "context canceled") {
+		t.Fatalf("request cancellation reached enrichment queries:\n%s", logs.String())
+	}
+
+	health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	stateEndpoints, ok := health["state_endpoints"].(map[string]any)
+	if !ok {
+		t.Fatalf("state_endpoints = %#v", health["state_endpoints"])
+	}
+	projectEndpoint, ok := stateEndpoints["project"].(map[string]any)
+	if !ok || projectEndpoint["request_count"].(float64) < 9 || projectEndpoint["target_latency_ms"] != float64(500) {
+		t.Fatalf("project state endpoint telemetry = %#v", stateEndpoints["project"])
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case recorder := <-enrichmentResult:
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("enrichment request status = %d, want %d", recorder.Code, http.StatusOK)
+		}
+	case <-time.After(requestDeadline):
+		t.Fatal("dashboard enrichment request did not complete after store release")
+	}
+}
+
+func TestHealthReportsStateEndpointLatencyAndCancellation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		path               string
+		endpoint           string
+		requestContext     func() (context.Context, context.CancelFunc)
+		wantOutcome        string
+		wantEndpointStatus string
+		wantHealthStatus   string
+		wantTimeouts       float64
+		wantCancellations  float64
+	}{
+		{
+			name:     "fleet cancellation",
+			path:     "/api/v1/state",
+			endpoint: "fleet",
+			requestContext: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			wantOutcome:        "canceled",
+			wantEndpointStatus: "ok",
+			wantHealthStatus:   "ok",
+			wantCancellations:  1,
+		},
+		{
+			name:     "project timeout",
+			path:     "/api/v1/projects/detent/state",
+			endpoint: "project",
+			requestContext: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+			},
+			wantOutcome:        "timeout",
+			wantEndpointStatus: "degraded",
+			wantHealthStatus:   "needs_attention",
+			wantTimeouts:       1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: time.Date(2026, 9, 4, 15, 4, 5, 0, time.UTC),
+				Projects: []telemetry.ProjectSnapshot{{
+					Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+				}},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			ctx, cancel := tt.requestContext()
+			defer cancel()
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequestWithContext(ctx, http.MethodGet, tt.path, nil)
+			server.Handler().ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("state status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+			}
+
+			health := requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+			if health["status"] != tt.wantHealthStatus || health["ready"] != true || health["lifecycle"] != "ready" {
+				t.Fatalf("health summary = %#v, want ready %s", health, tt.wantHealthStatus)
+			}
+			endpoints := health["state_endpoints"].(map[string]any)
+			endpoint := endpoints[tt.endpoint].(map[string]any)
+			if endpoint["status"] != tt.wantEndpointStatus || endpoint["last_outcome"] != tt.wantOutcome {
+				t.Fatalf("%s endpoint = %#v", tt.endpoint, endpoint)
+			}
+			if endpoint["request_count"] != float64(1) || endpoint["target_latency_ms"] != float64(500) {
+				t.Fatalf("%s endpoint counts = %#v", tt.endpoint, endpoint)
+			}
+			if endpoint["timeout_count"] != tt.wantTimeouts || endpoint["canceled_request_count"] != tt.wantCancellations {
+				t.Fatalf("%s endpoint termination counts = %#v", tt.endpoint, endpoint)
+			}
+		})
+	}
+}
+
+func projectStateRequest(server *web.Server, ctx context.Context) *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/projects/detent/state", nil)
+	server.Handler().ServeHTTP(recorder, request)
+	return recorder
+}
+
 func TestDashboardReadsLatestSnapshotWithoutSubscribing(t *testing.T) {
 	t.Parallel()
 
@@ -9472,7 +9701,7 @@ func TestServerEventsEnrichesSnapshotOncePerPublish(t *testing.T) {
 	}
 }
 
-func TestSnapshotEnrichmentDoesNotCacheCanceledContext(t *testing.T) {
+func TestStateRequestCancellationDoesNotReachSnapshotEnrichment(t *testing.T) {
 	t.Parallel()
 
 	generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
@@ -9506,16 +9735,20 @@ func TestSnapshotEnrichmentDoesNotCacheCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil).WithContext(ctx)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/state", nil)
 	server.Handler().ServeHTTP(rec, req)
+	if got := budgetCalls.Load(); got != 0 {
+		t.Fatalf("BudgetCostEvents calls after canceled state request = %d, want 0", got)
+	}
 
+	requestDashboardEnrichment(t, server)
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	budget := state["budget"].(map[string]any)
 	if reason, ok := budget["degraded_reason"]; ok {
 		t.Fatalf("budget degraded_reason = %#v, want omitted", reason)
 	}
-	if got := budgetCalls.Load(); got < 2 {
-		t.Fatalf("BudgetCostEvents calls = %d, want canceled and healthy calls", got)
+	if got := budgetCalls.Load(); got != 2 {
+		t.Fatalf("BudgetCostEvents calls = %d, want snapshot and project dashboard enrichment calls", got)
 	}
 }
 
@@ -10568,6 +10801,7 @@ func TestServerEnrichesBudgetBurnDownFromStoreAndRegistry(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
+	requestDashboardEnrichment(t, server)
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	budget := state["budget"].(map[string]any)
 	if budget["enabled"] != true || budget["today_spend_usd"] != float64(3.5) || budget["projected_spend_usd"] != float64(7) {
@@ -10916,6 +11150,7 @@ func TestServerSurfacesFleetSpendWhenBudgetCapsAreDisabled(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
+	requestDashboardEnrichment(t, server)
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	budgetState := state["budget"].(map[string]any)
 	if budgetState["enabled"] != false || budgetState["today_spend_usd"] != float64(3.22) {
@@ -10991,6 +11226,7 @@ func TestServerDistinguishesNoBudgetSpendFromSpendQueryFailure(t *testing.T) {
 				t.Fatalf("NewServer() error = %v", err)
 			}
 
+			requestDashboardEnrichment(t, server)
 			state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 			budget := state["budget"].(map[string]any)
 			if tt.wantReason == "" {
@@ -11368,6 +11604,7 @@ func TestWorkflowMetricsStateAPIIncludesLaneTrendComparisons(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
+	requestDashboardEnrichment(t, server)
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	window := workflowMetricsWindow(t, state, "24h")
 
@@ -11436,6 +11673,7 @@ func TestProjectDiagnosticsRendersRuntimeStoreEvidence(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
+	requestDashboardEnrichment(t, server)
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	html := requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/diagnostics", http.StatusOK)
 	for _, want := range []string{
@@ -11489,7 +11727,7 @@ func TestProjectDiagnosticsRendersWorkflowMetricsEmptyHistory(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
-	requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	requestDashboardEnrichment(t, server)
 	html := requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/diagnostics", http.StatusOK)
 	for _, want := range []string{
 		"SQLite history is empty.",
@@ -11525,7 +11763,7 @@ func TestProjectDiagnosticsRendersWorkflowMetricsTrends(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
-	requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	requestDashboardEnrichment(t, server)
 	html := requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/diagnostics", http.StatusOK)
 	for _, want := range []string{
 		"Lane trends",
@@ -11571,6 +11809,7 @@ func TestProjectDiagnosticsRendersWorkflowFlowEfficiencyCharts(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
+	requestDashboardEnrichment(t, server)
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	window := workflowMetricsWindow(t, state, "24h")
 	inProgress := workflowMetricLane(t, window, "In Progress")
@@ -12463,6 +12702,16 @@ func usageBucket(t *testing.T, rows []any, bucket string) map[string]any {
 	}
 	t.Fatalf("missing bucket %q in %#v", bucket, rows)
 	return nil
+}
+
+func requestDashboardEnrichment(t *testing.T, server *web.Server) {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/reports", nil)
+	server.Handler().ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /reports status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
 }
 
 func requestJSON(t *testing.T, server *web.Server, method string, path string, wantStatus int) map[string]any {


### PR DESCRIPTION
## Summary

- serve state endpoints from the latest published snapshot without waiting for store-backed enrichment
- expose enrichment freshness/degradation metadata and fleet/project endpoint latency telemetry
- cover concurrent refresh plus blocked runtime-store enrichment with a 500 ms regression target

Fixes #2164

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual layout changes; this updates state API and health telemetry behavior.

## Test Plan

- [x] `make check`
- [x] concurrent project-state/store-enrichment regression test
- [x] table-driven state endpoint timeout and cancellation telemetry tests
