### PR TITLE
fix(workspace): restrict process ownership to cwd

### DIFF
--- a/.detent/skills/workspace-process-ownership.md
+++ b/.detent/skills/workspace-process-ownership.md
@@ -1,0 +1,41 @@
+---
+name: workspace-process-ownership
+description: Diagnose extra workspace reap matches caused by outside processes holding files, especially during macOS container validation.
+when_to_use: Use when workspace cleanup counts vary under concurrent load or host services disappear while a workspace is reaped.
+---
+
+# Diagnose workspace process ownership
+
+Capture identities before cleanup signals erase the evidence. On macOS,
+`lsof -FpcRfn +D "$workspace"` records PID, parent PID, command, descriptor,
+and matched path. Compare each process's working directory with its ordinary
+file descriptors; an open file alone does not establish worker ownership.
+Keep the original reap count and termination assertions until every extra
+match is explained.
+
+Docker Desktop can make host file-sharing services hold descriptors inside
+a bind-mounted workspace. Mounting a parent directory and opening a file in
+a child workspace from a bounded container can reproduce this safely. Run
+only read-only process scans against that probe; do not feed host service
+PIDs to the old reaper. Allow the probe container to exit naturally. A mount
+of the workspace itself can also expose the Docker backend's mount-root
+descriptor, producing an additional match.
+
+Check the intended ownership contract across platforms. Detent's Linux
+scanner selects `/proc/<pid>/cwd` beneath the workspace. The corresponding
+lsof selection is `-a -d cwd -t +D "$workspace"`; `-a` intersects the
+descriptor and directory selectors. Validate both the workspace root and
+its descendants when changing this boundary. Keep process-group cleanup
+responsible for registered worker descendants independently of cwd.
+
+Turn the observed distinction into a deterministic regression without
+depending on Docker: start one helper with cwd inside the workspace and an
+exclusive lock, and another with cwd outside but a different locked file
+inside. Use readiness pipes to establish both locks before completing or
+canceling the turn. Require exactly one reap, the inside helper's exit and
+released lock, and the outside helper's survival and retained lock. Capture
+the native file matches before reaping so failures retain ownership evidence.
+
+Repeat race tests under concurrent validation load, then run the full gate.
+Separate reproduced identities from historical attribution when the original
+failure recorded only a count.

--- a/internal/runner/duration_limit_unix_test.go
+++ b/internal/runner/duration_limit_unix_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -21,35 +22,35 @@ import (
 
 func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
 	tests := []struct {
-		name      string
-		completed bool
-		wantErr   error
+		name         string
+		subdirectory string
+		completed    bool
+		wantErr      error
 	}{
 		{name: "completed turn abandons command", completed: true},
 		{name: "session cancellation", wantErr: ErrSessionDurationExceeded},
+		{name: "completed turn in nested directory", subdirectory: "nested", completed: true},
+		{name: "session cancellation in nested directory", subdirectory: "nested", wantErr: ErrSessionDurationExceeded},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			workspacePath := t.TempDir()
+			workingDirectory := filepath.Join(workspacePath, tt.subdirectory)
+			if err := os.MkdirAll(workingDirectory, 0o700); err != nil {
+				t.Fatalf("create command working directory: %v", err)
+			}
 			lockPath := filepath.Join(workspacePath, "gate.lock")
 			durationLimit := &controlledDurationLimit{}
-			command, readyReader, readyWriter := workspaceLockCommand(t, workspacePath, lockPath)
-			backend := &orphanLockAgentBackend{
-				command:       command,
-				readyReader:   readyReader,
-				readyWriter:   readyWriter,
-				expireSession: durationLimit.Expire,
-				completed:     tt.completed,
+			backend := newOrphanLockAgentBackend(t, workingDirectory, lockPath)
+			backend.expireSession = durationLimit.Expire
+			backend.completed = tt.completed
+			observerLockPath := filepath.Join(workspacePath, "observer.lock")
+			observer := newOrphanLockAgentBackend(t, t.TempDir(), observerLockPath)
+			observer.completed = true
+			if _, err := observer.RunTurn(t.Context(), AgentTurnRequest{}, func(AgentUpdate) error { return nil }); err != nil {
+				t.Fatalf("start outside workspace file holder: %v", err)
 			}
-			t.Cleanup(func() {
-				if backend.command.Process != nil {
-					_ = backend.command.Process.Kill()
-				}
-				if backend.waitDone != nil {
-					<-backend.waitDone
-				}
-			})
 			var reaped int
 			var reapErr error
 
@@ -65,6 +66,13 @@ func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
 				sessionLimit:    durationLimit.Context,
 				WorkerReapGrace: 5 * time.Second,
 				ReapWorkspaceProcesses: func(ctx context.Context, path string, grace time.Duration) (int, error) {
+					t.Logf("workspace holder: pid=%d cwd=%q lock=%q; outside holder: pid=%d cwd=%q lock=%q",
+						backend.command.Process.Pid, backend.command.Dir, lockPath,
+						observer.command.Process.Pid, observer.command.Dir, observerLockPath)
+					if runtime.GOOS != "linux" {
+						output, err := exec.CommandContext(ctx, "lsof", "-FpcRfn", "+D", path).CombinedOutput()
+						t.Logf("workspace file matches before reap: error=%v\n%s", err, output)
+					}
 					reaped, reapErr = workspace.ReapProcesses(ctx, path, grace)
 					return reaped, reapErr
 				},
@@ -83,7 +91,7 @@ func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
 				t.Fatalf("Run() error = %v, want %v", runErr, tt.wantErr)
 			}
 			if reapErr != nil || reaped != 1 {
-				t.Fatalf("workspace reap = (%d, %v), want (1, nil)", reaped, reapErr)
+				t.Errorf("workspace reap = (%d, %v), want (1, nil)", reaped, reapErr)
 			}
 
 			select {
@@ -92,6 +100,19 @@ func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
 				t.Fatal("workspace lock holder survived terminal session")
 			}
 			assertLockAvailable(t, lockPath)
+			select {
+			case <-observer.waitDone:
+				t.Fatal("file holder outside the workspace was terminated")
+			default:
+			}
+			observerLock, err := os.OpenFile(observerLockPath, os.O_RDWR, 0o600)
+			if err != nil {
+				t.Fatalf("open observer lock: %v", err)
+			}
+			defer observerLock.Close()
+			if err := syscall.Flock(int(observerLock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); !errors.Is(err, syscall.EWOULDBLOCK) {
+				t.Fatalf("outside workspace file holder lock = %v, want EWOULDBLOCK", err)
+			}
 		})
 	}
 }
