### PR TITLE
fix(orchestrator): restore breaker-parked issues

### DIFF
--- a/internal/orchestrator/blocked_cause_recovery.go
+++ b/internal/orchestrator/blocked_cause_recovery.go
@@ -26,6 +26,8 @@ const (
 	blockedRecoveryPredicateFingerprintChange      = "fingerprint_changed"
 	blockedRecoveryPredicateOncePerFingerprint     = "once_per_fingerprint"
 	blockedRecoveryPredicateManaged                = "managed"
+	blockedRecoveryPredicateBreakerCooldown        = "breaker_cooldown_elapsed"
+	blockedRecoveryReasonBreakerCooldownActive     = "breaker_cooldown_active"
 	blockedCauseFingerprintVersion                 = 3
 	workflowActionCauseBlockedRecovery             = "cause_blocked_recovery"
 	workflowActionBlockedReadyPRReconciliation     = "blocked_ready_pr_reconciliation"
@@ -34,6 +36,9 @@ const (
 	blockedReadyPullRequestLookupFoundReason       = "ready_pr_lookup_found"
 	blockedReadyPullRequestLookupNoneReason        = "ready_pr_lookup_none"
 	blockedReadyPullRequestLookupUnavailableReason = "ready_pr_lookup_unavailable"
+	instantFailureCircuitBreakerCause              = "instant_failure_circuit_breaker"
+	instantFailureCircuitBreakerLaneReason         = "instant_fail_circuit_breaker"
+	schedulerParkRecoveryUnavailableReason         = "scheduler_park_recovery_unavailable"
 )
 
 type blockedCauseSignals struct {
@@ -89,18 +94,27 @@ func (o *Orchestrator) newBlockedRecoveryMetadata(
 	fallback DiffStats,
 ) workflowLaneMetadata {
 	cause = strings.TrimSpace(cause)
+	predicate = strings.TrimSpace(predicate)
+	if breakerParkCause(cause) && predicate == blockedRecoveryPredicateFingerprintChange {
+		predicate = blockedRecoveryPredicateBreakerCooldown
+		if previousState := strings.TrimSpace(issue.State); previousState != "" && normalizeState(previousState) != normalizeState(blockedStatusState) {
+			targetState = previousState
+		}
+	}
 	signals := o.blockedCauseSignals(ctx, issue, runMode, targetState, fallback)
-	targetState = blockedCauseTargetState(issue, signals, targetState)
+	if predicate != blockedRecoveryPredicateBreakerCooldown || strings.TrimSpace(targetState) == "" {
+		targetState = blockedCauseTargetState(issue, signals, targetState)
+	}
 	return workflowLaneMetadata{
 		BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
 			Owner:                   blockedRecoveryOwnerOrchestrator,
 			Cause:                   cause,
-			Predicate:               strings.TrimSpace(predicate),
+			Predicate:               predicate,
 			CauseFingerprint:        blockedCauseFingerprint(cause, signals),
 			CauseFingerprintVersion: blockedCauseFingerprintVersion,
 			TargetState:             targetState,
 			RunMode:                 strings.TrimSpace(runMode),
-			IntentResumable:         blockedCauseResumable(issue, signals),
+			IntentResumable:         predicate == blockedRecoveryPredicateBreakerCooldown || blockedCauseResumable(issue, signals),
 		},
 	}
 }
@@ -256,6 +270,7 @@ func breakerParkCause(cause string) bool {
 	case dispatchLoopDetectedReason,
 		noProgressLimitReason,
 		spendProgressReason,
+		instantFailureCircuitBreakerCause,
 		repeatedFailureCircuitBreakerCause,
 		"token_ceiling_circuit_breaker",
 		terminalAttemptRetryLimitCause,
@@ -301,7 +316,15 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "operator_stop", nil, "")
 		return false
 	}
-	_, currentParkFound := o.currentBlockedRecoveryPark(ctx, state, issue)
+	park, currentParkFound := o.currentBlockedRecoveryPark(ctx, state, issue)
+	if currentParkFound {
+		park = o.normalizeCurrentBreakerRecoveryPark(ctx, state, issue, park)
+	}
+	derivedLaneReason := ""
+	derivationFailure := ""
+	if !currentParkFound {
+		park, currentParkFound, derivedLaneReason, derivationFailure = o.deriveCurrentBreakerRecoveryPark(ctx, state, issue)
+	}
 	withDependencies := o.issueWithDependencyRefs(issue)
 	withDependencies, workpadRefs, workpadCurrent := o.issueWithCurrentWorkpadDependencyRefs(ctx, withDependencies)
 	blockers := o.resolveDependencyBlockers(ctx, withDependencies)
@@ -400,8 +423,15 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "rework_breaker_recovery", nil, park.Signature)
 		return false
 	}
-	park, ok := o.currentBlockedRecoveryParkWithLegacyRESTBudget(ctx, state, issue)
-	if !ok {
+	if !currentParkFound {
+		park, currentParkFound = o.currentBlockedRecoveryParkWithLegacyRESTBudget(ctx, state, issue)
+	}
+	if !currentParkFound {
+		if derivationFailure != "" {
+			o.logSchedulerBreakerRecoveryDerivationFailure(issue, derivedLaneReason, derivationFailure)
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", schedulerParkRecoveryUnavailableReason, nil, "")
+			return false
+		}
 		recoveryCfg := normalizeBlockedRecoveryConfig(o.cfg.BlockedRecovery)
 		reasonCode, reasonFound := o.latestWorkflowLaneReason(ctx, issue, issue.State)
 		if recoveryCfg.Enabled && reasonFound && blockedRecoveryReasonAllowed(recoveryCfg, reasonCode) {
@@ -438,12 +468,22 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "managed_recovery", &park, park.CauseFingerprint)
 		return false
 	}
-	if park.Predicate != blockedRecoveryPredicateFingerprintChange &&
-		park.Predicate != blockedRecoveryPredicateOncePerFingerprint {
-		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "no_recovery_predicate", &park, park.CauseFingerprint)
-		return false
-	}
 	breakerPark := breakerParkCause(park.Cause)
