### PR TITLE
fix(orchestrator): retain work on lane revocation

### DIFF
--- a/internal/orchestrator/lane_mutation.go
+++ b/internal/orchestrator/lane_mutation.go
@@ -146,9 +146,9 @@ func (o *Orchestrator) applyLaneMutationDisposition(
 func (o *Orchestrator) laneMutationReceipt(
 	ctx context.Context,
 	running Running,
-	toState string,
+	observed connector.Issue,
 ) (store.LaneMutationReceipt, bool, error) {
-	if runningLaneMutationMatches(running, connector.Issue{State: toState}) {
+	if runningLaneMutationMatches(running, observed) {
 		return running.laneMutation, true, nil
 	}
 	if o.laneMutations == nil || running.WorkAttemptID <= 0 || running.Generation == 0 || strings.TrimSpace(running.Issue.ID) == "" {
@@ -159,7 +159,7 @@ func (o *Orchestrator) laneMutationReceipt(
 		IssueID:       running.Issue.ID,
 		WorkAttemptID: running.WorkAttemptID,
 		Generation:    running.Generation,
-		ToState:       toState,
+		ToState:       observed.State,
 	})
 	if errors.Is(err, store.ErrNotFound) {
 		return store.LaneMutationReceipt{}, false, nil
@@ -170,8 +170,11 @@ func (o *Orchestrator) laneMutationReceipt(
 	if receipt.IssueID != strings.TrimSpace(running.Issue.ID) ||
 		receipt.WorkAttemptID != running.WorkAttemptID ||
 		receipt.Generation != running.Generation ||
-		normalizeState(receipt.ToState) != normalizeState(toState) {
+		normalizeState(receipt.ToState) != normalizeState(observed.State) {
 		return store.LaneMutationReceipt{}, false, errors.New("live worker lane mutation receipt does not match the current owner")
+	}
+	if !laneMutationMatchesObservation(receipt, observed) {
+		return store.LaneMutationReceipt{}, false, nil
 	}
 	return receipt, true, nil
 }
@@ -219,5 +222,13 @@ func runningLaneMutationMatches(running Running, issue connector.Issue) bool {
 		receipt.IssueID == strings.TrimSpace(running.Issue.ID) &&
 		receipt.WorkAttemptID == running.WorkAttemptID &&
 		receipt.Generation == running.Generation &&
-		normalizeState(receipt.ToState) == normalizeState(issue.State)
+		laneMutationMatchesObservation(receipt, issue)
+}
+
+func laneMutationMatchesObservation(receipt store.LaneMutationReceipt, issue connector.Issue) bool {
+	if normalizeState(receipt.ToState) != normalizeState(issue.State) {
+		return false
+	}
+	return receipt.ResolvedAt.IsZero() || issue.StageUpdatedAt == nil || issue.StageUpdatedAt.IsZero() ||
+		!issue.StageUpdatedAt.After(receipt.ResolvedAt)
 }

--- a/internal/orchestrator/lane_mutation_test.go
+++ b/internal/orchestrator/lane_mutation_test.go
@@ -62,6 +62,62 @@ func TestLiveLeaseLaneMutationFailsClosed(t *testing.T) {
 	}
 }
 
+func TestLaneMutationReceiptDistinguishesEchoFromLaterReentry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		later     bool
+		restarted bool
+	}{
+		{name: "cached Detent echo"},
+		{name: "persisted Detent echo", restarted: true},
+		{name: "cached later operator reentry", later: true},
+		{name: "persisted later operator reentry", later: true, restarted: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 4, 4, 11, 0, 0, time.UTC)
+			issue := laneRevocationIssue("echo-owner", "digitaldrywood/detent#2138", "In Progress")
+			parked := cloneIssue(issue)
+			parked.State = "Human Review"
+			cfg := laneMutationTestConfig()
+			runtimeStore, attemptID := openLaneMutationTestStore(t, t.Context(), cfg.Project.ID, issue, now)
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
+			orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, &recordingWorkAttemptStore{}, now)
+			state := newState(cfg)
+			runCtx, stop := context.WithCancelCause(t.Context())
+			state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: attemptID, Generation: 38, stop: stop}
+			if err := orch.updateIssueState(t.Context(), &state, issue, parked.State, now, "gate_transition", laneMutationPreserveOwnership); err != nil {
+				t.Fatal(err)
+			}
+			observedAt := now
+			if tt.later {
+				observedAt = observedAt.Add(time.Minute)
+			}
+			parked.StageUpdatedAt = &observedAt
+			parked.StageUpdatedActor = connector.IssueActor{Login: "shared-token", Kind: "User"}
+			tracker.stateIssues = []connector.Issue{parked}
+			if tt.restarted {
+				running := state.Running[issue.ID]
+				running.laneMutation = store.LaneMutationReceipt{}
+				state.Running[issue.ID] = running
+			}
+			orch.reconcileRunningIssues(t.Context(), &state, observedAt)
+			if revoked := errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked); revoked != tt.later {
+				t.Fatalf("revoked = %v, want %v", revoked, tt.later)
+			}
+			if tt.later {
+				pending := orch.pendingLaneRevocations[issue.ID]
+				if pending == nil || pending.origin != provenance.OriginIndeterminate || pending.mutation.ID != 0 {
+					t.Fatalf("later shared-token change borrowed previous Detent attribution: %#v", pending)
+				}
+			}
+		})
+	}
+}
+
 func TestGatePromotionReceiptSurvivesRestartAndCompletionFence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/lane_mutation_test.go
