### PR TITLE
perf(github): cache project card state reads

### DIFF
--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -5,10 +5,10 @@
 The web dashboard starts with the main `detent` command. In running mode it
 shows live counts, running issues, retry queue, blocked work, completed
 sessions, token totals, budget status, Codex rate-limit snapshots, and GitHub
-REST and GraphQL rate-limit snapshots with rolling one-hour request totals and
-per-cycle query cost contributors when the GitHub connector reports them.
-Hourly totals count requests observed by this Detent process, reset on restart,
-and exclude other tools sharing the token. The remaining quota reflects the
+REST and GraphQL rate-limit snapshots. GraphQL also reports rolling one-hour
+request totals and per-cycle query cost contributors. REST request totals
+cover the current cycle. GraphQL hourly totals count requests observed by this
+project's connector, reset on restart, and exclude other tools sharing the token. The remaining quota reflects the
 shared token budget. The shared GitHub API health indicator
 separates primary quota exhaustion from observed secondary REST backoff, so a
 healthy primary budget can still show `backoff` when GitHub returned `429` for

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -5,8 +5,11 @@
 The web dashboard starts with the main `detent` command. In running mode it
 shows live counts, running issues, retry queue, blocked work, completed
 sessions, token totals, budget status, Codex rate-limit snapshots, and GitHub
-REST and GraphQL rate-limit snapshots with per-cycle query cost contributors
-when the GitHub connector reports them. The shared GitHub API health indicator
+REST and GraphQL rate-limit snapshots with rolling one-hour request totals and
+per-cycle query cost contributors when the GitHub connector reports them.
+Hourly totals count requests observed by this Detent process, reset on restart,
+and exclude other tools sharing the token. The remaining quota reflects the
+shared token budget. The shared GitHub API health indicator
 separates primary quota exhaustion from observed secondary REST backoff, so a
 healthy primary budget can still show `backoff` when GitHub returned `429` for
 endpoint families such as pull requests or check runs. Open the indicator to see

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4184,15 +4184,15 @@ func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testi
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"repository":{"nameWithOwner":"example/repo"}},{"__typename":"Issue","id":"I_kw2","number":2,"repository":{"nameWithOwner":"example/repo"}}]}}`,
+			body: projectItemsPageResponseWithTotal(2, false, "", []string{
+				`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":1,"title":"First","state":"OPEN","url":"https://github.com/example/repo/issues/1","repository":{"nameWithOwner":"example/repo"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[]}}`,
+				`{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":2,"title":"Second","state":"OPEN","url":"https://github.com/example/repo/issues/2","repository":{"nameWithOwner":"example/repo"}},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"No priority"},"fieldValues":{"nodes":[]}}`,
+			}),
 		},
 		{
 			method: http.MethodGet,
 			path:   "/repos/example/repo/issues/2",
 			body:   `{"node_id":"I_kw2","number":2,"title":"Second","body":"","state":"open","html_url":"https://github.com/example/repo/issues/2","assignees":[],"labels":[]}`,
-		},
-		{
-			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_2","project":{"id":"PVT_1"},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"No priority"},"fieldValues":{"nodes":[]}}]}}}}`,
 		},
 		{
 			status: http.StatusNotFound,
@@ -4206,7 +4206,14 @@ func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testi
 			body:   `{"node_id":"I_kw1","number":1,"title":"First","body":"","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[],"labels":[]}`,
 		},
 		{
-			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[]}}]}}}}`,
+			method: http.MethodGet,
+			path:   "/repos/example/repo/issues/2",
+			body:   `{"node_id":"I_kw2","number":2,"title":"Second","body":"","state":"open","html_url":"https://github.com/example/repo/issues/2","assignees":[],"labels":[]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/issues/1",
+			body:   `{"node_id":"I_kw1","number":1,"title":"First","body":"","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[],"labels":[]}`,
 		},
 	})
 
@@ -4235,6 +4242,30 @@ func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testi
 	if got[1].PriorityName != "P1" {
 		t.Fatalf("second PriorityName = %q, want P1", got[1].PriorityName)
 	}