+	if !breakerPark && park.Predicate != blockedRecoveryPredicateFingerprintChange &&
+		park.Predicate != blockedRecoveryPredicateOncePerFingerprint {
+		derivedPark, found, laneReason, failure := o.deriveCurrentBreakerRecoveryPark(ctx, state, issue)
+		if !found {
+			if failure != "" {
+				o.logSchedulerBreakerRecoveryDerivationFailure(issue, laneReason, failure)
+				o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", schedulerParkRecoveryUnavailableReason, &park, park.CauseFingerprint)
+				return false
+			}
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "no_recovery_predicate", &park, park.CauseFingerprint)
+			return false
+		}
+		park = derivedPark
+		breakerPark = true
+	}
 	signals := blockedCauseSignals{}
 	currentFingerprint := ""
 	if park.CauseFingerprintVersion != blockedCauseFingerprintVersion {
@@ -456,6 +496,7 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		}
 		park = rebased
 	}
+	var breakerParkedAt time.Time
 	if breakerPark {
 		parkedAt, found := o.currentBlockedRecoveryParkedAt(ctx, state, issue)
 		if !found {
@@ -464,24 +505,31 @@ func (o *Orchestrator) recoverCauseBlockedIssue(
 		}
 		cooldown := normalizeBlockedRecoveryConfig(o.cfg.BlockedRecovery).BreakerCooldown
 		if now.Before(parkedAt.Add(cooldown)) {
-			o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", "breaker_cooldown_active", &park, park.CauseFingerprint)
+			o.recordBlockedRecoveryDecision(ctx, state, issue, "defer", blockedRecoveryReasonBreakerCooldownActive, &park, park.CauseFingerprint)
 			return false
 		}
+		breakerParkedAt = parkedAt
 	}
 	if currentFingerprint == "" {
 		signals = o.blockedCauseSignals(ctx, issue, park.RunMode, park.TargetState, DiffStats{})
 		currentFingerprint = blockedCauseFingerprint(park.Cause, signals)
 	}
-	if park.Predicate == blockedRecoveryPredicateFingerprintChange && currentFingerprint == park.CauseFingerprint {
+	if !breakerPark && park.Predicate == blockedRecoveryPredicateFingerprintChange && currentFingerprint == park.CauseFingerprint {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "cause_unchanged", &park, currentFingerprint)
 		return false
 	}
 	signature := blockedCauseRecoverySignature(park.Cause, currentFingerprint)
+	if breakerPark {
+		signature = blockedCauseRecoverySignature(park.Cause, breakerParkedAt.UTC().Format(time.RFC3339Nano))
+	}
 	if _, consumed := o.workflowTimelineActionSignature(ctx, issue, workflowActionCauseBlockedRecovery, signature); consumed {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "fingerprint_already_consumed", &park, currentFingerprint)
 		return false
 	}
-	targetState := blockedCauseTargetState(issue, signals, park.TargetState)
+	targetState := strings.TrimSpace(park.TargetState)
+	if !breakerPark || targetState == "" {
+		targetState = blockedCauseTargetState(issue, signals, targetState)
+	}
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionCauseBlockedRecovery, signature)
 	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, now, "cause_blocked_recovery", metadata, laneMutationPreserveOwnership); err != nil {
 		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "transition_failed", &park, currentFingerprint)