+++ b/internal/orchestrator/lane_mutation_test.go
@@ -69,11 +69,15 @@ func TestLaneMutationReceiptDistinguishesEchoFromLaterReentry(t *testing.T) {
 		name      string
 		later     bool
 		restarted bool
+		project   bool
 	}{
 		{name: "cached Detent echo"},
 		{name: "persisted Detent echo", restarted: true},
 		{name: "cached later operator reentry", later: true},
 		{name: "persisted later operator reentry", later: true, restarted: true},
+		{name: "cached project echo", project: true},
+		{name: "persisted project echo", project: true, restarted: true},
+		{name: "later project reentry", project: true, later: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -86,19 +90,28 @@ func TestLaneMutationReceiptDistinguishesEchoFromLaterReentry(t *testing.T) {
 			runtimeStore, attemptID := openLaneMutationTestStore(t, t.Context(), cfg.Project.ID, issue, now)
 			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
 			orch := newLaneMutationTestOrchestrator(cfg, tracker, runtimeStore, &recordingWorkAttemptStore{}, now)
+			confirmedAt := now
+			if tt.project {
+				confirmedAt = now.Add(2 * time.Second)
+				parked.StageUpdatedAt = &confirmedAt
+				orch.connector = &workflowMetricsConnector{stateIssues: []connector.Issue{parked}}
+			}
 			state := newState(cfg)
 			runCtx, stop := context.WithCancelCause(t.Context())
 			state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: attemptID, Generation: 38, stop: stop}
 			if err := orch.updateIssueState(t.Context(), &state, issue, parked.State, now, "gate_transition", laneMutationPreserveOwnership); err != nil {
 				t.Fatal(err)
 			}
-			observedAt := now
+			observedAt := confirmedAt
 			if tt.later {
 				observedAt = observedAt.Add(time.Minute)
 			}
 			parked.StageUpdatedAt = &observedAt
 			parked.StageUpdatedActor = connector.IssueActor{Login: "shared-token", Kind: "User"}
 			tracker.stateIssues = []connector.Issue{parked}
+			if tt.project {
+				orch.connector.(*workflowMetricsConnector).stateIssues = []connector.Issue{parked}
+			}
 			if tt.restarted {
 				running := state.Running[issue.ID]
 				running.laneMutation = store.LaneMutationReceipt{}

--- a/internal/orchestrator/lane_preservation_test.go
+++ b/internal/orchestrator/lane_preservation_test.go
@@ -1,0 +1,158 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestLaneRevocationRetainsWorkspaceForEveryWriter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source provenance.Source
+		pushed bool
+	}{
+		{name: "operator unpushed", source: provenance.SourceHumanSession},
+		{name: "operator pushed", source: provenance.SourceHumanSession, pushed: true},
+		{name: "Detent unpushed", source: provenance.SourceDetentInstance},
+		{name: "Detent pushed", source: provenance.SourceDetentInstance, pushed: true},
+		{name: "agent unpushed", source: provenance.SourceDetentAgentSession},
+		{name: "external automation unpushed", source: provenance.SourceExternalAutomation},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 4, 4, 11, 0, 0, time.UTC)
+			issue := laneRevocationIssue("retention", "digitaldrywood/detent#2138", "In Progress")
+			parked := cloneIssue(issue)
+			parked.State = "Done"
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
+			attempts := &recordingWorkAttemptStore{}
+			retention := &laneRetentionProbe{t: t, result: workspace.Preservation{
+				Path: "/retained/workspace", Branch: "detent/2138", HeadSHA: "abc123", Preserved: true,
+				UnpushedCommits: 1, TrackedPaths: []string{"implementation.go"},
+			}}
+			cfg := laneMutationTestConfig()
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, reaper: retention,
+				logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return now }}
+			state := newState(cfg)
+			runCtx, stop := context.WithCancelCause(t.Context())
+			state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: 2138, Generation: 38,
+				StartedAt: now.Add(-time.Hour), WorkProductPushed: tt.pushed, stop: stop}
+			state.Claimed[issue.ID] = Claimed{Issue: issue}
+			attribution := provenance.AttributionFromSource(tt.source, provenance.Actor{Login: "writer", Kind: "User"})
+			state.laneProvenance[workflowLaneEntryKey(parked)] = attribution
+			orch.reconcileRunningIssues(t.Context(), &state, now)
+			if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+				t.Fatalf("worker cause = %v, want revocation", context.Cause(runCtx))
+			}
+			pending := orch.pendingLaneRevocations[issue.ID]
+			if pending == nil || !pending.reapDone {
+				t.Fatal("worker must be reaped before preservation")
+			}
+			orch.handleRunResult(runCtx, &state, runpkg.Completion{
+				IssueID: issue.ID, Request: runpkg.RunRequest{Issue: issue, WorkAttemptID: 2138, Generation: 38},
+				CompletedAt: now, Err: runpkg.ErrLaneRevoked, Result: runpkg.RunResult{FinalState: runpkg.FinalStateLaneRevoked},
+			})
+			if len(attempts.completions) != 1 || retention.preserveCalls != 1 || retention.reapCalls != 1 {
+				t.Fatalf("completions = %d, preservation calls = %d, reap calls = %d", len(attempts.completions), retention.preserveCalls, retention.reapCalls)
+			}
+			var metadata struct {
+				Preservation workspace.Preservation `json:"workspace_preservation"`
+				Revocation   struct {
+					Classification string                 `json:"classification"`
+					Provenance     provenance.Attribution `json:"provenance"`
+					WorkDiscarded  bool                   `json:"work_discarded"`
+				} `json:"lane_revocation"`
+			}
+			completion := attempts.completions[0]
+			if err := json.Unmarshal([]byte(completion.WorkerMetadataJSON), &metadata); err != nil {
+				t.Fatal(err)
+			}
+			wantClass, wantTerminal := laneRevocationPreservedClassification, store.WorkAttemptTerminalLaneRevoked
+			if tt.pushed {
+				wantClass, wantTerminal = laneRevocationDeliveredClassification, store.WorkAttemptTerminalDelivered
+			}
+			if completion.TerminalState != wantTerminal || metadata.Revocation.Classification != wantClass || metadata.Revocation.WorkDiscarded {
+				t.Fatalf("completion = %#v, metadata = %#v", completion, metadata)
+			}
+			if metadata.Preservation.Path != retention.result.Path || metadata.Revocation.Provenance.Initiator != attribution.Initiator {
+				t.Fatalf("retention/writer evidence = %#v", metadata)
+			}
+			if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "workspace_path: /retained/workspace") {
+				t.Fatalf("retention notice = %#v", tracker.comments)
+			}
+			if len(tracker.updates) != 0 || len(state.Running) != 0 || len(state.Claimed) != 0 || len(state.CleanupFailures) != 0 {
+				t.Fatal("revocation must release ownership without changing the tracker or reporting retention as a cleanup fault")
+			}
+			if !hasLaneRevocationEvent(state.RecentEvents, "workspace_reap_preserved") {
+				t.Fatal("terminal cleanup did not report preserved work")
+			}
+		})
+	}
+}
+
+func TestLaneRevocationRetriesFailedRetentionBeforeReleasingOwnership(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	issue := laneRevocationIssue("retention-retry", "digitaldrywood/detent#2138", "Blocked")
+	retention := &laneRetentionProbe{t: t, err: errors.New("retention record unavailable")}
+	attempts := &recordingWorkAttemptStore{}
+	orch := &Orchestrator{cfg: laneMutationTestConfig(), reaper: retention, workAttempts: attempts}
+	state := newState(orch.cfg)
+	running := Running{Issue: issue, WorkAttemptID: 2138, Generation: 38}
+	state.Running[issue.ID] = running
+	state.Claimed[issue.ID] = Claimed{Issue: issue}
+	pending := &pendingLaneRevocation{issue: issue, running: running, reapDone: true, mutationRead: true,
+		completion: &runpkg.Completion{IssueID: issue.ID, CompletedAt: now}}
+	orch.pendingLaneRevocations = map[string]*pendingLaneRevocation{issue.ID: pending}
+	orch.finishLaneRevocation(t.Context(), &state, pending)
+	if len(attempts.completions) != 0 || len(state.Running) != 1 || len(state.Claimed) != 1 {
+		t.Fatal("failed retention released durable ownership")
+	}
+	retention.result = workspace.Preservation{Path: "/retained/retry", Preserved: true, UnpushedCommits: 1}
+	retention.err = nil
+	orch.finishLaneRevocation(t.Context(), &state, pending)
+	if len(attempts.completions) != 1 || len(state.Running) != 0 || len(state.Claimed) != 0 || retention.preserveCalls != 2 {
+		t.Fatal("successful retention retry did not finish revocation exactly once")
+	}
+}
+
+type laneRetentionProbe struct {
+	t             *testing.T
+	result        workspace.Preservation
+	err           error
+	preserveCalls int
+	reapCalls     int
+}
+
+func (p *laneRetentionProbe) PreserveWorkspace(ctx context.Context, _ connector.Issue) (workspace.Preservation, error) {
+	p.t.Helper()
+	if err := ctx.Err(); err != nil {
+		p.t.Fatalf("preservation inherited worker cancellation: %v", err)
+	}
+	p.preserveCalls++
+	return p.result, p.err
+}
+
+func (p *laneRetentionProbe) ReapWorkspace(context.Context, connector.Issue) (WorkspaceReapResult, error) {
+	p.t.Helper()
+	if p.preserveCalls == 0 {
+		p.t.Fatal("cleanup preceded preservation")
+	}
+	p.reapCalls++
+	return WorkspaceReapResult{}, workspace.ErrWorkspacePreserved
+}

