### PR TITLE
fix(config): reconcile missed file events

### DIFF
--- a/.detent/skills/resilient-file-watch-reconciliation.md
+++ b/.detent/skills/resilient-file-watch-reconciliation.md
@@ -8,9 +8,11 @@ when_to_use: Use when a long-running Detent watcher must react to atomic replace
 
 - Attach the initial filesystem watch synchronously before reporting readiness so an immediate write cannot race watcher startup.
 - If the watched directory is absent, retain ownership of the target and retry attachment on a bounded interval instead of dropping it.
-- Capture a comparable file stamp before returning from successful initial setup. Include modification time, size, and mode when content does not need to be read.
+- Capture a comparable file stamp before returning from successful initial setup. Metadata alone cannot distinguish same-size rewrites or timestamp-preserving replacements. If stamp equality suppresses matched events, include a content digest for regular config files; otherwise preserve the event-triggered reload.
 - Keep filesystem events as the fast path, but reconcile the stamp periodically. OS watcher delivery can miss an atomic rename under load.
 - Route event-driven and periodic observations through the same stamp comparison so one replacement produces one notification.
 - When attachment succeeds after retries, compare the current stamp with the last observation and notify if the file appeared or changed while detached.
 - Stop retry timers, poll timers, and watcher goroutines on context cancellation, and expose a completion channel so the owner can wait for shutdown.
 - Inject short retry and poll intervals in tests. Cover initial replacement, an absent parent followed by file creation, duplicate suppression, cancellation, and a race-enabled repetition.
+- Reproduce metadata collisions by writing different equal-length content and restoring a fixed modification time with `os.Chtimes`. Assert the metadata is equal, then test both event and poll delivery with controlled debounce expiry.
+- Compare watched symlink target directories after `filepath.EvalSymlinks`. Temporary paths can contain aliases on macOS and Windows; reproduce this locally with a temporary directory reached through a symlink.

