### PR TITLE
fix(explain): report post-selection dispatch refusal

### DIFF
--- a/internal/explain/model.go
+++ b/internal/explain/model.go
@@ -166,13 +166,17 @@ type Eligibility struct {
 }
 
 type EligibilityDecision struct {
-	Historical bool             `json:"historical,omitempty"`
-	EvidenceID string           `json:"evidence_id"`
-	Source     string           `json:"source"`
-	State      EligibilityState `json:"state"`
-	Outcome    string           `json:"outcome"`
-	Reason     string           `json:"reason,omitempty"`
-	At         time.Time        `json:"at"`
+	Historical          bool             `json:"historical,omitempty"`
+	EvidenceID          string           `json:"evidence_id"`
+	Source              string           `json:"source"`
+	State               EligibilityState `json:"state"`
+	Outcome             string           `json:"outcome"`
+	Reason              string           `json:"reason,omitempty"`
+	ReasonCode          string           `json:"reason_code,omitempty"`
+	AttemptNumber       int              `json:"attempt_number,omitempty"`
+	SelectionEvidenceID string           `json:"selection_evidence_id,omitempty"`
+	At                  time.Time        `json:"at"`
+	sequence            int64
 }
 
 type Attempt struct {

--- a/internal/explain/select.go
+++ b/internal/explain/select.go
@@ -511,6 +511,20 @@ func selectTransition(events []store.WorkflowPhaseEvent, trustworthySince time.T
 }
 
 func buildEligibility(collected collectedEvidence) Eligibility {
+	type schedulerCycle struct {
+		at      time.Time
+		attempt int
+	}
+	selections := make(map[schedulerCycle]int64, len(collected.schedulerDecisions))
+	for _, decision := range collected.schedulerDecisions {
+		if !decision.Selected && decision.Result != store.SchedulerDecisionResultSelected {
+			continue
+		}
+		cycle := schedulerCycle{at: decision.DecisionAt.UTC(), attempt: decision.AttemptNumber}
+		if decision.ID > selections[cycle] {
+			selections[cycle] = decision.ID
+		}
+	}
 	decisions := make([]EligibilityDecision, 0, len(collected.schedulerDecisions)+len(collected.admissionProposals))
 	for _, decision := range collected.schedulerDecisions {
 		state := EligibilityUnknown
@@ -523,14 +537,24 @@ func buildEligibility(collected collectedEvidence) Eligibility {
 		if state == EligibilityUnknown {
 			continue
 		}
-		decisions = append(decisions, EligibilityDecision{
+		eligibilityDecision := EligibilityDecision{
 			EvidenceID: fmt.Sprintf("scheduler:%d", decision.ID),
 			Source:     "scheduler",
 			State:      state,
 			Outcome:    string(decision.Result),
 			Reason:     firstNonEmpty(decision.WaitReason, decision.Reason),
 			At:         decision.DecisionAt.UTC(),
-		})
+			sequence:   decision.ID,
+		}
+		if state == EligibilityRefused {
+			eligibilityDecision.ReasonCode = strings.TrimSpace(decision.Reason)
+			cycle := schedulerCycle{at: decision.DecisionAt.UTC(), attempt: decision.AttemptNumber}
+			if selectionID := selections[cycle]; selectionID > 0 && selectionID < decision.ID {
+				eligibilityDecision.AttemptNumber = decision.AttemptNumber
+				eligibilityDecision.SelectionEvidenceID = fmt.Sprintf("scheduler:%d", selectionID)
+			}
+		}
+		decisions = append(decisions, eligibilityDecision)
 	}
 	for _, proposal := range collected.admissionProposals {
 		state := EligibilityUnknown
@@ -592,6 +616,12 @@ func compareEligibilityDecisions(left EligibilityDecision, right EligibilityDeci
 		if right.Source == "scheduler" {
 			return 1
 		}
+	}
+	if left.Source == "scheduler" && left.sequence != right.sequence {
+		if left.sequence > right.sequence {
+			return -1
+		}
+		return 1
 	}
 	return -strings.Compare(left.EvidenceID, right.EvidenceID)
 }

--- a/internal/explain/service_test.go
+++ b/internal/explain/service_test.go
@@ -281,6 +281,49 @@ func TestServiceReportsOnlyRecordedEligibility(t *testing.T) {
 	}
 }
 
+func TestServiceCorrelatesPostSelectionDispatchRefusal(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 19, 1, 6, 0, time.UTC)
+	tests := []struct {
+		name   string
+		reason string
+		detail string
+	}{
+		{name: "CPU pressure", reason: "cpu_pressure_high", detail: "CPU pressure is above the admission threshold"},
+		{name: "claim rejected", reason: "claim_failed", detail: "claim_failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader := &evidenceReader{
+				observation: liveIssueObservation(now, telemetry.Issue{ID: "issue-1", ProjectID: "detent", State: "Todo"}),
+				decisions: []store.SchedulerDecision{
+					{ID: 9, ProjectID: "detent", IssueID: "issue-1", Result: store.SchedulerDecisionResultSelected, Selected: true, AttemptNumber: 4, DecisionAt: now},
+					{ID: 10, ProjectID: "detent", IssueID: "issue-1", Result: store.SchedulerDecisionResultSkipped, Reason: tt.reason, WaitReason: tt.detail, AttemptNumber: 4, DecisionAt: now},
+				},
+			}
+
+			got, err := newTestService(now, reader).Explain(t.Context(), Query{ProjectID: "detent", IssueID: "issue-1"})
+			if err != nil {
+				t.Fatalf("Explain() error = %v", err)
+			}
+			latest := got.Eligibility.Latest
+			if got.Eligibility.State != EligibilityRefused || latest == nil {
+				t.Fatalf("eligibility = %#v, want refused latest decision", got.Eligibility)
+			}
+			if latest.Outcome != string(store.SchedulerDecisionResultSkipped) || latest.Reason != tt.detail {
+				t.Fatalf("latest eligibility = %#v, want skipped %q", latest, tt.detail)
+			}
+			if latest.ReasonCode != tt.reason || latest.AttemptNumber != 4 || latest.SelectionEvidenceID != "scheduler:9" {
+				t.Fatalf("latest correlation = %#v, want %q attempt 4 selection scheduler:9", latest, tt.reason)
+			}
+		})
+	}
+}
+
 func TestServiceAttemptSessionAndGatePrecedence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -102,18 +102,24 @@ func (o *Orchestrator) recordPostSelectionDispatchRefusal(
 	selection dispatchPlanDecision,
 	outcome dispatchIssueOutcome,
 ) {
+	reason := strings.TrimSpace(outcome.reason)
+	waitReason := schedulerDecisionWaitReason(reason)
+	if detail := strings.TrimSpace(outcome.waitReason); detail != "" {
+		waitReason = detail
+	}
 	for _, decision := range state.SchedulerDecisions {
 		if decision.IssueID == selection.Issue.ID &&
 			decision.AttemptNumber == selection.Attempt &&
 			decision.DecisionAt.Equal(now) &&
 			!decision.Selected &&
-			decision.Result == string(store.SchedulerDecisionResultSkipped) {
+			decision.Result == string(store.SchedulerDecisionResultSkipped) &&
+			postSelectionDispatchRefusalEquivalent(decision.Reason, decision.WaitReason, reason, waitReason) {
 			return
 		}
 	}
 	selection.Selected = false
 	selection.SelectionReason = ""
-	selection.SkipReason = strings.TrimSpace(outcome.reason)
+	selection.SkipReason = reason
 	selection.SkipDetail = strings.TrimSpace(outcome.waitReason)
 	o.recordSchedulerDecision(
 		ctx,
@@ -123,6 +129,14 @@ func (o *Orchestrator) recordPostSelectionDispatchRefusal(
 		string(store.SchedulerDecisionResultSkipped),
 		selection.SkipReason,
 	)
+}
+
+func postSelectionDispatchRefusalEquivalent(recordedReason, recordedWaitReason, outcomeReason, outcomeWaitReason string) bool {
+	if strings.TrimSpace(outcomeReason) == dispatchIssueFailureGlobalSlotUnavailable {
+		return true
+	}
+	return strings.TrimSpace(recordedReason) == strings.TrimSpace(outcomeReason) &&
+		strings.TrimSpace(recordedWaitReason) == strings.TrimSpace(outcomeWaitReason)
 }
 
 func (o *Orchestrator) escalateCorrectableDispatchDecision(state *State, now time.Time, issue connector.Issue, reason string) bool {

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -95,6 +95,36 @@ func correctableDispatchEscalated(state *State, issueID string, reason string) b
 	return ok
 }
 
+func (o *Orchestrator) recordPostSelectionDispatchRefusal(
+	ctx context.Context,
+	state *State,
+	now time.Time,
+	selection dispatchPlanDecision,
+	outcome dispatchIssueOutcome,
+) {
+	for _, decision := range state.SchedulerDecisions {
+		if decision.IssueID == selection.Issue.ID &&
+			decision.AttemptNumber == selection.Attempt &&
+			decision.DecisionAt.Equal(now) &&
+			!decision.Selected &&
+			decision.Result == string(store.SchedulerDecisionResultSkipped) {
+			return
+		}
+	}
+	selection.Selected = false
+	selection.SelectionReason = ""
+	selection.SkipReason = strings.TrimSpace(outcome.reason)
+	selection.SkipDetail = strings.TrimSpace(outcome.waitReason)
+	o.recordSchedulerDecision(
+		ctx,
+		state,
+		now,
+		selection,
+		string(store.SchedulerDecisionResultSkipped),
+		selection.SkipReason,
+	)
+}
+
 func (o *Orchestrator) escalateCorrectableDispatchDecision(state *State, now time.Time, issue connector.Issue, reason string) bool {
 	if state == nil {
 		return false

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -140,6 +140,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	var lastDispatchFailure string
 	decisions := make([]dispatchPlanDecision, 0, len(issues))
 	outcomes := make(map[string]dispatchIssueOutcome, len(issues))
+	selections := make(map[string]dispatchPlanDecision, len(issues))
 	planner.plan(state, issues, now, dispatchPlanHooks{
 		hydrate: func(issue connector.Issue) (connector.Issue, bool) {
 			return o.hydrateDispatchIssue(ctx, state, issue, now)
@@ -154,6 +155,11 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			outcome := o.dispatchIssueWithAction(ctx, state, action, now)
 			if identity := workflowIssueIdentityKey(action.issue); identity != "" {
 				outcomes[identity] = outcome
+				if !outcome.dispatched {
+					if selection, ok := selections[identity]; ok {
+						o.recordPostSelectionDispatchRefusal(ctx, state, now, selection, outcome)
+					}
+				}
 			}
 			if !outcome.dispatched {
 				lastDispatchFailure = outcome.reason
@@ -194,6 +200,11 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		decision: func(decision dispatchPlanDecision) {
 			decisions = append(decisions, decision)
 			o.logDispatchPlanDecision(ctx, state, now, decision)
+			if decision.Selected {
+				if identity := workflowIssueIdentityKey(decision.Issue); identity != "" {
+					selections[identity] = decision
+				}
+			}
 		},
 	})
 	o.releaseDeferredSchedulingClaims(ctx, state, issues)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3502,6 +3502,76 @@ func TestDispatchReadyIssuesRecordsPostSelectionRefusal(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesPreservesConcretePressureRefusal(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 19, 1, 6, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Project:             scheduler.ProjectCandidate{ID: "detent"},
+	})
+	globalGate := scheduler.NewGlobalDispatchGate(
+		scheduler.NewRoundRobin(scheduler.Config{Capacity: 2}),
+		cfg.Project,
+	)
+	heldSlot, ok, decision, err := globalGate.TryAcquireWithDecision(
+		t.Context(),
+		cfg.Project,
+		scheduler.SlotRequest{State: "Todo"},
+		now.Add(-time.Minute),
+	)
+	if err != nil || !ok {
+		t.Fatalf("TryAcquireWithDecision() = %#v, %v, want acquired slot; decision = %#v", heldSlot, err, decision)
+	}
+	t.Cleanup(func() {
+		if err := globalGate.Release(heldSlot); err != nil {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
+
+	state := newState(cfg)
+	state.CPUPressure = telemetry.CPUPressure{
+		Supported:                    true,
+		Some:                         telemetry.PressureAverages{Avg10: 84.78},
+		SomeAvg10Max:                 80,
+		CapacityConstrained:          true,
+		EffectiveMaxConcurrentAgents: 1,
+		ConstrainedSince:             now.Add(-time.Minute),
+	}
+	attempts := &recordingWorkAttemptStore{}
+	orch := Orchestrator{
+		cfg:                cfg,
+		workAttempts:       attempts,
+		globalDispatchGate: globalGate,
+		now:                func() time.Time { return now },
+	}
+	issue := dispatchTestIssue("issue-pressure-capacity", "Todo")
+
+	orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{issue}, now)
+
+	if len(attempts.starts) != 0 {
+		t.Fatalf("work attempt starts = %#v, want none", attempts.starts)
+	}
+	if len(attempts.decisions) != 3 {
+		t.Fatalf("scheduler decisions = %#v, want selection, gate refusal, and concrete pressure refusal", attempts.decisions)
+	}
+	selected, gateRefusal, pressureRefusal := attempts.decisions[0], attempts.decisions[1], attempts.decisions[2]
+	if selected.Result != store.SchedulerDecisionResultSelected || !selected.Selected {
+		t.Fatalf("selected decision = %#v", selected)
+	}
+	if gateRefusal.Reason != scheduler.DispatchGateReasonPressureCapacityFull {
+		t.Fatalf("gate refusal = %#v, want %q", gateRefusal, scheduler.DispatchGateReasonPressureCapacityFull)
+	}
+	if pressureRefusal.Result != store.SchedulerDecisionResultSkipped || pressureRefusal.Selected || pressureRefusal.Reason != dispatchIssueFailureCPUPressure {
+		t.Fatalf("pressure refusal = %#v, want skipped %q", pressureRefusal, dispatchIssueFailureCPUPressure)
+	}
+	if !selected.DecisionAt.Equal(pressureRefusal.DecisionAt) || selected.AttemptNumber != pressureRefusal.AttemptNumber {
+		t.Fatalf("decision correlation = selected %#v pressure refusal %#v", selected, pressureRefusal)
+	}
+}
+
 func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3432,6 +3432,76 @@ func TestDispatchReadyIssuesPersistsEveryCapacitySkip(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesRecordsPostSelectionRefusal(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 9, 4, 19, 1, 6, 0, time.UTC)
+	tests := []struct {
+		name      string
+		configure func(*Config, *State)
+		want      string
+	}{
+		{
+			name: "CPU pressure",
+			configure: func(_ *Config, state *State) {
+				state.CPUPressure = telemetry.CPUPressure{
+					Supported:        true,
+					Some:             telemetry.PressureAverages{Avg10: 84.78},
+					SomeAvg10Max:     80,
+					DispatchHeld:     true,
+					ConstrainedSince: now.Add(-time.Minute),
+				}
+			},
+			want: dispatchIssueFailureCPUPressure,
+		},
+		{
+			name: "claim rejected",
+			configure: func(cfg *Config, _ *State) {
+				cfg.Claiming = ClaimingConfig{Enabled: true, LeaseField: "lease"}
+			},
+			want: dispatchIssueFailureClaimFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+				Project:             scheduler.ProjectCandidate{ID: "detent"},
+			})
+			state := newState(cfg)
+			tt.configure(&cfg, &state)
+			attempts := &recordingWorkAttemptStore{}
+			orch := Orchestrator{cfg: cfg, workAttempts: attempts, now: func() time.Time { return now }}
+			issue := dispatchTestIssue("issue-post-selection-refusal", "Todo")
+
+			orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{issue}, now)
+
+			if len(attempts.starts) != 0 {
+				t.Fatalf("work attempt starts = %#v, want none", attempts.starts)
+			}
+			if len(attempts.decisions) != 2 {
+				t.Fatalf("scheduler decisions = %#v, want selection and refusal", attempts.decisions)
+			}
+			selected := attempts.decisions[0]
+			refused := attempts.decisions[1]
+			if selected.Result != store.SchedulerDecisionResultSelected || !selected.Selected {
+				t.Fatalf("selected decision = %#v", selected)
+			}
+			if refused.Result != store.SchedulerDecisionResultSkipped || refused.Selected || refused.Reason != tt.want {
+				t.Fatalf("refusal decision = %#v, want skipped %q", refused, tt.want)
+			}
+			if !selected.DecisionAt.Equal(refused.DecisionAt) || selected.AttemptNumber != refused.AttemptNumber {
+				t.Fatalf("decision correlation = selected %#v refused %#v", selected, refused)
+			}
+		})
+	}
+}
+
 func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Persist a correlated scheduler refusal when dispatch rejects a planner-selected issue before handoff.
- Report the stable refusal reason, attempt number, and originating selection evidence in schema 3 explanations while preserving successful-selection output.

Fixes #2167

## UI Surface Contract

- [x] N/A; this change only affects schema 3 explanation data.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `GOTOOLCHAIN=go1.26.6 make check`
- [x] Focused CPU-pressure, claim-rejection, explanation-correlation, and pool-contention regression tests