+	warm, err := c.FetchIssueStatesByIDs(context.Background(), []string{"I_kw2", "I_kw1"})
+	if err != nil {
+		t.Fatalf("warm FetchIssueStatesByIDs() error = %v", err)
+	}
+	if len(warm) != 2 || warm[0].State != "Human Review" || warm[1].State != "Todo" {
+		t.Fatalf("warm FetchIssueStatesByIDs() = %#v, want cached project states", warm)
+	}
+	requests := server.requests()
+	if len(requests) != 6 {
+		t.Fatalf("request count = %d, want one project scan, four REST issues, and one dependency capability probe", len(requests))
+	}
+	var projectQueries int
+	for _, request := range requests {
+		query, _ := request["query"].(string)
+		if strings.Contains(query, "DetentGitHubProjectItemForIssue") {
+			t.Fatalf("query = %q, want no per-issue project-item lookup", query)
+		}
+		if strings.Contains(query, "query DetentGitHubProjectItems") {
+			projectQueries++
+		}
+	}
+	if projectQueries != 1 {
+		t.Fatalf("project query count = %d, want one query across cold and warm passes", projectQueries)
+	}
 }
 
 func TestConnectorFetchIssueStatesByIDsCapturesIssueMetadata(t *testing.T) {
@@ -4242,15 +4273,14 @@ func TestConnectorFetchIssueStatesByIDsCapturesIssueMetadata(t *testing.T) {
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"repository":{"nameWithOwner":"example/repo"}}]}}`,
+			body: projectItemsPageResponseWithTotal(1, false, "", []string{
+				`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":1,"title":"First","state":"CLOSED","stateReason":"not_planned","url":"https://github.com/example/repo/issues/1","author":{"login":"author-1"},"assignees":{"nodes":[{"login":"worker-1"},{"login":"worker-2"}]},"repository":{"nameWithOwner":"example/repo"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"Ready","field":{"name":"Status"}},{"__typename":"ProjectV2ItemFieldTextValue","text":"team-a","field":{"name":"Owner"}},{"__typename":"ProjectV2ItemFieldNumberValue","number":3,"field":{"name":"Weight"}}]}}`,
+			}),
 		},
 		{
 			method: http.MethodGet,
 			path:   "/repos/example/repo/issues/1",
 			body:   `{"node_id":"I_kw1","number":1,"title":"First","body":"","state":"closed","state_reason":"not_planned","html_url":"https://github.com/example/repo/issues/1","user":{"login":"author-1"},"assignees":[{"node_id":"U_1","login":"worker-1"},{"node_id":"U_2","login":"worker-2"}],"labels":[]}`,
-		},
-		{
-			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"Ready","field":{"name":"Status"}},{"__typename":"ProjectV2ItemFieldTextValue","text":"team-a","field":{"name":"Owner"}},{"__typename":"ProjectV2ItemFieldNumberValue","number":3,"field":{"name":"Weight"}}]}}]}}}}`,
 		},
 		{
 			status: http.StatusNotFound,
@@ -4316,18 +4346,19 @@ func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"repository":{"nameWithOwner":"example/repo"}}]}}`,
+			body: projectItemsPageResponseWithTotal(2, true, "cursor-1", []string{
+				`{"id":"PVTI_other","content":{"__typename":"Issue","id":"I_other","number":2,"title":"Other","state":"OPEN","url":"https://github.com/example/repo/issues/2","repository":{"nameWithOwner":"example/repo"}},"statusValue":{"name":"Open"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[]}}`,
+			}),
+		},
+		{
+			body: projectItemsPageResponseWithTotal(2, false, "", []string{
+				`{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":1,"title":"Later project","state":"OPEN","url":"https://github.com/example/repo/issues/1","repository":{"nameWithOwner":"example/repo"}},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"P2"},"fieldValues":{"nodes":[]}}`,
+			}),
 		},
 		{
 			method: http.MethodGet,
 			path:   "/repos/example/repo/issues/1",
 			body:   `{"node_id":"I_kw1","number":1,"title":"Later project","body":"","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[],"labels":[]}`,
-		},
-		{
-			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[{"id":"PVTI_other","project":{"id":"PVT_other"},"statusValue":{"name":"Open"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[]}}]}}}}`,
-		},
-		{
-			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"P2"}}]}}}}`,
 		},
 		{
 			status: http.StatusNotFound,
@@ -4360,15 +4391,15 @@ func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 5 {
-		t.Fatalf("request count = %d, want identity, REST issue, 2 project item pages, and dependency probe", len(requests))
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want 2 project scan pages, REST issue, and dependency probe", len(requests))
 	}
-	variables := requests[3]["variables"].(map[string]any)
+	variables := requests[1]["variables"].(map[string]any)
 	if variables["after"] != "cursor-1" {
 		t.Fatalf("after = %v, want cursor-1", variables["after"])
 	}
-	if variables["issueId"] != "I_kw1" {
-		t.Fatalf("issueId = %v, want I_kw1", variables["issueId"])
+	if variables["projectId"] != "PVT_1" {
+		t.Fatalf("projectId = %v, want PVT_1", variables["projectId"])
 	}
 }
 
@@ -6955,4 +6986,37 @@ func githubIssueIDs(issues []connector.Issue) []string {
 		ids = append(ids, issue.ID)
 	}
 	return ids
+}
+
+func TestProjectFieldsRefreshUsesTargetedQueryOnlyForChangedCard(t *testing.T) {
+	t.Parallel()
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"fieldValues":{"nodes":[]}}]}}}}`}})
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+	c.projectCache.ReplaceProjectFields("PVT_1", map[string]projectItemFields{
+		"I_1": {itemID: "PVTI_1", statusName: "Todo"},
+		"I_2": {itemID: "PVTI_2", statusName: "Todo"},
+	}, c.projectCache.Revision("PVT_1"))
+	c.projectCache.SetItemID("PVT_1", "I_1", "PVTI_1")
+	c.projectCache.InvalidateProjectFields("PVT_1", "I_1")
+	for range 2 {
+		if err := c.ensureProjectFieldsCached(t.Context(), []string{"I_1", "I_2"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tt := range []struct{ id, status string }{{"I_1", "Done"}, {"I_2", "Todo"}} {
+		t.Run(tt.id, func(t *testing.T) {
+			fields, present, known := c.projectCache.GetProjectFields("PVT_1", tt.id)
+			if !present || !known || fields.statusName != tt.status {
+				t.Fatalf("fields = %#v, present %t known %t", fields, present, known)
+			}
+		})
+	}
+	requests := server.requests()
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want one targeted refresh", len(requests))
+	}
+	query, _ := requests[0]["query"].(string)
+	if !strings.Contains(query, "DetentGitHubProjectItemForIssue") {
+		t.Fatalf("query = %q, want targeted refresh", query)
+	}
 }

--- a/internal/connector/github/candidate.go
+++ b/internal/connector/github/candidate.go
@@ -398,7 +398,7 @@ func (c *Connector) readProjectCandidates(
 		itemsRead += len(pageItems)
 		totalItems = max(totalItems, response.Node.Items.TotalCount)
 		for _, item := range pageItems {
-			issue, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
+			issue, _, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
 			if err != nil {
 				return nil, 0, 0, false, err
 			}

--- a/internal/connector/github/intake.go
+++ b/internal/connector/github/intake.go
@@ -112,7 +112,11 @@ func (c *Connector) SetIntakeIssueState(ctx context.Context, issueID string, sta
 			}
 			itemID = item.ID
 		}
-		return c.setProjectItemStatus(ctx, itemID, c.detentToGitHubState(state))
+		if err := c.setProjectItemStatus(ctx, itemID, c.detentToGitHubState(state)); err != nil {
+			return err
+		}
+		c.projectCache.InvalidateProjectFields(c.projectID, issueID)
+		return nil
 	}
 	return c.UpdateIssueState(ctx, issueID, state)
 }

--- a/internal/connector/github/issue_read.go
+++ b/internal/connector/github/issue_read.go
@@ -885,6 +885,9 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 	if c.projectID == "" {
 		return nil, ErrMissingProject
 	}
+	if err := c.ensureProjectFieldsCached(ctx, ids); err != nil {
+		return nil, fmt.Errorf("fetch github issue states by ids: %w", err)
+	}
 
 	refs, err := c.issueRefsForIDs(ctx, ids, graphQLQueryRunningStates)
 	if err != nil {
@@ -1253,9 +1256,13 @@ func (c *Connector) fetchIssueByRef(ctx context.Context, ref issueRef) (connecto
 	}
 	c.cacheIssueRef(issue)
 
-	stateName, priorityName, statusUpdatedAt, fields, ok, err := c.fetchProjectFieldsPage(ctx, issue.ID, nil)
-	if err != nil {
-		return connector.Issue{}, false, err
+	stateName, priorityName, statusUpdatedAt, fields, ok, known := c.cachedIssueProjectFields(issue.ID)
+	if !known {
+		var err error
+		stateName, priorityName, statusUpdatedAt, fields, ok, err = c.fetchProjectFieldsPage(ctx, issue.ID, nil)
+		if err != nil {
+			return connector.Issue{}, false, err
+		}
 	}
 	if ok {
 		return c.buildIssue(issue, stateName, priorityName, statusUpdatedAt, fields), true, nil
@@ -1273,9 +1280,13 @@ func (c *Connector) fetchProjectIssueByRef(ctx context.Context, ref issueRef) (c
 	}
 	c.cacheIssueRef(issue)
 
-	stateName, priorityName, statusUpdatedAt, fields, ok, err := c.fetchProjectFieldsPage(ctx, issue.ID, nil)
-	if err != nil {
-		return connector.Issue{}, false, err
+	stateName, priorityName, statusUpdatedAt, fields, ok, known := c.cachedIssueProjectFields(issue.ID)
+	if !known {
+		var err error
+		stateName, priorityName, statusUpdatedAt, fields, ok, err = c.fetchProjectFieldsPage(ctx, issue.ID, nil)
+		if err != nil {
+			return connector.Issue{}, false, err
+		}
 	}
 	if !ok {
 		return connector.Issue{}, false, nil

--- a/internal/connector/github/issue_write.go
+++ b/internal/connector/github/issue_write.go
@@ -258,7 +258,11 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 	}
 
 	githubState := c.detentToGitHubState(stateName)
-	return c.setProjectItemStatus(ctx, item.ID, githubState)
+	if err := c.setProjectItemStatus(ctx, item.ID, githubState); err != nil {
+		return err
+	}
+	c.projectCache.InvalidateProjectFields(c.projectID, issueID)
+	return nil
 }
 
 func (c *Connector) RemoveIssueFromProject(ctx context.Context, issueID string) error {
@@ -370,13 +374,21 @@ func (c *Connector) SetField(ctx context.Context, issueID string, fieldName stri
 		return err
 	}
 	if projectTextField(field) {
-		return c.updateProjectV2TextFieldValue(ctx, item.ID, field.ID, strings.TrimSpace(value), ErrProjectFieldUpdateFailed)
+		if err := c.updateProjectV2TextFieldValue(ctx, item.ID, field.ID, strings.TrimSpace(value), ErrProjectFieldUpdateFailed); err != nil {
+			return err
+		}
+		c.projectCache.InvalidateProjectFields(c.projectID, issueID)
+		return nil
 	}
 	fieldID, optionID, err := c.resolveSingleSelectFieldOptionFromField(ctx, fieldName, value, field)
 	if err != nil {
 		return err
 	}
-	return c.updateProjectV2SingleSelectFieldValue(ctx, item.ID, fieldID, optionID, ErrProjectFieldUpdateFailed)
+	if err := c.updateProjectV2SingleSelectFieldValue(ctx, item.ID, fieldID, optionID, ErrProjectFieldUpdateFailed); err != nil {
+		return err
+	}
+	c.projectCache.InvalidateProjectFields(c.projectID, issueID)
+	return nil
 }
 
 func (c *Connector) addAssignee(ctx context.Context, ref issueRef, login string) error {

--- a/internal/connector/github/projectcache.go
+++ b/internal/connector/github/projectcache.go
@@ -7,16 +7,27 @@ import (
 )
 
 type projectCache struct {
-	mu      sync.RWMutex
-	ttl     time.Duration
-	now     func() time.Time
-	entries map[string]map[string]projectItemCacheEntry
-	refs    map[string]issueRefCacheEntry
+	mu        sync.RWMutex
+	ttl       time.Duration
+	now       func() time.Time
+	entries   map[string]map[string]projectItemCacheEntry
+	scanned   map[string]time.Time
+	revisions map[string]uint64
+	refs      map[string]issueRefCacheEntry
 }
 
 type projectItemCacheEntry struct {
-	itemID   string
-	cachedAt time.Time
+	projectItemFields
+	fieldsKnown bool
+	cachedAt    time.Time
+}
+
+type projectItemFields struct {
+	itemID          string
+	statusName      string
+	priorityName    string
+	statusUpdatedAt *time.Time
+	fields          map[string]string
 }
 
 type issueRefCacheEntry struct {
@@ -36,10 +47,12 @@ func newProjectCache(ttl time.Duration, now func() time.Time) *projectCache {
 	}
 
 	return &projectCache{
-		ttl:     ttl,
-		now:     now,
-		entries: map[string]map[string]projectItemCacheEntry{},
-		refs:    map[string]issueRefCacheEntry{},
+		ttl:       ttl,
+		now:       now,
+		entries:   map[string]map[string]projectItemCacheEntry{},
+		scanned:   map[string]time.Time{},
+		revisions: map[string]uint64{},
+		refs:      map[string]issueRefCacheEntry{},
 	}
 }
 
@@ -58,7 +71,7 @@ func (c *projectCache) GetItemID(projectID string, issueID string) (string, bool
 	}
 	entry, ok := projectEntries[issueID]
 	c.mu.RUnlock()
-	if !ok {
+	if !ok || entry.itemID == "" {
 		return "", false
 	}
 	if c.fresh(entry.cachedAt) {
@@ -98,10 +111,94 @@ func (c *projectCache) SetItemID(projectID string, issueID string, itemID string
 		projectEntries = map[string]projectItemCacheEntry{}
 		c.entries[projectID] = projectEntries
 	}
-	projectEntries[issueID] = projectItemCacheEntry{
-		itemID:   itemID,
-		cachedAt: c.now(),
+	if entry, ok := projectEntries[issueID]; ok && entry.itemID == itemID && c.fresh(entry.cachedAt) {
+		c.mu.Unlock()
+		return
 	}
+	projectEntries[issueID] = projectItemCacheEntry{
+		projectItemFields: projectItemFields{itemID: itemID},
+		cachedAt:          c.now(),
+	}
+	c.revisions[projectID]++
+	delete(c.scanned, projectID)
+	c.mu.Unlock()
+}
+
+func (c *projectCache) GetProjectFields(projectID string, issueID string) (projectItemFields, bool, bool) {
+	projectID = strings.TrimSpace(projectID)
+	issueID = strings.TrimSpace(issueID)
+	if projectID == "" || issueID == "" {
+		return projectItemFields{}, false, false
+	}
+
+	c.mu.RLock()
+	entry, found := c.entries[projectID][issueID]
+	scannedAt, scanned := c.scanned[projectID]
+	c.mu.RUnlock()
+
+	if found && c.fresh(entry.cachedAt) {
+		if !entry.fieldsKnown {
+			return projectItemFields{}, false, false
+		}
+		return cloneProjectItemFields(entry.projectItemFields), true, true
+	}
+	if scanned && c.fresh(scannedAt) {
+		return projectItemFields{}, false, true
+	}
+	return projectItemFields{}, false, false
+}
+
+func (c *projectCache) SetProjectFields(projectID string, issueID string, fields projectItemFields) {
+	projectID = strings.TrimSpace(projectID)
+	issueID = strings.TrimSpace(issueID)
+	fields.itemID = strings.TrimSpace(fields.itemID)
+	if projectID == "" || issueID == "" || fields.itemID == "" {
+		return
+	}
+
+	c.mu.Lock()
+	projectEntries := c.entries[projectID]
+	if projectEntries == nil {
+		projectEntries = map[string]projectItemCacheEntry{}
+		c.entries[projectID] = projectEntries
+	}
+	c.revisions[projectID]++
+	projectEntries[issueID] = projectItemCacheEntry{
+		projectItemFields: cloneProjectItemFields(fields),
+		fieldsKnown:       true,
+		cachedAt:          c.now(),
+	}
+	c.mu.Unlock()
+}
+
+func (c *projectCache) ReplaceProjectFields(projectID string, fieldsByIssue map[string]projectItemFields, revision uint64) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return
+	}
+
+	cachedAt := c.now()
+	next := make(map[string]projectItemCacheEntry, len(fieldsByIssue))
+	for issueID, fields := range fieldsByIssue {
+		issueID = strings.TrimSpace(issueID)
+		fields.itemID = strings.TrimSpace(fields.itemID)
+		if issueID == "" || fields.itemID == "" {
+			continue
+		}
+		next[issueID] = projectItemCacheEntry{
+			projectItemFields: cloneProjectItemFields(fields),
+			fieldsKnown:       true,
+			cachedAt:          cachedAt,
+		}
+	}
+
+	c.mu.Lock()
+	if c.revisions[projectID] != revision {
+		c.mu.Unlock()
+		return
+	}
+	c.entries[projectID] = next
+	c.scanned[projectID] = cachedAt
 	c.mu.Unlock()
 }
 
@@ -165,6 +262,8 @@ func (c *projectCache) ClearItemID(projectID string, issueID string) {
 			delete(c.entries, projectID)
 		}
 	}
+	c.revisions[projectID]++
+	delete(c.scanned, projectID)
 	c.mu.Unlock()
 }
 
@@ -176,9 +275,57 @@ func (c *projectCache) ClearProject(projectID string) {
 
 	c.mu.Lock()
 	delete(c.entries, projectID)
+	c.revisions[projectID]++
+	delete(c.scanned, projectID)
 	c.mu.Unlock()
+}
+
+func (c *projectCache) InvalidateProjectFields(projectID, issueID string) {
+	projectID = strings.TrimSpace(projectID)
+	issueID = strings.TrimSpace(issueID)
+	if projectID == "" || issueID == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.revisions[projectID]++
+	if c.entries[projectID] == nil {
+		c.entries[projectID] = map[string]projectItemCacheEntry{}
+	}
+	entry := c.entries[projectID][issueID]
+	entry.fieldsKnown = false
+	entry.cachedAt = c.now()
+	c.entries[projectID][issueID] = entry
+}
+
+func (c *projectCache) ProjectFieldsScanned(projectID string) bool {
+	c.mu.RLock()
+	scannedAt, ok := c.scanned[projectID]
+	c.mu.RUnlock()
+	return ok && c.fresh(scannedAt)
+}
+
+func (c *projectCache) Revision(projectID string) uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.revisions[projectID]
 }
 
 func (c *projectCache) fresh(cachedAt time.Time) bool {
 	return c.ttl > 0 && c.now().Sub(cachedAt) < c.ttl
+}
+
+func cloneProjectItemFields(fields projectItemFields) projectItemFields {
+	cloned := fields
+	if fields.statusUpdatedAt != nil {
+		updatedAt := *fields.statusUpdatedAt
+		cloned.statusUpdatedAt = &updatedAt
+	}
+	if fields.fields != nil {
+		cloned.fields = make(map[string]string, len(fields.fields))
+		for name, value := range fields.fields {
+			cloned.fields[name] = value
+		}
+	}
+	return cloned
 }

--- a/internal/connector/github/projectcache_test.go
+++ b/internal/connector/github/projectcache_test.go
@@ -123,3 +123,130 @@ func TestProjectCacheIgnoresBlankKeys(t *testing.T) {
 		t.Fatal("GetIssueRef() ok = true for blank issue ref, want false")
 	}
 }
+
+func TestProjectCacheTracksCompleteProjectFieldsScans(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		advance     time.Duration
+		issueID     string
+		wantPresent bool
+		wantKnown   bool
+	}{
+		{name: "present", issueID: "I_1", wantPresent: true, wantKnown: true},
+		{name: "negative membership", issueID: "I_missing", wantKnown: true},
+		{name: "expired membership", advance: 5 * time.Minute, issueID: "I_1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now := base
+			cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+			updatedAt := base.Add(-time.Minute)
+			cache.ReplaceProjectFields("PVT_1", map[string]projectItemFields{
+				"I_1": {
+					itemID:          "PVTI_1",
+					statusName:      "In Progress",
+					priorityName:    "P1",
+					statusUpdatedAt: &updatedAt,
+					fields:          map[string]string{"Owner": "worker-1"},
+				},
+			}, cache.Revision("PVT_1"))
+			now = now.Add(test.advance)
+
+			fields, present, known := cache.GetProjectFields("PVT_1", test.issueID)
+			if present != test.wantPresent || known != test.wantKnown {
+				t.Fatalf("GetProjectFields() = present %t known %t, want present %t known %t", present, known, test.wantPresent, test.wantKnown)
+			}
+			if !present {
+				return
+			}
+			if fields.itemID != "PVTI_1" || fields.statusName != "In Progress" || fields.priorityName != "P1" {
+				t.Fatalf("project fields = %#v, want cached item status and priority", fields)
+			}
+			fields.fields["Owner"] = "mutated"
+			cached, _, _ := cache.GetProjectFields("PVT_1", "I_1")
+			if cached.fields["Owner"] != "worker-1" {
+				t.Fatalf("cached Owner = %q, want defensive copy", cached.fields["Owner"])
+			}
+		})
+	}
+}
+
+func TestProjectCacheInvalidatesCompleteScanOnMembershipChange(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.ReplaceProjectFields("PVT_1", map[string]projectItemFields{
+		"I_1": {itemID: "PVTI_1", statusName: "Todo"},
+	}, cache.Revision("PVT_1"))
+
+	cache.SetItemID("PVT_1", "I_2", "PVTI_2")
+	if _, _, known := cache.GetProjectFields("PVT_1", "I_missing"); known {
+		t.Fatal("GetProjectFields() known = true after SetItemID invalidated complete scan")
+	}
+
+	cache.ReplaceProjectFields("PVT_1", map[string]projectItemFields{
+		"I_1": {itemID: "PVTI_1", statusName: "Todo"},
+		"I_2": {itemID: "PVTI_2", statusName: "Todo"},
+	}, cache.Revision("PVT_1"))
+	cache.ClearItemID("PVT_1", "I_2")
+	if _, _, known := cache.GetProjectFields("PVT_1", "I_missing"); known {
+		t.Fatal("GetProjectFields() known = true after ClearItemID invalidated complete scan")
+	}
+}
+
+func TestProjectCacheRejectsScanInvalidatedInFlight(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		invalidate func(*projectCache)
+	}{
+		{"fields invalidated", func(c *projectCache) { c.InvalidateProjectFields("PVT_1", "I_1") }},
+		{"project cleared", func(c *projectCache) { c.ClearProject("PVT_1") }},
+		{"item removed", func(c *projectCache) { c.ClearItemID("PVT_1", "I_1") }},
+		{"item added", func(c *projectCache) { c.SetItemID("PVT_1", "I_2", "PVTI_2") }},
+		{"targeted refresh", func(c *projectCache) {
+			c.SetProjectFields("PVT_1", "I_2", projectItemFields{itemID: "PVTI_2", statusName: "Done"})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+			cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+			revision := cache.Revision("PVT_1")
+			tt.invalidate(cache)
+			cache.ReplaceProjectFields("PVT_1", map[string]projectItemFields{"I_1": {itemID: "PVTI_1", statusName: "Todo"}}, revision)
+			if _, _, known := cache.GetProjectFields("PVT_1", "I_1"); known {
+				t.Fatal("scan restored fields after invalidation")
+			}
+		})
+	}
+}
+
+func TestProjectCacheInvalidatesOnlyChangedCard(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.ReplaceProjectFields("PVT_1", map[string]projectItemFields{
+		"I_1": {itemID: "PVTI_1", statusName: "Todo"},
+		"I_2": {itemID: "PVTI_2", statusName: "Todo"},
+	}, cache.Revision("PVT_1"))
+	cache.InvalidateProjectFields("PVT_1", "I_1")
+	for _, tt := range []struct {
+		id    string
+		known bool
+	}{{"I_1", false}, {"I_2", true}, {"I_missing", true}} {
+		t.Run(tt.id, func(t *testing.T) {
+			if _, _, known := cache.GetProjectFields("PVT_1", tt.id); known != tt.known {
+				t.Fatalf("known = %t, want %t", known, tt.known)
+			}
+		})
+	}
+	if !cache.ProjectFieldsScanned("PVT_1") {
+		t.Fatal("invalidation discarded complete scan")
+	}
+}

--- a/internal/connector/github/projects_v2.go
+++ b/internal/connector/github/projects_v2.go
@@ -56,6 +56,68 @@ query DetentGitHubProjectItems(
   rateLimit { limit used remaining cost resetAt }
 }`
 
