### PR TITLE
fix(capacity): isolate provider outages

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -635,17 +635,20 @@ ORDER BY finished_at, id;
 
 -- name: IssueSpendSince :one
 SELECT
-  CAST(COALESCE(SUM(cost_usd), 0) AS REAL) AS cost_usd,
-  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COALESCE(SUM(usage_events.cost_usd), 0) AS REAL) AS cost_usd,
+  CAST(COALESCE(SUM(usage_events.total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions,
-  CAST(COALESCE(MIN(finished_at), '') AS TEXT) AS first_session_at,
-  CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at
+  CAST(COALESCE(MIN(usage_events.finished_at), '') AS TEXT) AS first_session_at,
+  CAST(COALESCE(MAX(usage_events.finished_at), '') AS TEXT) AS last_session_at
 FROM usage_events
-WHERE project_id = sqlc.arg(project_id)
-  AND started_at > sqlc.arg(since)
+LEFT JOIN codex_sessions AS session ON session.id = usage_events.session_id
+LEFT JOIN work_attempts AS attempt ON attempt.id = session.work_attempt_id
+WHERE usage_events.project_id = sqlc.arg(project_id)
+  AND usage_events.started_at > sqlc.arg(since)
+  AND lower(trim(COALESCE(attempt.terminal_state, ''))) != 'capacity'
   AND (
-    (sqlc.arg(issue_id) != '' AND COALESCE(issue_id, '') = sqlc.arg(issue_id))
-    OR (sqlc.arg(identifier) != '' AND COALESCE(identifier, '') = sqlc.arg(identifier))
+    (sqlc.arg(issue_id) != '' AND COALESCE(usage_events.issue_id, '') = sqlc.arg(issue_id))
+    OR (sqlc.arg(identifier) != '' AND COALESCE(usage_events.identifier, '') = sqlc.arg(identifier))
   );
 
 -- name: ListFairShareUsage :many

--- a/internal/backendcapacity/capacity.go
+++ b/internal/backendcapacity/capacity.go
@@ -25,6 +25,7 @@ type ErrorType string
 const (
 	ErrorTypeUsageLimit        ErrorType = "usage_limit"
 	ErrorTypeTransientOverload ErrorType = "transient_overload"
+	ErrorTypeProviderOutage    ErrorType = "provider_outage"
 )
 
 var retryAtPattern = regexp.MustCompile(`(?i)(?:try again|resets?)\s+(?:at\s+)?([0-9]{1,2}:[0-9]{2}\s*(?:am|pm))(?:\s*\(([A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*)\))?`)

--- a/internal/cli/capacity.go
+++ b/internal/cli/capacity.go
@@ -15,10 +15,11 @@ import (
 )
 
 type capacityClearResult struct {
-	Status  string `json:"status"`
-	Project string `json:"project,omitempty"`
-	Scope   string `json:"scope,omitempty"`
-	Cleared int    `json:"cleared"`
+	Status    string `json:"status"`
+	Project   string `json:"project,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	Cleared   int    `json:"cleared,omitempty"`
+	Requested int    `json:"requested,omitempty"`
 }
 
 type dashboardAddress struct {
@@ -67,6 +68,10 @@ func newCapacityClearCommand(configPath *string, host *string, port *int, opts o
 				return err
 			}
 			return out.Write(func(writer io.Writer) error {
+				if result.Status == "requested" {
+					_, err := fmt.Fprintf(writer, "requested capacity clear for %d project(s)\n", result.Requested)
+					return err
+				}
 				_, err := fmt.Fprintf(writer, "cleared %d capacity outage(s)\n", result.Cleared)
 				return err
 			}, result)

--- a/internal/cli/capacity_test.go
+++ b/internal/cli/capacity_test.go
@@ -34,7 +34,8 @@ func TestRunCapacityClear(t *testing.T) {
 			t.Fatalf("form = %#v", request.Form)
 		}
 		writer.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(writer).Encode(capacityClearResult{Status: "cleared", Project: "detent", Scope: "codex", Cleared: 1})
+		writer.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(writer).Encode(capacityClearResult{Status: "requested", Project: "detent", Scope: "codex", Requested: 1})
 	}))
 	t.Cleanup(server.Close)
 	serverURL, err := url.Parse(server.URL)
@@ -59,7 +60,7 @@ func TestRunCapacityClear(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runCapacityClear() error = %v", err)
 	}
-	if result.Cleared != 1 || result.Project != "detent" || result.Scope != "codex" {
+	if result.Requested != 1 || result.Project != "detent" || result.Scope != "codex" {
 		t.Fatalf("result = %#v", result)
 	}
 }

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 )
 
 const codexCapacityAvailableThresholdPercent = 5
+
+var codexProviderOutageStatusPattern = regexp.MustCompile(`(?i)(?:http(?:/[0-9.]+)?\s+|status(?:[\s_-]*code)?["']?\s*[:=]?\s*)(404|5[0-9]{2})\b`)
 
 var codexCapacityRules = backendcapacity.Rules{
 	Kinds: []string{
@@ -92,6 +95,9 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	if !ok {
 		return backendcapacity.Details{}, false
 	}
+	if details, ok := codexProviderOutage(err, evidence); ok {
+		return details, true
+	}
 	if details, ok := backendcapacity.ClassifyTransientOverload(evidence, codexOverloadRules); ok {
 		details.Trigger = boundedCapacityTrigger(evidence)
 		return details, true
@@ -105,6 +111,23 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	}
 	details.Trigger = boundedCapacityTrigger(evidence)
 	return details, true
+}
+
+func codexProviderOutage(err error, evidence string) (backendcapacity.Details, bool) {
+	var turnFailed *TurnFailedError
+	if !errors.As(err, &turnFailed) || turnFailed == nil {
+		return backendcapacity.Details{}, false
+	}
+	match := codexProviderOutageStatusPattern.FindStringSubmatch(evidence)
+	if len(match) != 2 {
+		return backendcapacity.Details{}, false
+	}
+	return backendcapacity.Details{
+		Type:    backendcapacity.ErrorTypeProviderOutage,
+		Kind:    "http_" + match[1],
+		Reason:  "provider responses endpoint unavailable",
+		Trigger: boundedCapacityTrigger(evidence),
+	}, true
 }
 
 func startupEvidencePointer(evidence backendcapacity.StartupEvidence, ok bool) *backendcapacity.StartupEvidence {

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -17,6 +17,7 @@ import (
 const codexCapacityAvailableThresholdPercent = 5
 
 var codexProviderOutageStatusPattern = regexp.MustCompile(`(?i)(?:http(?:/[0-9.]+)?\s+|status(?:[\s_-]*code)?["']?\s*[:=]?\s*)(404|5[0-9]{2})\b`)
+var codexResponsesEndpointPattern = regexp.MustCompile(`(?i)(?:/responses(?:[?"'\s]|$)|responses endpoint)`)
 
 var codexCapacityRules = backendcapacity.Rules{
 	Kinds: []string{
@@ -121,6 +122,20 @@ func codexProviderOutage(err error, evidence string) (backendcapacity.Details, b
 	match := codexProviderOutageStatusPattern.FindStringSubmatch(evidence)
 	if len(match) != 2 {
 		return backendcapacity.Details{}, false
+	}
+	if match[1] == "404" {
+		if !codexResponsesEndpointPattern.MatchString(evidence) {
+			return backendcapacity.Details{}, false
+		}
+		lower := strings.ToLower(evidence)
+		for _, resourceError := range []string{"model_not_found", "model not found", "invalid_model", "invalid model"} {
+			if strings.Contains(lower, resourceError) {
+				return backendcapacity.Details{}, false
+			}
+		}
+		if strings.Contains(lower, "model") && strings.Contains(lower, "does not exist") {
+			return backendcapacity.Details{}, false
+		}
 	}
 	return backendcapacity.Details{
 		Type:    backendcapacity.ErrorTypeProviderOutage,

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -17,7 +17,7 @@ import (
 const codexCapacityAvailableThresholdPercent = 5
 
 var codexProviderOutageStatusPattern = regexp.MustCompile(`(?i)(?:http(?:/[0-9.]+)?\s+|status(?:[\s_-]*code)?["']?\s*[:=]?\s*)(404|5[0-9]{2})\b`)
-var codexResponsesEndpointPattern = regexp.MustCompile(`(?i)(?:/responses(?:[?"'\s]|$)|responses endpoint)`)
+var codexResponsesEndpointPattern = regexp.MustCompile(`(?i)(?:/responses(?:[?,"'\s]|$)|responses endpoint)`)
 
 var codexCapacityRules = backendcapacity.Rules{
 	Kinds: []string{

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -69,6 +69,40 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 			wantKind: "http_529",
 		},
 		{
+			name:     "responses URL http 404",
+			err:      &TurnFailedError{Status: "failed", Body: `{"message":"unexpected status 404 Not Found, url: https://chatgpt.com/backend-api/codex/responses"}`},
+			want:     true,
+			wantType: backendcapacity.ErrorTypeProviderOutage,
+			wantKind: "http_404",
+		},
+		{
+			name: "model not found http 404",
+			err:  &TurnFailedError{Status: "failed", Body: `{"status":404,"message":"model not found"}`},
+		},
+		{
+			name:     "responses endpoint missing route",
+			err:      &TurnFailedError{Status: "failed", Body: `{"status":404,"message":"responses endpoint does not exist"}`},
+			want:     true,
+			wantType: backendcapacity.ErrorTypeProviderOutage,
+			wantKind: "http_404",
+		},
+		{
+			name: "model not found at responses endpoint",
+			err:  &TurnFailedError{Status: "failed", Body: `{"status":404,"message":"model not found at responses endpoint","code":"model_not_found"}`},
+		},
+		{
+			name: "missing model at responses URL",
+			err:  &TurnFailedError{Status: "failed", Body: `{"message":"unexpected status 404 Not Found: the model does not exist, url: https://api.openai.com/v1/responses"}`},
+		},
+		{
+			name: "unknown resource http 404",
+			err:  &TurnFailedError{Status: "failed", Body: `{"status":404,"message":"not found"}`},
+		},
+		{
+			name: "missing stored response http 404",
+			err:  &TurnFailedError{Status: "failed", Body: `{"message":"unexpected status 404 Not Found, url: https://api.openai.com/v1/responses/resp_missing"}`},
+		},
+		{
 			name:     "provider http 503",
 			err:      &TurnFailedError{Status: "failed", Body: `{"status":503,"message":"retry later"}`},
 			want:     true,

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -55,16 +55,25 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 			wantType: backendcapacity.ErrorTypeTransientOverload,
 		},
 		{
+			name:     "provider responses endpoint http 404",
+			err:      &TurnFailedError{Status: "failed", Body: `{"message":"unexpected status 404 Not Found from responses endpoint"}`},
+			want:     true,
+			wantType: backendcapacity.ErrorTypeProviderOutage,
+			wantKind: "http_404",
+		},
+		{
 			name:     "provider http 529",
 			err:      &TurnFailedError{Status: "failed", Body: `{"status_code":529,"message":"retry later"}`},
 			want:     true,
-			wantType: backendcapacity.ErrorTypeTransientOverload,
+			wantType: backendcapacity.ErrorTypeProviderOutage,
+			wantKind: "http_529",
 		},
 		{
 			name:     "provider http 503",
 			err:      &TurnFailedError{Status: "failed", Body: `{"status":503,"message":"retry later"}`},
 			want:     true,
-			wantType: backendcapacity.ErrorTypeTransientOverload,
+			wantType: backendcapacity.ErrorTypeProviderOutage,
+			wantKind: "http_503",
 		},
 		{
 			name:     "thread start handshake timeout",
@@ -98,6 +107,10 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 		{
 			name: "invalid request",
 			err:  &TurnFailedError{Status: "failed", Body: `{"error":{"type":"invalid_request_error"}}`},
+		},
+		{
+			name: "provider http 400",
+			err:  &TurnFailedError{Status: "failed", Body: `{"status":400,"message":"invalid request"}`},
 		},
 		{
 			name: "untyped quota prose with rate telemetry",

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -87,6 +87,13 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 			wantKind: "http_404",
 		},
 		{
+			name:     "responses URL followed by diagnostic metadata",
+			err:      &TurnFailedError{Status: "failed", Body: `{"message":"unexpected status 404 Not Found, url: https://chatgpt.com/backend-api/codex/responses, request id: example"}`},
+			want:     true,
+			wantType: backendcapacity.ErrorTypeProviderOutage,
+			wantKind: "http_404",
+		},
+		{
 			name: "model not found at responses endpoint",
 			err:  &TurnFailedError{Status: "failed", Body: `{"status":404,"message":"model not found at responses endpoint","code":"model_not_found"}`},
 		},

--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -155,11 +155,18 @@ func (o *Orchestrator) registerBackendOutage(
 	}
 	if strings.TrimSpace(existing.ProbeIssueID) == "" {
 		delay := backendCapacityProbeDelayForAttempt(existing.ProbeAttempts)
+		if backendCapacityProviderOutage(existing) {
+			existing.ResumeAt = observedAt.Add(delay)
+		}
 		existing.NextProbeAt = backendCapacityBoundedProbeAt(existing.ResumeAt, observedAt.Add(delay), observedAt)
 	}
 	state.BackendOutages[key] = existing
 	delete(state.BackendRecoveries, key)
 	return existing
+}
+
+func backendCapacityProviderOutage(outage BackendOutage) bool {
+	return outage.Kind == "http_404" || (len(outage.Kind) == len("http_500") && strings.HasPrefix(outage.Kind, "http_5"))
 }
 
 func backendCapacityProbeDelayForAttempt(attempt int) time.Duration {
@@ -448,6 +455,9 @@ func (o *Orchestrator) recoverBackendCapacityFromStatus(
 		observedAt = o.clockNow()
 	}
 	key, outage, active := matchingBackendOutage(state.BackendOutages, running.CapacityScope)
+	if active && backendCapacityProviderOutage(outage) {
+		return
+	}
 	if status.Exhausted {
 		wasActive := active
 		details := status.Details

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -7,13 +7,16 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/claudecode"
+	"github.com/digitaldrywood/detent/internal/codex"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -21,6 +24,87 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
+
+func TestCodexProviderOutagePausesAndRecoversWithoutParking(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{404, 500, 502, 503, 529, 599} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, 9, 3, 19, 0, 0, 0, time.UTC)
+			scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+			controller := backendCapacityTestController{scope: scope, hasStatus: true, status: runpkg.CapacityStatus{Available: true}}
+			attempts := &terminalRetryWorkAttemptStore{}
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{}}
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Todo", "In Progress"}, FailureBreaker: FailureBreakerConfig{SameClassLimit: 2, Window: time.Hour, Cooldown: time.Hour}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, capacityController: controller, capacityStatus: controller}
+			state := newState(cfg)
+			providerErr := &codex.TurnFailedError{Status: "failed", Body: fmt.Sprintf(`{"message":"unexpected status %d from responses endpoint"}`, status)}
+			details, ok := codex.ClassifyCapacityError(providerErr, nil, now)
+			if !ok || details.Type != backendcapacity.ErrorTypeProviderOutage {
+				t.Fatalf("capacity classification = %#v, %v", details, ok)
+			}
+			for attempt := 1; attempt <= 30; attempt++ {
+				issue := connector.Issue{ID: fmt.Sprintf("issue-%d", attempt%5), State: "In Progress"}
+				tracker.issues[issue.ID] = issue
+				state.Running[issue.ID] = Running{Issue: issue, Attempt: attempt, WorkAttemptID: int64(attempt), CapacityScope: scope, StartedAt: now.Add(-time.Second)}
+				state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-time.Second)}
+				orch.upsertWorkAttemptSnapshot(&state, telemetry.WorkAttempt{AttemptID: int64(attempt), IssueID: issue.ID, Status: string(store.WorkAttemptStatusActive), StartedAt: now.Add(-time.Second)})
+				orch.handleRunResult(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, Err: backendcapacity.NewError(scope, details, providerErr), CompletedAt: now})
+			}
+			if len(state.BackendOutages) != 1 || len(state.Retry) != 5 || len(state.Blocked) != 0 || state.FailureBreaker.Active() || len(state.FailureBreaker.Failures) != 0 || len(state.InstantFailures) != 0 || len(state.RepeatedFailures) != 0 {
+				t.Fatalf("outage state = outages %#v retries %#v blocked %#v breaker %#v", state.BackendOutages, state.Retry, state.Blocked, state.FailureBreaker)
+			}
+			if len(attempts.completions) != 30 {
+				t.Fatalf("completed attempts = %d, want 30", len(attempts.completions))
+			}
+			for _, attempt := range attempts.completions {
+				if attempt.TerminalState != store.WorkAttemptTerminalCapacity || attempt.ErrorClass != backendcapacity.ErrorClass {
+					t.Fatalf("completed attempt = %#v", attempt)
+				}
+			}
+			request := runpkg.RunRequest{Issue: connector.Issue{ID: "probe", State: "In Progress"}}
+			if _, _, paused := orch.backendCapacityDispatch(&state, request, now); !paused {
+				t.Fatal("dispatch continued during provider outage")
+			}
+			outage := state.BackendOutages[scope.Key()]
+			for probe := 1; probe <= 5; probe++ {
+				probeAt := outage.NextProbeAt
+				_, key, paused := orch.backendCapacityDispatch(&state, request, probeAt)
+				if paused || key == "" {
+					t.Fatal("due capacity probe did not become eligible")
+				}
+				orch.markBackendCapacityProbe(&state, key, request.Issue.ID, probeAt)
+				if _, _, paused := orch.backendCapacityDispatch(&state, request, probeAt); !paused {
+					t.Fatal("concurrent probe was allowed")
+				}
+				capacityErr, _ := backendcapacity.As(backendcapacity.NewError(scope, details, providerErr))
+				outage = orch.registerBackendOutage(&state, capacityErr, probeAt, true)
+				if want := probeAt.Add(backendCapacityProbeDelayForAttempt(probe)); !outage.NextProbeAt.Equal(want) {
+					t.Fatalf("probe %d next time = %s, want %s", probe, outage.NextProbeAt, want)
+				}
+			}
+			orch.recoverBackendCapacityFromStatus(&state, Running{CapacityScope: scope}, &telemetry.RateLimits{}, outage.LastObservedAt)
+			if len(state.BackendOutages) != 1 {
+				t.Fatal("quota status cleared an HTTP endpoint outage")
+			}
+			recoveredAt := outage.NextProbeAt
+			orch.recoverBackendCapacity(&state, Running{CapacityScope: scope, CapacityProbe: true}, recoveredAt)
+			if len(state.BackendOutages) != 0 || len(state.Blocked) != 0 || state.FailureBreaker.Active() {
+				t.Fatal("successful probe left the provider or cards parked")
+			}
+			if _, _, paused := orch.backendCapacityDispatch(&state, request, recoveredAt); paused {
+				t.Fatal("dispatch remained paused after recovery")
+			}
+			for _, retry := range state.Retry {
+				if !retry.DueAt.Equal(recoveredAt) {
+					t.Fatalf("capacity retry not released: %#v", retry)
+				}
+			}
+		})
+	}
+}
 
 func TestProductionClaudeSessionLimitRecordsOneCapacityOutage(t *testing.T) {
 	t.Parallel()
@@ -691,6 +775,99 @@ func TestClearBackendCapacityClearsScopeAndReleasesRetries(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "operator cleared backend capacity outage") || !stateEventExists(state, "backend_capacity_operator_cleared") {
 		t.Fatalf("operator evidence missing: logs %q events %#v", logs.String(), state.RecentEvents)
+	}
+}
+
+func TestRequestBackendCapacityClearUsesBoundedQueue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 19, 0, 0, 0, time.UTC)
+	orch := &Orchestrator{
+		capacityClearRequests: make(chan capacityClearRequest, 1),
+		done:                  make(chan struct{}),
+		now:                   func() time.Time { return now },
+	}
+	if err := orch.RequestBackendCapacityClear(t.Context(), " codex "); err != nil {
+		t.Fatalf("RequestBackendCapacityClear() error = %v", err)
+	}
+	if err := orch.RequestBackendCapacityClear(t.Context(), "codex"); !errors.Is(err, ErrCapacityClearQueueFull) {
+		t.Fatalf("RequestBackendCapacityClear() second error = %v, want %v", err, ErrCapacityClearQueueFull)
+	}
+	request := <-orch.capacityClearRequests
+	if request.scope != "codex" || !request.at.Equal(now) || request.reply != nil {
+		t.Fatalf("capacity clear request = %#v", request)
+	}
+	close(orch.done)
+	if err := orch.RequestBackendCapacityClear(t.Context(), "codex"); !errors.Is(err, ErrStopped) {
+		t.Fatalf("RequestBackendCapacityClear() stopped error = %v, want %v", err, ErrStopped)
+	}
+}
+
+type capacityClearBusyConnector struct {
+	connector.Connector
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (c *capacityClearBusyConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	select {
+	case c.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.release:
+		return nil, nil
+	}
+}
+
+func TestRequestBackendCapacityClearWhileRefreshIsBusy(t *testing.T) {
+	t.Parallel()
+
+	tracker := &capacityClearBusyConnector{Connector: memory.New(memory.Config{}), entered: make(chan struct{}, 1), release: make(chan struct{})}
+	orch, err := New(Config{PollInterval: time.Hour}, Dependencies{Connector: tracker, Runner: FakeRunner{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- orch.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Errorf("Run() error = %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("orchestrator did not stop")
+		}
+	})
+	select {
+	case <-tracker.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("refresh did not enter the tracker")
+	}
+	requestCtx, requestCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer requestCancel()
+	if err := orch.RequestBackendCapacityClear(requestCtx, "codex"); err != nil {
+		t.Fatalf("clear request blocked behind refresh: %v", err)
+	}
+	if err := orch.RequestBackendCapacityClear(requestCtx, "codex"); !errors.Is(err, ErrCapacityClearQueueFull) {
+		t.Fatalf("second request = %v, want bounded queue rejection", err)
+	}
+	close(tracker.release)
+	barrier := capacityClearRequest{scope: "codex", reply: make(chan capacityClearReply, 1)}
+	select {
+	case orch.capacityClearRequests <- barrier:
+	case <-requestCtx.Done():
+		t.Fatal("queued clear was not consumed after refresh")
+	}
+	select {
+	case <-barrier.reply:
+	case <-requestCtx.Done():
+		t.Fatal("clear processing did not complete")
 	}
 }
 

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -803,6 +803,52 @@ func TestRequestBackendCapacityClearUsesBoundedQueue(t *testing.T) {
 	}
 }
 
+func TestRequestBackendCapacityClearLifecycle(t *testing.T) {
+	t.Parallel()
+
+	for _, scenario := range []string{"nil context", "canceled", "stopped", "shutdown during request"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+
+			orch, err := New(Config{}, Dependencies{Connector: memory.New(memory.Config{}), Runner: FakeRunner{}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var ctx context.Context
+			var wantErr error
+			switch scenario {
+			case "canceled":
+				canceled, cancel := context.WithCancel(t.Context())
+				cancel()
+				ctx = canceled
+				wantErr = context.Canceled
+			case "stopped", "shutdown during request":
+				runCtx, stop := context.WithCancel(t.Context())
+				stop()
+				if scenario == "stopped" {
+					if err := orch.Run(runCtx); !errors.Is(err, context.Canceled) {
+						t.Fatalf("Run() error = %v", err)
+					}
+				} else {
+					orch.now = func() time.Time {
+						if err := orch.Run(runCtx); !errors.Is(err, context.Canceled) {
+							t.Errorf("Run() error = %v", err)
+						}
+						return time.Now()
+					}
+				}
+				wantErr = ErrStopped
+			}
+			if err := orch.RequestBackendCapacityClear(ctx, "codex"); !errors.Is(err, wantErr) {
+				t.Fatalf("RequestBackendCapacityClear() error = %v, want %v", err, wantErr)
+			}
+			if wantErr != nil && len(orch.capacityClearRequests) != 0 {
+				t.Fatal("rejected request remained queued")
+			}
+		})
+	}
+}
+
 type capacityClearBusyConnector struct {
 	connector.Connector
 	entered chan struct{}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -67,10 +67,11 @@ const (
 )
 
 var (
-	ErrMissingConnector      = errors.New("orchestrator connector is required")
-	ErrSchedulingClaimLost   = errors.New("scheduling claim lost")
-	ErrSchedulingUnavailable = errors.New("scheduling source unavailable")
-	ErrStopped               = errors.New("orchestrator stopped")
+	ErrMissingConnector       = errors.New("orchestrator connector is required")
+	ErrSchedulingClaimLost    = errors.New("scheduling claim lost")
+	ErrSchedulingUnavailable  = errors.New("scheduling source unavailable")
+	ErrStopped                = errors.New("orchestrator stopped")
+	ErrCapacityClearQueueFull = errors.New("capacity clear already pending")
 )
 
 type Config struct {
@@ -690,7 +691,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		configUpdates:           make(chan configUpdateRequest),
 		refreshes:               make(chan manualRefreshRequest, 1),
 		reconciles:              make(chan targetedRefreshRequest, 128),
-		capacityClearRequests:   make(chan capacityClearRequest),
+		capacityClearRequests:   make(chan capacityClearRequest, 1),
 		credentialChanges:       make(chan backendCredentialChangeRequest),
 		trackerClearRequests:    make(chan trackerClearRequest),
 		forgeClearRequests:      make(chan forgeClearRequest),
@@ -786,7 +787,10 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.finishTick(&state)
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.capacityClearRequests:
-			request.reply <- capacityClearReply{cleared: o.clearBackendCapacity(&state, request.scope, request.at)}
+			cleared := o.clearBackendCapacity(&state, request.scope, request.at)
+			if request.reply != nil {
+				request.reply <- capacityClearReply{cleared: cleared}
+			}
 		case request := <-o.credentialChanges:
 			scheduled := o.scheduleBackendCredentialProbe(&state, request.scope, request.at)
 			request.reply <- scheduled
@@ -901,6 +905,33 @@ func (o *Orchestrator) ClearBackendCapacity(ctx context.Context, scope string) (
 		return nil, ErrStopped
 	case reply := <-request.reply:
 		return reply.cleared, nil
+	}
+}
+
+func (o *Orchestrator) RequestBackendCapacityClear(ctx context.Context, scope string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request := capacityClearRequest{
+		scope: strings.TrimSpace(scope),
+		at:    o.clockNow(),
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	case o.capacityClearRequests <- request:
+		return nil
+	default:
+		return ErrCapacityClearQueueFull
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -316,6 +316,7 @@ type Orchestrator struct {
 	hydrationWarned         bool
 	ownershipStartupLogged  bool
 	dispatchStartMu         sync.Mutex
+	capacityClearMu         sync.Mutex
 	dispatchStarts          int
 	dispatchStartsDone      chan struct{}
 	dispatchClosed          atomic.Bool
@@ -722,7 +723,11 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	defer close(o.done)
+	defer func() {
+		o.capacityClearMu.Lock()
+		defer o.capacityClearMu.Unlock()
+		close(o.done)
+	}()
 	defer o.markGlobalProjectIdle()
 	watchdogCtx, stopWatchdog := context.WithCancel(ctx)
 	watchdogDone := make(chan struct{})
@@ -916,6 +921,8 @@ func (o *Orchestrator) RequestBackendCapacityClear(ctx context.Context, scope st
 		scope: strings.TrimSpace(scope),
 		at:    o.clockNow(),
 	}
+	o.capacityClearMu.Lock()
+	defer o.capacityClearMu.Unlock()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type releaseErrorSafetyScheduler struct {
@@ -37,6 +40,9 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 	f.Add(1, 0, 0, "old-output", "same-deliverable", int64(1), "old-receipt", "recut", int64(1), "new-receipt", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, uint8(0))
 	f.Add(2, 0, 0, "new-output", "new-deliverable", int64(1), "same-receipt", "recut", int64(2), "same-receipt", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, uint8(1))
 	f.Add(1, 0, 0, "tracked-output", "changed", int64(1), "same-head", "recut", int64(1), "same-head", "pending_review", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, true, uint8(1))
+	for _, scenario := range []uint8{4, 5, 6, 7} {
+		f.Add(0, 0, 0, "", "clean", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, scenario)
+	}
 
 	f.Fuzz(func(
 		t *testing.T,
@@ -189,6 +195,31 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 		}
 		if got := backendCapacityBoundedProbeAt(wantResumeAt, probeAt, now); !got.Equal(wantProbeAt) {
 			t.Fatalf("backendCapacityBoundedProbeAt(%s, %s, %s) = %s, want %s", wantResumeAt, probeAt, now, got, wantProbeAt)
+		}
+
+		scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+		controller := backendCapacityTestController{scope: scope, hasStatus: true, status: runpkg.CapacityStatus{Available: true, Exhausted: hasReset}}
+		capacityOrchestrator := &Orchestrator{capacityController: controller, capacityStatus: controller}
+		capacityState := newState(normalizeConfig(Config{}))
+		kind := []string{"http_404", "http_500", "http_503", "http_599"}[gateScenario%4]
+		capacityState.BackendOutages[scope.Key()] = BackendOutage{Scope: scope, Kind: kind, ProbeAttempts: int(gateScenario % 8)}
+		outage := capacityOrchestrator.registerBackendOutage(&capacityState, &backendcapacity.Error{Scope: scope, Details: backendcapacity.Details{Type: backendcapacity.ErrorTypeProviderOutage, Kind: kind}}, now, true)
+		if want := now.Add(backendCapacityProbeDelayForAttempt(outage.ProbeAttempts)); !outage.NextProbeAt.Equal(want) {
+			t.Fatalf("provider outage next probe = %s, want %s", outage.NextProbeAt, want)
+		}
+		capacityOrchestrator.recoverBackendCapacityFromStatus(&capacityState, Running{CapacityScope: scope}, &telemetry.RateLimits{}, now)
+		if len(capacityState.BackendOutages) != 1 {
+			t.Fatal("quota telemetry cleared a provider HTTP outage")
+		}
+		if _, _, paused := capacityOrchestrator.backendCapacityDispatch(&capacityState, runpkg.RunRequest{}, now); !paused {
+			t.Fatal("provider outage did not pause dispatch")
+		}
+		if terminalAttemptRetryableFailure(telemetry.WorkAttempt{TerminalState: string(store.WorkAttemptTerminalCapacity), ErrorClass: backendcapacity.ErrorClass}) {
+			t.Fatal("provider capacity counted toward retry parking")
+		}
+		capacityOrchestrator.recoverBackendCapacity(&capacityState, Running{CapacityScope: scope, CapacityProbe: true}, outage.NextProbeAt)
+		if _, _, paused := capacityOrchestrator.backendCapacityDispatch(&capacityState, runpkg.RunRequest{}, outage.NextProbeAt); paused {
+			t.Fatal("successful capacity probe did not resume dispatch")
 		}
 
 		createdSeconds %= 1_000_000_000

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -482,7 +483,7 @@ func workAttemptCompletedAfter(left telemetry.WorkAttempt, right telemetry.WorkA
 
 func terminalAttemptRetryableFailure(attempt telemetry.WorkAttempt) bool {
 	errorClass := strings.TrimSpace(attempt.ErrorClass)
-	if errorClass == forgeUnavailableErrorClass || errorClass == workspaceBranchHoldErrorClass || errorClass == workerGitHubMonitorErrorClass || errorClass == workerGitHubTokenResolutionErrorClass {
+	if errorClass == backendcapacity.ErrorClass || errorClass == forgeUnavailableErrorClass || errorClass == workspaceBranchHoldErrorClass || errorClass == workerGitHubMonitorErrorClass || errorClass == workerGitHubTokenResolutionErrorClass {
 		return false
 	}
 	if errorClass == githubRESTCapacityError {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -131,6 +131,34 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 	}
 }
 
+func TestTerminalAttemptRetryableFailureExcludesBackendCapacity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		terminal      store.WorkAttemptTerminalState
+		errorClass    string
+		wantRetryable bool
+	}{
+		{name: "ordinary failure", terminal: store.WorkAttemptTerminalFailure, errorClass: workAttemptErrorRunner, wantRetryable: true},
+		{name: "provider capacity", terminal: store.WorkAttemptTerminalCapacity, errorClass: backendcapacity.ErrorClass},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := terminalAttemptRetryableFailure(telemetry.WorkAttempt{
+				TerminalState: string(tt.terminal),
+				ErrorClass:    tt.errorClass,
+			})
+			if got != tt.wantRetryable {
+				t.Fatalf("terminalAttemptRetryableFailure() = %v, want %v", got, tt.wantRetryable)
+			}
+		})
+	}
+}
+
 func TestHandleRunResultPersistsPublishedPushCommandEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -2329,17 +2329,20 @@ func (q *Queries) GetWorkAttempt(ctx context.Context, id int64) (WorkAttempt, er
 
 const issueSpendSince = `-- name: IssueSpendSince :one
 SELECT
-  CAST(COALESCE(SUM(cost_usd), 0) AS REAL) AS cost_usd,
-  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COALESCE(SUM(usage_events.cost_usd), 0) AS REAL) AS cost_usd,
+  CAST(COALESCE(SUM(usage_events.total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions,
-  CAST(COALESCE(MIN(finished_at), '') AS TEXT) AS first_session_at,
-  CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at
+  CAST(COALESCE(MIN(usage_events.finished_at), '') AS TEXT) AS first_session_at,
+  CAST(COALESCE(MAX(usage_events.finished_at), '') AS TEXT) AS last_session_at
 FROM usage_events
-WHERE project_id = ?1
-  AND started_at > ?2
+LEFT JOIN codex_sessions AS session ON session.id = usage_events.session_id
+LEFT JOIN work_attempts AS attempt ON attempt.id = session.work_attempt_id
+WHERE usage_events.project_id = ?1
+  AND usage_events.started_at > ?2
+  AND lower(trim(COALESCE(attempt.terminal_state, ''))) != 'capacity'
   AND (
-    (?3 != '' AND COALESCE(issue_id, '') = ?3)
-    OR (?4 != '' AND COALESCE(identifier, '') = ?4)
+    (?3 != '' AND COALESCE(usage_events.issue_id, '') = ?3)
+    OR (?4 != '' AND COALESCE(usage_events.identifier, '') = ?4)
   )
 `
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2059,6 +2059,55 @@ func TestIssueSpendSinceUsesAcceptedProgressBoundaryAndIssueIdentity(t *testing.
 			t.Fatalf("RecordUsageEvent() error = %v", err)
 		}
 	}
+	capacityAttemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+		ProjectID:     "detent",
+		IssueID:       "issue-214",
+		Identifier:    "gopherguides/gopher-ai#214",
+		WorkerType:    "implementation",
+		AttemptNumber: 3,
+		StartedAt:     base.Add(5 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+	capacitySessionID, err := backend.StartSession(ctx, SessionStart{
+		WorkAttemptID: capacityAttemptID,
+		ProjectID:     "detent",
+		IssueID:       "issue-214",
+		Identifier:    "gopherguides/gopher-ai#214",
+		StartedAt:     base.Add(5 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, capacitySessionID, SessionFinish{
+		CompletedAt: base.Add(6 * time.Minute),
+		FinalState:  "failed",
+	}); err != nil {
+		t.Fatalf("FinishSession() error = %v", err)
+	}
+	if _, err := backend.RecordUsageEvent(ctx, UsageEvent{
+		ProjectID:   "detent",
+		SessionID:   capacitySessionID,
+		IssueID:     "issue-214",
+		Identifier:  "gopherguides/gopher-ai#214",
+		CostUSD:     50,
+		TotalTokens: 5_000,
+		StartedAt:   base.Add(5 * time.Minute),
+		FinishedAt:  base.Add(6 * time.Minute),
+		Outcome:     "failed",
+	}); err != nil {
+		t.Fatalf("RecordUsageEvent(capacity) error = %v", err)
+	}
+	if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
+		AttemptID:     capacityAttemptID,
+		CompletedAt:   base.Add(6 * time.Minute),
+		Status:        WorkAttemptStatusTerminal,
+		TerminalState: WorkAttemptTerminalCapacity,
+		ErrorClass:    "backend_capacity",
+	}); err != nil {
+		t.Fatalf("CompleteWorkAttempt() error = %v", err)
+	}
 
 	spend, err := backend.IssueSpendSince(ctx, IssueSpendSinceQuery{
 		ProjectID: "detent",
@@ -2073,6 +2122,57 @@ func TestIssueSpendSinceUsesAcceptedProgressBoundaryAndIssueIdentity(t *testing.
 	}
 	if !spend.FirstSessionAt.Equal(base.Add(2*time.Minute)) || !spend.LastSessionAt.Equal(base.Add(4*time.Minute)) {
 		t.Fatalf("session range = %s..%s", spend.FirstSessionAt, spend.LastSessionAt)
+	}
+}
+
+func TestIssueSpendSinceExcludesOnlyCapacityAttempts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		terminal WorkAttemptTerminalState
+		wantCost float64
+	}{
+		{terminal: WorkAttemptTerminalCapacity},
+		{terminal: WorkAttemptTerminalFailure, wantCost: 50},
+		{terminal: WorkAttemptTerminalSuccess, wantCost: 50},
+		{terminal: WorkAttemptTerminalTimedOut, wantCost: 50},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.terminal), func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			backend := openTestStore(t, ctx)
+			startedAt := time.Date(2026, 9, 3, 19, 0, 0, 0, time.UTC)
+			attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{ProjectID: "detent", IssueID: "issue", WorkerType: "implementation", AttemptNumber: 1, StartedAt: startedAt})
+			if err != nil {
+				t.Fatal(err)
+			}
+			sessionID, err := backend.StartSession(ctx, SessionStart{WorkAttemptID: attemptID, ProjectID: "detent", IssueID: "issue", StartedAt: startedAt})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := backend.RecordUsageEvent(ctx, UsageEvent{ProjectID: "detent", IssueID: "issue", SessionID: sessionID, CostUSD: 50, TotalTokens: 5000, StartedAt: startedAt, FinishedAt: startedAt.Add(time.Minute), Outcome: "failed"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{AttemptID: attemptID, CompletedAt: startedAt.Add(time.Minute), Status: WorkAttemptStatusTerminal, TerminalState: tt.terminal}); err != nil {
+				t.Fatal(err)
+			}
+			spend, err := backend.IssueSpendSince(ctx, IssueSpendSinceQuery{ProjectID: "detent", IssueID: "issue", Since: startedAt.Add(-time.Second)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if spend.CostUSD != tt.wantCost || spend.TotalTokens != int64(tt.wantCost*100) {
+				t.Fatalf("no-progress spend = %#v, want cost %.2f", spend, tt.wantCost)
+			}
+			costs, err := backend.BudgetCostEvents(ctx, BudgetCostQuery{ProjectIDs: []string{"detent"}, From: startedAt.Add(-time.Second), To: startedAt.Add(time.Hour)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(costs) != 1 || costs[0].CostUSD != 50 {
+				t.Fatalf("capacity usage disappeared from cost reporting: %#v", costs)
+			}
+		})
 	}
 }
 

--- a/internal/web/capacity.go
+++ b/internal/web/capacity.go
@@ -12,10 +12,10 @@ import (
 )
 
 type capacityClearResponse struct {
-	Status  string `json:"status"`
-	Project string `json:"project,omitempty"`
-	Scope   string `json:"scope,omitempty"`
-	Cleared int    `json:"cleared"`
+	Status    string `json:"status"`
+	Project   string `json:"project,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	Requested int    `json:"requested"`
 }
 
 func (s *Server) apiCapacityClear(c echo.Context) error {
@@ -30,9 +30,9 @@ func (s *Server) apiCapacityClear(c echo.Context) error {
 		projects = []*project.Project{selected}
 	}
 
-	cleared := 0
+	requested := 0
 	for _, candidate := range projects {
-		outages, err := candidate.Orchestrator().ClearBackendCapacity(c.Request().Context(), scope)
+		err := candidate.Orchestrator().RequestBackendCapacityClear(c.Request().Context(), scope)
 		if err != nil {
 			if errors.Is(err, orchestrator.ErrStopped) {
 				continue
@@ -40,18 +40,18 @@ func (s *Server) apiCapacityClear(c echo.Context) error {
 			s.logger.Warn("capacity clear failed", "project_id", candidate.ID(), "scope", scope, "error", err)
 			return c.JSON(http.StatusServiceUnavailable, errorResponse("capacity_clear_failed", "capacity outage clear failed"))
 		}
-		cleared += len(outages)
+		requested++
 	}
 
-	s.logger.Info("capacity clear requested", "project_id", projectID, "scope", scope, "cleared", cleared)
+	s.logger.Info("capacity clear requested", "project_id", projectID, "scope", scope, "requested", requested)
 	if c.Request().Header.Get("HX-Request") == "true" {
 		c.Response().Header().Set("HX-Trigger", "capacityCleared")
 		return c.NoContent(http.StatusNoContent)
 	}
-	return c.JSON(http.StatusOK, capacityClearResponse{
-		Status:  "cleared",
-		Project: projectID,
-		Scope:   scope,
-		Cleared: cleared,
+	return c.JSON(http.StatusAccepted, capacityClearResponse{
+		Status:    "requested",
+		Project:   projectID,
+		Scope:     scope,
+		Requested: requested,
 	})
 }

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -644,11 +644,18 @@ paths:
                 project_id: {type: string}
                 scope: {type: string}
       responses:
-        "200":
-          description: Capacity outage records cleared.
+        "202":
+          description: Capacity outage clear requested.
           content:
             application/json:
-              schema: {$ref: "#/components/schemas/Status"}
+              schema:
+                type: object
+                required: [status, requested]
+                properties:
+                  status: {type: string, enum: [requested]}
+                  project: {type: string}
+                  scope: {type: string}
+                  requested: {type: integer}
         "404": {$ref: "#/components/responses/Problem"}
         "503": {$ref: "#/components/responses/Unavailable"}
   /api/v1/projects/{project_id}/security-audits/dispositions:

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -308,6 +308,28 @@ func TestCapacityClearEndpointIsIdempotentWithoutOutages(t *testing.T) {
 	}
 }
 
+func TestCapacityClearEndpointAcceptsAsyncRequest(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/capacity/clear", strings.NewReader(url.Values{
+		"scope": {"codex"},
+	}.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusAccepted, recorder.Body.String())
+	}
+	if got := recorder.Body.String(); !strings.Contains(got, `"status":"requested"`) || !strings.Contains(got, `"requested":0`) {
+		t.Fatalf("body = %s", got)
+	}
+}
+
 func TestTrackerAvailabilityClearEndpointIsIdempotentWithoutConditions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Treat Codex response-endpoint HTTP 404/5xx failures as provider capacity outages, pause dispatch with exponential probe backoff, and require a successful canary before automatic recovery. Quota telemetry cannot clear an endpoint outage. HTTP 404 classification requires responses-endpoint evidence and excludes model/configuration errors and missing stored responses.
- Exclude capacity attempts from no-progress spend and retry parking while preserving their usage in cost reporting.
- Accept capacity-clear requests through a bounded queue so a busy scheduler does not hold the API or CLI open. The API returns `202` with `status: requested`; queue acceptance is serialized with shutdown.

Fixes #2107

## UI Surface Contract

- [x] N/A: scheduling, accounting, and API/CLI behavior only.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens.

## Test Plan

- [x] `make check` with repository-pinned Go 1.26.6 and golangci-lint 2.9.0; build, lint, vet, NilAway, race tests, and coverage gates passed.
- [x] `make generate`; generated SQL output included.
- [x] Focused regressions: 30 provider failures across five cards; durable capacity completion; probe backoff and automatic recovery; quota-status isolation; preserved cost reporting; clear acceptance and processing during a blocked tracker refresh.
- [x] Confirmed classification and spend regressions fail against the corresponding current-main implementation via Go overlays.
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s` with Go 1.26.6: passed 1,634,321 executions; all 11 committed seeds retained.
- [x] Overall coverage 78.9%; exact-file backend capacity control coverage 91.45% (90% required).