--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -27,22 +28,27 @@ type FileUpdate[T any] struct {
 type FileOption func(*fileOptions)
 
 type FileWatcher[T any] struct {
-	path       string
-	files      []watchedFile
-	dirs       []string
-	debounce   time.Duration
-	loader     FileLoader[T]
-	logger     *slog.Logger
-	newWatcher fileWatcherFactory
-	newTimer   fileTimerFactory
+	path          string
+	files         []watchedFile
+	debounce      time.Duration
+	retryInterval time.Duration
+	pollInterval  time.Duration
+	loader        FileLoader[T]
+	logger        *slog.Logger
+	newWatcher    fileWatcherFactory
+	newTimer      fileTimerFactory
+	newTicker     fileTickerFactory
 }
 
 type fileOptions struct {
-	debounce   time.Duration
-	logger     *slog.Logger
-	watchPaths []string
-	newWatcher fileWatcherFactory
-	newTimer   fileTimerFactory
+	debounce      time.Duration
+	retryInterval time.Duration
+	pollInterval  time.Duration
+	logger        *slog.Logger
+	watchPaths    []string
+	newWatcher    fileWatcherFactory
+	newTimer      fileTimerFactory
+	newTicker     fileTickerFactory
 }
 
 type watchedFile struct {
@@ -75,6 +81,38 @@ type standardFileTimer struct {
 
 type fileTimerFactory func(time.Duration) fileTimer
 
+type fileTicker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+type standardFileTicker struct {
+	ticker *time.Ticker
+}
+
+type fileTickerKind uint8
+
+const (
+	filePollTicker fileTickerKind = iota
+	fileRetryTicker
+)
+
+type fileTickerFactory func(fileTickerKind, time.Duration) fileTicker
+
+type fileStamp struct {
+	target  string
+	modTime time.Time
+	size    int64
+	mode    os.FileMode
+	err     string
+}
+
+type fileWatchState struct {
+	files       []watchedFile
+	watchedDirs map[string]struct{}
+	stamps      []fileStamp
+}
+
 func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*FileWatcher[T], error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -90,18 +128,27 @@ func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*Fil
 	}
 
 	cfg := fileOptions{
-		debounce:   defaultDebounce,
-		logger:     slog.Default(),
-		newWatcher: newFileEventWatcher,
+		debounce:      defaultDebounce,
+		retryInterval: defaultFileWatchRetryInterval,
+		pollInterval:  defaultFilePollInterval,
+		logger:        slog.Default(),
+		newWatcher:    newFileEventWatcher,
 		newTimer: func(duration time.Duration) fileTimer {
 			return &standardFileTimer{timer: time.NewTimer(duration)}
 		},
+		newTicker: newFileTicker,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 	if cfg.debounce <= 0 {
 		cfg.debounce = defaultDebounce
+	}
+	if cfg.retryInterval <= 0 {
+		cfg.retryInterval = defaultFileWatchRetryInterval
+	}
+	if cfg.pollInterval <= 0 {
+		cfg.pollInterval = defaultFilePollInterval
 	}
 	if cfg.logger == nil {
 		cfg.logger = slog.Default()
@@ -113,6 +160,9 @@ func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*Fil
 		cfg.newTimer = func(duration time.Duration) fileTimer {
 			return &standardFileTimer{timer: time.NewTimer(duration)}
 		}
+	}
+	if cfg.newTicker == nil {
+		cfg.newTicker = newFileTicker
 	}
 
 	path = filepath.Clean(absolute)
@@ -134,20 +184,17 @@ func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*Fil
 		seen[additionalPath] = struct{}{}
 		files = append(files, watchedFile{path: additionalPath, target: resolveWatchPath(additionalPath)})
 	}
-	watchPaths := make([]string, 0, len(files)*2)
-	for _, file := range files {
-		watchPaths = append(watchPaths, file.path, file.target)
-	}
-
 	return &FileWatcher[T]{
-		path:       path,
-		files:      files,
-		dirs:       watchDirs(watchPaths...),
-		debounce:   cfg.debounce,
-		loader:     loader,
-		logger:     cfg.logger,
-		newWatcher: cfg.newWatcher,
-		newTimer:   cfg.newTimer,
+		path:          path,
+		files:         files,
+		debounce:      cfg.debounce,
+		retryInterval: cfg.retryInterval,
+		pollInterval:  cfg.pollInterval,
+		loader:        loader,
+		logger:        cfg.logger,
+		newWatcher:    cfg.newWatcher,
+		newTimer:      cfg.newTimer,
+		newTicker:     cfg.newTicker,
 	}, nil
 }
 
@@ -187,10 +234,30 @@ func (t *standardFileTimer) Stop() bool {
 	return t.timer.Stop()
 }
 
-func withFileRuntime(newWatcher fileWatcherFactory, newTimer fileTimerFactory) FileOption {
+func newFileTicker(_ fileTickerKind, duration time.Duration) fileTicker {
+	return &standardFileTicker{ticker: time.NewTicker(duration)}
+}
+
+func (t *standardFileTicker) C() <-chan time.Time {
+	return t.ticker.C
+}
+
+func (t *standardFileTicker) Stop() {
+	t.ticker.Stop()
+}
+
+func withFileRuntime(newWatcher fileWatcherFactory, newTimer fileTimerFactory, newTicker fileTickerFactory) FileOption {
 	return func(opts *fileOptions) {
 		opts.newWatcher = newWatcher
 		opts.newTimer = newTimer
+		opts.newTicker = newTicker
+	}
+}
+
+func withFileIntervals(retryInterval, pollInterval time.Duration) FileOption {
+	return func(opts *fileOptions) {
+		opts.retryInterval = retryInterval
+		opts.pollInterval = pollInterval
 	}
 }
 
@@ -242,19 +309,27 @@ func (w *FileWatcher[T]) Watch(ctx context.Context) (<-chan FileUpdate[T], error
 	if err != nil {
 		return nil, fmt.Errorf("create config watcher: %w", err)
 	}
-	for _, dir := range w.dirs {
-		if err := fsWatcher.Add(dir); err != nil {
-			closeErr := fsWatcher.Close()
-			return nil, errors.Join(fmt.Errorf("watch config directory %s: %w", dir, err), closeErr)
-		}
+
+	state := newFileWatchState(w.files)
+	pending, err := state.syncWatchPaths(fsWatcher)
+	if err != nil {
+		closeErr := fsWatcher.Close()
+		return nil, errors.Join(err, closeErr)
 	}
+	state.stamps = state.captureStamps()
 
 	updates := make(chan FileUpdate[T], 1)
-	go w.run(ctx, fsWatcher, updates)
+	go w.run(ctx, fsWatcher, state, pending, updates)
 	return updates, nil
 }
 
-func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher fileEventWatcher, updates chan<- FileUpdate[T]) {
+func (w *FileWatcher[T]) run(
+	ctx context.Context,
+	fsWatcher fileEventWatcher,
+	state *fileWatchState,
+	pending bool,
+	updates chan<- FileUpdate[T],
+) {
 	defer close(updates)
 	defer func() {
 		if err := fsWatcher.Close(); err != nil {
@@ -263,11 +338,48 @@ func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher fileEventWatcher, up
 	}()
 
 	timer := w.newTimer(w.debounce)
-	if !timer.Stop() {
-		<-timer.C()
-	}
+	stopFileTimer(timer)
+	defer stopFileTimer(timer)
+	pollTicker := w.newTicker(filePollTicker, w.pollInterval)
+	defer pollTicker.Stop()
+
 	var timerC <-chan time.Time
+	var retryTicker fileTicker
+	var retryC <-chan time.Time
 	var lastUpdate *FileUpdate[T]
+	setRetry := func(needed bool) {
+		if needed && retryTicker == nil {
+			retryTicker = w.newTicker(fileRetryTicker, w.retryInterval)
+			retryC = retryTicker.C()
+			return
+		}
+		if !needed && retryTicker != nil {
+			retryTicker.Stop()
+			retryTicker = nil
+			retryC = nil
+		}
+	}
+	defer func() {
+		if retryTicker != nil {
+			retryTicker.Stop()
+		}
+	}()
+	setRetry(pending)
+
+	observe := func() {
+		needsRetry, err := state.syncWatchPaths(fsWatcher)
+		if err != nil {
+			w.logger.Warn("watch config directory failed; retrying", "path", w.path, "error", err)
+		}
+		setRetry(needsRetry)
+		stamps := state.captureStamps()
+		if slices.Equal(stamps, state.stamps) {
+			return
+		}
+		state.stamps = stamps
+		resetTimer(timer, w.debounce)
+		timerC = timer.C()
+	}
 
 	for {
 		select {
@@ -277,16 +389,18 @@ func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher fileEventWatcher, up
 			if !ok {
 				return
 			}
-			if w.matches(event) {
-				w.refreshWatchPath(fsWatcher.Add)
-				resetTimer(timer, w.debounce)
-				timerC = timer.C()
+			if state.matches(event) {
+				observe()
 			}
 		case err, ok := <-fsWatcher.Errors():
 			if !ok {
 				return
 			}
 			w.send(ctx, updates, FileUpdate[T]{Path: w.path, Err: err, WatcherErr: true, At: time.Now()})
+		case <-pollTicker.C():
+			observe()
+		case <-retryC:
+			observe()
 		case <-timerC:
 			timerC = nil
 			update := w.reload(ctx)
@@ -300,12 +414,19 @@ func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher fileEventWatcher, up
 	}
 }
 
-func (w *FileWatcher[T]) matches(event fsnotify.Event) bool {
+func newFileWatchState(files []watchedFile) *fileWatchState {
+	return &fileWatchState{
+		files:       slices.Clone(files),
+		watchedDirs: make(map[string]struct{}),
+	}
+}
+
+func (s *fileWatchState) matches(event fsnotify.Event) bool {
 	if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename|fsnotify.Remove|fsnotify.Chmod) == 0 {
 		return false
 	}
 	name := filepath.Clean(event.Name)
-	for _, file := range w.files {
+	for _, file := range s.files {
 		if name == file.path || name == file.target {
 			return true
 		}
@@ -313,36 +434,52 @@ func (w *FileWatcher[T]) matches(event fsnotify.Event) bool {
 	return false
 }
 
-func (w *FileWatcher[T]) refreshWatchPath(addDir func(string) error) {
-	for index := range w.files {
-		watchPath := resolveWatchPath(w.files[index].path)
-		if watchPath == w.files[index].target {
+func (s *fileWatchState) syncWatchPaths(fsWatcher fileEventWatcher) (bool, error) {
+	for index := range s.files {
+		s.files[index].target = resolveWatchPath(s.files[index].path)
+	}
+
+	pending := false
+	var watchErr error
+	for _, dir := range watchDirsForFiles(s.files) {
+		if _, ok := s.watchedDirs[dir]; ok {
 			continue
 		}
-
-		w.files[index].target = watchPath
-		for _, dir := range watchDirs(w.files[index].path, watchPath) {
-			if hasWatchDir(w.dirs, dir) {
-				continue
+		if err := fsWatcher.Add(dir); err != nil {
+			pending = true
+			if !errors.Is(err, os.ErrNotExist) {
+				watchErr = errors.Join(watchErr, fmt.Errorf("watch config directory %s: %w", dir, err))
 			}
-			if addDir != nil {
-				if err := addDir(dir); err != nil {
-					w.logger.Warn("watch config symlink target directory failed",
-						"path", w.files[index].path,
-						"target", watchPath,
-						"dir", dir,
-						"error", err,
-					)
-					continue
-				}
-			}
-			w.dirs = append(w.dirs, dir)
+			continue
 		}
+		s.watchedDirs[dir] = struct{}{}
 	}
+	return pending, watchErr
 }
 
-func hasWatchDir(dirs []string, dir string) bool {
-	return slices.Contains(dirs, dir)
+func watchDirsForFiles(files []watchedFile) []string {
+	paths := make([]string, 0, len(files)*2)
+	for _, file := range files {
+		paths = append(paths, file.path, file.target)
+	}
+	return watchDirs(paths...)
+}
+
+func (s *fileWatchState) captureStamps() []fileStamp {
+	stamps := make([]fileStamp, 0, len(s.files))
+	for _, file := range s.files {
+		stamp := fileStamp{target: file.target}
+		info, err := os.Stat(file.path)
+		if err != nil {
+			stamp.err = err.Error()
+		} else {
+			stamp.modTime = info.ModTime()
+			stamp.size = info.Size()
+			stamp.mode = info.Mode()
+		}
+		stamps = append(stamps, stamp)
+	}
+	return stamps
 }
 
 func (w *FileWatcher[T]) reload(ctx context.Context) FileUpdate[T] {

--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -104,6 +105,7 @@ type fileStamp struct {
 	modTime time.Time
 	size    int64
 	mode    os.FileMode
+	digest  [sha256.Size]byte
 	err     string
 }
 
@@ -476,6 +478,14 @@ func (s *fileWatchState) captureStamps() []fileStamp {
 			stamp.modTime = info.ModTime()
 			stamp.size = info.Size()
 			stamp.mode = info.Mode()
+			if info.Mode().IsRegular() {
+				content, readErr := os.ReadFile(file.path)
+				if readErr != nil {
+					stamp.err = readErr.Error()
+				} else {
+					stamp.digest = sha256.Sum256(content)
+				}
+			}
 		}
 		stamps = append(stamps, stamp)
 	}

--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	defaultDebounce     = 150 * time.Millisecond
-	reloadRetryInterval = 5 * time.Millisecond
+	defaultDebounce               = 150 * time.Millisecond
+	defaultFileWatchRetryInterval = 100 * time.Millisecond
+	defaultFilePollInterval       = 250 * time.Millisecond
+	reloadRetryInterval           = 5 * time.Millisecond
 )
 
 var ErrMissingPath = errors.New("workflow watch path is required")
@@ -152,4 +154,14 @@ func resetTimer(timer fileTimer, debounce time.Duration) {
 		}
 	}
 	timer.Reset(debounce)
+}
+
+func stopFileTimer(timer fileTimer) {
+	if timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C():
+	default:
+	}
 }

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,7 +45,7 @@ func TestWatchDebouncesWorkflowWrites(t *testing.T) {
 	writeWorkflow(t, path, 62000, "second")
 	runtime.sendEvent(t, path)
 	runtime.waitForReset(t)
-	runtime.fire(t)
+	runtime.fireTimer(t)
 
 	update := receiveUpdate(t, updates)
 	if update.Err != nil {
@@ -325,7 +326,7 @@ func TestFileWatcherDebouncesGlobalConfigWrites(t *testing.T) {
 	writeGlobalConfig(t, path, 4)
 	runtime.sendEvent(t, path)
 	runtime.waitForReset(t)
-	runtime.fire(t)
+	runtime.fireTimer(t)
 
 	update := receiveFileUpdate(t, updates)
 	if update.Err != nil {
@@ -436,6 +437,7 @@ func TestFileWatcherWatchesSymlinkTargetTouches(t *testing.T) {
 func TestFileWatcherRefreshesRetargetedSymlinkTarget(t *testing.T) {
 	t.Parallel()
 
+	runtime := newControlledFileRuntime()
 	linkDir := t.TempDir()
 	firstDir := t.TempDir()
 	nextDir := t.TempDir()
@@ -450,9 +452,15 @@ func TestFileWatcherRefreshesRetargetedSymlinkTarget(t *testing.T) {
 
 	w, err := NewFile(linkPath, func(path string) (globalconfig.Config, error) {
 		return globalconfig.Read(path)
-	})
+	}, runtime.option(), withFileIntervals(time.Hour, time.Hour))
 	if err != nil {
 		t.Fatalf("NewFile() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
 	}
 
 	if err := os.Remove(linkPath); err != nil {
@@ -461,23 +469,301 @@ func TestFileWatcherRefreshesRetargetedSymlinkTarget(t *testing.T) {
 	if err := os.Symlink(nextPath, linkPath); err != nil {
 		t.Fatalf("Symlink() retarget error = %v", err)
 	}
+	runtime.fireTicker(t, filePollTicker)
+	runtime.waitForReset(t)
+	runtime.fireTimer(t)
 
-	var added []string
-	w.refreshWatchPath(func(dir string) error {
-		added = append(added, dir)
-		return nil
-	})
+	update := receiveFileUpdate(t, updates)
+	if update.Err != nil {
+		t.Fatalf("retarget update error = %v", update.Err)
+	}
+	if update.Value.Global.MaxConcurrentAgents != 3 {
+		t.Fatalf("MaxConcurrentAgents = %d, want 3", update.Value.Global.MaxConcurrentAgents)
+	}
+	runtime.waitForAdd(t, nextDir)
+}
 
-	resolvedNext := resolveWatchPath(linkPath)
-	if w.files[0].target != resolvedNext {
-		t.Fatalf("watchPath = %q, want %q", w.files[0].target, resolvedNext)
+func TestFileWatcherReconcilesMissedEvents(t *testing.T) {
+	t.Parallel()
+
+	type step struct {
+		mutate  func(*testing.T)
+		ticker  fileTickerKind
+		want    int
+		wantErr bool
 	}
-	nextWatchDir := filepath.Dir(resolvedNext)
-	if !hasWatchDir(w.dirs, nextWatchDir) {
-		t.Fatalf("watch dirs = %#v, want %q", w.dirs, nextWatchDir)
+	tests := []struct {
+		name    string
+		prepare func(*testing.T, *controlledFileRuntime) (string, []step)
+	}{
+		{
+			name: "atomic replacement",
+			prepare: func(t *testing.T, _ *controlledFileRuntime) (string, []step) {
+				dir := t.TempDir()
+				path := filepath.Join(dir, "global.yaml")
+				writeGlobalConfig(t, path, 2)
+				return path, []step{{
+					mutate: func(t *testing.T) {
+						tmpPath := filepath.Join(dir, ".global.yaml.tmp")
+						writeGlobalConfig(t, tmpPath, 5)
+						if err := os.Rename(tmpPath, path); err != nil {
+							t.Fatalf("Rename() error = %v", err)
+						}
+					},
+					ticker: filePollTicker,
+					want:   5,
+				}}
+			},
+		},
+		{
+			name: "absent parent creation",
+			prepare: func(t *testing.T, runtime *controlledFileRuntime) (string, []step) {
+				path := filepath.Join(t.TempDir(), "missing", "global.yaml")
+				runtime.add = func(dir string) error {
+					_, err := os.Stat(dir)
+					return err
+				}
+				return path, []step{{
+					mutate: func(t *testing.T) {
+						if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+							t.Fatalf("MkdirAll() error = %v", err)
+						}
+						writeGlobalConfig(t, path, 4)
+					},
+					ticker: fileRetryTicker,
+					want:   4,
+				}}
+			},
+		},
+		{
+			name: "symlink target replacement",
+			prepare: func(t *testing.T, _ *controlledFileRuntime) (string, []step) {
+				linkDir := t.TempDir()
+				targetDir := t.TempDir()
+				targetPath := filepath.Join(targetDir, "global.yaml")
+				linkPath := filepath.Join(linkDir, "global.yaml")
+				writeGlobalConfig(t, targetPath, 2)
+				if err := os.Symlink(targetPath, linkPath); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				return linkPath, []step{{
+					mutate: func(t *testing.T) {
+						tmpPath := filepath.Join(targetDir, ".global.yaml.tmp")
+						writeGlobalConfig(t, tmpPath, 6)
+						if err := os.Rename(tmpPath, targetPath); err != nil {
+							t.Fatalf("Rename() error = %v", err)
+						}
+					},
+					ticker: filePollTicker,
+					want:   6,
+				}}
+			},
+		},
+		{
+			name: "delete and recreate",
+			prepare: func(t *testing.T, _ *controlledFileRuntime) (string, []step) {
+				dir := t.TempDir()
+				path := filepath.Join(dir, "global.yaml")
+				writeGlobalConfig(t, path, 2)
+				return path, []step{
+					{
+						mutate: func(t *testing.T) {
+							if err := os.Remove(path); err != nil {
+								t.Fatalf("Remove() error = %v", err)
+							}
+						},
+						ticker:  filePollTicker,
+						wantErr: true,
+					},
+					{
+						mutate: func(t *testing.T) {
+							writeGlobalConfig(t, path, 7)
+						},
+						ticker: filePollTicker,
+						want:   7,
+					},
+				}
+			},
+		},
 	}
-	if len(added) != 1 || added[0] != nextWatchDir {
-		t.Fatalf("added dirs = %#v, want [%q]", added, nextWatchDir)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newControlledFileRuntime()
+			path, steps := test.prepare(t, runtime)
+			w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
+				return globalconfig.Read(path)
+			}, runtime.option(), withFileIntervals(time.Hour, time.Hour))
+			if err != nil {
+				t.Fatalf("NewFile() error = %v", err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			updates, err := w.Watch(ctx)
+			if err != nil {
+				t.Fatalf("Watch() error = %v", err)
+			}
+
+			for _, step := range steps {
+				step.mutate(t)
+				runtime.fireTicker(t, step.ticker)
+				runtime.waitForReset(t)
+				runtime.fireTimer(t)
+				update := receiveFileUpdate(t, updates)
+				if step.wantErr {
+					if update.Err == nil {
+						t.Fatal("update error = nil, want file error")
+					}
+					continue
+				}
+				if update.Err != nil {
+					t.Fatalf("update error = %v", update.Err)
+				}
+				if update.Value.Global.MaxConcurrentAgents != step.want {
+					t.Fatalf("MaxConcurrentAgents = %d, want %d", update.Value.Global.MaxConcurrentAgents, step.want)
+				}
+			}
+		})
+	}
+}
+
+func TestFileWatcherDeduplicatesEventAndPollObservations(t *testing.T) {
+	t.Parallel()
+
+	runtime := newControlledFileRuntime()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "global.yaml")
+	writeGlobalConfig(t, path, 2)
+	w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
+		return globalconfig.Read(path)
+	}, runtime.option(), withFileIntervals(time.Hour, time.Hour))
+	if err != nil {
+		t.Fatalf("NewFile() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	writeGlobalConfig(t, path, 8)
+	runtime.fireTicker(t, filePollTicker)
+	runtime.waitForReset(t)
+	runtime.sendEvent(t, path)
+	runtime.fireTimer(t)
+	update := receiveFileUpdate(t, updates)
+	if update.Err != nil {
+		t.Fatalf("update error = %v", update.Err)
+	}
+	if update.Value.Global.MaxConcurrentAgents != 8 {
+		t.Fatalf("MaxConcurrentAgents = %d, want 8", update.Value.Global.MaxConcurrentAgents)
+	}
+	assertNoFileUpdate(t, updates)
+}
+
+func TestFileWatcherCompletesInitialAttachmentBeforeReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		addErr  error
+		wantErr bool
+	}{
+		{name: "attached"},
+		{name: "missing directory remains pending", addErr: os.ErrNotExist},
+		{name: "other attachment failure", addErr: errors.New("permission denied"), wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newControlledFileRuntime()
+			var addCalled atomic.Bool
+			runtime.add = func(string) error {
+				addCalled.Store(true)
+				return test.addErr
+			}
+			path := filepath.Join(t.TempDir(), "global.yaml")
+			writeGlobalConfig(t, path, 2)
+			w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
+				return globalconfig.Read(path)
+			}, runtime.option(), withFileIntervals(time.Hour, time.Hour))
+			if err != nil {
+				t.Fatalf("NewFile() error = %v", err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			updates, err := w.Watch(ctx)
+			if !addCalled.Load() {
+				t.Fatal("Watch() returned before initial attachment attempt")
+			}
+			if test.wantErr {
+				cancel()
+				if err == nil {
+					t.Fatal("Watch() error = nil, want attachment error")
+				}
+				runtime.waitForClosed(t)
+				return
+			}
+			if err != nil {
+				cancel()
+				t.Fatalf("Watch() error = %v", err)
+			}
+			cancel()
+			waitForFileUpdatesClosed(t, updates)
+		})
+	}
+}
+
+func TestFileWatcherCancellationStopsRuntime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		missingParent bool
+	}{
+		{name: "attached"},
+		{name: "pending attachment", missingParent: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newControlledFileRuntime()
+			path := filepath.Join(t.TempDir(), "global.yaml")
+			if test.missingParent {
+				path = filepath.Join(t.TempDir(), "missing", "global.yaml")
+				runtime.add = func(dir string) error {
+					_, err := os.Stat(dir)
+					return err
+				}
+			} else {
+				writeGlobalConfig(t, path, 2)
+			}
+			w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
+				return globalconfig.Read(path)
+			}, runtime.option(), withFileIntervals(time.Hour, time.Hour))
+			if err != nil {
+				t.Fatalf("NewFile() error = %v", err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			updates, err := w.Watch(ctx)
+			if err != nil {
+				t.Fatalf("Watch() error = %v", err)
+			}
+			cancel()
+			waitForFileUpdatesClosed(t, updates)
+			runtime.waitForClosed(t)
+			runtime.poll.waitForStopped(t)
+			if test.missingParent {
+				runtime.retry.waitForStopped(t)
+			}
+			if runtime.timer.stops.Load() < 2 {
+				t.Fatalf("debounce timer stops = %d, want at least 2", runtime.timer.stops.Load())
+			}
+		})
 	}
 }
 
@@ -537,11 +823,24 @@ type controlledFileRuntime struct {
 	events chan fsnotify.Event
 	errors chan error
 	timer  *controlledFileTimer
+	poll   *controlledFileTicker
+	retry  *controlledFileTicker
+	added  chan string
+	closed chan struct{}
+	add    func(string) error
+	close  sync.Once
 }
 
 type controlledFileTimer struct {
 	ticks  chan time.Time
 	resets chan time.Duration
+	stops  atomic.Int32
+}
+
+type controlledFileTicker struct {
+	ticks   chan time.Time
+	stopped chan struct{}
+	stop    sync.Once
 }
 
 func newControlledFileRuntime() *controlledFileRuntime {
@@ -550,8 +849,19 @@ func newControlledFileRuntime() *controlledFileRuntime {
 		errors: make(chan error),
 		timer: &controlledFileTimer{
 			ticks:  make(chan time.Time, 1),
-			resets: make(chan time.Duration, 2),
+			resets: make(chan time.Duration, 8),
 		},
+		poll:   newControlledFileTicker(),
+		retry:  newControlledFileTicker(),
+		added:  make(chan string, 16),
+		closed: make(chan struct{}),
+	}
+}
+
+func newControlledFileTicker() *controlledFileTicker {
+	return &controlledFileTicker{
+		ticks:   make(chan time.Time, 1),
+		stopped: make(chan struct{}),
 	}
 }
 
@@ -559,14 +869,27 @@ func (r *controlledFileRuntime) option() FileOption {
 	return withFileRuntime(
 		func() (fileEventWatcher, error) { return r, nil },
 		func(time.Duration) fileTimer { return r.timer },
+		func(kind fileTickerKind, _ time.Duration) fileTicker {
+			if kind == fileRetryTicker {
+				return r.retry
+			}
+			return r.poll
+		},
 	)
 }
 
-func (r *controlledFileRuntime) Add(string) error {
+func (r *controlledFileRuntime) Add(path string) error {
+	r.added <- path
+	if r.add != nil {
+		return r.add(path)
+	}
 	return nil
 }
 
 func (r *controlledFileRuntime) Close() error {
+	r.close.Do(func() {
+		close(r.closed)
+	})
 	return nil
 }
 
@@ -598,13 +921,53 @@ func (r *controlledFileRuntime) waitForReset(t *testing.T) {
 	}
 }
 
-func (r *controlledFileRuntime) fire(t *testing.T) {
+func (r *controlledFileRuntime) fireTimer(t *testing.T) {
 	t.Helper()
 
 	select {
 	case r.timer.ticks <- time.Now():
 	case <-time.After(time.Second):
 		t.Fatal("timed out firing debounce timer")
+	}
+}
+
+func (r *controlledFileRuntime) fireTicker(t *testing.T, kind fileTickerKind) {
+	t.Helper()
+
+	ticker := r.poll
+	if kind == fileRetryTicker {
+		ticker = r.retry
+	}
+	select {
+	case ticker.ticks <- time.Now():
+	case <-time.After(time.Second):
+		t.Fatal("timed out firing file ticker")
+	}
+}
+
+func (r *controlledFileRuntime) waitForAdd(t *testing.T, want string) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case got := <-r.added:
+			if got == want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting to watch directory %q", want)
+		}
+	}
+}
+
+func (r *controlledFileRuntime) waitForClosed(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-r.closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for file watcher close")
 	}
 }
 
@@ -618,7 +981,41 @@ func (t *controlledFileTimer) Reset(duration time.Duration) bool {
 }
 
 func (t *controlledFileTimer) Stop() bool {
+	t.stops.Add(1)
 	return true
+}
+
+func (t *controlledFileTicker) C() <-chan time.Time {
+	return t.ticks
+}
+
+func (t *controlledFileTicker) Stop() {
+	t.stop.Do(func() {
+		close(t.stopped)
+	})
+}
+
+func (t *controlledFileTicker) waitForStopped(testingT *testing.T) {
+	testingT.Helper()
+
+	select {
+	case <-t.stopped:
+	case <-time.After(time.Second):
+		testingT.Fatal("timed out waiting for file ticker stop")
+	}
+}
+
+func waitForFileUpdatesClosed[T any](t *testing.T, updates <-chan FileUpdate[T]) {
+	t.Helper()
+
+	select {
+	case _, ok := <-updates:
+		if ok {
+			t.Fatal("updates channel remained open")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for updates channel close")
+	}
 }
 
 func writeWorkflow(t *testing.T, path string, intervalMS int, prompt string) {

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -480,7 +480,11 @@ func TestFileWatcherRefreshesRetargetedSymlinkTarget(t *testing.T) {
 	if update.Value.Global.MaxConcurrentAgents != 3 {
 		t.Fatalf("MaxConcurrentAgents = %d, want 3", update.Value.Global.MaxConcurrentAgents)
 	}
-	runtime.waitForAdd(t, nextDir)
+	resolvedNextPath, err := filepath.EvalSymlinks(nextPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error = %v", err)
+	}
+	runtime.waitForAdd(t, filepath.Dir(resolvedNextPath))
 }
 
 func TestFileWatcherReconcilesMissedEvents(t *testing.T) {
@@ -625,6 +629,95 @@ func TestFileWatcherReconcilesMissedEvents(t *testing.T) {
 					t.Fatalf("MaxConcurrentAgents = %d, want %d", update.Value.Global.MaxConcurrentAgents, step.want)
 				}
 			}
+		})
+	}
+}
+
+func TestFileWatcherObservesContentChangesWithUnchangedMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		replace bool
+		poll    bool
+	}{
+		{name: "write event"},
+		{name: "write poll", poll: true},
+		{name: "replacement event", replace: true},
+		{name: "replacement poll", replace: true, poll: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newControlledFileRuntime()
+			path := filepath.Join(t.TempDir(), "global.yaml")
+			writeGlobalConfig(t, path, 2)
+			modifiedAt := time.Unix(1700000000, 0)
+			if err := os.Chtimes(path, modifiedAt, modifiedAt); err != nil {
+				t.Fatalf("Chtimes() error = %v", err)
+			}
+			before, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Stat() error = %v", err)
+			}
+			w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
+				return globalconfig.Read(path)
+			}, runtime.option(), withFileIntervals(time.Hour, time.Hour))
+			if err != nil {
+				t.Fatalf("NewFile() error = %v", err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			updates, err := w.Watch(ctx)
+			if err != nil {
+				t.Fatalf("Watch() error = %v", err)
+			}
+
+			writePath := path
+			if test.replace {
+				writePath += ".tmp"
+			}
+			writeGlobalConfig(t, writePath, 5)
+			if err := os.Chtimes(writePath, modifiedAt, modifiedAt); err != nil {
+				t.Fatalf("Chtimes() error = %v", err)
+			}
+			if test.replace {
+				if err := os.Rename(writePath, path); err != nil {
+					t.Fatalf("Rename() error = %v", err)
+				}
+			}
+			after, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Stat() error = %v", err)
+			}
+			if before.Size() != after.Size() || before.Mode() != after.Mode() || !before.ModTime().Equal(after.ModTime()) {
+				t.Fatal("rewrite changed metadata")
+			}
+			if test.poll {
+				runtime.fireTicker(t, filePollTicker)
+			} else {
+				runtime.sendEvent(t, path)
+			}
+			runtime.waitForReset(t)
+			runtime.fireTimer(t)
+			update := receiveFileUpdate(t, updates)
+			if update.Err != nil {
+				t.Fatalf("update error = %v", update.Err)
+			}
+			if update.Value.Global.MaxConcurrentAgents != 5 {
+				t.Fatalf("MaxConcurrentAgents = %d, want 5", update.Value.Global.MaxConcurrentAgents)
+			}
+
+			runtime.sendEvent(t, path)
+			runtime.sendEvent(t, path+".unwatched")
+			select {
+			case <-runtime.timer.resets:
+				t.Fatal("duplicate observation reset debounce")
+			default:
+			}
+			cancel()
+			waitForFileUpdatesClosed(t, updates)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Watcher updates could be lost when filesystem notifications were missed or changed content retained the same file metadata. Attach available directories before reporting readiness, retry absent directories, and reconcile events and periodic polls through one debounce path using metadata plus a content digest.

Deterministic tests cover atomic replacements, same-metadata rewrites, absent-parent creation, symlink writes and retargeting, delete/recreate lifecycles, duplicate suppression, and cancellation. Symlink attachment assertions use resolved paths on macOS and Windows.

Fixes #2169

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] Four same-metadata write/replacement cases reproduced the failure before the fix.
- [x] Aliased temporary directory reproduced the symlink attachment assertion failure before the fix; 50 race repetitions passed afterward.
- [x] `env -u DETENT_API_TOKEN GOTOOLCHAIN=go1.26.6 go test -race ./internal/config/watcher -count=50` on `60937cf4` (9.575s).
- [x] `PATH="$TMPDIR/bin:$PATH" GOTOOLCHAIN=go1.26.6 make check` on `60937cf4`, using golangci-lint 2.9.0 built with Go 1.26.6.
- [x] All 11 current-head CI jobs: [run 33927183667](https://github.com/digitaldrywood/detent/actions/runs/33927183667).

Local gate: lint 0 issues; build, vet, NilAway, and full race suite passed; overall coverage 78.9%, watcher coverage 86.1%, all package and file floors passed.