+const projectItemsWithFieldsQuery = `
+query DetentGitHubProjectItems(
+  $projectId: ID!
+  $first: Int!
+  $after: String
+) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: $first, after: $after) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          content {
+            __typename
+            ... on Issue {
+              id
+              number
+              title
+              state
+              stateReason
+              url
+              author { login }
+              authorAssociation
+              assignees(first: 10) { nodes { login } }
+              repository { nameWithOwner }
+              labels(first: 20) { nodes { name } }
+            }
+          }
+          statusValue: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+          }
+          priorityValue: fieldValueByName(name: "Priority") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+          fieldValues(first: 100) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                updatedAt
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                updatedAt
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+                updatedAt
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
 const observedStatusProjectItemsQuery = `
 query DetentGitHubObservedStatusProjectItems(
   $projectId: ID!
@@ -248,6 +310,30 @@ func (c *Connector) fetchProjectItemsWithLimit(
 	return scan.Issues, err
 }
 
+func (c *Connector) ensureProjectFieldsCached(ctx context.Context, issueIDs []string) error {
+	missing := false
+	for _, issueID := range issueIDs {
+		if _, _, known := c.projectCache.GetProjectFields(c.projectID, issueID); !known {
+			if c.projectCache.ProjectFieldsScanned(c.projectID) {
+				if _, _, _, _, _, err := c.fetchProjectFieldsPage(ctx, issueID, nil); err != nil {
+					return err
+				}
+				continue
+			}
+			missing = true
+			break
+		}
+	}
+	if !missing {
+		return nil
+	}
+
+	_, err := c.fetchProjectItemsWithLimit(ctx, projectItemsWithFieldsQuery, graphQLQueryRunningStates, func(connector.Issue) bool {
+		return false
+	}, 0, false)
+	return err
+}
+
 func (c *Connector) fetchProjectItemsScanWithLimit(
 	ctx context.Context,
 	queryDocument string,
@@ -256,8 +342,11 @@ func (c *Connector) fetchProjectItemsScanWithLimit(
 	limit int,
 	repairBlankStatuses bool,
 ) (connector.IssueStateScan, error) {
+	scanRevision := c.projectCache.Revision(c.projectID)
+	cacheProjectFields := queryDocument == projectItemsWithFieldsQuery
 	var after *string
 	blankStatusItemIDs := []string{}
+	projectFieldsByIssue := map[string]projectItemFields{}
 	scan := connector.IssueStateScan{
 		Issues:           []connector.Issue{},
 		BoardCounts:      map[string]int{},
@@ -287,12 +376,15 @@ func (c *Connector) fetchProjectItemsScanWithLimit(
 			if state, ok := c.projectItemBoardState(item); ok {
 				scan.BoardCounts[state]++
 			}
-			issue, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
+			issue, cachedFields, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
 			if err != nil {
 				return connector.IssueStateScan{}, err
 			}
 			if !ok {
 				continue
+			}
+			if cacheProjectFields {
+				projectFieldsByIssue[issue.ID] = cachedFields
 			}
 			if blankStatusItemID != "" && repairBlankStatuses {
 				blankStatusItemIDs = append(blankStatusItemIDs, blankStatusItemID)
@@ -309,6 +401,9 @@ func (c *Connector) fetchProjectItemsScanWithLimit(
 		if !response.Node.Items.PageInfo.HasNextPage {
 			if err := c.validateProjectItemsComplete(ctx, scan.ItemsFetched, scan.TotalItems); err != nil {
 				return connector.IssueStateScan{}, err
+			}
+			if cacheProjectFields {
+				c.projectCache.ReplaceProjectFields(c.projectID, projectFieldsByIssue, scanRevision)
 			}
 			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
 			if err := c.resolveBlockedByProjectState(ctx, scan.Issues); err != nil {
@@ -345,28 +440,38 @@ func (c *Connector) validateProjectItemsComplete(ctx context.Context, fetched in
 }
 
 func projectItemsQueryForType(queryType string) string {
+	if queryType == graphQLQueryCandidateIssues {
+		return projectItemsQuery
+	}
 	if queryType == graphQLQueryObservedStatus {
 		return observedStatusProjectItemsQuery
 	}
-	return projectItemsQuery
+	return projectItemsWithFieldsQuery
 }
 
-func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, bool, string, error) {
+func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, projectItemFields, bool, string, error) {
 	if item.Content == nil || item.Content.TypeName != "Issue" {
-		return connector.Issue{}, false, "", nil
+		return connector.Issue{}, projectItemFields{}, false, "", nil
 	}
 	c.cacheIssueRef(*item.Content)
 	statusName, statusUpdatedAt, blankStatusItemID, err := c.projectItemStatusOrDefault(item)
 	if err != nil {
-		return connector.Issue{}, false, "", err
+		return connector.Issue{}, projectItemFields{}, false, "", err
+	}
+	fields := projectItemFields{
+		itemID:          item.ID,
+		statusName:      statusName,
+		priorityName:    singleSelectName(item.PriorityValue),
+		statusUpdatedAt: statusUpdatedAt,
+		fields:          projectFieldValues(item.FieldValues),
 	}
 	return c.buildIssue(
 		*item.Content,
-		statusName,
-		singleSelectName(item.PriorityValue),
-		statusUpdatedAt,
-		projectFieldValues(item.FieldValues),
-	), true, blankStatusItemID, nil
+		fields.statusName,
+		fields.priorityName,
+		fields.statusUpdatedAt,
+		fields.fields,
+	), fields, true, blankStatusItemID, nil
 }
 
 func (c *Connector) projectItemStatusOrDefault(item projectItemNode) (string, *time.Time, string, error) {
@@ -477,14 +582,29 @@ func (c *Connector) resolveIssueProjectFields(ctx context.Context, issueID strin
 	return c.fetchProjectFieldsPage(ctx, issueID, &cursor)
 }
 
+func (c *Connector) cachedIssueProjectFields(issueID string) (string, string, *time.Time, map[string]string, bool, bool) {
+	fields, present, known := c.projectCache.GetProjectFields(c.projectID, issueID)
+	if !present {
+		return "", "", nil, nil, false, known
+	}
+	return fields.statusName, fields.priorityName, fields.statusUpdatedAt, fields.fields, true, true
+}
+
 func (c *Connector) projectFields(issueID string, items *projectItemsConnection) (string, string, *time.Time, map[string]string, bool) {
 	if items == nil {
 		return "", "", nil, nil, false
 	}
 	for _, item := range items.Nodes {
 		if item.Project != nil && item.Project.ID == c.projectID {
-			c.projectCache.SetItemID(c.projectID, issueID, item.ID)
-			return singleSelectName(item.StatusValue), singleSelectName(item.PriorityValue), singleSelectUpdatedAt(item.StatusValue), projectFieldValues(item.FieldValues), true
+			fields := projectItemFields{
+				itemID:          item.ID,
+				statusName:      singleSelectName(item.StatusValue),
+				priorityName:    singleSelectName(item.PriorityValue),
+				statusUpdatedAt: singleSelectUpdatedAt(item.StatusValue),
+				fields:          projectFieldValues(item.FieldValues),
+			}
+			c.projectCache.SetProjectFields(c.projectID, issueID, fields)
+			return fields.statusName, fields.priorityName, fields.statusUpdatedAt, fields.fields, true
 		}
 	}
 	return "", "", nil, nil, false

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -265,9 +265,16 @@ func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, state *State, i
 	if strings.TrimSpace(issue.ID) == "" || len(issue.Fields) > 0 || o.connector == nil {
 		return issue, true
 	}
-	request := runpkg.RunRequest{Issue: issue, Mode: o.dispatchMode(ctx, state, issue), SelectorContext: o.selectorContext()}
-	if _, _, paused := o.backendCapacityDispatch(state, request, now); paused {
-		return issue, true
+	if retry, ok := state.Retry[issue.ID]; ok {
+		if _, outage, active := matchingBackendOutage(state.BackendOutages, retry.CapacityScope); active {
+			probeAt := outage.NextProbeAt
+			if probeAt.IsZero() {
+				probeAt = outage.ResumeAt
+			}
+			if strings.TrimSpace(outage.ProbeIssueID) != "" || now.Before(probeAt) {
+				return issue, true
+			}
+		}
 	}
 	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{issue.ID})
 	if err != nil {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -142,7 +142,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	outcomes := make(map[string]dispatchIssueOutcome, len(issues))
 	planner.plan(state, issues, now, dispatchPlanHooks{
 		hydrate: func(issue connector.Issue) (connector.Issue, bool) {
-			return o.hydrateDispatchIssue(ctx, issue)
+			return o.hydrateDispatchIssue(ctx, state, issue, now)
 		},
 		beforeDispatch: func(_ connector.Issue, continuationIndex int) bool {
 			if continuationIndex < 0 {
@@ -261,8 +261,12 @@ func (o *Orchestrator) preserveMissingDueRetry(state *State, retry Retry) bool {
 	return !o.mergeWorkerLocalSlotsAvailable(state)
 }
 
-func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector.Issue) (connector.Issue, bool) {
+func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, state *State, issue connector.Issue, now time.Time) (connector.Issue, bool) {
 	if strings.TrimSpace(issue.ID) == "" || len(issue.Fields) > 0 || o.connector == nil {
+		return issue, true
+	}
+	request := runpkg.RunRequest{Issue: issue, Mode: o.dispatchMode(ctx, state, issue), SelectorContext: o.selectorContext()}
+	if _, _, paused := o.backendCapacityDispatch(state, request, now); paused {
 		return issue, true
 	}
 	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{issue.ID})
@@ -292,7 +296,7 @@ func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, iss
 		if o.dispatchPlanner().hardAvailableSlots(state) == 0 {
 			return
 		}
-		issue, ok := o.hydrateDispatchIssue(ctx, issue)
+		issue, ok := o.hydrateDispatchIssue(ctx, state, issue, now)
 		if !ok {
 			continue
 		}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3976,16 +3976,22 @@ func TestHydrateDispatchIssueSkipsPausedProvider(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name        string
-		outage      bool
-		probeAt     time.Time
-		probeIssue  string
-		wantFetches int
+		name           string
+		outage         bool
+		knownScope     bool
+		unrelatedScope bool
+		resumeAt       time.Time
+		probeAt        time.Time
+		probeIssue     string
+		wantFetches    int
 	}{
 		{name: "healthy", wantFetches: 1},
-		{name: "outage waiting", outage: true, probeAt: now.Add(time.Minute)},
-		{name: "probe already running", outage: true, probeAt: now, probeIssue: "probe"},
-		{name: "recovery probe due", outage: true, probeAt: now, wantFetches: 1},
+		{name: "unrelated recorded scope", outage: true, knownScope: true, unrelatedScope: true, probeAt: now.Add(time.Minute), wantFetches: 1},
+		{name: "waiting for resume without probe time", outage: true, knownScope: true, resumeAt: now.Add(time.Minute)},
+		{name: "unknown route with paused fallback", outage: true, probeAt: now.Add(time.Minute), wantFetches: 1},
+		{name: "outage waiting", outage: true, knownScope: true, probeAt: now.Add(time.Minute)},
+		{name: "probe already running", outage: true, knownScope: true, probeAt: now, probeIssue: "probe"},
+		{name: "recovery probe due", outage: true, knownScope: true, probeAt: now, wantFetches: 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3995,8 +4001,15 @@ func TestHydrateDispatchIssueSkipsPausedProvider(t *testing.T) {
 			cfg := normalizeConfig(Config{})
 			orch := Orchestrator{cfg: cfg, connector: hydratingDispatchConnector{issue: issue, fetches: &fetches}, capacityController: backendCapacityTestController{scope: scope}}
 			state := newState(cfg)
+			if tt.knownScope {
+				retryScope := scope
+				if tt.unrelatedScope {
+					retryScope.BackendID = "healthy"
+				}
+				state.Retry[issue.ID] = Retry{Issue: issue, CapacityScope: retryScope}
+			}
 			if tt.outage {
-				state.BackendOutages[scope.Key()] = BackendOutage{Scope: scope, NextProbeAt: tt.probeAt, ProbeIssueID: tt.probeIssue}
+				state.BackendOutages[scope.Key()] = BackendOutage{Scope: scope, NextProbeAt: tt.probeAt, ResumeAt: tt.resumeAt, ProbeIssueID: tt.probeIssue}
 			}
 			for range 3 {
 				if _, ok := orch.hydrateDispatchIssue(t.Context(), &state, issue, now); !ok {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/budget"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -3780,6 +3781,7 @@ func (c *budgetRefusalCommentConnector) SetField(context.Context, string, string
 var _ connector.Connector = (*budgetRefusalCommentConnector)(nil)
 
 type hydratingDispatchConnector struct {
+	fetches  *int
 	issue    connector.Issue
 	blockers []connector.Issue
 }
@@ -3797,6 +3799,9 @@ func (c hydratingDispatchConnector) FetchIssuesByStates(context.Context, []strin
 }
 
 func (c hydratingDispatchConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
+	if c.fetches != nil {
+		*c.fetches++
+	}
 	if slices.Contains(ids, c.issue.ID) {
 		return []connector.Issue{c.issue}, nil
 	}
@@ -3965,4 +3970,42 @@ func (s *recordingWorkAttemptStore) RecordSchedulerDecision(_ context.Context, a
 
 func (s *recordingWorkAttemptStore) ListRecentSchedulerDecisions(context.Context, store.SchedulerDecisionQuery) ([]store.SchedulerDecision, error) {
 	return nil, nil
+}
+
+func TestHydrateDispatchIssueSkipsPausedProvider(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		outage      bool
+		probeAt     time.Time
+		probeIssue  string
+		wantFetches int
+	}{
+		{name: "healthy", wantFetches: 1},
+		{name: "outage waiting", outage: true, probeAt: now.Add(time.Minute)},
+		{name: "probe already running", outage: true, probeAt: now, probeIssue: "probe"},
+		{name: "recovery probe due", outage: true, probeAt: now, wantFetches: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+			issue := connector.Issue{ID: "issue", State: "Todo"}
+			fetches := 0
+			cfg := normalizeConfig(Config{})
+			orch := Orchestrator{cfg: cfg, connector: hydratingDispatchConnector{issue: issue, fetches: &fetches}, capacityController: backendCapacityTestController{scope: scope}}
+			state := newState(cfg)
+			if tt.outage {
+				state.BackendOutages[scope.Key()] = BackendOutage{Scope: scope, NextProbeAt: tt.probeAt, ProbeIssueID: tt.probeIssue}
+			}
+			for range 3 {
+				if _, ok := orch.hydrateDispatchIssue(t.Context(), &state, issue, now); !ok {
+					t.Fatal("hydration failed")
+				}
+			}
+			if fetches != tt.wantFetches*3 {
+				t.Fatalf("fetches = %d, want %d", fetches, tt.wantFetches*3)
+			}
+		})
+	}
 }

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -198,6 +198,9 @@ func TestTickPublishesAndLogsGitHubGraphQLCostSummary(t *testing.T) {
 	if state.RateLimits.GraphQLCost.TotalCost != 8 || state.RateLimits.GraphQLCost.TotalQueries != 2 {
 		t.Fatalf("GraphQLCost = %#v, want cost 8 queries 2", state.RateLimits.GraphQLCost)
 	}
+	if state.RateLimits.GraphQLCost.LastHourCost != 8 || state.RateLimits.GraphQLCost.LastHourQueries != 2 {
+		t.Fatalf("GraphQLCost = %#v, want last-hour cost 8 queries 2", state.RateLimits.GraphQLCost)
+	}
 	if len(state.RateLimits.GraphQLCost.Contributors) != 2 {
 		t.Fatalf("GraphQLCost.Contributors = %#v, want 2 contributors", state.RateLimits.GraphQLCost.Contributors)
 	}
@@ -214,6 +217,50 @@ func TestTickPublishesAndLogsGitHubGraphQLCostSummary(t *testing.T) {
 		if !strings.Contains(logOutput, want) {
 			t.Fatalf("log output missing %q:\n%s", want, logOutput)
 		}
+	}
+}
+
+func TestRecordGraphQLUsageWindow(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		at          time.Time
+		usage       connector.GraphQLRateLimitUsage
+		wantQueries int64
+		wantCost    int64
+	}{
+		{
+			name:        "records first cycle",
+			at:          start,
+			usage:       connector.GraphQLRateLimitUsage{TotalQueries: 2, TotalCost: 8},
+			wantQueries: 2,
+			wantCost:    8,
+		},
+		{
+			name:        "accumulates cycles within hour",
+			at:          start.Add(30 * time.Minute),
+			usage:       connector.GraphQLRateLimitUsage{TotalQueries: 3, TotalCost: 5},
+			wantQueries: 5,
+			wantCost:    13,
+		},
+		{
+			name:        "retains boundary and expires older samples",
+			at:          start.Add(90 * time.Minute),
+			wantQueries: 3,
+			wantCost:    5,
+		},
+	}
+
+	state := State{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queries, cost := recordGraphQLUsageWindow(&state, tt.usage, tt.at)
+			if queries != tt.wantQueries || cost != tt.wantCost {
+				t.Fatalf("recordGraphQLUsageWindow() = (%d, %d), want (%d, %d)", queries, cost, tt.wantQueries, tt.wantCost)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -24,6 +24,12 @@ type graphQLRateLimitCycle struct {
 	HasSummary bool
 }
 
+type graphQLUsageSample struct {
+	observedAt time.Time
+	queries    int64
+	cost       int64
+}
+
 type restRateLimitCycle struct {
 	Bucket     *telemetry.RateLimitBucket
 	Budgets    []telemetry.RESTBudget
@@ -36,6 +42,15 @@ func (o *Orchestrator) captureConnectorRateLimits(state *State, now time.Time) g
 	if reporter, ok := o.connector.(connector.GraphQLRateLimitUsageReporter); ok {
 		usage = reporter.FlushGraphQLRateLimitUsage()
 	}
+	lastHourQueries, lastHourCost := recordGraphQLUsageWindow(state, usage, now)
+	cost := graphQLCostSummary(usage)
+	if cost == nil && (lastHourQueries > 0 || lastHourCost > 0) {
+		cost = &telemetry.GraphQLCost{}
+	}
+	if cost != nil {
+		cost.LastHourQueries = lastHourQueries
+		cost.LastHourCost = lastHourCost
+	}
 
 	var rateLimit connector.GraphQLRateLimit
 	hasRateLimit := usage.HasRateLimit
@@ -45,18 +60,19 @@ func (o *Orchestrator) captureConnectorRateLimits(state *State, now time.Time) g
 	} else if status == "" {
 		reporter, ok := o.connector.(connector.RateLimitReporter)
 		if !ok {
-			return graphQLRateLimitCycle{}
+			setGraphQLCost(state, cost)
+			return graphQLRateLimitCycle{Cost: cost}
 		} else {
 			var okRateLimit bool
 			rateLimit, okRateLimit = reporter.GraphQLRateLimit()
 			if !okRateLimit {
-				return graphQLRateLimitCycle{}
+				setGraphQLCost(state, cost)
+				return graphQLRateLimitCycle{Cost: cost}
 			}
 			hasRateLimit = okRateLimit
 		}
 	}
 
-	cost := graphQLCostSummary(usage)
 	bucket := gitHubGraphQLBucket(rateLimit, now, status)
 	if cost != nil {
 		bucket.Cost = cost.TotalCost
@@ -71,6 +87,41 @@ func (o *Orchestrator) captureConnectorRateLimits(state *State, now time.Time) g
 		Cost:       cost,
 		HasSummary: hasRateLimit,
 	}
+}
+
+func recordGraphQLUsageWindow(state *State, usage connector.GraphQLRateLimitUsage, now time.Time) (int64, int64) {
+	if usage.TotalQueries > 0 || usage.TotalCost > 0 {
+		state.graphQLUsageSamples = append(state.graphQLUsageSamples, graphQLUsageSample{
+			observedAt: now,
+			queries:    usage.TotalQueries,
+			cost:       usage.TotalCost,
+		})
+	}
+
+	cutoff := now.Add(-time.Hour)
+	retained := state.graphQLUsageSamples[:0]
+	var queries int64
+	var cost int64
+	for _, sample := range state.graphQLUsageSamples {
+		if sample.observedAt.Before(cutoff) {
+			continue
+		}
+		retained = append(retained, sample)
+		queries += sample.queries
+		cost += sample.cost
+	}
+	state.graphQLUsageSamples = retained
+	return queries, cost
+}
+
+func setGraphQLCost(state *State, cost *telemetry.GraphQLCost) {
+	if state.RateLimits == nil {
+		if cost == nil {
+			return
+		}
+		state.RateLimits = &telemetry.RateLimits{}
+	}
+	state.RateLimits.GraphQLCost = cost
 }
 
 func (o *Orchestrator) captureConnectorRESTRateLimits(state *State, now time.Time) restRateLimitCycle {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -110,6 +110,7 @@ type State struct {
 	ReapedWorkspaces         map[string]time.Time
 	TokenTotals              TokenTotals
 	RateLimits               *telemetry.RateLimits
+	graphQLUsageSamples      []graphQLUsageSample
 	laneEntries              map[string]time.Time
 	laneProvenance           map[string]provenance.Attribution
 	planRework               map[string]struct{}
@@ -510,6 +511,7 @@ func (s State) clone() State {
 		ReapedWorkspaces:         make(map[string]time.Time, len(s.ReapedWorkspaces)),
 		TokenTotals:              s.TokenTotals,
 		RateLimits:               cloneRateLimits(s.RateLimits),
+		graphQLUsageSamples:      append([]graphQLUsageSample(nil), s.graphQLUsageSamples...),
 		laneEntries:              maps.Clone(s.laneEntries),
 		laneProvenance:           maps.Clone(s.laneProvenance),
 		planRework:               make(map[string]struct{}, len(s.planRework)),

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1564,9 +1564,11 @@ type RateLimitBucket struct {
 }
 
 type GraphQLCost struct {
-	TotalQueries int64                    `json:"total_queries,omitempty"`
-	TotalCost    int64                    `json:"total_cost,omitempty"`
-	Contributors []GraphQLCostContributor `json:"contributors,omitempty"`
+	TotalQueries    int64                    `json:"total_queries,omitempty"`
+	TotalCost       int64                    `json:"total_cost,omitempty"`
+	LastHourQueries int64                    `json:"last_hour_queries,omitempty"`
+	LastHourCost    int64                    `json:"last_hour_cost,omitempty"`
+	Contributors    []GraphQLCostContributor `json:"contributors,omitempty"`
 }
 
 type GraphQLCostContributor struct {

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -166,6 +166,12 @@ func TestSnapshotJSONShape(t *testing.T) {
 				ObservedRequests: 22, DetentRequests: 2, AttributedRequests: 20,
 				WindowStartedAt: &divergenceStartedAt, LastObservedAt: &generatedAt, ResetAt: &divergenceResetAt,
 			}}},
+			GraphQLCost: &telemetry.GraphQLCost{
+				TotalQueries:    2,
+				TotalCost:       8,
+				LastHourQueries: 42,
+				LastHourCost:    137,
+			},
 		},
 		Tokens: telemetry.Tokens{
 			Input:          110,
@@ -238,6 +244,11 @@ func TestSnapshotJSONShape(t *testing.T) {
 		if _, ok := got[key]; !ok {
 			t.Fatalf("snapshot JSON missing %q: %s", key, string(data))
 		}
+	}
+	rateLimitJSON := got["rate_limits"].(map[string]any)
+	graphQLCost := rateLimitJSON["graphql_cost"].(map[string]any)
+	if graphQLCost["last_hour_queries"] != float64(42) || graphQLCost["last_hour_cost"] != float64(137) {
+		t.Fatalf("rate_limits.graphql_cost = %#v, want rolling-hour usage", graphQLCost)
 	}
 
 	project := got["project"].(map[string]any)

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -4450,6 +4450,10 @@ templ graphQLBudgetCard(data DashboardData) {
 					</div>
 				</div>
 				<div class="flex items-center justify-between gap-3 border-t border-line pt-3 text-sm">
+					<span class="text-sec">Last-hour queries</span>
+					<strong class="font-mono font-medium text-text">{ graphQLBudgetLastHourQueryCount(data.Snapshot.RateLimits) }</strong>
+				</div>
+				<div class="flex items-center justify-between gap-3 border-t border-line pt-3 text-sm">
 					<span class="text-sec">Cycle queries</span>
 					<strong class="font-mono font-medium text-text">{ graphQLBudgetQueryCount(data.Snapshot.RateLimits) }</strong>
 				</div>

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -8009,6 +8009,14 @@ func graphQLBudgetQueryCount(limits *telemetry.RateLimits) string {
 	return formatInt(limits.GraphQLCost.TotalQueries) + " " + pluralize("query", limits.GraphQLCost.TotalQueries)
 }
 
+func graphQLBudgetLastHourQueryCount(limits *telemetry.RateLimits) string {
+	if limits == nil || limits.GraphQLCost == nil {
+		return "0 queries"
+	}
+	count := limits.GraphQLCost.LastHourQueries
+	return formatInt(count) + " " + pluralize("query", count)
+}
+
 func graphQLBudgetContributorRows(limits *telemetry.RateLimits) []graphQLBudgetContributorRow {
 	if limits == nil || limits.GraphQLCost == nil || len(limits.GraphQLCost.Contributors) == 0 {
 		return nil

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -16188,20 +16188,33 @@ func graphQLBudgetCard(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1196, "</span></div></div><div class=\"flex items-center justify-between gap-3 border-t border-line pt-3 text-sm\"><span class=\"text-sec\">Cycle queries</span> <strong class=\"font-mono font-medium text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1196, "</span></div></div><div class=\"flex items-center justify-between gap-3 border-t border-line pt-3 text-sm\"><span class=\"text-sec\">Last-hour queries</span> <strong class=\"font-mono font-medium text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var784 string
-			templ_7745c5c3_Var784, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetQueryCount(data.Snapshot.RateLimits))
+			templ_7745c5c3_Var784, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetLastHourQueryCount(data.Snapshot.RateLimits))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4454, Col: 104}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4454, Col: 112}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var784))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1197, "</strong></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1197, "</strong></div><div class=\"flex items-center justify-between gap-3 border-t border-line pt-3 text-sm\"><span class=\"text-sec\">Cycle queries</span> <strong class=\"font-mono font-medium text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var785 string
+			templ_7745c5c3_Var785, templ_7745c5c3_Err = templ.JoinStringErrs(graphQLBudgetQueryCount(data.Snapshot.RateLimits))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4458, Col: 104}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var785))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1198, "</strong></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -16211,74 +16224,74 @@ func graphQLBudgetCard(data DashboardData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1198, "<div class=\"grid gap-2 border-t border-line pt-3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1199, "<div class=\"grid gap-2 border-t border-line pt-3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range graphQLBudgetContributorRows(data.Snapshot.RateLimits) {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1199, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var785 string
-					templ_7745c5c3_Var785, templ_7745c5c3_Err = templ.JoinStringErrs(row.QueryType)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4462, Col: 78}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var785))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1200, "</span> <span class=\"font-mono text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1200, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var786 string
-					templ_7745c5c3_Var786, templ_7745c5c3_Err = templ.JoinStringErrs(row.Cost)
+					templ_7745c5c3_Var786, templ_7745c5c3_Err = templ.JoinStringErrs(row.QueryType)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4463, Col: 51}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4466, Col: 78}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var786))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1201, "</span> <span class=\"font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1201, "</span> <span class=\"font-mono text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var787 string
-					templ_7745c5c3_Var787, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count)
+					templ_7745c5c3_Var787, templ_7745c5c3_Err = templ.JoinStringErrs(row.Cost)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4464, Col: 60}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4467, Col: 51}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var787))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1202, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1202, "</span> <span class=\"font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var788 string
-					templ_7745c5c3_Var788, templ_7745c5c3_Err = templ.JoinStringErrs(row.Percent)
+					templ_7745c5c3_Var788, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4465, Col: 73}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4468, Col: 60}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var788))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1203, "</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1203, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var789 string
+					templ_7745c5c3_Var789, templ_7745c5c3_Err = templ.JoinStringErrs(row.Percent)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4469, Col: 73}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var789))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1204, "</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1204, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1205, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1205, "</div></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1206, "</div></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -16303,17 +16316,17 @@ func restBudgetCard(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var789 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var789 == nil {
-			templ_7745c5c3_Var789 = templ.NopComponent
+		templ_7745c5c3_Var790 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var790 == nil {
+			templ_7745c5c3_Var790 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if hasRESTBudget(data.Snapshot.RateLimits) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1206, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"REST budget\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1207, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\" aria-label=\"REST budget\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var790 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var791 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -16325,105 +16338,105 @@ func restBudgetCard(data DashboardData) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1207, "<span class=\"shrink-0 rounded-full bg-warn/15 px-2 py-1 font-mono text-xs font-medium text-warn\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var791 string
-				templ_7745c5c3_Var791, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRequestCount(data.Snapshot.RateLimits))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4479, Col: 151}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var791))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1208, "</span>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				return nil
-			})
-			templ_7745c5c3_Err = panelHeader(icon.Server(icon.Props{Class: "size-4 shrink-0"}), "REST budget", helpRateLimits, "rest-budget-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var790), templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1209, "<div class=\"mt-5 grid gap-3\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if len(data.Snapshot.RateLimits.GitHubRESTBudgets) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1210, "<div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Credentials</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1208, "<span class=\"shrink-0 rounded-full bg-warn/15 px-2 py-1 font-mono text-xs font-medium text-warn\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var792 string
-				templ_7745c5c3_Var792, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(restBudgetCredentialCount(data.Snapshot.RateLimits)))
+				templ_7745c5c3_Var792, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRequestCount(data.Snapshot.RateLimits))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4486, Col: 131}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4483, Col: 151}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var792))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1211, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Endpoint budgets</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1209, "</span>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = panelHeader(icon.Server(icon.Props{Class: "size-4 shrink-0"}), "REST budget", helpRateLimits, "rest-budget-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var791), templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1210, "<div class=\"mt-5 grid gap-3\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if len(data.Snapshot.RateLimits.GitHubRESTBudgets) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1211, "<div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Credentials</span> <strong class=\"font-mono text-base font-semibold text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var793 string
-				templ_7745c5c3_Var793, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(data.Snapshot.RateLimits.GitHubRESTBudgets))))
+				templ_7745c5c3_Var793, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(restBudgetCredentialCount(data.Snapshot.RateLimits)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4490, Col: 134}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4490, Col: 131}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var793))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1212, "</strong></div></div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1213, "<div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1212, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Endpoint budgets</span> <strong class=\"font-mono text-base font-semibold text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var794 string
-				templ_7745c5c3_Var794, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRemaining(data.Snapshot.RateLimits))
+				templ_7745c5c3_Var794, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(data.Snapshot.RateLimits.GitHubRESTBudgets))))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4497, Col: 124}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4494, Col: 134}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var794))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1214, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1213, "</strong></div></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1214, "<div class=\"grid grid-cols-2 gap-3 text-sm\"><div class=\"grid gap-1\"><span class=\"text-sec\">Remaining</span> <strong class=\"break-all font-mono text-base font-semibold text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var795 string
-				templ_7745c5c3_Var795, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
+				templ_7745c5c3_Var795, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetRemaining(data.Snapshot.RateLimits))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4501, Col: 137}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4501, Col: 124}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var795))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1215, "</strong> <span class=\"font-mono text-xs text-sec\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1215, "</strong></div><div class=\"grid gap-1\"><span class=\"text-sec\">Reset</span> <strong class=\"font-mono text-base font-semibold text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var796 string
-				templ_7745c5c3_Var796, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetResetAt(data.Snapshot.RateLimits))
+				templ_7745c5c3_Var796, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetReset(data.Snapshot.RateLimits, data.Snapshot.GeneratedAt))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4502, Col: 93}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4505, Col: 137}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var796))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1216, "</span></div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1216, "</strong> <span class=\"font-mono text-xs text-sec\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var797 string
+				templ_7745c5c3_Var797, templ_7745c5c3_Err = templ.JoinStringErrs(restBudgetResetAt(data.Snapshot.RateLimits))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4506, Col: 93}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var797))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1217, "</span></div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -16434,20 +16447,20 @@ func restBudgetCard(data DashboardData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1217, "<details class=\"group border-t border-line pt-3\" data-preserve-details=\"rest-budget-contributors\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 text-sm text-sec marker:hidden\"><span class=\"font-medium text-text\">Endpoint details</span> <span class=\"inline-flex shrink-0 items-center gap-2\"><span class=\"rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1218, "<details class=\"group border-t border-line pt-3\" data-preserve-details=\"rest-budget-contributors\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 text-sm text-sec marker:hidden\"><span class=\"font-medium text-text\">Endpoint details</span> <span class=\"inline-flex shrink-0 items-center gap-2\"><span class=\"rounded-md bg-elev px-2 py-1 font-mono text-xs text-sec\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var797 string
-				templ_7745c5c3_Var797, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(restBudgetContributorRows(data.Snapshot.RateLimits)))))
+				var templ_7745c5c3_Var798 string
+				templ_7745c5c3_Var798, templ_7745c5c3_Err = templ.JoinStringErrs(formatInt(int64(len(restBudgetContributorRows(data.Snapshot.RateLimits)))))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4513, Col: 154}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4517, Col: 154}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var797))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var798))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1218, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1219, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -16455,100 +16468,100 @@ func restBudgetCard(data DashboardData) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1219, "</span></summary><div class=\"mt-3 grid gap-2\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1220, "</span></summary><div class=\"mt-3 grid gap-2\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range restBudgetContributorRows(data.Snapshot.RateLimits) {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1220, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var798 string
-					templ_7745c5c3_Var798, templ_7745c5c3_Err = templ.JoinStringErrs(row.EndpointFamily)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4520, Col: 84}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var798))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1221, "</span> <span class=\"font-mono text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1221, "<div class=\"grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 text-sm\"><span class=\"truncate font-mono font-medium text-text\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var799 string
-					templ_7745c5c3_Var799, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
+					templ_7745c5c3_Var799, templ_7745c5c3_Err = templ.JoinStringErrs(row.EndpointFamily)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4521, Col: 57}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4524, Col: 84}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var799))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1222, "</span> <span class=\"truncate font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1222, "</span> <span class=\"font-mono text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var800 string
-					templ_7745c5c3_Var800, templ_7745c5c3_Err = templ.JoinStringErrs(row.Consumer + " · " + row.CredentialIdentity)
+					templ_7745c5c3_Var800, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4522, Col: 107}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4525, Col: 57}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var800))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1223, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1223, "</span> <span class=\"truncate font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var801 string
-					templ_7745c5c3_Var801, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reset)
+					templ_7745c5c3_Var801, templ_7745c5c3_Err = templ.JoinStringErrs(row.Consumer + " · " + row.CredentialIdentity)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4523, Col: 72}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4526, Col: 107}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var801))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1224, "</span> <span class=\"truncate font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1224, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var802 string
-					templ_7745c5c3_Var802, templ_7745c5c3_Err = templ.JoinStringErrs(row.Resource)
+					templ_7745c5c3_Var802, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reset)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4524, Col: 73}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4527, Col: 72}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var802))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1225, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1225, "</span> <span class=\"truncate font-mono text-xs text-sec\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var803 string
-					templ_7745c5c3_Var803, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count + " · " + row.Status)
+					templ_7745c5c3_Var803, templ_7745c5c3_Err = templ.JoinStringErrs(row.Resource)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4525, Col: 94}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4528, Col: 73}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var803))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1226, "</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1226, "</span> <span class=\"text-right font-mono text-xs text-sec\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var804 string
+					templ_7745c5c3_Var804, templ_7745c5c3_Err = templ.JoinStringErrs(row.Count + " · " + row.Status)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4529, Col: 94}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var804))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1227, "</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1227, "</div></details>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1228, "</div></details>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1228, "</div></section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1229, "</div></section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -16573,16 +16586,16 @@ func tokenCard(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var804 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var804 == nil {
-			templ_7745c5c3_Var804 = templ.NopComponent
+		templ_7745c5c3_Var805 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var805 == nil {
+			templ_7745c5c3_Var805 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1229, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1230, "<section class=\"dashboard-panel min-w-0 rounded-md border border-line bg-surface p-4 shadow-sm sm:p-5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var805 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var806 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -16594,56 +16607,56 @@ func tokenCard(data DashboardData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1230, "<span class=\"shrink-0 rounded-full bg-elev px-2 py-1 font-mono text-xs font-medium text-sec\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1231, "<span class=\"shrink-0 rounded-full bg-elev px-2 py-1 font-mono text-xs font-medium text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var806 string
-			templ_7745c5c3_Var806, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
+			var templ_7745c5c3_Var807 string
+			templ_7745c5c3_Var807, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4539, Col: 122}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4543, Col: 122}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var806))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var807))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1231, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1232, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = panelHeader(icon.Coins(icon.Props{Class: "size-4 shrink-0"}), "Tokens", helpTokens, "tokens-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var805), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = panelHeader(icon.Coins(icon.Props{Class: "size-4 shrink-0"}), "Tokens", helpTokens, "tokens-card").Render(templ.WithChildren(ctx, templ_7745c5c3_Var806), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1232, "<div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-text sm:text-3xl\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var807 string
-		templ_7745c5c3_Var807, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4542, Col: 117}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var807))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1233, "</div><div class=\"font-mono text-sm text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1233, "<div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-text sm:text-3xl\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var808 string
-		templ_7745c5c3_Var808, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
+		templ_7745c5c3_Var808, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4543, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4546, Col: 117}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var808))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1234, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1234, "</div><div class=\"font-mono text-sm text-sec\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var809 string
+		templ_7745c5c3_Var809, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4547, Col: 87}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var809))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1235, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -16651,20 +16664,20 @@ func tokenCard(data DashboardData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1235, "<span class=\"font-mono text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1236, "<span class=\"font-mono text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var809 string
-		templ_7745c5c3_Var809, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
+		var templ_7745c5c3_Var810 string
+		templ_7745c5c3_Var810, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4548, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 4552, Col: 98}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var809))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var810))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1236, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1237, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -16678,12 +16691,12 @@ func tokenCard(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1237, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-sec\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-ok\"></span>Output</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1238, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-sec\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-ok\"></span>Output</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1238, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1239, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -120,6 +120,10 @@ func TestProjectDiagnosticsPageRendersTabbedOperationsView(t *testing.T) {
 				Status:        telemetry.RefreshStatusReady,
 				LastRefreshAt: &now,
 			},