@@ -128,6 +149,25 @@ type orphanLockAgentBackend struct {
 	expireSession func()
 	completed     bool
 	waitDone      chan struct{}
+}
+
+func newOrphanLockAgentBackend(t *testing.T, workspacePath string, lockPath string) *orphanLockAgentBackend {
+	t.Helper()
+	command, readyReader, readyWriter := workspaceLockCommand(t, workspacePath, lockPath)
+	backend := &orphanLockAgentBackend{
+		command:     command,
+		readyReader: readyReader,
+		readyWriter: readyWriter,
+	}
+	t.Cleanup(func() {
+		if backend.command.Process != nil {
+			_ = backend.command.Process.Kill()
+		}
+		if backend.waitDone != nil {
+			<-backend.waitDone
+		}
+	})
+	return backend
 }
 
 func (b *orphanLockAgentBackend) RunTurn(ctx context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -193,7 +193,7 @@ func linuxWorkspaceProcessIDs(path string) ([]int, error) {
 }
 
 func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
-	cmd := exec.CommandContext(ctx, "lsof", "-t", "+D", path) // #nosec G204 -- the workspace path is passed as an lsof argument without a shell.
+	cmd := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-t", "+D", path) // #nosec G204 -- the workspace path is passed as an lsof argument without a shell.
 	output, err := cmd.Output()
 	if err != nil && len(output) == 0 {
 		var exitErr *exec.ExitError


### PR DESCRIPTION
## Summary

macOS workspace cleanup treated any open workspace file as process ownership. A safe concurrent Docker bind-mount probe reproduced two matches: the process working inside the workspace and Apple’s Virtualization service holding ordinary file descriptors. Restrict the lsof selection to working directories beneath the workspace, matching Linux ownership.

Completion and cancellation tests now coordinate an inside lock holder and an outside file holder, at both root and nested working directories. They retain the exact one-process count, command exit, and lock-release assertions, require the outside process to retain its lock, and log process identities and workspace file matches before cleanup. Include a reusable ownership-diagnosis skill draft.

The original failure did not capture PIDs, so the historical second identity cannot be proven. The controlled regression reproduced `(2, nil)` in both original terminal variants before the fix; the Docker probe establishes how concurrent browser validation can add a host-service match.

Fixes #2208

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, first-viewport, or responsive visibility changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A: no visual changes requiring screenshot or browser verification.

## Test Plan

- [x] Reproduce `(2, nil)` with synchronized inside/outside file holders before the fix; capture PID, parent, command, descriptors, and workspace paths.
- [x] Read-only Docker parent-bind-mount probe: unrestricted scan matches two PIDs; cwd selection matches only the workspace process. No host service signaled.
- [x] `env -u DETENT_API_TOKEN go test -race ./internal/runner -run '^TestRunnerTerminalSessionReapsEscapedWorkspaceProcess$' -count=30` — 120 cases passed concurrently with the full gate.
- [x] `make check` — passed after skill draft, 79.8% coverage and all package/file floors.
