### PR TITLE
fix(config): preserve sessions during reload

### DIFF
--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -306,7 +306,7 @@ can include `--workflow-ref origin/main` during registration or add
 
 | Field | Reload behavior |
 | --- | --- |
-| Project list and project settings, including active hours and overrides | Live reload |
+| Project list and project settings, including active hours and overrides | Live reload; additions start only the new project, while removals and non-runtime definition changes replace only the affected project runtime |
 | Credentials: `github_token`, `trust_loopback_peer_read`, and project credentials | Live reload |
 | `dashboard_access` mode, token, and write access | Live reload; token changes invalidate private dashboard sessions |
 | `auth` | Restart required; persisted sessions remain valid until their configured expiry |
@@ -317,11 +317,24 @@ can include `--workflow-ref origin/main` during registration or add
 | `global.active_hours` | Live reload at the next dispatch decision; running agents drain when a window closes |
 | `global.rate_window_pacing` and `agent.rate_window_pacing` | Live reload at the next dispatch decision without interrupting running agents; the project value wins when explicitly set |
 | `global.max_concurrent_agents`, `global.scheduling`, `global.agent_pools`, `global.fair_share`, and project pool assignments | Live reload at the next dispatch decision; adding, removing, or lowering `burst_to` preserves active workers and drains to the new ceiling, and removed pools drain their active workers before retirement |
+| `global.memory.pressure_some_avg60_threshold`, `global.memory.poll_interval_ms`, `global.io`, and `global.cpu` | Live reload in each project orchestrator without interrupting active attempts or provider sessions; threshold changes immediately re-evaluate the latest supported pressure sample instead of waiting for the next poll |
 | `log_level` | Live reload |
 | `port`, `env`, `log_max_size_bytes`, `log_max_backups` | Restart required |
 
 When a changed field requires restart, Detent logs
 `global config setting change requires restart` with the field name.