--- a/internal/orchestrator/lane_preservation_test.go
+++ b/internal/orchestrator/lane_preservation_test.go
@@ -21,9 +21,10 @@ func TestLaneRevocationRetainsWorkspaceForEveryWriter(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		source provenance.Source
-		pushed bool
+		name       string
+		source     provenance.Source
+		pushed     bool
+		filesystem bool
 	}{
 		{name: "operator unpushed", source: provenance.SourceHumanSession},
 		{name: "operator pushed", source: provenance.SourceHumanSession, pushed: true},
@@ -31,6 +32,7 @@ func TestLaneRevocationRetainsWorkspaceForEveryWriter(t *testing.T) {
 		{name: "Detent pushed", source: provenance.SourceDetentInstance, pushed: true},
 		{name: "agent unpushed", source: provenance.SourceDetentAgentSession},
 		{name: "external automation unpushed", source: provenance.SourceExternalAutomation},
+		{name: "filesystem artifact", source: provenance.SourceHumanSession, filesystem: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -45,6 +47,9 @@ func TestLaneRevocationRetainsWorkspaceForEveryWriter(t *testing.T) {
 				Path: "/retained/workspace", Branch: "detent/2138", HeadSHA: "abc123", Preserved: true,
 				UnpushedCommits: 1, TrackedPaths: []string{"implementation.go"},
 			}}
+			if tt.filesystem {
+				retention.result = workspace.Preservation{Path: "/retained/workspace", Preserved: true, Files: 1}
+			}
 			cfg := laneMutationTestConfig()
 			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, reaper: retention,
 				logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return now }}

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
 const (
@@ -23,7 +24,8 @@ const (
 	laneRevocationDetentErrorClass           = "detent_lane_revoked"
 	laneRevocationCompletionFenceUnavailable = "completion_fence_unavailable"
 	laneRevocationDeliveredClassification    = "delivered_before_revocation"
-	laneRevocationDiscardedClassification    = "unpushed_work_discarded"
+	laneRevocationPreservedClassification    = "unpushed_work_preserved"
+	laneRevocationUnverifiedClassification   = "work_preservation_unverified"
 	laneRevocationEmptyClassification        = "revoked_without_work"
 	laneRevocationDeliveryReceiptKind        = "pushed_work_product"
 )
@@ -51,21 +53,25 @@ type laneRevocationOutcome struct {
 }
 
 type pendingLaneRevocation struct {
-	issue         connector.Issue
-	fromState     string
-	toState       string
-	reason        string
-	origin        provenance.Origin
-	requestedAt   time.Time
-	generation    uint64
-	running       Running
-	completion    *runpkg.Completion
-	workerProcess procgroup.Identity
-	reapOutcome   procgroup.TerminationOutcome
-	reapDone      bool
-	reapErr       error
-	mutation      store.LaneMutationReceipt
-	mutationRead  bool
+	issue            connector.Issue
+	fromState        string
+	toState          string
+	reason           string
+	origin           provenance.Origin
+	requestedAt      time.Time
+	generation       uint64
+	running          Running
+	completion       *runpkg.Completion
+	workerProcess    procgroup.Identity
+	reapOutcome      procgroup.TerminationOutcome
+	reapDone         bool
+	reapErr          error
+	mutation         store.LaneMutationReceipt
+	mutationRead     bool
+	attribution      provenance.Attribution
+	preservation     *workspace.Preservation
+	preservationRead bool
+	preservationErr  error
 }
 
 func (o *Orchestrator) beginLaneRevocation(
@@ -141,6 +147,7 @@ func (o *Orchestrator) beginLaneRevocationWithMutation(
 		running:      running,
 		mutation:     receipt,
 		mutationRead: receipt.ID == 0,
+		attribution:  attribution,
 	}
 	o.pendingLaneRevocations[issueID] = pending
 	state.Running[issueID] = running
@@ -162,6 +169,10 @@ func (o *Orchestrator) beginLaneRevocationWithMutation(
 			"from_state", fromState,
 			"to_state", running.Issue.State,
 			"reason", pending.reason,
+			"lane_change_origin", pending.origin,
+			"lane_change_initiator", attribution.Initiator,
+			"lane_change_basis", attribution.Basis,
+			"lane_mutation_receipt_id", receipt.ID,
 			"grace", o.workerReapGrace,
 		)
 	}
@@ -275,6 +286,9 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 	if completedAt.IsZero() {
 		completedAt = o.clockNow().UTC()
 	}
+	if !o.preserveLaneRevocationWorkspace(ctx, state, pending, completedAt) {
+		return
+	}
 	o.heartbeats.remove(event.IssueID)
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	running.globalSlot = scheduler.Slot{}
@@ -292,25 +306,34 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 	running.Tokens = tokens
 	running.WorkProductPushed = running.WorkProductPushed || event.Result.PullRequestHeadPushed || event.Result.PullRequestUpdated
 	receipt := laneRevocationReceipt(event, running, completedAt)
-	outcome := classifyLaneRevocation(receipt, laneRevocationProducedWork(event, running, tokens), pending.reason, pending.origin)
+	workProduced := laneRevocationProducedWork(event, running, tokens) || laneRevocationLocalWork(pending.preservation)
+	outcome := classifyLaneRevocation(receipt, pending.preservation, workProduced, pending.reason, pending.origin)
 	metadata := map[string]any{"lane_revocation": map[string]any{
-		"classification":  outcome.classification,
-		"generation":      pending.generation,
-		"from_state":      pending.fromState,
-		"to_state":        pending.toState,
-		"reason":          pending.reason,
-		"origin":          pending.origin,
-		"requested_at":    pending.requestedAt,
-		"reap_outcome":    pending.reapOutcome,
-		"work_discarded":  outcome.workDiscarded,
-		"output_tokens":   tokens.OutputTokens,
-		"total_tokens":    tokens.TotalTokens,
-		"runtime_seconds": tokens.RuntimeSeconds,
-		"turns":           running.TurnCount,
-		"files_changed":   running.DiffStats.FilesChanged,
+		"classification":   outcome.classification,
+		"generation":       pending.generation,
+		"from_state":       pending.fromState,
+		"to_state":         pending.toState,
+		"reason":           pending.reason,
+		"origin":           pending.origin,
+		"provenance":       pending.attribution,
+		"mutation_receipt": pending.mutation,
+		"requested_at":     pending.requestedAt,
+		"reap_outcome":     pending.reapOutcome,
+		"work_discarded":   outcome.workDiscarded,
+		"output_tokens":    tokens.OutputTokens,
+		"total_tokens":     tokens.TotalTokens,
+		"runtime_seconds":  tokens.RuntimeSeconds,
+		"turns":            running.TurnCount,
+		"files_changed":    running.DiffStats.FilesChanged,
 	}}
 	if receipt != nil {
 		metadata["delivery_receipt"] = receipt
+	}
+	if pending.preservation != nil {
+		metadata["workspace_preservation"] = pending.preservation
+	}
+	if pending.preservationErr != nil {
+		metadata["workspace_preservation_error"] = pending.preservationErr.Error()
 	}
 	attemptCompleted := o.completeDurableWorkAttemptWithSessionState(
 		ctx,
@@ -372,7 +395,9 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 			RuntimeIdentity: running.RuntimeIdentity,
 		}
 		o.recordEfficiencyReceipt(ctx, running.Issue, completedAt)
-		o.reapWorkspace(ctx, state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates), completedAt)
+		if !workProduced || pending.preservation != nil && pending.preservation.Preserved {
+			o.reapWorkspace(ctx, state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates), completedAt)
+		}
 	}
 	if o.logger != nil {
 		o.logger.Info(
@@ -388,9 +413,42 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 	}
 }
 