@@ -565,9 +613,11 @@ func (o *Orchestrator) rebaselineLegacyBlockedRecoveryPark(
 	rebased.Cause = strings.TrimSpace(rebased.Cause)
 	rebased.CauseFingerprint = strings.TrimSpace(fingerprint)
 	rebased.CauseFingerprintVersion = blockedCauseFingerprintVersion
-	rebased.TargetState = blockedCauseTargetState(issue, signals, rebased.TargetState)
+	if rebased.Predicate != blockedRecoveryPredicateBreakerCooldown || strings.TrimSpace(rebased.TargetState) == "" {
+		rebased.TargetState = blockedCauseTargetState(issue, signals, rebased.TargetState)
+	}
 	rebased.RunMode = strings.TrimSpace(rebased.RunMode)
-	rebased.IntentResumable = blockedCauseResumable(issue, signals)
+	rebased.IntentResumable = rebased.Predicate == blockedRecoveryPredicateBreakerCooldown || blockedCauseResumable(issue, signals)
 	rebased.Resumable = false
 	rebased.Reachability = ""
 	rebased.HoldReason = ""
@@ -941,6 +991,123 @@ func (o *Orchestrator) currentBlockedOperatorStop(ctx context.Context, state *St
 		strings.EqualFold(strings.TrimSpace(entry.Event.Reason), string(store.WorkAttemptTerminalOperatorStopped))
 }
 
+func breakerParkCauseFromLaneReason(reason string) (string, bool) {
+	reason = strings.TrimSpace(reason)
+	if reason == instantFailureCircuitBreakerLaneReason {
+		return instantFailureCircuitBreakerCause, true
+	}
+	return reason, breakerParkCause(reason)
+}
+
+func (o *Orchestrator) normalizeCurrentBreakerRecoveryPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	park workflowLaneBlockedRecoveryMetadata,
+) workflowLaneBlockedRecoveryMetadata {
+	if !breakerParkCause(park.Cause) ||
+		strings.EqualFold(strings.TrimSpace(park.Owner), blockedRecoveryOwnerHuman) ||
+		strings.EqualFold(strings.TrimSpace(park.Owner), blockedRecoveryOwnerOperator) {
+		return park
+	}
+	normalized := park
+	normalized.Predicate = strings.TrimSpace(normalized.Predicate)
+	if normalized.Predicate == "" || normalized.Predicate == blockedRecoveryPredicateFingerprintChange {
+		normalized.Predicate = blockedRecoveryPredicateBreakerCooldown
+	}
+	entry, entryFound := o.latestWorkflowLaneEntry(ctx, issue)
+	if entryFound && normalizeState(entry.Event.PhaseName) == normalizeState(blockedStatusState) && workflowLaneEntryMatchesCurrent(issue, entry.Event) {
+		previousState := strings.TrimSpace(entry.Event.PreviousPhaseName)
+		if previousState != "" && normalizeState(previousState) != normalizeState(blockedStatusState) {
+			normalized.TargetState = previousState
+		}
+	}
+	if normalized == park {
+		return normalized
+	}
+	o.persistCurrentBlockedRecoveryPark(ctx, state, issue, entry, entryFound, normalized)
+	return normalized
+}
+
+func (o *Orchestrator) deriveCurrentBreakerRecoveryPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+) (workflowLaneBlockedRecoveryMetadata, bool, string, string) {
+	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	if !ok || normalizeState(entry.Event.PhaseName) != normalizeState(blockedStatusState) || !workflowLaneEntryMatchesCurrent(issue, entry.Event) {
+		return workflowLaneBlockedRecoveryMetadata{}, false, "", ""
+	}
+	laneReason := strings.TrimSpace(entry.Event.Reason)
+	cause, schedulerPark := breakerParkCauseFromLaneReason(laneReason)
+	if !schedulerPark {
+		return workflowLaneBlockedRecoveryMetadata{}, false, "", ""
+	}
+	previousState := strings.TrimSpace(entry.Event.PreviousPhaseName)
+	if previousState == "" || normalizeState(previousState) == normalizeState(blockedStatusState) {
+		return workflowLaneBlockedRecoveryMetadata{}, false, laneReason, "previous_lane_unavailable"
+	}
+	runMode := RunModeImplement
+	if normalizeState(previousState) == normalizeState(autoPromoteMergingState) {
+		runMode = RunModeMerge
+	}
+	metadata := o.newBlockedRecoveryMetadata(
+		ctx,
+		issue,
+		runMode,
+		cause,
+		blockedRecoveryPredicateBreakerCooldown,
+		previousState,
+		DiffStats{},
+	)
+	park := *metadata.BlockedRecovery
+	park.TargetState = previousState
+	o.persistCurrentBlockedRecoveryPark(ctx, state, issue, entry, true, park)
+	return park, true, laneReason, ""
+}
+
+func (o *Orchestrator) persistCurrentBlockedRecoveryPark(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	entry workflowTimelineMetadataMatch,
+	entryFound bool,
+	park workflowLaneBlockedRecoveryMetadata,
+) {
+	if entryFound && entry.Event.ID > 0 {
+		if updater, ok := o.workflowMetrics.(WorkflowMetricsMetadataUpdater); ok {
+			metadata := entry.Metadata
+			metadata.BlockedRecovery = &park
+			if err := updater.UpdateWorkflowPhaseEventMetadata(ctx, entry.Event.ID, workflowLaneMetadataJSON(issue, metadata)); err != nil && o.logger != nil {
+				o.logger.Warn("scheduler breaker recovery metadata persistence failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+			}
+		}
+	}
+	if state == nil {
+		return
+	}
+	blocked, ok := state.Blocked[strings.TrimSpace(issue.ID)]
+	if !ok || !blockedEntryMatchesCurrent(issue, blocked.BlockedAt) {
+		return
+	}
+	blocked.Recovery = &park
+	blocked.RecoveryTarget = park.TargetState
+	state.Blocked[strings.TrimSpace(issue.ID)] = blocked
+}
+
+func (o *Orchestrator) logSchedulerBreakerRecoveryDerivationFailure(issue connector.Issue, laneReason string, reason string) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	o.logger.Warn(
+		"scheduler breaker recovery derivation failed",
+		"issue_id", strings.TrimSpace(issue.ID),
+		"identifier", strings.TrimSpace(issue.Identifier),
+		"lane_reason", strings.TrimSpace(laneReason),
+		"reason", strings.TrimSpace(reason),
+	)
+}
+
 func (o *Orchestrator) currentBlockedRecoveryPark(
 	ctx context.Context,
 	state *State,
@@ -980,10 +1147,11 @@ func (o *Orchestrator) currentBlockedRecoveryParkedAt(
 	}
 	entry, ok := o.latestWorkflowLaneEntry(ctx, issue)
 	parkedAt := workflowLaneTransitionAt(entry.Event)
+	_, schedulerPark := breakerParkCauseFromLaneReason(entry.Event.Reason)
 	if ok &&
 		normalizeState(entry.Event.PhaseName) == normalizeState(blockedStatusState) &&
 		workflowLaneEntryMatchesCurrent(issue, entry.Event) &&
-		entry.Metadata.BlockedRecovery != nil &&
+		(entry.Metadata.BlockedRecovery != nil || schedulerPark) &&
 		!parkedAt.IsZero() {
 		return parkedAt, true
 	}
@@ -1170,10 +1338,12 @@ func BlockedRecoveryOperatorRemedy(issue connector.Issue, reason string) string 
 		return "Change the blocking cause, or move the issue to a lane that starts fresh work."
 	case "legacy_cause_fingerprint":
 		return "Park predates the current recovery schema; move the issue to Todo or Rework to re-evaluate it."
-	case "breaker_cooldown_active":
-		return "Detent will re-evaluate this circuit-breaker park after its cooldown expires."
+	case blockedRecoveryReasonBreakerCooldownActive:
+		return "Detent will return the issue to its prior lane after the breaker cooldown ends."
 	case "breaker_cooldown_unavailable":
 		return "Restore the recorded Blocked transition time or move the issue to a lane that starts fresh work."
+	case schedulerParkRecoveryUnavailableReason:
+		return "Restore the scheduler-recorded previous lane or move the issue to the intended recovery lane."
 	case "transition_failed":
 		return "Retry the lane transition after restoring tracker write access."
 	case githubRESTBudgetWaitingReason, githubRESTBudgetObservationPendingReason:

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -310,7 +310,7 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 			wantTransition: true,
 		},
 		{
-			name:                  "unchanged no-progress cause",
+			name:                  "unchanged generic cause",
 			predicate:             blockedRecoveryPredicateFingerprintChange,
 			parked:                runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
 			current:               runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "config-same", Health: "ready", WorkspaceStatus: "missing"},
@@ -388,7 +388,7 @@ func TestCauseBlockedRecoveryPersistsAndBoundsFingerprintAttempts(t *testing.T) 
 			parkedAt := time.Date(2026, 7, 29, 18, 30, 0, 0, time.UTC)
 			cause := tt.cause
 			if cause == "" {
-				cause = noProgressLimitReason
+				cause = "configuration_guard"
 			}
 			metadata := parkOrch.newBlockedRecoveryMetadata(
 				t.Context(),
@@ -505,7 +505,7 @@ func TestCauseBlockedRecoveryCooldownSurvivesRestart(t *testing.T) {
 	restarted := blockedCauseTestOrchestrator(tracker)
 	restarted.workflowMetrics = metrics
 	restarted.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{
-		ConfigFingerprint: "config-after",
+		ConfigFingerprint: "config-before",
 		Health:            "ready",
 	}}
 	state := newState(restarted.cfg)
@@ -520,10 +520,211 @@ func TestCauseBlockedRecoveryCooldownSurvivesRestart(t *testing.T) {
 	}
 }
 
+func TestBreakerRecoveryUsesCurrentPark(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		stale bool
+	}{
+		{name: "each cooldown restores the issue"},
+		{name: "stale lane history cannot restore a new park", stale: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			orch.workflowMetrics = metrics
+			issue := dependencyAutoUnblockIssue("issue-current-park", blockedStatusState)
+			parkedAt := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+			for episode := range 2 {
+				at := parkedAt.Add(time.Duration(episode) * 2 * defaultBreakerParkCooldown)
+				issue.StageUpdatedAt = timePointer(at)
+				if tt.stale {
+					issue.StageUpdatedAt = timePointer(at.Add(time.Hour))
+				}
+				if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+					ProjectID: defaultWorkflowMetricsProjectID, IssueID: issue.ID,
+					Identifier: issue.Identifier, IssueURL: issue.URL,
+					PhaseType: store.WorkflowPhaseTypeLane, PhaseName: blockedStatusState,
+					PreviousPhaseName: "In Progress", Reason: instantFailureCircuitBreakerLaneReason,
+					Status: "entered", StartedAt: at, MetadataJSON: "{}",
+				}); err != nil {
+					t.Fatal(err)
+				}
+				state := newState(orch.cfg)
+				orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, at.Add(time.Hour+defaultBreakerParkCooldown))
+				want := episode + 1
+				if tt.stale {
+					want = 0
+				}
+				if len(tracker.updates) != want {
+					t.Fatalf("episode %d: updates = %#v, want %d; recovery = %#v", episode, tracker.updates, want, state.Blocked[issue.ID])
+				}
+			}
+		})
+	}
+}
+
+func TestBreakerRecoveryMetadataRemembersPreviousLane(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		cause string
+	}{
+		{name: "instant failure", cause: instantFailureCircuitBreakerCause},
+		{name: "repeated failure", cause: repeatedFailureCircuitBreakerCause},
+		{name: "token ceiling", cause: "token_ceiling_circuit_breaker"},
+		{name: "terminal attempt retry", cause: terminalAttemptRetryLimitCause},
+		{name: "workspace preparation retry", cause: workspacePreparationRetryLimitCause},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := dependencyAutoUnblockIssue("issue-"+strings.ReplaceAll(tt.name, " ", "-"), "In Progress")
+			orch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+			metadata := orch.newBlockedRecoveryMetadata(
+				t.Context(),
+				issue,
+				RunModeImplement,
+				tt.cause,
+				blockedRecoveryPredicateFingerprintChange,
+				"Todo",
+				DiffStats{},
+			)
+
+			if metadata.BlockedRecovery.Predicate != blockedRecoveryPredicateBreakerCooldown {
+				t.Fatalf("predicate = %q, want breaker_cooldown_elapsed", metadata.BlockedRecovery.Predicate)
+			}
+			if metadata.BlockedRecovery.TargetState != issue.State {
+				t.Fatalf("target state = %q, want previous lane %q", metadata.BlockedRecovery.TargetState, issue.State)
+			}
+		})
+	}
+}
+
+func TestCauseBlockedRecoveryDerivesSchedulerBreakerPark(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 9, 3, 14, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		metadataJSON func(connector.Issue) string
+	}{
+		{name: "missing metadata", metadataJSON: func(connector.Issue) string { return "{}" }},
+		{
+			name: "incomplete metadata",
+			metadataJSON: func(issue connector.Issue) string {
+				return workflowLaneMetadataJSON(issue, workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{}})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := dependencyAutoUnblockIssue("issue-derived-breaker-park-"+strings.ReplaceAll(tt.name, " ", "-"), blockedStatusState)
+			issue.StageUpdatedAt = timePointer(parkedAt)
+			issue.BlockedBy = []connector.BlockedRef{{Source: connector.BlockedRefSourceNative}}
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+				ProjectID:         defaultWorkflowMetricsProjectID,
+				IssueID:           issue.ID,
+				Identifier:        issue.Identifier,
+				IssueURL:          issue.URL,
+				PhaseType:         store.WorkflowPhaseTypeLane,
+				PhaseName:         blockedStatusState,
+				PreviousPhaseName: "In Progress",
+				Reason:            instantFailureCircuitBreakerLaneReason,
+				Status:            "entered",
+				StartedAt:         parkedAt,
+				MetadataJSON:      tt.metadataJSON(issue),
+			}); err != nil {
+				t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+			}
+
+			tracker := &dependencyAutoUnblockConnector{}
+			orch := blockedCauseTestOrchestrator(tracker)
+			orch.cfg.DependencySource = "native_only"
+			orch.workflowMetrics = metrics
+			state := newState(orch.cfg)
+			orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(2*time.Minute))
+
+			blocked := state.Blocked[issue.ID]
+			if blocked.RecoveryAction != "defer" || blocked.RecoveryReason != blockedRecoveryReasonBreakerCooldownActive || blocked.NeedsHumanAttention {
+				t.Fatalf("blocked recovery = %#v, want machine-deferred breaker cooldown", blocked)
+			}
+			if blocked.Recovery == nil || blocked.Recovery.Predicate != blockedRecoveryPredicateBreakerCooldown || blocked.RecoveryTarget != "In Progress" {
+				t.Fatalf("blocked recovery metadata = %#v, target = %q", blocked.Recovery, blocked.RecoveryTarget)
+			}
+
+			restartedTracker := &dependencyAutoUnblockConnector{}
+			restarted := blockedCauseTestOrchestrator(restartedTracker)
+			restarted.cfg.DependencySource = "native_only"
+			restarted.workflowMetrics = metrics
+			restartedState := newState(restarted.cfg)
+			restarted.recoverBlockedIssues(t.Context(), &restartedState, []connector.Issue{issue}, parkedAt.Add(time.Minute+defaultBreakerParkCooldown))
+
+			if len(restartedTracker.updates) != 1 || restartedTracker.updates[0].state != "In Progress" {
+				t.Fatalf("post-cooldown updates = %#v, want previous lane In Progress", restartedTracker.updates)
+			}
+		})
+	}
+}
+
+func TestCauseBlockedRecoveryLogsSchedulerParkDerivationFailure(t *testing.T) {
+	t.Parallel()
+
+	parkedAt := time.Date(2026, 9, 3, 15, 0, 0, 0, time.UTC)
+	issue := dependencyAutoUnblockIssue("issue-invalid-breaker-park", blockedStatusState)
+	issue.StageUpdatedAt = timePointer(parkedAt)
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    blockedStatusState,
+		Reason:       "instant_fail_circuit_breaker",
+		Status:       "entered",
+		StartedAt:    parkedAt,
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+
+	var logs bytes.Buffer
+	orch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+	orch.workflowMetrics = metrics
+	orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	state := newState(orch.cfg)
+	orch.recoverBlockedIssues(t.Context(), &state, []connector.Issue{issue}, parkedAt.Add(time.Minute))
+
+	blocked := state.Blocked[issue.ID]
+	if blocked.RecoveryReason != "scheduler_park_recovery_unavailable" {
+		t.Fatalf("recovery reason = %q, want scheduler_park_recovery_unavailable", blocked.RecoveryReason)
+	}
+	for _, want := range []string{
+		"msg=\"scheduler breaker recovery derivation failed\"",
+		"reason=previous_lane_unavailable",
+		"lane_reason=instant_fail_circuit_breaker",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs = %q, want %q", logs.String(), want)
+		}
+	}
+}
+
 func TestBreakerParkCauseIncludesRetryCycleLimits(t *testing.T) {
 	t.Parallel()
 
-	for _, cause := range []string{terminalAttemptRetryLimitCause, workspacePreparationRetryLimitCause} {
+	for _, cause := range []string{instantFailureCircuitBreakerCause, terminalAttemptRetryLimitCause, workspacePreparationRetryLimitCause} {
 		if !breakerParkCause(cause) {
 			t.Fatalf("breakerParkCause(%q) = false, want true", cause)
 		}
@@ -560,12 +761,11 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 			wantSurfaceParts: []string{"transient GitHub REST budget", "remaining=940/5000", "reserve=1250"},
 		},
 		{
-			name:          "non-transient failure stays parked",
-			errorMessage:  "run agent turn: runner transport closed",
-			remaining:     4927,
-			wantAction:    "hold",
-			wantReason:    "cause_unchanged",
-			recoveryAfter: defaultBreakerParkCooldown,
+			name:           "non-transient failure recovers after cooldown",
+			errorMessage:   "run agent turn: runner transport closed",
+			remaining:      4927,
+			wantTransition: true,
+			recoveryAfter:  defaultBreakerParkCooldown,
 		},
 		{
 			name:             "same exhaustion episode does not rearm twice",
@@ -601,6 +801,7 @@ func TestRepeatedFailureParkRecoveryUsesRecordedRESTBudgetFailures(t *testing.T)
 				"Todo",
 				DiffStats{},
 			)
+			metadata.BlockedRecovery.TargetState = "In Progress"
 			metrics := &autoPromoteWorkflowMetricsRecorder{}
 			if tt.consumed {
 				signature := githubRESTBudgetRecoverySignature(githubRESTBudgetEvidence{
@@ -904,6 +1105,7 @@ func TestRepeatedFailureLegacyRESTBudgetParkRecoversAfterTrackerTransitionDelay(
 				"Todo",
 				DiffStats{},
 			)
+			metadata.BlockedRecovery.Predicate = blockedRecoveryPredicateFingerprintChange
 			if tt.parkOwner != "" {
 				metadata.BlockedRecovery.Owner = tt.parkOwner
 			}
@@ -1223,7 +1425,7 @@ func TestCauseBlockedRecoveryRebaselinesLegacyFingerprint(t *testing.T) {
 	}{
 		{
 			name:      "fingerprint change resumes after a later cause change",
-			cause:     noProgressLimitReason,
+			cause:     "configuration_guard",
 			predicate: blockedRecoveryPredicateFingerprintChange,
 		},
 		{

--- a/internal/orchestrator/blocked_cause_recovery_test.go
+++ b/internal/orchestrator/blocked_cause_recovery_test.go
@@ -567,6 +567,29 @@ func TestBreakerRecoveryUsesCurrentPark(t *testing.T) {
 	}
 }
 
+func TestSpendProgressParkSurfacesCooldownImmediately(t *testing.T) {
+	t.Parallel()
+
+	for _, progressCase := range []string{spendProgressCaseNoPR, spendProgressCaseStatic, spendProgressCaseNoArtifact, spendProgressCaseStaticArtifact} {
+		t.Run(progressCase, func(t *testing.T) {
+			t.Parallel()
+			orch := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+			state := newState(orch.cfg)
+			issue := dependencyAutoUnblockIssue("issue-spend-cooldown", "In Progress")
+			if !orch.blockSpendProgress(t.Context(), &state, Running{Issue: issue}, spendProgressDecision{Case: progressCase}, time.Now()) {
+				t.Fatal("blockSpendProgress() = false")
+			}
+			blocked := state.Blocked[issue.ID]
+			if blocked.RecoveryAction != "defer" || blocked.RecoveryReason != blockedRecoveryReasonBreakerCooldownActive || !blocked.RecoveryIntentResumable || blocked.NeedsHumanAttention {
+				t.Fatalf("recovery = %#v, want automatic cooldown recovery", blocked)
+			}
+			if blocked.RecoveryTarget != issue.State || !strings.Contains(blocked.RecoveryRemedy, "prior lane") {
+				t.Fatalf("target = %q, remedy = %q, want prior lane recovery", blocked.RecoveryTarget, blocked.RecoveryRemedy)
+			}
+		})
+	}
+}
+
 func TestBreakerRecoveryMetadataRemembersPreviousLane(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -748,6 +748,9 @@ func (o *Orchestrator) resolveDependencyBlockers(ctx context.Context, issue conn
 		ref.Identifier = strings.TrimSpace(ref.Identifier)
 		ref.ID = strings.TrimSpace(ref.ID)
 		ref.State = strings.TrimSpace(ref.State)
+		if ref.Identifier == "" && ref.ID == "" {
+			continue
+		}
 		blockers = append(blockers, dependencyBlocker{Ref: ref})
 		if ref.Identifier == "" {
 			continue

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1067,13 +1067,13 @@ func (o *Orchestrator) parkInstantFailure(
 		ctx,
 		issue,
 		running.Mode,
-		"instant_failure_circuit_breaker",
+		instantFailureCircuitBreakerCause,
 		blockedRecoveryPredicateFingerprintChange,
 		"Todo",
 		running.DiffStats,
 	)
 	if targetState != "" {
-		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker", metadata, laneMutationRevokeWorker); err != nil {
+		if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, event.CompletedAt, instantFailureCircuitBreakerLaneReason, metadata, laneMutationRevokeWorker); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"instant fail circuit breaker state transition failed",
@@ -1104,13 +1104,17 @@ func (o *Orchestrator) parkInstantFailure(
 		state.Blocked = map[string]Blocked{}
 	}
 	state.Blocked[issue.ID] = Blocked{
-		Issue:          issue,
-		Reason:         instantFailureBlockedReasonPrefix + failure.Error,
-		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
-		RecoveryTarget: "Todo",
-		BlockedAt:      event.CompletedAt,
-		Source:         BlockedSourceProjectStatus,
-		Recovery:       metadata.BlockedRecovery,
+		Issue:                   issue,
+		Reason:                  instantFailureBlockedReasonPrefix + failure.Error,
+		RecoveryAction:          "defer",
+		RecoveryReason:          blockedRecoveryReasonBreakerCooldownActive,
+		RecoveryTarget:          metadata.BlockedRecovery.TargetState,
+		RecoveryRemedy:          BlockedRecoveryOperatorRemedy(issue, blockedRecoveryReasonBreakerCooldownActive),
+		RecoveryReachability:    blockedRecoveryReachability("defer"),
+		RecoveryIntentResumable: true,
+		BlockedAt:               event.CompletedAt,
+		Source:                  BlockedSourceProjectStatus,
+		Recovery:                metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
@@ -1201,13 +1205,17 @@ func (o *Orchestrator) tripTokenCeilingCircuitBreaker(
 	}
 	reason := tokenCeilingFailureReason(ceilingErr)
 	state.Blocked[issue.ID] = Blocked{
-		Issue:          issue,
-		Reason:         reason,
-		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
-		RecoveryTarget: "Rework",
-		BlockedAt:      event.CompletedAt,
-		Source:         BlockedSourceProjectStatus,
-		Recovery:       metadata.BlockedRecovery,
+		Issue:                   issue,
+		Reason:                  reason,
+		RecoveryAction:          "defer",
+		RecoveryReason:          blockedRecoveryReasonBreakerCooldownActive,
+		RecoveryTarget:          metadata.BlockedRecovery.TargetState,
+		RecoveryRemedy:          BlockedRecoveryOperatorRemedy(issue, blockedRecoveryReasonBreakerCooldownActive),
+		RecoveryReachability:    blockedRecoveryReachability("defer"),
+		RecoveryIntentResumable: true,
+		BlockedAt:               event.CompletedAt,
+		Source:                  BlockedSourceProjectStatus,
+		Recovery:                metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
@@ -1255,7 +1263,7 @@ func tokenCeilingFailureComment(
 	if targetState = strings.TrimSpace(targetState); targetState != "" {
 		b.WriteString("\n\nIssue parked in `")
 		b.WriteString(targetState)
-		b.WriteString("` until its recovery fingerprint changes.")
+		b.WriteString("` until the configured breaker cooldown ends.")
 	}
 	b.WriteString("\n\n- issue: ")
 	b.WriteString(issueLabel(issue))
@@ -1269,7 +1277,7 @@ func tokenCeilingFailureComment(
 	b.WriteString(strconv.FormatInt(ceilingErr.CeilingTokens, 10))
 	b.WriteString("\n- ceiling_source: ")
 	b.WriteString(strings.TrimSpace(ceilingErr.Source))
-	b.WriteString("\n\nChoose one recovery: split the issue into narrower work, apply the label configured by `agent.max_session_token_override_label` for a deliberate per-issue bypass, or raise `agent.max_session_tokens` (and `agent.max_session_context_multiplier` when it is the active guard). Detent requeues the issue once the responsible model, backend, issue, or configuration fingerprint changes.")
+	b.WriteString("\n\nBefore the cooldown ends, split the issue into narrower work, apply the label configured by `agent.max_session_token_override_label` for a deliberate per-issue bypass, or raise `agent.max_session_tokens` (and `agent.max_session_context_multiplier` when it is the active guard). Detent then returns the issue to its prior lane automatically.")
 	return b.String()
 }
 
@@ -1387,13 +1395,17 @@ func (o *Orchestrator) parkRepeatedFailure(
 		state.Blocked = map[string]Blocked{}
 	}
 	blocked := Blocked{
-		Issue:          issue,
-		Reason:         repeatedFailureBlockedReasonPrefix + failure.Error,
-		RecoveryReason: recoveryPredicate,
-		RecoveryTarget: recoveryTarget,
-		BlockedAt:      event.CompletedAt,
-		Source:         BlockedSourceProjectStatus,
-		Recovery:       metadata.BlockedRecovery,
+		Issue:                   issue,
+		Reason:                  repeatedFailureBlockedReasonPrefix + failure.Error,
+		RecoveryAction:          "defer",
+		RecoveryReason:          blockedRecoveryReasonBreakerCooldownActive,
+		RecoveryTarget:          metadata.BlockedRecovery.TargetState,
+		RecoveryRemedy:          BlockedRecoveryOperatorRemedy(issue, blockedRecoveryReasonBreakerCooldownActive),
+		RecoveryReachability:    blockedRecoveryReachability("defer"),
+		RecoveryIntentResumable: true,
+		BlockedAt:               event.CompletedAt,
+		Source:                  BlockedSourceProjectStatus,
+		Recovery:                metadata.BlockedRecovery,
 	}
 	if budgetPark {
 		blocked.Reason = githubRESTBudgetStatusMessage("waiting for capacity", budgetEvidence)
@@ -1450,7 +1462,7 @@ func repeatedFailureComment(issue connector.Issue, err error, failure RepeatedFa
 	if budgetPark {
 		b.WriteString("\n\nDetent returns the issue to its prior lane once per GitHub REST exhaustion episode after remaining capacity rises above the recorded worker reserve.")
 	} else {
-		b.WriteString("\n\nFix the workflow or agent configuration causing every attempt to fail. Detent requeues the issue when the cause fingerprint changes.")
+		b.WriteString("\n\nFix the workflow or agent configuration causing every attempt to fail before the breaker cooldown ends. Detent then returns the issue to its prior lane automatically.")
 	}
 	return b.String()
 }
@@ -1480,7 +1492,7 @@ func instantFailureComment(issue connector.Issue, err error, failure InstantFail
 		b.WriteString(body)
 		b.WriteString("\n```")
 	}
-	b.WriteString("\n\nFix the pinned agent model or backend configuration. Detent requeues the issue when the cause fingerprint changes.")
+	b.WriteString("\n\nFix the pinned agent model or backend configuration before the breaker cooldown ends. Detent then returns the issue to its prior lane automatically.")
 	return b.String()
 }
 

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -70,13 +70,13 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 	if blocked.Issue.State != blockedStatusState {
 		t.Fatalf("Blocked[%q].Issue.State = %q, want %q", issue.ID, blocked.Issue.State, blockedStatusState)
 	}
-	if blocked.RecoveryReason != blockedRecoveryPredicateFingerprintChange || blocked.RecoveryTarget != "Rework" {
-		t.Fatalf("Blocked[%q] recovery = %q to %q, want fingerprint recovery to Rework", issue.ID, blocked.RecoveryReason, blocked.RecoveryTarget)
+	if blocked.RecoveryAction != "defer" || blocked.RecoveryReason != blockedRecoveryReasonBreakerCooldownActive || blocked.RecoveryTarget != "In Progress" {
+		t.Fatalf("Blocked[%q] recovery = %q/%q to %q, want cooldown recovery to In Progress", issue.ID, blocked.RecoveryAction, blocked.RecoveryReason, blocked.RecoveryTarget)
 	}
 	if blocked.Recovery == nil ||
 		blocked.Recovery.Owner != blockedRecoveryOwnerOrchestrator ||
 		blocked.Recovery.Cause != "token_ceiling_circuit_breaker" ||
-		blocked.Recovery.Predicate != blockedRecoveryPredicateFingerprintChange ||
+		blocked.Recovery.Predicate != blockedRecoveryPredicateBreakerCooldown ||
 		blocked.Recovery.CauseFingerprint == "" {
 		t.Fatalf("Blocked[%q].Recovery = %#v, want durable token-ceiling predicate", issue.ID, blocked.Recovery)
 	}
@@ -87,7 +87,7 @@ func TestHandleRunResultParksSlowTokenCeilingFailureWithoutRetry(t *testing.T) {
 	laneMetadata, ok := workflowLaneMetadataFromJSON(events[1].MetadataJSON)
 	if !ok || laneMetadata.BlockedRecovery == nil ||
 		laneMetadata.BlockedRecovery.Cause != "token_ceiling_circuit_breaker" ||
-		laneMetadata.BlockedRecovery.Predicate != blockedRecoveryPredicateFingerprintChange ||
+		laneMetadata.BlockedRecovery.Predicate != blockedRecoveryPredicateBreakerCooldown ||
 		laneMetadata.BlockedRecovery.CauseFingerprint == "" {
 		t.Fatalf("workflow recovery metadata = %#v, want durable token-ceiling predicate", laneMetadata.BlockedRecovery)
 	}

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -691,13 +691,17 @@ func (o *Orchestrator) blockSpendProgress(
 		state.Blocked = map[string]Blocked{}
 	}
 	state.Blocked[issueID] = Blocked{
-		Issue:          issue,
-		Reason:         spendProgressReason,
-		RecoveryReason: spendProgressRecoveryReason(decision),
-		RecoveryTarget: "Rework",
-		BlockedAt:      blockedAt,
-		Source:         BlockedSourceProjectStatus,
-		Recovery:       metadata.BlockedRecovery,
+		Issue:                   issue,
+		Reason:                  spendProgressReason,
+		RecoveryAction:          "defer",
+		RecoveryReason:          blockedRecoveryReasonBreakerCooldownActive,
+		RecoveryTarget:          metadata.BlockedRecovery.TargetState,
+		RecoveryRemedy:          spendProgressRecoveryReason(decision) + ". " + BlockedRecoveryOperatorRemedy(issue, blockedRecoveryReasonBreakerCooldownActive),
+		RecoveryReachability:    blockedRecoveryReachability("defer"),
+		RecoveryIntentResumable: true,
+		BlockedAt:               blockedAt,
+		Source:                  BlockedSourceProjectStatus,
+		Recovery:                metadata.BlockedRecovery,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      blockedAt,
@@ -863,13 +867,13 @@ func spendProgressUsageSummary(decision spendProgressDecision) string {
 func spendProgressRecoveryReason(decision spendProgressDecision) string {
 	switch decision.Case {
 	case spendProgressCaseStatic:
-		return "inspect merge-train capacity, Merging serialization, and dispatch priority before moving the issue back to Rework"
+		return "inspect merge-train capacity, Merging serialization, and dispatch priority before the breaker cooldown ends"
 	case spendProgressCaseStaticArtifact:
-		return "identify why the completion receipt, artifact status, deliverable metadata, and output files stayed static before moving the item back to Rework"
+		return "identify why the completion receipt, artifact status, deliverable metadata, and output files stayed static before the breaker cooldown ends"
 	case spendProgressCaseNoArtifact:
-		return "restore a writable completion receipt, artifact status, deliverable metadata, or output path before moving the item back to Todo or Rework"
+		return "restore a writable completion receipt, artifact status, deliverable metadata, or output path before the breaker cooldown ends"
 	default:
-		return "narrow or split the task, then identify why no linked PR evidence was produced before moving the issue back to Todo or Rework"
+		return "narrow or split the task, then identify why no linked PR evidence was produced before the breaker cooldown ends"
 	}
 }
 

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -268,15 +268,19 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		state.Blocked = map[string]Blocked{}
 	}
 	state.Blocked[issue.ID] = Blocked{
-		Issue:          cloneIssue(issue),
-		Reason:         cause,
-		RecoveryReason: blockedRecoveryPredicateFingerprintChange,
-		RecoveryTarget: metadata.BlockedRecovery.TargetState,
-		BlockedAt:      at,
-		Source:         BlockedSourceProjectStatus,
-		AttemptError:   attemptError,
-		WorkAttemptID:  latest.AttemptID,
-		Recovery:       metadata.BlockedRecovery,
+		Issue:                   cloneIssue(issue),
+		Reason:                  cause,
+		RecoveryAction:          "defer",
+		RecoveryReason:          blockedRecoveryReasonBreakerCooldownActive,
+		RecoveryTarget:          metadata.BlockedRecovery.TargetState,
+		RecoveryRemedy:          BlockedRecoveryOperatorRemedy(issue, blockedRecoveryReasonBreakerCooldownActive),
+		RecoveryReachability:    blockedRecoveryReachability("defer"),
+		RecoveryIntentResumable: true,
+		BlockedAt:               at,
+		Source:                  BlockedSourceProjectStatus,
+		AttemptError:            attemptError,
+		WorkAttemptID:           latest.AttemptID,
+		Recovery:                metadata.BlockedRecovery,
 	}
 	if o.connector != nil {
 		comment := retryCycleLimitComment(issue, cause, count, targetState, latest, attemptError)
@@ -318,7 +322,7 @@ func retryCycleLimitComment(
 	attemptError string,
 ) string {
 	comment := fmt.Sprintf(
-		"Detent stopped retrying %s after %d consecutive %s attempts. The issue is parked in `%s` until its recovery fingerprint changes.",
+		"Detent stopped retrying %s after %d consecutive %s attempts. The issue is parked in `%s` until the configured breaker cooldown ends, then Detent returns it to its prior lane automatically.",
 		issueLabel(issue),
 		count,
 		retryCycleDescription(cause),

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -632,7 +632,7 @@ func TestReconcileTerminalAttemptRetryStatesBoundsDurableFailures(t *testing.T) 
 			attempts:     terminalRetryFailureAttempts("issue-at-limit", now, retryLimit),
 			wantState:    "Blocked",
 			wantBlocked:  true,
-			wantRecovery: "fingerprint_changed",
+			wantRecovery: blockedRecoveryReasonBreakerCooldownActive,
 		},
 		{
 			name: "successful completion resets the sequence",
@@ -702,8 +702,8 @@ func TestReconcileTerminalAttemptRetryStatesBoundsDurableFailures(t *testing.T) 
 			if ok != tt.wantBlocked {
 				t.Fatalf("Blocked[%q] present = %v, want %v: %#v", issue.ID, ok, tt.wantBlocked, blocked)
 			}
-			if tt.wantBlocked && (blocked.RecoveryReason != tt.wantRecovery || blocked.Recovery == nil) {
-				t.Fatalf("Blocked[%q] = %#v, want durable fingerprint recovery", issue.ID, blocked)
+			if tt.wantBlocked && (blocked.RecoveryReason != tt.wantRecovery || blocked.Recovery == nil || blocked.Recovery.Predicate != blockedRecoveryPredicateBreakerCooldown) {
+				t.Fatalf("Blocked[%q] = %#v, want durable breaker cooldown recovery", issue.ID, blocked)
 			}
 		})
 	}

--- a/internal/orchestrator/workspace_preparation_test.go
+++ b/internal/orchestrator/workspace_preparation_test.go
@@ -90,8 +90,8 @@ func TestWorkspacePreparationRetriesAreBoundedAndPreserveFailureBreakers(t *test
 			}
 
 			blocked, ok := state.Blocked[issue.ID]
-			if !ok || blocked.Reason != workspacePreparationRetryLimitCause || blocked.Recovery == nil || blocked.RecoveryReason != blockedRecoveryPredicateFingerprintChange {
-				t.Fatalf("Blocked[%q] = %#v, want durable fingerprint-recovery park", issue.ID, blocked)
+			if !ok || blocked.Reason != workspacePreparationRetryLimitCause || blocked.Recovery == nil || blocked.RecoveryReason != blockedRecoveryReasonBreakerCooldownActive || blocked.Recovery.Predicate != blockedRecoveryPredicateBreakerCooldown {
+				t.Fatalf("Blocked[%q] = %#v, want durable breaker cooldown park", issue.ID, blocked)
 			}
 			if blocked.AttemptError != tt.err.Error() || blocked.WorkAttemptID != retryLimit {
 				t.Fatalf("Blocked[%q] attempt evidence = %q/%d, want %q/%d", issue.ID, blocked.AttemptError, blocked.WorkAttemptID, tt.err.Error(), retryLimit)


### PR DESCRIPTION
## Summary

- Scheduler breaker parks record cooldown recovery and the previous lane, then restore that lane automatically after cooldown, including after restart.
- Repair missing legacy breaker metadata from current lane history, log unresolvable parks, and ignore empty dependency references while preserving real dependency and human-owned holds.
- Spend-progress parks immediately show deferred cooldown recovery and the prior-lane destination.
- Scope recovery to each parking event so stale lane history cannot restore a new park and earlier cooldowns cannot prevent subsequent recovery.

Fixes #2108

## UI Surface Contract

- [x] N/A: this change updates recovery behavior and existing status text without changing UI layout or visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Focused table-driven orchestrator regression tests for cooldowns, restart recovery, missing metadata, stale lane history, repeated parks, and breaker call sites.
- [x] `make check` using CI-pinned Go 1.26.6 and golangci-lint v2.9.0: build, lint, vet, NilAway, race tests, and coverage all pass. Coverage is 78.9% (70% required); package and file floors pass.

- [x] Safety-boundary fuzz: all seven seeds and 906,433 executions pass; spend-progress exact-file coverage is 92.4% (90% required).