+
+Each reload rereads the configured file before reconciliation and again after
+reconciliation. If the file changes while reconciliation is running, Detent
+continues with the newer snapshot and publishes only the final applied config.
+Periodic source reconciliation also applies a valid change when the filesystem
+watcher misses an event.
+
+Project removal or a definition change that cannot be applied to the live
+runtime inventories the affected project's active sessions before replacing
+it. The `global config reconciliation completed` and `global config reloaded`
+records list those sessions under `drained_sessions`. Unchanged project
+runtimes and their sessions continue without interruption.
 
 ## Running Multiple Instances
 

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -15,6 +15,8 @@ import (
 
 var errMissingGlobalConfigManager = errors.New("global config reload manager is required")
 
+const globalConfigReconcileInterval = 30 * time.Second
+
 type globalConfigManager interface {
 	Reconcile(context.Context, project.ManagerConfig) (project.ReconcileResult, error)
 }
@@ -81,10 +83,14 @@ func startGlobalConfigWatcher(
 	syncLatestGlobalConfig(ctx, path, reloader)
 	go func() {
 		defer close(done)
+		reconcile := time.NewTicker(globalConfigReconcileInterval)
+		defer reconcile.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
+			case <-reconcile.C:
+				syncLatestGlobalConfig(ctx, path, reloader)
 			case update, ok := <-updates:
 				if !ok {
 					return
@@ -130,23 +136,103 @@ func (r *globalConfigReloader) handle(ctx context.Context, update configwatcher.
 	}
 
 	previous := r.current
-	result, err := r.apply(ctx, update)
-	if err != nil {
-		logger.Warn("global config reload failed", "path", update.Path, "error", err)
-		return
+	update = latestGlobalConfigUpdate(update)
+	logger.Info("global config reconciliation started",
+		"path", update.Path,
+		"configured_projects", globalProjectIDs(update.Value.Projects),
+	)
+	var result project.ReconcileResult
+	var drainedSessions []project.ReconcileSession
+	applied := false
+	for {
+		var err error
+		result, err = r.applyCandidate(ctx, update)
+		if err != nil {
+			if applied {
+				r.publishReload()
+			}
+			logger.Warn("global config reconciliation failed", "path", update.Path, "error", err)
+			return
+		}
+		applied = true
+		drainedSessions = appendUniqueReconcileSessions(drainedSessions, result.DrainedSessions)
+
+		latest := latestGlobalConfigUpdate(configwatcher.FileUpdate[globalconfig.Config]{
+			Path:  update.Path,
+			Value: r.current,
+			At:    time.Now(),
+		})
+		if reflect.DeepEqual(r.current, latest.Value) {
+			break
+		}
+		logger.Info("global config reconciliation superseded",
+			"path", update.Path,
+			"configured_projects", globalProjectIDs(latest.Value.Projects),
+		)
+		update = latest
 	}
 
+	result.DrainedSessions = drainedSessions
+	r.publishReload()
 	logGlobalConfigChanges(logger, previous, r.current)
+	logger.Info("global config reconciliation completed",
+		"path", update.Path,
+		"added_projects", projectIDs(result.Added),
+		"removed_projects", projectIDs(result.Removed),
+		"changed_projects", projectIDs(result.Changed),
+		"unchanged_projects", projectIDs(result.Unchanged),
+		"drained_sessions", result.DrainedSessions,
+	)
 	logger.Info("global config reloaded",
 		"path", update.Path,
 		"added_projects", projectIDs(result.Added),
 		"removed_projects", projectIDs(result.Removed),
 		"changed_projects", projectIDs(result.Changed),
 		"unchanged_projects", projectIDs(result.Unchanged),
+		"drained_sessions", result.DrainedSessions,
 	)
 }
 
+func appendUniqueReconcileSessions(current []project.ReconcileSession, additions []project.ReconcileSession) []project.ReconcileSession {
+	seen := make(map[project.ReconcileSession]struct{}, len(current)+len(additions))
+	for _, session := range current {
+		seen[session] = struct{}{}
+	}
+	for _, session := range additions {
+		if _, ok := seen[session]; ok {
+			continue
+		}
+		seen[session] = struct{}{}
+		current = append(current, session)
+	}
+	return current
+}
+
+func latestGlobalConfigUpdate(update configwatcher.FileUpdate[globalconfig.Config]) configwatcher.FileUpdate[globalconfig.Config] {
+	if update.WatcherErr || strings.TrimSpace(update.Path) == "" {
+		return update
+	}
+	latest, err := readGlobalConfig(update.Path)
+	if err != nil {
+		return update
+	}
+	update.Value = latest
+	update.Err = nil
+	return update
+}
+
 func (r *globalConfigReloader) apply(
+	ctx context.Context,
+	update configwatcher.FileUpdate[globalconfig.Config],
+) (project.ReconcileResult, error) {
+	result, err := r.applyCandidate(ctx, update)
+	if err == nil {
+		r.publishReload()
+	}
+	return result, err
+}
+
+func (r *globalConfigReloader) applyCandidate(
 	ctx context.Context,
 	update configwatcher.FileUpdate[globalconfig.Config],
 ) (project.ReconcileResult, error) {
@@ -190,10 +276,13 @@ func (r *globalConfigReloader) apply(
 	}
 
 	r.current = update.Value
-	if r.onReload != nil {
-		r.onReload(update.Value)
-	}
 	return result, nil
+}
+
+func (r *globalConfigReloader) publishReload() {
+	if r.onReload != nil {
+		r.onReload(r.current)
+	}
 }
 
 func (r *globalConfigReloader) runtimeGitHubToken(ctx context.Context, cfg globalconfig.Config) (string, error) {
@@ -333,6 +422,33 @@ func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Set
 	}
 	if !reflect.DeepEqual(previous.Startup, next.Startup) {
 		fields = append(fields, globalConfigChange{Field: "global.startup", Old: previous.Startup, New: next.Startup})
+	}
+	if previous.Memory.MaxAgentRSSBytes != next.Memory.MaxAgentRSSBytes {
+		fields = append(fields, globalConfigChange{Field: "global.memory.max_agent_rss_bytes", Old: previous.Memory.MaxAgentRSSBytes, New: next.Memory.MaxAgentRSSBytes})
+	}
+	if previous.Memory.PressureSomeAvg60Threshold != next.Memory.PressureSomeAvg60Threshold {
+		fields = append(fields, globalConfigChange{Field: "global.memory.pressure_some_avg60_threshold", Old: previous.Memory.PressureSomeAvg60Threshold, New: next.Memory.PressureSomeAvg60Threshold})
+	}
+	if previous.Memory.PollIntervalMS != next.Memory.PollIntervalMS {
+		fields = append(fields, globalConfigChange{Field: "global.memory.poll_interval_ms", Old: previous.Memory.PollIntervalMS, New: next.Memory.PollIntervalMS})
+	}
+	if previous.IO.PressureFullAvg10Threshold != next.IO.PressureFullAvg10Threshold {
+		fields = append(fields, globalConfigChange{Field: "global.io.pressure_full_avg10_threshold", Old: previous.IO.PressureFullAvg10Threshold, New: next.IO.PressureFullAvg10Threshold})
+	}
+	if previous.IO.DegradedMaxConcurrentAgents != next.IO.DegradedMaxConcurrentAgents {
+		fields = append(fields, globalConfigChange{Field: "global.io.degraded_max_concurrent_agents", Old: previous.IO.DegradedMaxConcurrentAgents, New: next.IO.DegradedMaxConcurrentAgents})
+	}
+	if previous.IO.PollIntervalMS != next.IO.PollIntervalMS {
+		fields = append(fields, globalConfigChange{Field: "global.io.poll_interval_ms", Old: previous.IO.PollIntervalMS, New: next.IO.PollIntervalMS})
+	}
+	if previous.CPU.PressureSomeAvg10Threshold != next.CPU.PressureSomeAvg10Threshold {
+		fields = append(fields, globalConfigChange{Field: "global.cpu.pressure_some_avg10_threshold", Old: previous.CPU.PressureSomeAvg10Threshold, New: next.CPU.PressureSomeAvg10Threshold})
+	}
+	if previous.CPU.DegradedMaxConcurrentAgents != next.CPU.DegradedMaxConcurrentAgents {
+		fields = append(fields, globalConfigChange{Field: "global.cpu.degraded_max_concurrent_agents", Old: previous.CPU.DegradedMaxConcurrentAgents, New: next.CPU.DegradedMaxConcurrentAgents})
+	}
+	if previous.CPU.PollIntervalMS != next.CPU.PollIntervalMS {
+		fields = append(fields, globalConfigChange{Field: "global.cpu.poll_interval_ms", Old: previous.CPU.PollIntervalMS, New: next.CPU.PollIntervalMS})
 	}
 	return fields
 }

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -101,6 +102,262 @@ func TestGlobalConfigReloaderApply(t *testing.T) {
 				t.Fatalf("current = %#v, want %#v", reloader.current, tt.wantCurrent)
 			}
 		})
+	}
+}
+
+func TestGlobalConfigReloaderUsesLatestFileSnapshot(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	current := reloadTestConfig(path, 2, []globalconfig.Project{{
+		ID:       "alpha",
+		Workflow: alpha.workflowPath,
+		Workdir:  alpha.workdirPath,
+		Weight:   1,
+	}})
+	if err := globalconfig.Write(path, current); err != nil {
+		t.Fatalf("Write(current) error = %v", err)
+	}
+	current, err := globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(current) error = %v", err)
+	}
+	stale := current
+	stale.Global.MaxConcurrentAgents = 4
+	latest := current
+	latest.Global.MaxConcurrentAgents = 6
+	if err := globalconfig.Write(path, latest); err != nil {
+		t.Fatalf("Write(latest) error = %v", err)
+	}
+	latest, err = globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(latest) error = %v", err)
+	}
+
+	manager := &globalReloadManager{}
+	reloaded := []globalconfig.Config{}
+	reloader := &globalConfigReloader{
+		current: current,
+		manager: manager,
+		onReload: func(cfg globalconfig.Config) {
+			reloaded = append(reloaded, cfg)
+		},
+	}
+	reloader.handle(context.Background(), configwatcher.FileUpdate[globalconfig.Config]{
+		Path:  path,
+		Value: stale,
+	})
+
+	if manager.calls != 1 {
+		t.Fatalf("manager calls = %d, want 1", manager.calls)
+	}
+	if want := project.ManagerConfigFromGlobal(latest); !reflect.DeepEqual(manager.config, want) {
+		t.Fatalf("manager config = %#v, want latest %#v", manager.config, want)
+	}
+	if !reflect.DeepEqual(reloader.current, latest) {
+		t.Fatalf("current = %#v, want latest %#v", reloader.current, latest)
+	}
+	if !reflect.DeepEqual(reloaded, []globalconfig.Config{latest}) {
+		t.Fatalf("reload callbacks = %#v, want latest only", reloaded)
+	}
+}
+
+func TestSyncLatestGlobalConfigReconcilesMissedWatchEvent(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	current := reloadTestConfig(path, 2, []globalconfig.Project{{
+		ID:       "alpha",
+		Workflow: alpha.workflowPath,
+		Workdir:  alpha.workdirPath,
+		Weight:   1,
+	}})
+	if err := globalconfig.Write(path, current); err != nil {
+		t.Fatalf("Write(current) error = %v", err)
+	}
+	current, err := globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(current) error = %v", err)
+	}
+	latest := current
+	latest.Global.MaxConcurrentAgents = 6
+	if err := globalconfig.Write(path, latest); err != nil {
+		t.Fatalf("Write(latest) error = %v", err)
+	}
+	latest, err = globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(latest) error = %v", err)
+	}
+
+	manager := &globalReloadManager{}
+	reloader := &globalConfigReloader{current: current, manager: manager}
+	syncLatestGlobalConfig(context.Background(), path, reloader)
+
+	if manager.calls != 1 {
+		t.Fatalf("manager calls = %d, want 1", manager.calls)
+	}
+	if !reflect.DeepEqual(reloader.current, latest) {
+		t.Fatalf("current = %#v, want latest %#v", reloader.current, latest)
+	}
+}
+
+func TestGlobalConfigReloaderConvergesWhenFileChangesDuringReconciliation(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	current := reloadTestConfig(path, 2, []globalconfig.Project{{
+		ID:       "alpha",
+		Workflow: alpha.workflowPath,
+		Workdir:  alpha.workdirPath,
+		Weight:   1,
+	}})
+	if err := globalconfig.Write(path, current); err != nil {
+		t.Fatalf("Write(current) error = %v", err)
+	}
+	current, err := globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(current) error = %v", err)
+	}
+	first := current
+	first.Global.MaxConcurrentAgents = 4
+	if err := globalconfig.Write(path, first); err != nil {
+		t.Fatalf("Write(first) error = %v", err)
+	}
+	first, err = globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+
+	manager := newBlockingGlobalReloadManager()
+	manager.results = []project.ReconcileResult{
+		{DrainedSessions: []project.ReconcileSession{{ProjectID: "alpha", Identifier: "alpha#1"}}},
+		{DrainedSessions: []project.ReconcileSession{{ProjectID: "alpha", Identifier: "alpha#2"}}},
+	}
+	reloaded := []globalconfig.Config{}
+	applied := []int{}
+	var logs bytes.Buffer
+	reloader := &globalConfigReloader{
+		current: current,
+		manager: manager,
+		applyRuntime: func(cfg globalconfig.Config) error {
+			applied = append(applied, cfg.Global.MaxConcurrentAgents)
+			return nil
+		},
+		onReload: func(cfg globalconfig.Config) {
+			reloaded = append(reloaded, cfg)
+		},
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		reloader.handle(context.Background(), configwatcher.FileUpdate[globalconfig.Config]{
+			Path:  path,
+			Value: first,
+		})
+	}()
+
+	select {
+	case <-manager.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first reconciliation")
+	}
+	latest := current
+	latest.Global.MaxConcurrentAgents = 6
+	if err := globalconfig.Write(path, latest); err != nil {
+		t.Fatalf("Write(latest) error = %v", err)
+	}
+	latest, err = globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(latest) error = %v", err)
+	}
+	close(manager.release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for converged reconciliation")
+	}
+
+	if len(manager.configs) != 2 || manager.configs[0].Projects[0].ID != "alpha" || manager.configs[1].Projects[0].ID != "alpha" {
+		t.Fatalf("manager configs = %#v, want two alpha reconciliations", manager.configs)
+	}
+	if !reflect.DeepEqual(applied, []int{4, 6}) {
+		t.Fatalf("applied runtime capacities = %v, want [4 6]", applied)
+	}
+	if !reflect.DeepEqual(reloader.current, latest) {
+		t.Fatalf("current = %#v, want latest %#v", reloader.current, latest)
+	}
+	if !reflect.DeepEqual(reloaded, []globalconfig.Config{latest}) {
+		t.Fatalf("reload callbacks = %#v, want latest only", reloaded)
+	}
+	for _, identifier := range []string{"alpha#1", "alpha#2"} {
+		if !strings.Contains(logs.String(), identifier) {
+			t.Fatalf("completion logs missing drained session %q:\n%s", identifier, logs.String())
+		}
+	}
+}
+
+func TestGlobalConfigReloaderLogsReconciliationLifecycleAndDrainedSessions(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	current := reloadTestConfig(path, 2, []globalconfig.Project{{
+		ID:       "alpha",
+		Workflow: alpha.workflowPath,
+		Workdir:  alpha.workdirPath,
+		Weight:   1,
+	}})
+	if err := globalconfig.Write(path, current); err != nil {
+		t.Fatalf("Write(current) error = %v", err)
+	}
+	current, err := globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(current) error = %v", err)
+	}
+	next := current
+	next.Global.CPU.PressureSomeAvg10Threshold = 95
+	if err := globalconfig.Write(path, next); err != nil {
+		t.Fatalf("Write(next) error = %v", err)
+	}
+	next, err = globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read(next) error = %v", err)
+	}
+
+	var logs bytes.Buffer
+	reloader := &globalConfigReloader{
+		current: current,
+		manager: &globalReloadManager{result: project.ReconcileResult{
+			Changed: []project.ID{"alpha"},
+			DrainedSessions: []project.ReconcileSession{{
+				ProjectID:         "alpha",
+				IssueID:           "2058",
+				Identifier:        "digitaldrywood/pyroapex#2058",
+				WorkAttemptID:     7755,
+				DetentSessionID:   9900,
+				ProviderSessionID: "thread-2058-turn-1",
+			}},
+		}},
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	reloader.handle(context.Background(), configwatcher.FileUpdate[globalconfig.Config]{Path: path, Value: next})
+
+	for _, want := range []string{
+		"global config reconciliation started",
+		"global config reconciliation completed",
+		"global.cpu.pressure_some_avg10_threshold",
+		"drained_sessions",
+		"digitaldrywood/pyroapex#2058",
+		"9900",
+		"thread-2058-turn-1",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("reconciliation logs missing %q:\n%s", want, logs.String())
+		}
 	}
 }
 