+func (o *Orchestrator) preserveLaneRevocationWorkspace(ctx context.Context, state *State, pending *pendingLaneRevocation, at time.Time) bool {
+	if pending.preservationRead {
+		return true
+	}
+	preserver, ok := o.reaper.(runpkg.WorkspacePreserver)
+	if !ok {
+		pending.preservationErr = runpkg.ErrWorkspacePreservationUnavailable
+		pending.preservationRead = true
+		return true
+	}
+	preservationCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+	preservation, err := preserver.PreserveWorkspace(preservationCtx, pending.issue)
+	pending.preservation = &preservation
+	pending.preservationErr = err
+	pending.preservationRead = err == nil || preservation.Preserved ||
+		errors.Is(err, workspace.ErrMissingWorkspace) || errors.Is(err, runpkg.ErrWorkspacePreservationUnavailable)
+	if !pending.preservationRead {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      at,
+			Event:   "worker_lane_preservation_failed",
+			Message: "retaining worker ownership for " + issueLabel(pending.issue) + " until workspace preservation succeeds: " + err.Error(),
+		})
+	}
+	return pending.preservationRead
+}
+
+func laneRevocationLocalWork(preservation *workspace.Preservation) bool {
+	return preservation != nil && (preservation.UnpushedCommits > 0 || len(preservation.TrackedPaths) > 0 || len(preservation.UntrackedPaths) > 0)
+}
+
 func laneRevocationAttribution(state *State, issue connector.Issue) provenance.Attribution {
 	if state != nil {
-		if attribution, ok := state.laneProvenance[workflowLaneEntryKey(issue)]; ok {
+		key := workflowLaneEntryKey(issue)
+		current := issue.StageUpdatedAt == nil || issue.StageUpdatedAt.IsZero() || !issue.StageUpdatedAt.After(state.laneEntries[key])
+		if attribution, ok := state.laneProvenance[key]; ok && current {
 			attribution = provenance.Prepare(attribution)
 			if provenance.NormalizeOrigin(attribution.Origin) != provenance.OriginIndeterminate {
 				return attribution
@@ -436,7 +494,7 @@ func laneRevocationReceipt(event runpkg.Completion, running Running, completedAt
 	return receipt
 }
 
-func classifyLaneRevocation(receipt *laneRevocationDeliveryReceipt, workProduced bool, reason string, origin provenance.Origin) laneRevocationOutcome {
+func classifyLaneRevocation(receipt *laneRevocationDeliveryReceipt, preservation *workspace.Preservation, workProduced bool, reason string, origin provenance.Origin) laneRevocationOutcome {
 	if receipt != nil && receipt.Schema == 1 && receipt.Kind == laneRevocationDeliveryReceiptKind {
 		return laneRevocationOutcome{
 			classification:    laneRevocationDeliveredClassification,
@@ -459,10 +517,15 @@ func classifyLaneRevocation(receipt *laneRevocationDeliveryReceipt, workProduced
 		activityEvent:     "worker_lane_revoked",
 	}
 	if workProduced {
-		outcome.classification = laneRevocationDiscardedClassification
-		outcome.activityEvent = "worker_lane_output_discarded"
+		outcome.classification = laneRevocationUnverifiedClassification
+		outcome.activityEvent = "worker_lane_preservation_unverified"
+		outcome.statusMessage = "worker stopped; workspace preservation could not be verified"
 		outcome.comment = true
-		outcome.workDiscarded = true
+		if preservation != nil && preservation.Preserved {
+			outcome.classification = laneRevocationPreservedClassification
+			outcome.activityEvent = "worker_lane_workspace_preserved"
+			outcome.statusMessage = "worker stopped; local workspace retained for recovery"
+		}
 	}
 	return outcome
 }
@@ -495,8 +558,8 @@ func (o *Orchestrator) reportLaneRevocationOutcome(
 	message := "worker for " + issueLabel(running.Issue) + " was stopped after a " + origin + " lane change from " + pending.fromState + " to " + pending.toState
 	if outcome.terminalState == store.WorkAttemptTerminalDelivered {
 		message = "pushed work for " + issueLabel(running.Issue) + " was preserved after finalization was rejected by a " + origin + " lane change from " + pending.fromState + " to " + pending.toState
-	} else if outcome.workDiscarded {
-		message = "unpushed worker output for " + issueLabel(running.Issue) + " was discarded after a " + origin + " lane change from " + pending.fromState + " to " + pending.toState
+	} else if outcome.classification == laneRevocationPreservedClassification {
+		message = "local workspace for " + issueLabel(running.Issue) + " was retained after a " + origin + " lane change from " + pending.fromState + " to " + pending.toState
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      at,
@@ -530,9 +593,12 @@ func laneRevocationOutcomeComment(
 	if outcome.terminalState == store.WorkAttemptTerminalDelivered {
 		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. Your work was pushed but finalization was rejected; the pushed work remains available.")
 		b.WriteString("\n\n- reason: worker_lane_revocation_delivery_preserved")
+	} else if outcome.classification == laneRevocationPreservedClassification {
+		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. The local workspace is retained for recovery, including unpushed commits and uncommitted files. Finalization was rejected; the work has not been delivered.")
+		b.WriteString("\n\n- reason: worker_lane_revocation_workspace_preserved")
 	} else {
-		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. The session produced work that was not pushed and could not be delivered.")
-		b.WriteString("\n\n- reason: worker_lane_revocation_output_discarded")
+		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. Workspace preservation could not be verified. The session's output is not evidence that local work was discarded.")
+		b.WriteString("\n\n- reason: worker_lane_revocation_preservation_unverified")
 	}
 	b.WriteString("\n- classification: ")
 	b.WriteString(outcome.classification)
@@ -540,6 +606,30 @@ func laneRevocationOutcomeComment(
 	b.WriteString(pending.reason)
 	b.WriteString("\n- lane_change_origin: ")
 	b.WriteString(string(provenance.NormalizeOrigin(pending.origin)))
+	b.WriteString("\n- lane_change_initiator: ")
+	b.WriteString(string(pending.attribution.Initiator))
+	b.WriteString("\n- lane_change_basis: ")
+	b.WriteString(string(pending.attribution.Basis))
+	if pending.attribution.Actor != nil {
+		b.WriteString("\n- lane_change_actor: ")
+		b.WriteString(pending.attribution.Actor.Login)
+	}
+	if pending.mutation.ID > 0 {
+		b.WriteString("\n- lane_mutation_receipt_id: ")
+		b.WriteString(strconv.FormatInt(pending.mutation.ID, 10))
+		b.WriteString("\n- lane_mutation_disposition: ")
+		b.WriteString(string(pending.mutation.Disposition))
+	}
+	if pending.preservation != nil {
+		b.WriteString("\n- workspace_path: ")
+		b.WriteString(pending.preservation.Path)
+		b.WriteString("\n- workspace_head: ")
+		b.WriteString(pending.preservation.HeadSHA)
+	}
+	if pending.preservationErr != nil {
+		b.WriteString("\n- preservation_error: ")
+		b.WriteString(pending.preservationErr.Error())
+	}
 	b.WriteString("\n- from_state: ")
 	b.WriteString(pending.fromState)
 	b.WriteString("\n- to_state: ")

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -441,7 +441,7 @@ func (o *Orchestrator) preserveLaneRevocationWorkspace(ctx context.Context, stat
 }
 
 func laneRevocationLocalWork(preservation *workspace.Preservation) bool {
-	return preservation != nil && (preservation.UnpushedCommits > 0 || len(preservation.TrackedPaths) > 0 || len(preservation.UntrackedPaths) > 0)
+	return preservation != nil && (preservation.Files > 0 || preservation.UnpushedCommits > 0 || len(preservation.TrackedPaths) > 0 || len(preservation.UntrackedPaths) > 0)
 }
 
 func laneRevocationAttribution(state *State, issue connector.Issue) provenance.Attribution {

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -113,6 +113,20 @@ func TestLaneRevocationPreservesTrackerDestination(t *testing.T) {
 	}
 }
 
+func TestLaneRevocationDoesNotInferWorkLoss(t *testing.T) {
+	t.Parallel()
+
+	for _, origin := range []provenance.Origin{provenance.OriginHuman, provenance.OriginDetent, provenance.OriginAgent, provenance.OriginIndeterminate} {
+		t.Run(string(origin), func(t *testing.T) {
+			t.Parallel()
+			outcome := classifyLaneRevocation(nil, nil, true, laneRevocationStateChanged, origin)
+			if outcome.workDiscarded {
+				t.Fatal("revocation declares unpushed output discarded without inspecting or removing the workspace")
+			}
+		})
+	}
+}
+
 func TestLaneRevocationPreservesPushedWork(t *testing.T) {
 	t.Parallel()
 
@@ -275,12 +289,12 @@ func TestClassifyLaneRevocationDrivesAllOutcomeSurfaces(t *testing.T) {
 		{
 			name:          "genuinely unpushed work",
 			workProduced:  true,
-			wantClass:     laneRevocationDiscardedClassification,
+			wantClass:     laneRevocationUnverifiedClassification,
 			wantTerminal:  store.WorkAttemptTerminalLaneRevoked,
 			wantSession:   runpkg.FinalStateLaneRevoked,
-			wantEvent:     "worker_lane_output_discarded",
+			wantEvent:     "worker_lane_preservation_unverified",
 			wantComment:   true,
-			wantDiscarded: true,
+			wantDiscarded: false,
 		},
 		{
 			name:         "revoked before work",
@@ -295,7 +309,7 @@ func TestClassifyLaneRevocationDrivesAllOutcomeSurfaces(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := classifyLaneRevocation(tt.receipt, tt.workProduced, laneRevocationStateChanged, provenance.OriginHuman)
+			got := classifyLaneRevocation(tt.receipt, nil, tt.workProduced, laneRevocationStateChanged, provenance.OriginHuman)
 			if got.classification != tt.wantClass || got.terminalState != tt.wantTerminal || got.sessionFinalState != tt.wantSession {
 				t.Fatalf("classification = %#v, want class %q terminal %q session %q", got, tt.wantClass, tt.wantTerminal, tt.wantSession)
 			}
@@ -447,7 +461,7 @@ func TestCompletionLaneHandshakeClassifiesCurrentAttempt(t *testing.T) {
 	}
 }
 
-func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
+func TestLaneRevocationRecordsOriginAndUnverifiedWork(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 18, 19, 20, 0, 0, time.UTC)
@@ -589,19 +603,19 @@ func TestLaneRevocationRecordsOriginAndDiscardedWork(t *testing.T) {
 			if err := json.Unmarshal([]byte(completion.WorkerMetadataJSON), &metadata); err != nil {
 				t.Fatalf("decode worker metadata: %v", err)
 			}
-			if metadata.LaneRevocation.Origin != tt.wantOrigin || !metadata.LaneRevocation.WorkDiscarded || metadata.LaneRevocation.OutputTokens != 13_422 {
-				t.Fatalf("lane revocation metadata = %#v, want origin %q and discarded output", metadata.LaneRevocation, tt.wantOrigin)
+			if metadata.LaneRevocation.Origin != tt.wantOrigin || metadata.LaneRevocation.WorkDiscarded || metadata.LaneRevocation.OutputTokens != 13_422 {
+				t.Fatalf("lane revocation metadata = %#v, want origin %q without declaring discarded output", metadata.LaneRevocation, tt.wantOrigin)
 			}
 			if len(tracker.comments) != 1 {
-				t.Fatalf("comments = %#v, want discarded-work notice", tracker.comments)
+				t.Fatalf("comments = %#v, want preservation-unverified notice", tracker.comments)
 			}
 			for _, fragment := range []string{tt.wantReason, "lane_change_origin: " + string(tt.wantOrigin), "output_tokens: 13422", "runtime_seconds: 397"} {
 				if !strings.Contains(tracker.comments[0].body, fragment) {
 					t.Fatalf("comment %q missing %q", tracker.comments[0].body, fragment)
 				}
 			}
-			if !hasLaneRevocationEvent(state.RecentEvents, "worker_lane_output_discarded") {
-				t.Fatalf("RecentEvents = %#v, want discarded output event", state.RecentEvents)
+			if !hasLaneRevocationEvent(state.RecentEvents, "worker_lane_preservation_unverified") {
+				t.Fatalf("RecentEvents = %#v, want preservation-unverified event", state.RecentEvents)
 			}
 		})
 	}

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
 type workspaceCleanupDiagnostic interface {
@@ -86,6 +87,7 @@ func (o *Orchestrator) reconcileResidualWorkspaces(ctx context.Context, state *S
 			slog.Int("affected_path_count", len(state.CleanupFailures)),
 			slog.Int("removed", result.Removed),
 			slog.Int("active_skipped", result.ActiveSkipped),
+			slog.Int("preserved_skipped", result.PreservedSkipped),
 			slog.Int("registered_skipped", result.RegisteredSkipped),
 			slog.Int("unowned_skipped", result.UnownedSkipped),
 			slog.Any("error", err),
@@ -370,6 +372,14 @@ func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue co
 		return false
 	}
 	result, err := o.reaper.ReapWorkspace(ctx, issue)
+	if errors.Is(err, workspace.ErrWorkspacePreserved) {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(now),
+			Event:   "workspace_reap_preserved",
+			Message: "workspace retained for " + issueLabel(issue) + ": " + err.Error(),
+		})
+		return false
+	}
 	if err != nil {
 		args := []any{
 			slog.String("issue_id", issue.ID),

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -304,7 +304,7 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 		mergeWorker := running.Mode == runpkg.RunModeMerge || mergeWorkerIssue(running.Issue)
 		refreshedRunning := running
 		refreshedRunning.Issue = o.hydrateRunningIssueComments(ctx, mergeIssueTrackerFields(running.Issue, issue))
-		receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, running, refreshedRunning.Issue.State)
+		receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, running, refreshedRunning.Issue)
 		if receiptErr != nil {
 			if o.logger != nil {
 				o.logger.Warn("running issue lane mutation receipt lookup failed", "issue_id", id, "error", receiptErr)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -159,7 +159,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			}
 		} else {
 			receiptAccepted := false
-			receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, running, refreshed.State)
+			receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, running, refreshed)
 			if receiptErr != nil {
 				o.rejectWorkerCompletion(ctx, state, event, running, "lane mutation receipt is unavailable", receiptErr)
 				return

--- a/internal/orchestrator/targeted_reconcile.go
+++ b/internal/orchestrator/targeted_reconcile.go
@@ -78,7 +78,7 @@ func (o *Orchestrator) applyTargetedReconcile(
 	if running, ok := state.Running[issue.ID]; ok &&
 		(!stateIn(running.Issue.State, o.cfg.ActiveStates) || workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates)) {
 		if hadRunning {
-			receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, priorRunning, running.Issue.State)
+			receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, priorRunning, running.Issue)
 			if receiptErr != nil {
 				if o.logger != nil {
 					o.logger.Warn("targeted lane mutation receipt lookup failed", "issue_id", issue.ID, "error", receiptErr)

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -242,6 +242,7 @@ func (o *Orchestrator) confirmTrackerStateTransition(
 	transitioned.StageUpdatedAt = nil
 	transitioned.StageUpdatedActor = connector.IssueActor{}
 	if reader, ok := o.connector.(connector.IssueStateTransitionReader); ok && reader != nil {
+		allowStateFetch = true
 		transition, found, err := reader.IssueStateTransition(ctx, transitioned)
 		if err != nil {
 			if o.logger != nil {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -189,13 +189,15 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		}
 		return errors.Join(err, o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerFailed, at, err))
 	}
-	receiptErr := o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerApplied, at, nil)
-	if metadata.BlockedRecovery != nil {
-		mutationAt, ok := o.confirmTrackerStateTransition(ctx, issueID, issue, targetState)
+	transitionAt := at
+	if normalizeState(issue.State) != normalizeState(targetState) {
+		mutationAt, ok := o.confirmTrackerStateTransition(ctx, issueID, issue, targetState, metadata.BlockedRecovery != nil)
 		if ok {
 			metadata.TrackerMutationAt = mutationAt.Format(time.RFC3339Nano)
+			transitionAt = mutationAt
 		}
 	}
+	receiptErr := o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerApplied, transitionAt, nil)
 	if stateIn(targetState, o.cfg.TerminalStates) {
 		terminalIssue := cloneIssue(issue)
 		if strings.TrimSpace(terminalIssue.ID) == "" {
@@ -212,8 +214,8 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		}
 		o.clearMergeRequiredCheckStreaks(ctx, terminalIssue)
 	}
-	updateIssueStateSnapshots(state, issueID, issue, targetState, at)
-	recordIssueStateMutationProvenance(state, issueID, issue, targetState, at, reason, metadata)
+	updateIssueStateSnapshots(state, issueID, issue, targetState, transitionAt)
+	recordIssueStateMutationProvenance(state, issueID, issue, targetState, transitionAt, reason, metadata)
 	if strings.TrimSpace(issue.ID) == "" {
 		issue.ID = issueID
 	}
@@ -222,7 +224,7 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		o.captureReworkLesson(issue, at, reason)
 	}
 	if leased {
-		o.applyLaneMutationDisposition(ctx, state, running, receipt, issue, at)
+		o.applyLaneMutationDisposition(ctx, state, running, receipt, issue, transitionAt)
 	}
 	return receiptErr
 }
@@ -232,6 +234,7 @@ func (o *Orchestrator) confirmTrackerStateTransition(
 	issueID string,
 	issue connector.Issue,
 	targetState string,
+	allowStateFetch bool,
 ) (time.Time, bool) {
 	transitioned := cloneIssue(issue)
 	transitioned.ID = strings.TrimSpace(firstNonBlank(transitioned.ID, issueID))
@@ -247,6 +250,9 @@ func (o *Orchestrator) confirmTrackerStateTransition(
 		} else if found && !transition.EnteredAt.IsZero() {
 			return transition.EnteredAt.UTC(), true
 		}
+	}
+	if !allowStateFetch {
+		return time.Time{}, false
 	}
 
 	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{issueID})
@@ -437,6 +443,7 @@ func recordIssueStateMutationProvenance(
 func workflowLaneMutationAttribution(reason string, metadata workflowLaneMetadata) provenance.Attribution {
 	attribution := metadata.Provenance
 	if attribution.Origin == "" {
+		attribution = provenance.AttributionFromSource(provenance.SourceDetentInstance, provenance.Actor{})
 		attribution.Origin = workflowOriginForReason(reason)
 	}
 	return provenance.Prepare(attribution)

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -643,6 +643,45 @@ func TestUpdateIssueStateRecordsTrackerMutationConfirmation(t *testing.T) {
 	}
 }
 
+func TestDetentLaneWriteEchoKeepsWriter(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range []string{"Blocked", "Rework", "Merging"} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			requestedAt := time.Date(2026, 9, 4, 4, 11, 0, 0, time.UTC)
+			trackerAt := requestedAt.Add(2 * time.Second)
+			issue := laneRevocationIssue("echo", "digitaldrywood/detent#2138", "In Progress")
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			tracker := &workflowMetricsConnector{stateEnteredAt: trackerAt, stateEnteredAtFound: true}
+			orch := &Orchestrator{cfg: normalizeConfig(Config{}), connector: tracker, workflowMetrics: metrics}
+			state := newState(orch.cfg)
+			state.BoardIssues = []connector.Issue{issue}
+			if err := orch.updateIssueState(t.Context(), &state, issue, target, requestedAt, "machine_transition"); err != nil {
+				t.Fatal(err)
+			}
+			issue.State = target
+			issue.StageUpdatedAt = &trackerAt
+			issue.StageUpdatedActor = connector.IssueActor{Login: "shared-token", Kind: "User"}
+			state.BoardIssues = []connector.Issue{issue}
+			orch.refreshCurrentLaneEntries(t.Context(), &state, requestedAt.Add(time.Minute))
+			if got := len(metrics.snapshot()); got != 2 {
+				t.Fatalf("events after write echo = %d, want only the original exit and entry", got)
+			}
+			if got := laneRevocationAttribution(&state, issue); got.Origin != provenance.OriginDetent || got.Basis != provenance.BasisDetentOperation {
+				t.Fatalf("write echo attribution = %#v, want Detent", got)
+			}
+			later := trackerAt.Add(time.Minute)
+			issue.StageUpdatedAt = &later
+			state.BoardIssues = []connector.Issue{issue}
+			orch.refreshCurrentLaneEntries(t.Context(), &state, later)
+			if got := laneRevocationAttribution(&state, issue); got.Origin != provenance.OriginIndeterminate {
+				t.Fatalf("later shared-token reentry attribution = %#v, want indeterminate", got)
+			}
+		})
+	}
+}
+
 func TestUpdateIssueStateByIDCapturesReworkLesson(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -99,7 +99,7 @@ func TestApplyAutoPromoteDecisionUpdatesSnapshotBeforePoll(t *testing.T) {
 				State:          "In Progress",
 				StageUpdatedAt: &previousStageAt,
 			}
-			tracker := &workflowMetricsConnector{name: tt.trackerName}
+			tracker := &workflowMetricsConnector{name: tt.trackerName, stateEnteredAt: transitionAt, stateEnteredAtFound: true}
 			orch := &Orchestrator{connector: tracker}
 			state := newState(Config{})
 			state.BoardIssues = []connector.Issue{cloneIssue(issue)}
@@ -646,14 +646,29 @@ func TestUpdateIssueStateRecordsTrackerMutationConfirmation(t *testing.T) {
 func TestDetentLaneWriteEchoKeepsWriter(t *testing.T) {
 	t.Parallel()
 
-	for _, target := range []string{"Blocked", "Rework", "Merging"} {
-		t.Run(target, func(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		target          string
+		labelTransition bool
+	}{
+		{"label blocked", "Blocked", true},
+		{"label rework", "Rework", true},
+		{"label merging", "Merging", true},
+		{"project blocked", "Blocked", false},
+		{"project rework", "Rework", false},
+		{"project merging", "Merging", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			target := tt.target
 			t.Parallel()
 			requestedAt := time.Date(2026, 9, 4, 4, 11, 0, 0, time.UTC)
 			trackerAt := requestedAt.Add(2 * time.Second)
 			issue := laneRevocationIssue("echo", "digitaldrywood/detent#2138", "In Progress")
 			metrics := &autoPromoteWorkflowMetricsRecorder{}
-			tracker := &workflowMetricsConnector{stateEnteredAt: trackerAt, stateEnteredAtFound: true}
+			confirmed := cloneIssue(issue)
+			confirmed.State = target
+			confirmed.StageUpdatedAt = &trackerAt
+			tracker := &workflowMetricsConnector{stateEnteredAt: trackerAt, stateEnteredAtFound: tt.labelTransition, stateIssues: []connector.Issue{confirmed}}
 			orch := &Orchestrator{cfg: normalizeConfig(Config{}), connector: tracker, workflowMetrics: metrics}
 			state := newState(orch.cfg)
 			state.BoardIssues = []connector.Issue{issue}
@@ -911,7 +926,7 @@ func (c *workflowMetricsConnector) FetchIssuesByStates(_ context.Context, states
 
 func (c *workflowMetricsConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
 	c.fetches++
-	return nil, nil
+	return cloneIssues(c.stateIssues), nil
 }
 
 func (c *workflowMetricsConnector) CreateComment(context.Context, string, string) error {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -3121,6 +3121,7 @@ func (r *Runner) ReconcileWorkspaces(ctx context.Context, activeIssues []connect
 	return WorkspaceReconcileResult{
 		Removed:           result.Removed,
 		ActiveSkipped:     result.ActiveSkipped,
+		PreservedSkipped:  result.PreservedSkipped,
 		RegisteredSkipped: result.RegisteredSkipped,
 		UnownedSkipped:    result.UnownedSkipped,
 		CompletedPaths:    result.CompletedPaths,

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -301,6 +301,7 @@ type WorkspaceCleanupFailure struct {
 type WorkspaceReconcileResult struct {
 	Removed           int
 	ActiveSkipped     int
+	PreservedSkipped  int
 	RegisteredSkipped int
 	UnownedSkipped    int
 	CompletedPaths    []string

--- a/internal/runner/workspace_preservation.go
+++ b/internal/runner/workspace_preservation.go
@@ -1,0 +1,23 @@
+package runner
+
+import (
+	"context"
+	"errors"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+var ErrWorkspacePreservationUnavailable = errors.New("workspace backend does not support retention")
+
+type WorkspacePreserver interface {
+	PreserveWorkspace(context.Context, connector.Issue) (workspace.Preservation, error)
+}
+
+func (r *Runner) PreserveWorkspace(ctx context.Context, issue connector.Issue) (workspace.Preservation, error) {
+	preserver, ok := r.workspace.(workspace.IssuePreserver)
+	if !ok {
+		return workspace.Preservation{}, ErrWorkspacePreservationUnavailable
+	}
+	return preserver.PreserveIssue(ctx, workspaceIssue(r.projectID, issue))
+}

--- a/internal/runner/workspace_preservation_test.go
+++ b/internal/runner/workspace_preservation_test.go
@@ -1,0 +1,50 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestRunnerPreservesWorkspaceThroughBackend(t *testing.T) {
+	t.Parallel()
+
+	for _, supported := range []bool{true, false} {
+		name := "unsupported"
+		if supported {
+			name = "supported"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			probe := &workspacePreservationProbe{}
+			runner := &Runner{projectID: "detent", workspace: probe}
+			if !supported {
+				runner.workspace = &fakeWorkspaceBackend{}
+			}
+			issue := connector.Issue{ID: "2138", Identifier: "digitaldrywood/detent#2138"}
+			result, err := runner.PreserveWorkspace(t.Context(), issue)
+			if !supported {
+				if !errors.Is(err, ErrWorkspacePreservationUnavailable) || result.Preserved {
+					t.Fatalf("unsupported preservation = %#v, error = %v", result, err)
+				}
+				return
+			}
+			if err != nil || !result.Preserved || result.Path != "/retained/2138" || probe.issue.ID != issue.ID || probe.issue.ProjectID != "detent" {
+				t.Fatalf("preservation = %#v, issue = %#v, error = %v", result, probe.issue, err)
+			}
+		})
+	}
+}
+
+type workspacePreservationProbe struct {
+	fakeWorkspaceBackend
+	issue workspace.Issue
+}
+
+func (p *workspacePreservationProbe) PreserveIssue(_ context.Context, issue workspace.Issue) (workspace.Preservation, error) {
+	p.issue = issue
+	return workspace.Preservation{Path: "/retained/2138", Preserved: true}, nil
+}

--- a/internal/workspace/cleanup_registry.go
+++ b/internal/workspace/cleanup_registry.go
@@ -28,6 +28,7 @@ type cleanupOwnershipRecord struct {
 	Identifier      string `json:"identifier,omitempty"`
 	Branch          string `json:"branch,omitempty"`
 	SourceCommonDir string `json:"source_common_dir"`
+	Preserve        bool   `json:"preserve,omitempty"`
 }
 
 func (l *LocalGit) recordCleanupOwnership(ctx context.Context, info Info, issue Issue, isDir bool) error {
@@ -60,6 +61,13 @@ func (l *LocalGit) recordCleanupOwnership(ctx context.Context, info Info, issue 
 	}
 	if record.Identifier != "" && issueKey(issue) != record.Key {
 		return fmt.Errorf("cleanup ownership issue does not match workspace key %q", record.Key)
+	}
+	previous, err := l.readOwnershipRecord(cleanupOwnershipRecordRelativePath(path))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read previous cleanup ownership: %w", err)
+	}
+	if l.validOwnershipRecord(ctx, cleanupOwnershipRecordRelativePath(path), previous) {
+		record.Preserve = previous.Preserve
 	}
 	if err := l.writeOwnershipRecord(record); err != nil {
 		return fmt.Errorf("record cleanup ownership: %w", err)
@@ -226,6 +234,10 @@ func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue)
 		}
 		if _, active := activeKeys[record.Key]; active {
 			result.ActiveSkipped++
+			continue
+		}
+		if record.Preserve {
+			result.PreservedSkipped++
 			continue
 		}
 		exists, _, statErr := pathExists(record.Path)

--- a/internal/workspace/filesystem.go
+++ b/internal/workspace/filesystem.go
@@ -146,6 +146,9 @@ func (f *Filesystem) CleanupIssue(ctx context.Context, issue Issue) (CleanupResu
 	if !exists {
 		return result, nil
 	}
+	if err := f.checkPreservedWorkspace(info); err != nil {
+		return result, err
+	}
 	result.Processes = reapWorkspaceProcesses(ctx, info.Path, f.logger)
 	if err := f.runHook(ctx, "before_remove", f.hooks.BeforeRemove, info, issue); err != nil {
 		f.logger.Warn("filesystem workspace before_remove hook failed", slog.String("path", info.Path), slog.Any("error", err))

--- a/internal/workspace/preservation.go
+++ b/internal/workspace/preservation.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 var ErrWorkspacePreserved = errors.New("workspace retained for recovery")
@@ -13,6 +17,7 @@ type Preservation struct {
 	Path            string   `json:"path"`
 	Branch          string   `json:"branch,omitempty"`
 	Preserved       bool     `json:"preserved"`
+	Files           int      `json:"files,omitempty"`
 	HeadSHA         string   `json:"head_sha,omitempty"`
 	UnpushedCommits int      `json:"unpushed_commits,omitempty"`
 	TrackedPaths    []string `json:"tracked_paths,omitempty"`
@@ -53,7 +58,10 @@ func (l *LocalGit) PreserveIssue(ctx context.Context, issue Issue) (Preservation
 		return result, fmt.Errorf("inspect retained workspace: %w", err)
 	}
 	result.HeadSHA = recovery.HeadSHA
-	result.UnpushedCommits = recovery.UnpushedCommits
+	result.UnpushedCommits, err = retainedGitCommitCount(ctx, info.Path)
+	if err != nil {
+		return result, err
+	}
 	result.TrackedPaths = recovery.TrackedPaths
 	result.UntrackedPaths = recovery.UntrackedPaths
 	return result, nil
@@ -81,8 +89,78 @@ func (l *LocalGit) checkPreservedWorkspace(ctx context.Context, info Info, issue
 	if err != nil {
 		return fmt.Errorf("%w at %s: %w", ErrWorkspacePreserved, info.Path, err)
 	}
-	if recovery.UnpushedCommits > 0 || len(recovery.TrackedPaths) > 0 || len(recovery.UntrackedPaths) > 0 {
+	unpushed, err := retainedGitCommitCount(ctx, info.Path)
+	if err != nil {
+		return fmt.Errorf("%w at %s: %w", ErrWorkspacePreserved, info.Path, err)
+	}
+	if unpushed > 0 || len(recovery.TrackedPaths) > 0 || len(recovery.UntrackedPaths) > 0 {
 		return fmt.Errorf("%w at %s: unpushed commits or uncommitted files remain", ErrWorkspacePreserved, info.Path)
 	}
 	return nil
+}
+
+func retainedGitCommitCount(ctx context.Context, path string) (int, error) {
+	output, err := runGitAt(ctx, path, "rev-list", "--count", "HEAD", "--not", "--remotes")
+	if err != nil {
+		return 0, fmt.Errorf("inspect retained commits: %w", err)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(output))
+	if err != nil {
+		return 0, fmt.Errorf("parse retained commit count: %w", err)
+	}
+	return count, nil
+}
+
+func (f *Filesystem) PreserveIssue(ctx context.Context, issue Issue) (Preservation, error) {
+	info, err := f.infoForIssue(issue)
+	if err != nil {
+		return Preservation{}, err
+	}
+	result := Preservation{Path: info.Path}
+	exists, isDir, err := pathExists(info.Path)
+	if err != nil {
+		return result, err
+	}
+	if !exists {
+		return result, ErrMissingWorkspace
+	}
+	if !isDir {
+		return result, fmt.Errorf("filesystem workspace is not a directory: %s", info.Path)
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	root, err := os.OpenRoot(f.root)
+	if err != nil {
+		return result, err
+	}
+	defer f.closeRoot("preservation", root)
+	if err := root.MkdirAll(filesystemRetentionPath(info), 0o700); err != nil {
+		return result, fmt.Errorf("retain filesystem workspace: %w", err)
+	}
+	result.Preserved = true
+	stat, err := f.DiffStat(ctx, info, issue)
+	if err != nil {
+		return result, fmt.Errorf("inspect retained filesystem workspace: %w", err)
+	}
+	result.Files = stat.Files
+	return result, nil
+}
+
+func (f *Filesystem) checkPreservedWorkspace(info Info) error {
+	root, err := os.OpenRoot(f.root)
+	if err != nil {
+		return err
+	}
+	defer f.closeRoot("preservation", root)
+	if _, err := root.Lstat(filesystemRetentionPath(info)); errors.Is(err, fs.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("read filesystem workspace retention: %w", err)
+	}
+	return fmt.Errorf("%w at %s: filesystem output requires explicit disposition", ErrWorkspacePreserved, info.Path)
+}
+
+func filesystemRetentionPath(info Info) string {
+	return filepath.Join(info.Key, ".detent", "retained")
 }

--- a/internal/workspace/preservation.go
+++ b/internal/workspace/preservation.go
@@ -1,0 +1,88 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+)
+
+var ErrWorkspacePreserved = errors.New("workspace retained for recovery")
+
+type Preservation struct {
+	Path            string   `json:"path"`
+	Branch          string   `json:"branch,omitempty"`
+	Preserved       bool     `json:"preserved"`
+	HeadSHA         string   `json:"head_sha,omitempty"`
+	UnpushedCommits int      `json:"unpushed_commits,omitempty"`
+	TrackedPaths    []string `json:"tracked_paths,omitempty"`
+	UntrackedPaths  []string `json:"untracked_paths,omitempty"`
+}
+
+type IssuePreserver interface {
+	PreserveIssue(context.Context, Issue) (Preservation, error)
+}
+
+func (l *LocalGit) PreserveIssue(ctx context.Context, issue Issue) (Preservation, error) {
+	info, err := l.infoForIssue(issue)
+	if err != nil {
+		return Preservation{}, err
+	}
+	result := Preservation{Path: info.Path, Branch: info.Branch}
+	exists, isDir, err := pathExists(info.Path)
+	if err != nil {
+		return result, err
+	}
+	if !exists {
+		return result, ErrMissingWorkspace
+	}
+	if err := l.recordCleanupOwnership(ctx, info, issue, isDir); err != nil {
+		return result, err
+	}
+	record, err := l.readOwnershipRecord(cleanupOwnershipRecordRelativePath(info.Path))
+	if err != nil {
+		return result, err
+	}
+	record.Preserve = true
+	if err := l.writeOwnershipRecord(record); err != nil {
+		return result, fmt.Errorf("retain workspace ownership: %w", err)
+	}
+	result.Preserved = true
+	recovery, err := l.RecoveryState(ctx, info, issue)
+	if err != nil {
+		return result, fmt.Errorf("inspect retained workspace: %w", err)
+	}
+	result.HeadSHA = recovery.HeadSHA
+	result.UnpushedCommits = recovery.UnpushedCommits
+	result.TrackedPaths = recovery.TrackedPaths
+	result.UntrackedPaths = recovery.UntrackedPaths
+	return result, nil
+}
+
+func (l *LocalGit) checkPreservedWorkspace(ctx context.Context, info Info, issue Issue) error {
+	recordPath := cleanupOwnershipRecordRelativePath(info.Path)
+	record, err := l.readOwnershipRecord(recordPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read workspace retention: %w", err)
+	}
+	if !record.Preserve {
+		return nil
+	}
+	if !l.validOwnershipRecord(ctx, recordPath, record) {
+		return fmt.Errorf("invalid workspace retention record: %s", info.Path)
+	}
+	if !l.isSourceWorktree(ctx, info.Path) {
+		return fmt.Errorf("%w at %s: worktree registration is unavailable", ErrWorkspacePreserved, info.Path)
+	}
+	recovery, err := l.RecoveryState(ctx, info, issue)
+	if err != nil {
+		return fmt.Errorf("%w at %s: %w", ErrWorkspacePreserved, info.Path, err)
+	}
+	if recovery.UnpushedCommits > 0 || len(recovery.TrackedPaths) > 0 || len(recovery.UntrackedPaths) > 0 {
+		return fmt.Errorf("%w at %s: unpushed commits or uncommitted files remain", ErrWorkspacePreserved, info.Path)
+	}
+	return nil
+}

--- a/internal/workspace/preservation_test.go
+++ b/internal/workspace/preservation_test.go
@@ -1,0 +1,126 @@
+package workspace
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalGitPreservesRevokedWorkAcrossCleanupAndRestart(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []string{"tracked", "staged", "untracked", "unpushed", "pushed"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			remote := initBareRemote(t)
+			runGit(t, source, "remote", "add", "origin", remote)
+			runGit(t, source, "push", "-u", "origin", "main")
+			opts := LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true}
+			backend, err := NewLocalGit(opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := Issue{ProjectID: "detent", ID: "2138", Identifier: "digitaldrywood/detent#2138"}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			name := "README.md"
+			if kind == "untracked" {
+				name = "implementation.go"
+			}
+			content := []byte("completed worker implementation\n")
+			if err := os.WriteFile(filepath.Join(info.Path, name), content, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if kind == "staged" || kind == "unpushed" || kind == "pushed" {
+				runGit(t, info.Path, "add", name)
+			}
+			if kind == "unpushed" || kind == "pushed" {
+				runGit(t, info.Path, "commit", "-m", "completed implementation")
+			}
+			if kind == "pushed" {
+				runGit(t, info.Path, "push", "-u", "origin", info.Branch)
+			}
+			head := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
+			status := runGit(t, info.Path, "status", "--porcelain")
+			preserved, err := backend.PreserveIssue(t.Context(), issue)
+			if err != nil || !preserved.Preserved || preserved.Path != info.Path || preserved.HeadSHA != head {
+				t.Fatalf("preservation = %#v, error = %v", preserved, err)
+			}
+			backend, err = NewLocalGit(opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, cleanupErr := backend.CleanupIssue(t.Context(), issue)
+			if kind != "pushed" {
+				if !errors.Is(cleanupErr, ErrWorkspacePreserved) {
+					t.Fatalf("cleanup error = %v, want retained workspace", cleanupErr)
+				}
+				actual, err := os.ReadFile(filepath.Join(info.Path, name))
+				if err != nil || string(actual) != string(content) {
+					t.Fatalf("retained file = %q, error = %v", actual, err)
+				}
+				if got := runGit(t, info.Path, "status", "--porcelain"); got != status {
+					t.Fatalf("retained index/status = %q, want %q", got, status)
+				}
+				if got := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD")); got != head {
+					t.Fatalf("retained head = %q, want %q", got, head)
+				}
+				residual, err := backend.ReconcileResiduals(t.Context(), nil)
+				if err != nil || residual.Removed != 0 || residual.PreservedSkipped != 1 {
+					t.Fatalf("residual cleanup = %#v, error = %v", residual, err)
+				}
+				resumed, err := backend.Create(t.Context(), issue)
+				if err != nil || resumed.Path != info.Path || resumed.Created {
+					t.Fatalf("resumed workspace = %#v, error = %v", resumed, err)
+				}
+				if kind != "unpushed" {
+					runGit(t, info.Path, "add", name)
+					runGit(t, info.Path, "commit", "-m", "publish recovered implementation")
+				}
+				runGit(t, info.Path, "push", "-u", "origin", info.Branch)
+				_, cleanupErr = backend.CleanupIssue(t.Context(), issue)
+			}
+			if cleanupErr != nil {
+				t.Fatalf("cleanup after delivery: %v", cleanupErr)
+			}
+			if _, err := os.Stat(info.Path); !errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("delivered workspace remains: %v", err)
+			}
+		})
+	}
+}
+
+func TestLocalGitPreservationInspectionFailureKeepsFiles(t *testing.T) {
+	t.Parallel()
+	backend, err := NewLocalGit(LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: initSourceRepo(t), AutoBranch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	issue := Issue{Identifier: "detent#2138"}
+	info, err := backend.Create(t.Context(), issue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.PreserveIssue(t.Context(), issue); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(filepath.Join(info.Path, ".git"), filepath.Join(info.Path, "saved-git-pointer")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.CleanupIssue(t.Context(), issue); !errors.Is(err, ErrWorkspacePreserved) {
+		t.Fatalf("cleanup error = %v, want preservation on failed inspection", err)
+	}
+	result, err := backend.ReconcileResiduals(t.Context(), nil)
+	if err != nil || result.PreservedSkipped != 1 || result.Removed != 0 {
+		t.Fatalf("residual cleanup = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(filepath.Join(info.Path, "README.md")); err != nil {
+		t.Fatalf("retained file missing: %v", err)
+	}
+}

--- a/internal/workspace/preservation_test.go
+++ b/internal/workspace/preservation_test.go
@@ -12,13 +12,15 @@ import (
 func TestLocalGitPreservesRevokedWorkAcrossCleanupAndRestart(t *testing.T) {
 	t.Parallel()
 
-	for _, kind := range []string{"tracked", "staged", "untracked", "unpushed", "pushed"} {
+	for _, kind := range []string{"tracked", "staged", "untracked", "unpushed", "pushed", "local only"} {
 		t.Run(kind, func(t *testing.T) {
 			t.Parallel()
 			source := initSourceRepo(t)
 			remote := initBareRemote(t)
-			runGit(t, source, "remote", "add", "origin", remote)
-			runGit(t, source, "push", "-u", "origin", "main")
+			if kind != "local only" {
+				runGit(t, source, "remote", "add", "origin", remote)
+				runGit(t, source, "push", "-u", "origin", "main")
+			}
 			opts := LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true}
 			backend, err := NewLocalGit(opts)
 			if err != nil {
@@ -37,10 +39,10 @@ func TestLocalGitPreservesRevokedWorkAcrossCleanupAndRestart(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(info.Path, name), content, 0o600); err != nil {
 				t.Fatal(err)
 			}
-			if kind == "staged" || kind == "unpushed" || kind == "pushed" {
+			if kind == "staged" || kind == "unpushed" || kind == "pushed" || kind == "local only" {
 				runGit(t, info.Path, "add", name)
 			}
-			if kind == "unpushed" || kind == "pushed" {
+			if kind == "unpushed" || kind == "pushed" || kind == "local only" {
 				runGit(t, info.Path, "commit", "-m", "completed implementation")
 			}
 			if kind == "pushed" {
@@ -79,9 +81,12 @@ func TestLocalGitPreservesRevokedWorkAcrossCleanupAndRestart(t *testing.T) {
 				if err != nil || resumed.Path != info.Path || resumed.Created {
 					t.Fatalf("resumed workspace = %#v, error = %v", resumed, err)
 				}
-				if kind != "unpushed" {
+				if kind != "unpushed" && kind != "local only" {
 					runGit(t, info.Path, "add", name)
 					runGit(t, info.Path, "commit", "-m", "publish recovered implementation")
+				}
+				if kind == "local only" {
+					runGit(t, source, "remote", "add", "origin", remote)
 				}
 				runGit(t, info.Path, "push", "-u", "origin", info.Branch)
 				_, cleanupErr = backend.CleanupIssue(t.Context(), issue)
@@ -122,5 +127,71 @@ func TestLocalGitPreservationInspectionFailureKeepsFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(info.Path, "README.md")); err != nil {
 		t.Fatalf("retained file missing: %v", err)
+	}
+}
+
+func TestFilesystemPreservationSurvivesRestartAndResumption(t *testing.T) {
+	t.Parallel()
+	for _, artifact := range []bool{false, true} {
+		name := "empty"
+		if artifact {
+			name = "artifact"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			opts := FilesystemOptions{Root: filepath.Join(t.TempDir(), "workspaces")}
+			backend, err := NewFilesystem(opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := Issue{ProjectID: "video", ID: "2138", Identifier: "video#2138"}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			artifactPath := filepath.Join(info.Path, "artifacts", "render.mp4")
+			if artifact {
+				if err := os.WriteFile(artifactPath, []byte("completed render"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := backend.DiffStat(t.Context(), info, issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			preserver, ok := any(backend).(IssuePreserver)
+			if !ok {
+				t.Fatal("filesystem backend does not support preservation")
+			}
+			preserved, err := preserver.PreserveIssue(t.Context(), issue)
+			if err != nil || !preserved.Preserved || preserved.Path != info.Path {
+				t.Fatalf("preservation = %#v, error = %v", preserved, err)
+			}
+			backend, err = NewFilesystem(opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, resumed := range []bool{false, true} {
+				if resumed {
+					resumedInfo, err := backend.Create(t.Context(), issue)
+					if err != nil || resumedInfo.Created || resumedInfo.Path != info.Path {
+						t.Fatalf("resumption = %#v, error = %v", resumedInfo, err)
+					}
+				}
+				if _, err := backend.CleanupIssue(t.Context(), issue); !errors.Is(err, ErrWorkspacePreserved) {
+					t.Fatalf("cleanup error = %v, want preservation", err)
+				}
+			}
+			after, err := backend.DiffStat(t.Context(), info, issue)
+			if err != nil || after != before {
+				t.Fatalf("retained artifact evidence = %#v, error = %v, want %#v", after, err, before)
+			}
+			if artifact {
+				content, err := os.ReadFile(artifactPath)
+				if err != nil || string(content) != "completed render" {
+					t.Fatalf("retained artifact = %q, error = %v", content, err)
+				}
+			}
+		})
 	}
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -181,6 +181,7 @@ type CleanupFailure struct {
 type ReconcileResult struct {
 	Removed           int
 	ActiveSkipped     int
+	PreservedSkipped  int
 	RegisteredSkipped int
 	UnownedSkipped    int
 	CompletedPaths    []string
@@ -548,6 +549,9 @@ func (l *LocalGit) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult
 	}
 
 	result := CleanupResult{Path: info.Path}
+	if err := l.checkPreservedWorkspace(ctx, info, issue); err != nil {
+		return result, err
+	}
 	exists, isDir, err := pathExists(info.Path)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
## Summary

- Confirm label and Project V2 transition timestamps before recording Detent writes. Stop attributing confirmed Detent lane-write echoes to a new tracker mutation. Preserve writer source and reason, and reject stale lease receipts when an issue later reenters the same lane.
- Retain revoked Git and filesystem artifact workspaces before releasing worker ownership, including commits with no remote refs, staged edits, and untracked files. Retention survives restart and terminal/residual cleanup; recovered work can resume at its original path and becomes eligible for cleanup after publication. Filesystem artifacts remain retained for explicit disposition.
- Record preservation evidence and mutation receipts in attempt metadata and issue notices. Keep operator cancellation and intentional machine brakes; preserve the existing delivered outcome for pushed work. Shared-token changes without supporting provenance remain explicitly indeterminate.

Fixes #2138

## UI Surface Contract

- [x] N/A — this change concerns worker ownership, tracker provenance, and workspace retention.
- [x] No persistent top-of-screen messaging is added.
- [x] N/A — no operator-screen layout or visual surface changes.

## Test Plan

- [x] `PATH="$TMPDIR/bin:$PATH" GOTOOLCHAIN=go1.26.6 make check`
- [x] Focused race regressions across orchestrator, runner, and workspace.
- [x] Full orchestrator race suite, including existing scheduling read-budget contracts.
- [x] Real Git cases cover modified/staged/untracked files, local commits with and without remote refs, pushed commits, restart, resumption, and cleanup after publication.
- [x] Filesystem artifact retention survives restart and resumption without changing artifact fingerprints.
- [x] Table-driven writer cases cover operators, Detent, agents, and external automation; cached and persisted receipts distinguish write echoes from later lane reentry.
- [x] `FuzzSafetyCriticalOrchestratorBoundaries`: seven seeds plus 1,637,587 executions in the bounded run; 78.9% overall coverage; all configured package and exact-file floors pass unchanged.

The original regressions failed before the fix. Historical evidence supports agent self-parking on #2123: the Blocked label was applied at 04:11:48 UTC, followed sixteen seconds later by the [agent Workpad](https://github.com/digitaldrywood/detent/issues/2123#issuecomment-5535172470) declaring a validation-runtime blocker and retaining WIP commit `3530d117`. Later Workpads also report recovered work for #2107, #2108, and #2114, so the old discarded classification did not establish actual loss. This attribution is an inference from correlated evidence; the shared-token actor does not identify the HTTP caller, and the live history API was unavailable. Confirmed Detent writes now retain their receipts and full provenance.