+			RateLimits: &telemetry.RateLimits{
+				GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 4880, Used: 120, Limit: 5000},
+				GraphQLCost:   &telemetry.GraphQLCost{TotalQueries: 2, TotalCost: 8, LastHourQueries: 42, LastHourCost: 137},
+			},
 			WorkAttempts: []telemetry.WorkAttempt{
 				{
 					AttemptID:     42,
@@ -212,6 +216,10 @@ func TestProjectDiagnosticsPageRendersTabbedOperationsView(t *testing.T) {
 		"Active work",
 		"Queues &amp; blockers",
 		"GitHub/API",
+		"Last-hour queries",
+		"42 queries",
+		"Cycle queries",
+		"2 queries",
 		"Runtime store",
 		"Raw/Debug",
 		`detent.ui.diagnostics.selectedTab.detent`,


### PR DESCRIPTION
## Summary

- Reuse complete ProjectV2 scans to cache card status, priority, custom claim fields and membership for five minutes. Warm issue-state passes avoid per-card GraphQL lookups; writes refresh only changed cards, and invalidated in-flight scans cannot restore stale state. Candidate discovery retains its lightweight query.
- Skip hydration for retries with a recorded paused provider scope while preserving recovery probes and existing reserve-based polling backoff. Candidates without a recorded scope still hydrate model routing inputs before admission.
- Show rolling-hour GraphQL request totals in diagnostics and request/cost totals in status JSON alongside the shared remaining budget. Hourly totals cover the project connector and reset on restart. REST totals remain per-cycle.

Fixes #2111

## UI Surface Contract

- [x] The issue explicitly requests GraphQL usage visibility; this adds one row to the existing diagnostics budget card.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] Verified the real diagnostics page through Chrome DevTools on an isolated random-port server. The GitHub/API tab displayed 42 last-hour queries, 2 cycle queries, and 4,880 / 5,000 remaining; viewport layout was inspected.

## Test Plan

- [x] Focused connector, orchestrator, telemetry and template tests with Go 1.26.6.
- [x] Regression coverage for batch and warm-pass request counts, pagination, claim metadata, TTL and negative membership, changed-card refresh, invalidation during a scan, provider pauses and recovery probes, hourly expiry, and JSON/template rendering.
- [x] `make generate`.
- [x] `make check` on the rebased commit: all checks passed, 79.0% coverage and all configured package/file floors satisfied.