@@ -264,6 +521,9 @@ func TestChangedGlobalConfigFieldsReloadClassification(t *testing.T) {
 		}},
 		{name: "fair share", field: "global.fair_share", mutate: func(cfg *globalconfig.Config) { cfg.Global.FairShare = map[string]any{"half_life": "2h"} }},
 		{name: "startup", field: "global.startup", mutate: func(cfg *globalconfig.Config) { cfg.Global.Startup = map[string]any{"jitter_seconds": 1} }},
+		{name: "memory pressure", field: "global.memory.pressure_some_avg60_threshold", mutate: func(cfg *globalconfig.Config) { cfg.Global.Memory.PressureSomeAvg60Threshold = 12 }},
+		{name: "IO pressure", field: "global.io.pressure_full_avg10_threshold", mutate: func(cfg *globalconfig.Config) { cfg.Global.IO.PressureFullAvg10Threshold = 7 }},
+		{name: "CPU pressure", field: "global.cpu.pressure_some_avg10_threshold", mutate: func(cfg *globalconfig.Config) { cfg.Global.CPU.PressureSomeAvg10Threshold = 95 }},
 	}
 
 	for _, tt := range tests {
@@ -526,7 +786,22 @@ func TestLogGlobalConfigChangesRedactsDashboardToken(t *testing.T) {
 type globalReloadManager struct {
 	calls  int
 	config project.ManagerConfig
+	result project.ReconcileResult
 	err    error
+}
+
+type blockingGlobalReloadManager struct {
+	started chan struct{}
+	release chan struct{}
+	configs []project.ManagerConfig
+	results []project.ReconcileResult
+}
+
+func newBlockingGlobalReloadManager() *blockingGlobalReloadManager {
+	return &blockingGlobalReloadManager{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
 }
 
 type globalReloadFairShareStore struct{}
@@ -545,7 +820,29 @@ func (m *globalReloadManager) Reconcile(
 ) (project.ReconcileResult, error) {
 	m.calls++
 	m.config = cfg
-	return project.ReconcileResult{Added: []project.ID{"bravo"}}, m.err
+	return m.result, m.err
+}
+
+func (m *blockingGlobalReloadManager) Reconcile(
+	ctx context.Context,
+	cfg project.ManagerConfig,
+) (project.ReconcileResult, error) {
+	m.configs = append(m.configs, cfg)
+	call := len(m.configs)
+	result := project.ReconcileResult{}
+	if call <= len(m.results) {
+		result = m.results[call-1]
+	}
+	if call != 1 {
+		return result, nil
+	}
+	close(m.started)
+	select {
+	case <-ctx.Done():
+		return project.ReconcileResult{}, ctx.Err()
+	case <-m.release:
+		return result, nil
+	}
 }
 
 func reloadTestConfig(path string, maxConcurrentAgents int, projects []globalconfig.Project) globalconfig.Config {

--- a/internal/orchestrator/host_pressure.go
+++ b/internal/orchestrator/host_pressure.go
@@ -190,6 +190,80 @@ func refreshCPUPressureCapacity(pressure *telemetry.CPUPressure, degraded int) {
 	}
 }
 
+func refreshCachedHostPressure(state *State, previous Config, current Config, now time.Time) {
+	refreshCachedMemoryPressure(&state.MemoryPressure, previous.MemoryPressureSomeAvg60Max, current.MemoryPressureSomeAvg60Max)
+	refreshCachedIOPressure(
+		&state.IOPressure,
+		previous.IOPressureFullAvg10Max,
+		current.IOPressureFullAvg10Max,
+		current.IOPressureDegradedMaxAgents,
+		now,
+	)
+	refreshCachedCPUPressure(
+		&state.CPUPressure,
+		previous.CPUPressureSomeAvg10Max,
+		current.CPUPressureSomeAvg10Max,
+		current.CPUPressureDegradedMaxAgents,
+		now,
+	)
+}
+
+func refreshCachedMemoryPressure(pressure *telemetry.MemoryPressure, previousThreshold float64, threshold float64) {
+	pressure.SomeAvg60Max = threshold
+	if threshold <= 0 {
+		pressure.DispatchHeld = false
+		return
+	}
+	if !pressure.Supported || previousThreshold == threshold {
+		return
+	}
+	pressure.DispatchHeld = pressure.Some.Avg60 > threshold
+}
+
+func refreshCachedIOPressure(
+	pressure *telemetry.IOPressure,
+	previousThreshold float64,
+	threshold float64,
+	degraded int,
+	now time.Time,
+) {
+	wasConstrained := pressure.CapacityConstrained || pressure.DispatchHeld
+	pressure.FullAvg10Max = threshold
+	if previousThreshold != threshold || threshold <= 0 {
+		constrained := pressure.Supported && threshold > 0 && pressure.Full.Avg10 > threshold
+		pressure.ConstrainedSince, pressure.ConstrainedForMS = pressureConstraintDuration(
+			wasConstrained,
+			pressure.ConstrainedSince,
+			constrained,
+			now,
+		)
+		pressure.CapacityConstrained = constrained
+	}
+	refreshIOPressureCapacity(pressure, degraded)
+}
+
+func refreshCachedCPUPressure(
+	pressure *telemetry.CPUPressure,
+	previousThreshold float64,
+	threshold float64,
+	degraded int,
+	now time.Time,
+) {
+	wasConstrained := pressure.CapacityConstrained || pressure.DispatchHeld
+	pressure.SomeAvg10Max = threshold
+	if previousThreshold != threshold || threshold <= 0 {
+		constrained := pressure.Supported && threshold > 0 && pressure.Some.Avg10 > threshold
+		pressure.ConstrainedSince, pressure.ConstrainedForMS = pressureConstraintDuration(
+			wasConstrained,
+			pressure.ConstrainedSince,
+			constrained,
+			now,
+		)
+		pressure.CapacityConstrained = constrained
+	}
+	refreshCPUPressureCapacity(pressure, degraded)
+}
+
 func refreshIOPressureDuration(pressure *telemetry.IOPressure, now time.Time) {
 	if pressure == nil || !pressure.CapacityConstrained || pressure.ConstrainedSince.IsZero() {
 		return

--- a/internal/orchestrator/host_pressure_regression_test.go
+++ b/internal/orchestrator/host_pressure_regression_test.go
@@ -61,6 +61,122 @@ func TestRecordedBuildHostPressureHoldsAdmission(t *testing.T) {
 	}
 }
 
+func TestRuntimePressureThresholdReloadReevaluatesCachedSample(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 20, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		configureInitial func(*Config, *Orchestrator)
+		configureReload  func(*Config)
+		constrained      func(State) bool
+		threshold        func(State) float64
+		constraintSince  func(State) time.Time
+		wantThreshold    float64
+	}{
+		{
+			name: "memory",
+			configureInitial: func(cfg *Config, orch *Orchestrator) {
+				cfg.MemoryPressureSomeAvg60Max = 10
+				cfg.MemoryPressurePollInterval = time.Second
+				orch.readMemoryPressure = pressureReader(now, hostpressure.Sample{Some: hostpressure.Pressure{Avg60: 11}}, nil)
+			},
+			configureReload: func(cfg *Config) {
+				cfg.MemoryPressureSomeAvg60Max = 12
+				cfg.MemoryPressurePollInterval = time.Hour
+			},
+			constrained: func(state State) bool {
+				return state.MemoryPressure.DispatchHeld
+			},
+			threshold: func(state State) float64 {
+				return state.MemoryPressure.SomeAvg60Max
+			},
+			constraintSince: func(State) time.Time {
+				return time.Time{}
+			},
+			wantThreshold: 12,
+		},
+		{
+			name: "IO",
+			configureInitial: func(cfg *Config, orch *Orchestrator) {
+				cfg.IOPressureFullAvg10Max = 5
+				cfg.IOPressurePollInterval = time.Second
+				orch.readIOPressure = pressureReader(now, hostpressure.Sample{Full: hostpressure.Pressure{Avg10: 6}}, nil)
+			},
+			configureReload: func(cfg *Config) {
+				cfg.IOPressureFullAvg10Max = 7
+				cfg.IOPressurePollInterval = time.Hour
+			},
+			constrained: func(state State) bool {
+				return state.IOPressure.CapacityConstrained || state.IOPressure.DispatchHeld
+			},
+			threshold: func(state State) float64 {
+				return state.IOPressure.FullAvg10Max
+			},
+			constraintSince: func(state State) time.Time {
+				return state.IOPressure.ConstrainedSince
+			},
+			wantThreshold: 7,
+		},
+		{
+			name: "CPU",
+			configureInitial: func(cfg *Config, orch *Orchestrator) {
+				cfg.CPUPressureSomeAvg10Max = 80
+				cfg.CPUPressurePollInterval = time.Second
+				orch.readCPUPressure = pressureReader(now, hostpressure.Sample{Some: hostpressure.Pressure{Avg10: 90}}, nil)
+			},
+			configureReload: func(cfg *Config) {
+				cfg.CPUPressureSomeAvg10Max = 100
+				cfg.CPUPressurePollInterval = time.Hour
+			},
+			constrained: func(state State) bool {
+				return state.CPUPressure.CapacityConstrained || state.CPUPressure.DispatchHeld
+			},
+			threshold: func(state State) float64 {
+				return state.CPUPressure.SomeAvg10Max
+			},
+			constraintSince: func(state State) time.Time {
+				return state.CPUPressure.ConstrainedSince
+			},
+			wantThreshold: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{PollInterval: time.Hour, MaxConcurrentAgents: 1}
+			orch := Orchestrator{now: func() time.Time { return now }}
+			tt.configureInitial(&cfg, &orch)
+			cfg = normalizeConfig(cfg)
+			orch.cfg = cfg
+			orch.supervisor = newTestSupervisor(t, FakeRunner{}, cfg)
+			state := newState(cfg)
+			orch.observeHostPressure(t.Context(), &state, now)
+			if !tt.constrained(state) {
+				t.Fatalf("initial pressure = %#v, want constrained", state)
+			}
+
+			reloaded := cfg
+			tt.configureReload(&reloaded)
+			ticker := time.NewTicker(time.Hour)
+			defer ticker.Stop()
+			orch.applyRuntimeUpdate(&state, RuntimeUpdate{Config: reloaded}, ticker)
+
+			if tt.constrained(state) {
+				t.Fatalf("reloaded pressure = %#v, want cached sample admitted", state)
+			}
+			if got := tt.threshold(state); got != tt.wantThreshold {
+				t.Fatalf("threshold = %v, want %v", got, tt.wantThreshold)
+			}
+			if since := tt.constraintSince(state); !since.IsZero() {
+				t.Fatalf("ConstrainedSince = %s, want zero", since)
+			}
+		})
+	}
+}
+
 func TestObserveIOAndCPUPressureControlsAdmission(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1235,6 +1235,7 @@ func (o *Orchestrator) dispatchQuiesced() bool {
 
 func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ticker *time.Ticker) {
 	cfg := normalizeConfig(update.Config)
+	previousCfg := o.cfg
 	if o.cfg.Claiming.OwnershipMode != cfg.Claiming.OwnershipMode ||
 		o.cfg.Claiming.AssigneeRequired != cfg.Claiming.AssigneeRequired {
 		o.ownershipStartupLogged = false
@@ -1247,7 +1248,8 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	if o.now != nil {
 		now = o.now
 	}
-	o.reloadProjectFailureBreaker(state, cfg.FailureBreaker, now())
+	updatedAt := now()
+	o.reloadProjectFailureBreaker(state, cfg.FailureBreaker, updatedAt)
 	if update.Connector != nil {
 		o.connector = update.Connector
 	}
@@ -1270,13 +1272,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	state.RateWindowPacing = cfg.RateWindowPacing
 	state.StrandedActiveThreshold = cfg.StrandedActiveThreshold
 	state.DispatchStallThreshold = cfg.DispatchStallThreshold
-	state.MemoryPressure.SomeAvg60Max = cfg.MemoryPressureSomeAvg60Max
-	state.IOPressure.FullAvg10Max = cfg.IOPressureFullAvg10Max
-	state.IOPressure.DegradedMaxConcurrentAgents = cfg.IOPressureDegradedMaxAgents
-	state.CPUPressure.SomeAvg10Max = cfg.CPUPressureSomeAvg10Max
-	state.CPUPressure.DegradedMaxConcurrentAgents = cfg.CPUPressureDegradedMaxAgents
-	refreshIOPressureCapacity(&state.IOPressure, cfg.IOPressureDegradedMaxAgents)
-	refreshCPUPressureCapacity(&state.CPUPressure, cfg.CPUPressureDegradedMaxAgents)
+	refreshCachedHostPressure(state, previousCfg, cfg, updatedAt)
 	state.AutoPromoteQuietDuration = cfg.AutoPromote.QuietDuration
 	state.AutoPromote = cloneAutoPromoteConfig(cfg.AutoPromote)
 	state.ActiveStates = append([]string(nil), cfg.ActiveStates...)

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math/big"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -56,10 +57,20 @@ type ConnectorRetryConfig struct {
 }
 
 type ReconcileResult struct {
-	Added     []ID
-	Removed   []ID
-	Changed   []ID
-	Unchanged []ID
+	Added           []ID
+	Removed         []ID
+	Changed         []ID
+	Unchanged       []ID
+	DrainedSessions []ReconcileSession
+}
+
+type ReconcileSession struct {
+	ProjectID         ID
+	IssueID           string
+	Identifier        string
+	WorkAttemptID     int64
+	DetentSessionID   int64
+	ProviderSessionID string
 }
 
 type startedProject struct {
@@ -436,6 +447,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	if err := validatePauseExitReferences(validationProjects); err != nil {
 		return result, errors.Join(err, closePreparedProjects(ctx, prepared))
 	}
+	result.DrainedSessions = m.reconcileSessionInventory(ctx, result, liveConfigChanges)
 
 	previous := m.cfg
 	previousSpawned := m.spawned
@@ -601,6 +613,52 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		item.project.publishStarted()
 	}
 	return result, closeStoppedProjects(ctx, stopped)
+}
+
+func (m *Manager) reconcileSessionInventory(
+	ctx context.Context,
+	result ReconcileResult,
+	liveConfigChanges map[ID]*Project,
+) []ReconcileSession {
+	projectIDs := append([]ID(nil), result.Removed...)
+	for _, id := range result.Changed {
+		if _, live := liveConfigChanges[id]; !live {
+			projectIDs = append(projectIDs, id)
+		}
+	}
+
+	var sessions []ReconcileSession
+	for _, id := range projectIDs {
+		trackedProject, ok := m.registry.Get(id)
+		if !ok || trackedProject == nil || !trackedProject.Running() || trackedProject.Orchestrator() == nil {
+			continue
+		}
+		state, err := trackedProject.Orchestrator().State(ctx)
+		if err != nil {
+			m.logger.Warn("inventory project reconciliation sessions failed", "project_id", id, "error", err)
+			continue
+		}
+		for issueID, running := range state.Running {
+			sessions = append(sessions, ReconcileSession{
+				ProjectID:         id,
+				IssueID:           issueID,
+				Identifier:        running.Issue.Identifier,
+				WorkAttemptID:     running.WorkAttemptID,
+				DetentSessionID:   running.DetentSessionID,
+				ProviderSessionID: running.SessionID,
+			})
+		}
+	}
+	sort.Slice(sessions, func(left int, right int) bool {
+		if sessions[left].ProjectID != sessions[right].ProjectID {
+			return sessions[left].ProjectID < sessions[right].ProjectID
+		}
+		if sessions[left].Identifier != sessions[right].Identifier {
+			return sessions[left].Identifier < sessions[right].Identifier
+		}
+		return sessions[left].IssueID < sessions[right].IssueID
+	})
+	return sessions
 }
 
 func validatePauseExitReferences(projects []*Project) error {
@@ -1398,6 +1456,10 @@ func sameProjectConfigExceptLiveFields(left globalconfig.Project, right globalco
 	left.GlobalActiveHours = right.GlobalActiveHours
 	left.ActiveHoursOverrideUntil = right.ActiveHoursOverrideUntil
 	left.GlobalRateWindowPacing = right.GlobalRateWindowPacing
+	left.GlobalMemory.PressureSomeAvg60Threshold = right.GlobalMemory.PressureSomeAvg60Threshold
+	left.GlobalMemory.PollIntervalMS = right.GlobalMemory.PollIntervalMS
+	left.GlobalIO = right.GlobalIO
+	left.GlobalCPU = right.GlobalCPU
 	return reflect.DeepEqual(left, right)
 }
 

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -1314,6 +1314,251 @@ func TestManagerReconcileAddedProjectBeginsPolling(t *testing.T) {
 	}
 }
 
+func TestManagerReconcileHotAppliesGlobalPressureWithoutInterruptingActiveSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*globalconfig.Project)
+		assert func(*testing.T, orchestrator.State)
+	}{
+		{
+			name: "memory",
+			mutate: func(cfg *globalconfig.Project) {
+				cfg.GlobalMemory.PressureSomeAvg60Threshold = 12
+			},
+			assert: func(t *testing.T, state orchestrator.State) {
+				t.Helper()
+				if state.MemoryPressure.SomeAvg60Max != 12 {
+					t.Fatalf("memory pressure threshold = %v, want 12", state.MemoryPressure.SomeAvg60Max)
+				}
+			},
+		},
+		{
+			name: "IO",
+			mutate: func(cfg *globalconfig.Project) {
+				cfg.GlobalIO.PressureFullAvg10Threshold = 7
+			},
+			assert: func(t *testing.T, state orchestrator.State) {
+				t.Helper()
+				if state.IOPressure.FullAvg10Max != 7 {
+					t.Fatalf("IO pressure threshold = %v, want 7", state.IOPressure.FullAvg10Max)
+				}
+			},
+		},
+		{
+			name: "CPU",
+			mutate: func(cfg *globalconfig.Project) {
+				cfg.GlobalCPU.PressureSomeAvg10Threshold = 95
+			},
+			assert: func(t *testing.T, state orchestrator.State) {
+				t.Helper()
+				if state.CPUPressure.SomeAvg10Max != 95 {
+					t.Fatalf("CPU pressure threshold = %v, want 95", state.CPUPressure.SomeAvg10Max)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const issueID = "issue-active"
+			initial := globalconfig.Project{
+				ID:           "alpha",
+				Weight:       1,
+				GlobalMemory: globalconfig.Memory{PressureSomeAvg60Threshold: 1_000_000},
+				GlobalIO:     globalconfig.IO{PressureFullAvg10Threshold: 1_000_000},
+				GlobalCPU:    globalconfig.CPU{PressureSomeAvg10Threshold: 1_000_000},
+			}
+			next := initial
+			tt.mutate(&next)
+			runner := newCancellationTrackingRunner()
+			created := 0
+			manager, err := project.NewManager(project.ManagerConfig{Projects: []globalconfig.Project{initial}}, project.ManagerDependencies{
+				ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+					created++
+					workflowCfg := workflowConfigWithMemoryIssue(issueID)
+					workflowCfg.Tracker.Issues[0].State = "Todo"
+					workflowCfg.Tracker.Issues[0].Title = "Keep active session running"
+					workflowCfg.Tracker.Issues[0].AssignedToWorker = true
+					return project.New(project.Config{
+						Project:  cfg,
+						Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Keep working."},
+					}, project.Dependencies{Runner: runner})
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewManager() error = %v", err)
+			}
+			if err := manager.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			before, ok := manager.Registry().Get("alpha")
+			if !ok {
+				t.Fatal("project alpha missing before reconcile")
+			}
+			t.Cleanup(func() {
+				runner.releaseAll()
+				for _, item := range manager.Registry().List() {
+					if err := item.Close(); err != nil {
+						t.Errorf("Close(%s) error = %v", item.ID(), err)
+					}
+				}
+			})
+			receiveRunRequest(t, runner.started)
+			beforeState, err := before.Orchestrator().State(context.Background())
+			if err != nil {
+				t.Fatalf("State() before reload error = %v", err)
+			}
+			beforeRunning, ok := beforeState.Running[issueID]
+			if !ok {
+				t.Fatalf("Running[%q] missing before pressure reload", issueID)
+			}
+
+			result, err := manager.Reconcile(context.Background(), project.ManagerConfig{Projects: []globalconfig.Project{next}})
+			if err != nil {
+				t.Fatalf("Reconcile() error = %v", err)
+			}
+			if want := (project.ReconcileResult{Changed: []project.ID{"alpha"}}); !reflect.DeepEqual(result, want) {
+				t.Fatalf("Reconcile() = %#v, want %#v", result, want)
+			}
+			select {
+			case canceled := <-runner.canceled:
+				t.Fatalf("active session %q was canceled during pressure reload", canceled.Issue.ID)
+			default:
+			}
+			after, ok := manager.Registry().Get("alpha")
+			if !ok {
+				t.Fatal("project alpha missing after reconcile")
+			}
+			if before != after || created != 1 {
+				t.Fatalf("project restarted: before=%p after=%p created=%d", before, after, created)
+			}
+			state, err := after.Orchestrator().State(context.Background())
+			if err != nil {
+				t.Fatalf("State() error = %v", err)
+			}
+			running, ok := state.Running[issueID]
+			if !ok {
+				t.Fatalf("Running[%q] missing after pressure reload", issueID)
+			}
+			if running.Issue.State != beforeRunning.Issue.State {
+				t.Fatalf("running issue state = %q, want preserved %q", running.Issue.State, beforeRunning.Issue.State)
+			}
+			if _, ok := state.Retry[issueID]; ok {
+				t.Fatalf("Retry[%q] present after pressure reload", issueID)
+			}
+			tt.assert(t, state)
+		})
+	}
+}
+
+func TestManagerReconcileInventoriesOnlySessionsDrainedByProjectChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		next        []globalconfig.Project
+		wantRemoved []project.ID
+		wantChanged []project.ID
+	}{
+		{
+			name: "removal",
+			next: []globalconfig.Project{
+				{ID: "bravo", Weight: 1, Workdir: "/repo/bravo"},
+			},
+			wantRemoved: []project.ID{"alpha"},
+		},
+		{
+			name: "definition change",
+			next: []globalconfig.Project{
+				{ID: "alpha", Weight: 1, Workdir: "/repo/alpha-next"},
+				{ID: "bravo", Weight: 1, Workdir: "/repo/bravo"},
+			},
+			wantChanged: []project.ID{"alpha"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runners := map[project.ID]*cancellationTrackingRunner{
+				"alpha": newCancellationTrackingRunner(),
+				"bravo": newCancellationTrackingRunner(),
+			}
+			manager, err := project.NewManager(project.ManagerConfig{Projects: []globalconfig.Project{
+				{ID: "alpha", Weight: 1, Workdir: "/repo/alpha"},
+				{ID: "bravo", Weight: 1, Workdir: "/repo/bravo"},
+			}}, project.ManagerDependencies{
+				ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+					id := project.ID(cfg.ID)
+					workflowCfg := workflowConfigWithMemoryIssue("issue-" + cfg.ID)
+					workflowCfg.Tracker.Issues[0].State = "Todo"
+					workflowCfg.Tracker.Issues[0].Title = "Run " + cfg.ID
+					workflowCfg.Tracker.Issues[0].AssignedToWorker = true
+					return project.New(project.Config{
+						Project:  cfg,
+						Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Keep working."},
+					}, project.Dependencies{Runner: runners[id]})
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewManager() error = %v", err)
+			}
+			if err := manager.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			t.Cleanup(func() {
+				for _, runner := range runners {
+					runner.releaseAll()
+				}
+				for _, item := range manager.Registry().List() {
+					if err := item.Close(); err != nil {
+						t.Errorf("Close(%s) error = %v", item.ID(), err)
+					}
+				}
+			})
+			receiveRunRequest(t, runners["alpha"].started)
+			receiveRunRequest(t, runners["bravo"].started)
+
+			result, err := manager.Reconcile(context.Background(), project.ManagerConfig{Projects: tt.next})
+			if err != nil {
+				t.Fatalf("Reconcile() error = %v", err)
+			}
+			if !reflect.DeepEqual(result.Removed, tt.wantRemoved) || !reflect.DeepEqual(result.Changed, tt.wantChanged) || !reflect.DeepEqual(result.Unchanged, []project.ID{"bravo"}) {
+				t.Fatalf("Reconcile() project diff = removed %v changed %v unchanged %v", result.Removed, result.Changed, result.Unchanged)
+			}
+			wantSessions := []project.ReconcileSession{{
+				ProjectID:  "alpha",
+				IssueID:    "issue-alpha",
+				Identifier: "issue-alpha",
+			}}
+			if !reflect.DeepEqual(result.DrainedSessions, wantSessions) {
+				t.Fatalf("DrainedSessions = %#v, want %#v", result.DrainedSessions, wantSessions)
+			}
+			select {
+			case canceled := <-runners["bravo"].canceled:
+				t.Fatalf("unchanged project session %q was canceled", canceled.Issue.ID)
+			default:
+			}
+			bravo, ok := manager.Registry().Get("bravo")
+			if !ok {
+				t.Fatal("project bravo missing after reconcile")
+			}
+			state, err := bravo.Orchestrator().State(context.Background())
+			if err != nil {
+				t.Fatalf("State(bravo) error = %v", err)
+			}
+			if _, ok := state.Running["issue-bravo"]; !ok {
+				t.Fatalf("unchanged project running sessions = %#v, want issue-bravo", state.Running)
+			}
+		})
+	}
+}
+
 func TestManagerReconcileRecordsAddedProjectStartFailure(t *testing.T) {
 	t.Parallel()
 
@@ -2650,6 +2895,43 @@ func receiveRunRequest(t *testing.T, requests <-chan orchestrator.RunRequest) or
 		t.Fatal("timed out waiting for runner request")
 	}
 	return orchestrator.RunRequest{}
+}
+
+type cancellationTrackingRunner struct {
+	started     chan orchestrator.RunRequest
+	canceled    chan orchestrator.RunRequest
+	release     chan struct{}
+	releaseOnce sync.Once
+}
+
+func newCancellationTrackingRunner() *cancellationTrackingRunner {
+	return &cancellationTrackingRunner{
+		started:  make(chan orchestrator.RunRequest, 2),
+		canceled: make(chan orchestrator.RunRequest, 2),
+		release:  make(chan struct{}),
+	}
+}
+
+func (r *cancellationTrackingRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	select {
+	case r.started <- request:
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+
+	select {
+	case <-r.release:
+		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+	case <-ctx.Done():
+		r.canceled <- request
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+}
+
+func (r *cancellationTrackingRunner) releaseAll() {
+	r.releaseOnce.Do(func() {
+		close(r.release)
+	})
 }
 
 func runningProjects(t *testing.T, manager *project.Manager) int {


### PR DESCRIPTION
## Summary

- hot-apply CPU, memory-pressure, and IO settings to live project orchestrators without canceling active sessions
- reconcile the latest persisted global config before and after updates, with periodic recovery for missed file events
- log reconciliation lifecycle and affected-session inventory while documenting reload semantics

Fixes #2168

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `PATH="$TMPDIR/pinned-lint/bin:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] `go test ./internal/project ./internal/cli -count=1`
- [x] focused active-session, affected-project, latest-wins, missed-event, and lifecycle-log regressions