### PR TITLE
fix(workspace): guard all cleanup candidates

### DIFF
--- a/internal/workspace/cleanup_registry.go
+++ b/internal/workspace/cleanup_registry.go
@@ -29,6 +29,7 @@ type cleanupOwnershipRecord struct {
 	Branch          string `json:"branch,omitempty"`
 	SourceCommonDir string `json:"source_common_dir"`
 	Preserve        bool   `json:"preserve,omitempty"`
+	CleanupStarted  bool   `json:"cleanup_started,omitempty"`
 }
 
 func (l *LocalGit) recordCleanupOwnership(ctx context.Context, info Info, issue Issue, isDir bool) error {
@@ -213,10 +214,7 @@ func (l *LocalGit) validOwnershipRecord(ctx context.Context, relativePath string
 
 func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue) (ReconcileResult, error) {
 	entries, err := os.ReadDir(filepath.Join(l.root, cleanupOwnershipRegistryDir))
-	if errors.Is(err, fs.ErrNotExist) {
-		return ReconcileResult{}, nil
-	}
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return ReconcileResult{}, fmt.Errorf("read cleanup ownership registry: %w", err)
 	}
 	activeKeys := make(map[string]struct{}, len(activeIssues))
@@ -224,7 +222,8 @@ func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue)
 		activeKeys[issueKey(issue)] = struct{}{}
 	}
 	result := ReconcileResult{}
-	var reconcileErrors []error
+	seen := map[string]bool{}
+	var records []cleanupOwnershipRecord
 	for _, entry := range entries {
 		relativePath := filepath.Join(cleanupOwnershipRegistryDir, entry.Name())
 		record, readErr := l.readOwnershipRecord(relativePath)
@@ -232,6 +231,16 @@ func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue)
 			result.UnownedSkipped++
 			continue
 		}
+		seen[record.Path] = true
+		records = append(records, record)
+	}
+	unrecorded, err := l.unrecordedWorkspaces(ctx, seen)
+	if err != nil {
+		return result, err
+	}
+	records = append(records, unrecorded...)
+	var reconcileErrors []error
+	for _, record := range records {
 		if _, active := activeKeys[record.Key]; active {
 			result.ActiveSkipped++
 			continue
@@ -240,56 +249,86 @@ func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue)
 			result.PreservedSkipped++
 			continue
 		}
-		exists, _, statErr := pathExists(record.Path)
-		if statErr != nil {
-			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: statErr.Error()})
-			reconcileErrors = append(reconcileErrors, statErr)
+		removed, reconcileErr := l.reconcileWorkspace(ctx, record, seen[record.Path], &result)
+		if reconcileErr != nil {
+			if errors.Is(reconcileErr, ErrWorkspacePreserved) {
+				result.PreservedSkipped++
+			}
+			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: reconcileErr.Error()})
+			reconcileErrors = append(reconcileErrors, reconcileErr)
 			continue
 		}
-		if exists {
-			registered, registrationErr := l.sourceWorktreeRegistered(ctx, record.Path)
-			if registrationErr != nil {
-				result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: registrationErr.Error()})
-				reconcileErrors = append(reconcileErrors, registrationErr)
-				continue
-			}
-			if registered {
-				result.RegisteredSkipped++
-				continue
-			}
-			pids, processErr := scanOwnedWorkspaceProcessIDs(ctx, record.Path, l.scanWorkspacePaths)
-			if processErr != nil {
-				result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: processErr.Error()})
-				reconcileErrors = append(reconcileErrors, processErr)
-				continue
-			}
-			if len(pids) > 0 {
-				result.ActiveSkipped++
-				continue
-			}
-			if removeErr := l.removeOwnedPath(l.root, record.Path); removeErr != nil {
-				result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: removeErr.Error()})
-				reconcileErrors = append(reconcileErrors, removeErr)
-				continue
-			}
-			result.Removed++
+		if removed {
+			result.CompletedPaths = append(result.CompletedPaths, record.Path)
 		}
-		if _, pruneErr := l.runGit(ctx, "worktree", "prune"); pruneErr != nil {
-			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: pruneErr.Error()})
-			reconcileErrors = append(reconcileErrors, pruneErr)
-			continue
-		}
-		if _, branchErr := l.deleteBranch(ctx, record.Branch); branchErr != nil {
-			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: branchErr.Error()})
-			reconcileErrors = append(reconcileErrors, branchErr)
-			continue
-		}
-		if removeErr := l.removeOwnershipRecord(record.Path); removeErr != nil {
-			result.Failures = append(result.Failures, CleanupFailure{Path: record.Path, Error: removeErr.Error()})
-			reconcileErrors = append(reconcileErrors, removeErr)
-			continue
-		}
-		result.CompletedPaths = append(result.CompletedPaths, record.Path)
 	}
 	return result, errors.Join(reconcileErrors...)
+}
+
+func (l *LocalGit) reconcileWorkspace(ctx context.Context, record cleanupOwnershipRecord, recorded bool, result *ReconcileResult) (bool, error) {
+	exists, _, err := pathExists(record.Path)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		registered, err := l.sourceWorktreeRegistered(ctx, record.Path)
+		if err != nil {
+			return false, err
+		}
+		if recorded && registered {
+			result.RegisteredSkipped++
+			return false, nil
+		}
+		pids, err := scanOwnedWorkspaceProcessIDs(ctx, record.Path, l.scanWorkspacePaths)
+		if err != nil {
+			return false, err
+		}
+		if len(pids) > 0 {
+			result.ActiveSkipped++
+			return false, nil
+		}
+	}
+	info := Info{Path: record.Path, Key: record.Key, Branch: record.Branch}
+	issue := Issue{ProjectID: record.ProjectID, ID: record.IssueID, Identifier: record.Identifier}
+	cleaned, err := l.cleanupWorkspace(ctx, info, issue)
+	result.Removed += cleaned.Worktrees
+	return err == nil, err
+}
+
+func (l *LocalGit) unrecordedWorkspaces(ctx context.Context, recorded map[string]bool) ([]cleanupOwnershipRecord, error) {
+	output, err := l.runGit(ctx, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return nil, fmt.Errorf("discover unrecorded workspaces: %w", err)
+	}
+	var records []cleanupOwnershipRecord
+	for index, entry := range strings.Split(output, "\x00\x00") {
+		if index == 0 {
+			continue
+		}
+		var path, branch string
+		for _, field := range strings.Split(entry, "\x00") {
+			if value, ok := strings.CutPrefix(field, "worktree "); ok {
+				path = value
+			}
+			if value, ok := strings.CutPrefix(field, "branch refs/heads/"); ok {
+				branch = value
+			}
+		}
+		if path == "" || recorded[path] || filepath.Dir(path) != l.root {
+			continue
+		}
+		path, err := validateWorkspacePath(l.root, path)
+		if err != nil {
+			return nil, err
+		}
+		exists, _, err := pathExists(path)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		records = append(records, cleanupOwnershipRecord{Path: path, Key: filepath.Base(path), Branch: branch})
+	}
+	return records, nil
 }

--- a/internal/workspace/cleanup_registry_test.go
+++ b/internal/workspace/cleanup_registry_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -16,6 +17,7 @@ func TestLocalGitCleanupRemovesHookArtifacts(t *testing.T) {
 	t.Parallel()
 
 	source := initSourceRepo(t)
+	publishCleanupSource(t, source)
 	root := filepath.Join(t.TempDir(), "workspaces")
 	hookCommand := "mkdir -p node_modules/pkg uploads .local/state && touch node_modules/pkg/index.js uploads/generated.bin .local/state/cache"
 	if runtime.GOOS == "windows" {
@@ -34,6 +36,10 @@ func TestLocalGitCleanupRemovesHookArtifacts(t *testing.T) {
 	info, err := backend.Create(t.Context(), issue)
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := ensureGitInfoExcludes(t.Context(), info.Path, []string{"node_modules/", "uploads/", ".local/"}); err != nil {
+		t.Fatal(err)
 	}
 
 	artifacts := []struct {
@@ -66,6 +72,7 @@ func TestLocalGitCleanupRetriesAfterGitDeregistration(t *testing.T) {
 	enclosing := initSourceRepo(t)
 	source := filepath.Join(enclosing, "source")
 	initSourceRepoAt(t, source)
+	publishCleanupSource(t, source)
 	root := filepath.Join(enclosing, "workspaces")
 	backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
 	if err != nil {
@@ -75,6 +82,9 @@ func TestLocalGitCleanupRetriesAfterGitDeregistration(t *testing.T) {
 	info, err := backend.Create(t.Context(), issue)
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
+	}
+	if err := ensureGitInfoExcludes(t.Context(), info.Path, []string{"node_modules/"}); err != nil {
+		t.Fatal(err)
 	}
 	locked := filepath.Join(info.Path, "node_modules", "locked")
 	if err := os.MkdirAll(locked, 0o700); err != nil {
@@ -136,12 +146,14 @@ func TestLocalGitReconcileResiduals(t *testing.T) {
 		active         bool
 		activeProcess  bool
 		registered     bool
+		unverified     bool
 		wantRemoved    int
 		wantActive     int
 		wantRegistered int
 		wantExists     bool
 	}{
 		{name: "removes owned residual", wantRemoved: 1},
+		{name: "retains unverified residual", unverified: true, wantExists: true},
 		{name: "skips active issue", active: true, wantActive: 1, wantExists: true},
 		{name: "skips active process", activeProcess: true, wantActive: 1, wantExists: true},
 		{name: "skips registered worktree", registered: true, wantRegistered: 1, wantExists: true},
@@ -151,6 +163,7 @@ func TestLocalGitReconcileResiduals(t *testing.T) {
 			enclosing := initSourceRepo(t)
 			source := filepath.Join(enclosing, "source")
 			initSourceRepoAt(t, source)
+			publishCleanupSource(t, source)
 			root := filepath.Join(enclosing, "workspaces")
 			backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
 			if err != nil {
@@ -169,6 +182,16 @@ func TestLocalGitReconcileResiduals(t *testing.T) {
 			} else {
 				info = strandCleanupWorkspace(t, backend, source, issue)
 			}
+			if tt.unverified {
+				record, err := backend.readOwnershipRecord(cleanupOwnershipRecordRelativePath(info.Path))
+				if err != nil {
+					t.Fatal(err)
+				}
+				record.CleanupStarted = false
+				if err := backend.writeOwnershipRecord(record); err != nil {
+					t.Fatal(err)
+				}
+			}
 			t.Cleanup(func() { restoreWritableTree(t, info.Path) })
 			if tt.activeProcess {
 				backend.scanWorkspacePaths = func(context.Context, string) ([]int, error) {
@@ -181,7 +204,11 @@ func TestLocalGitReconcileResiduals(t *testing.T) {
 			}
 
 			result, err := backend.ReconcileResiduals(t.Context(), active)
-			if err != nil {
+			if tt.unverified {
+				if !errors.Is(err, ErrWorkspacePreserved) || result.PreservedSkipped != 1 {
+					t.Fatalf("reconcile = %+v, %v; want preservation", result, err)
+				}
+			} else if err != nil {
 				t.Fatalf("ReconcileResiduals() error = %v", err)
 			}
 			if result.Removed != tt.wantRemoved || result.ActiveSkipped != tt.wantActive || result.RegisteredSkipped != tt.wantRegistered {
@@ -247,6 +274,9 @@ func strandCleanupWorkspace(t *testing.T, backend *LocalGit, source string, issu
 	if err := backend.recordCleanupOwnership(t.Context(), info, issue, true); err != nil {
 		t.Fatalf("recordCleanupOwnership() error = %v", err)
 	}
+	if err := ensureGitInfoExcludes(t.Context(), info.Path, []string{"node_modules/"}); err != nil {
+		t.Fatal(err)
+	}
 	locked := filepath.Join(info.Path, "node_modules", "locked")
 	if err := os.MkdirAll(locked, 0o700); err != nil {
 		t.Fatalf("create locked artifact directory: %v", err)
@@ -256,6 +286,9 @@ func strandCleanupWorkspace(t *testing.T, backend *LocalGit, source string, issu
 	}
 	if err := os.Chmod(locked, 0o500); err != nil {
 		t.Fatalf("lock artifact directory: %v", err)
+	}
+	if err := backend.beginWorkspaceCleanup(t.Context(), info, issue, true); err != nil {
+		t.Fatal(err)
 	}
 	cmd := exec.CommandContext(t.Context(), "git", "-C", source, "worktree", "remove", "--force", info.Path)
 	if output, err := cmd.CombinedOutput(); err == nil {
@@ -272,4 +305,115 @@ func strandCleanupWorkspace(t *testing.T, backend *LocalGit, source string, issu
 		t.Fatal("workspace remains registered after partial removal")
 	}
 	return info
+}
+
+func publishCleanupSource(t *testing.T, source string) {
+	t.Helper()
+	runGit(t, source, "remote", "add", "origin", initBareRemote(t))
+	runGit(t, source, "push", "-u", "origin", "main")
+}
+
+func TestLocalGitReconcileUnrecordedWorkspaces(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		work          string
+		active        bool
+		process       bool
+		wantRemoved   int
+		wantPreserved int
+		wantActive    int
+	}{
+		{name: "clean without registry", wantRemoved: 1},
+		{name: "dirty without registry", work: "dirty", wantPreserved: 1},
+		{name: "unpushed without registry", work: "unpushed", wantPreserved: 1},
+		{name: "active issue", active: true, wantActive: 1},
+		{name: "active process", process: true, wantActive: 1},
+		{name: "uninspectable orphan", work: "broken", wantPreserved: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			publishCleanupSource(t, source)
+			backend, err := NewLocalGit(LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := Issue{ProjectID: "detent", Identifier: "detent#2218"}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.work == "dirty" || tt.work == "unpushed" {
+				if err := os.WriteFile(filepath.Join(info.Path, "README.md"), []byte("unique work"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if tt.work == "unpushed" {
+					runGit(t, info.Path, "add", "README.md")
+					runGit(t, info.Path, "commit", "-m", "unique work")
+				}
+			}
+			if tt.work == "broken" {
+				if err := os.Rename(filepath.Join(info.Path, ".git"), filepath.Join(info.Path, "saved-git")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			backend.scanWorkspacePaths = func(context.Context, string) ([]int, error) {
+				if tt.process {
+					return []int{os.Getpid() + 1000}, nil
+				}
+				return nil, nil
+			}
+			var active []Issue
+			if tt.active {
+				active = []Issue{issue}
+			}
+			result, err := backend.ReconcileResiduals(t.Context(), active)
+			if (err != nil) != (tt.wantPreserved > 0) {
+				t.Fatalf("reconcile error = %v", err)
+			}
+			if result.Removed != tt.wantRemoved || result.PreservedSkipped != tt.wantPreserved || result.ActiveSkipped != tt.wantActive {
+				t.Fatalf("reconcile = %+v, want removed=%d preserved=%d active=%d", result, tt.wantRemoved, tt.wantPreserved, tt.wantActive)
+			}
+			if len(result.Failures) != tt.wantPreserved || len(result.CompletedPaths) != tt.wantRemoved {
+				t.Fatalf("reconcile evidence = %+v", result)
+			}
+			_, statErr := os.Stat(info.Path)
+			if tt.wantRemoved == 1 {
+				if !errors.Is(statErr, fs.ErrNotExist) || branchExists(t, source, info.Branch) {
+					t.Fatalf("clean workspace remains: %v", statErr)
+				}
+			} else if statErr != nil || !branchExists(t, source, info.Branch) {
+				t.Fatalf("retained workspace missing: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestLocalGitOrphanDiscoveryKeepsSourceRepository(t *testing.T) {
+	t.Parallel()
+	for _, nested := range []bool{false, true} {
+		t.Run(strconv.FormatBool(nested), func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			source := root
+			if nested {
+				source = filepath.Join(root, "source")
+			}
+			initSourceRepoAt(t, source)
+			publishCleanupSource(t, source)
+			backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := backend.ReconcileResiduals(t.Context(), nil)
+			if err != nil || result.Removed != 0 {
+				t.Fatalf("reconcile = %+v, %v", result, err)
+			}
+			if got := strings.TrimSpace(runGit(t, source, "rev-parse", "--is-inside-work-tree")); got != "true" {
+				t.Fatalf("source repository changed: %s", got)
+			}
+		})
+	}
 }

--- a/internal/workspace/preservation.go
+++ b/internal/workspace/preservation.go
@@ -67,25 +67,32 @@ func (l *LocalGit) PreserveIssue(ctx context.Context, issue Issue) (Preservation
 	return result, nil
 }
 
-func (l *LocalGit) checkPreservedWorkspace(ctx context.Context, info Info, issue Issue) error {
+func (l *LocalGit) checkWorkspaceCleanup(ctx context.Context, info Info) error {
 	recordPath := cleanupOwnershipRecordRelativePath(info.Path)
 	record, err := l.readOwnershipRecord(recordPath)
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("%w at %s: read workspace retention: %w", ErrWorkspacePreserved, info.Path, err)
 	}
+	if err == nil && !l.validOwnershipRecord(ctx, recordPath, record) {
+		return fmt.Errorf("%w: invalid workspace retention record: %s", ErrWorkspacePreserved, info.Path)
+	}
+	if err := l.checkCleanupBranch(ctx, info.Branch); err != nil {
+		return fmt.Errorf("%w at %s: %w", ErrWorkspacePreserved, info.Path, err)
+	}
+	exists, isDir, err := pathExists(info.Path)
 	if err != nil {
-		return fmt.Errorf("read workspace retention: %w", err)
+		return fmt.Errorf("%w at %s: %w", ErrWorkspacePreserved, info.Path, err)
 	}
-	if !record.Preserve {
+	if !exists && !record.Preserve {
 		return nil
 	}
-	if !l.validOwnershipRecord(ctx, recordPath, record) {
-		return fmt.Errorf("invalid workspace retention record: %s", info.Path)
+	if !isDir || !l.isSourceWorktree(ctx, info.Path) {
+		if exists && record.CleanupStarted && !record.Preserve && !l.isGitWorkspace(ctx, info.Path) {
+			return nil
+		}
+		return fmt.Errorf("%w at %s: worktree registration is unavailable or not managed by source", ErrWorkspacePreserved, info.Path)
 	}
-	if !l.isSourceWorktree(ctx, info.Path) {
-		return fmt.Errorf("%w at %s: worktree registration is unavailable", ErrWorkspacePreserved, info.Path)
-	}
-	recovery, err := l.RecoveryState(ctx, info, issue)
+	changed, err := l.worktreeHasChanges(ctx, info.Path)
 	if err != nil {
 		return fmt.Errorf("%w at %s: %w", ErrWorkspacePreserved, info.Path, err)
 	}
@@ -93,10 +100,43 @@ func (l *LocalGit) checkPreservedWorkspace(ctx context.Context, info Info, issue
 	if err != nil {
 		return fmt.Errorf("%w at %s: %w", ErrWorkspacePreserved, info.Path, err)
 	}
-	if unpushed > 0 || len(recovery.TrackedPaths) > 0 || len(recovery.UntrackedPaths) > 0 {
+	if unpushed > 0 || changed {
 		return fmt.Errorf("%w at %s: unpushed commits or uncommitted files remain", ErrWorkspacePreserved, info.Path)
 	}
 	return nil
+}
+
+func (l *LocalGit) checkCleanupBranch(ctx context.Context, branch string) error {
+	if !l.autoBranch || !strings.HasPrefix(branch, "detent/") {
+		return nil
+	}
+	exists, err := l.branchExists(ctx, branch)
+	if err != nil || !exists {
+		return err
+	}
+	output, err := l.runGit(ctx, "rev-list", "--count", "refs/heads/"+branch, "--not", "--remotes")
+	if err != nil {
+		return fmt.Errorf("inspect cleanup branch: %w", err)
+	}
+	if strings.TrimSpace(output) != "0" {
+		return fmt.Errorf("%w: branch %s contains commits absent from remote refs", ErrWorkspacePreserved, branch)
+	}
+	return nil
+}
+
+func (l *LocalGit) beginWorkspaceCleanup(ctx context.Context, info Info, issue Issue, isDir bool) error {
+	if err := l.checkWorkspaceCleanup(ctx, info); err != nil {
+		return err
+	}
+	if err := l.recordCleanupOwnership(ctx, info, issue, isDir); err != nil {
+		return err
+	}
+	record, err := l.readOwnershipRecord(cleanupOwnershipRecordRelativePath(info.Path))
+	if err != nil {
+		return err
+	}
+	record.CleanupStarted = true
+	return l.writeOwnershipRecord(record)
 }
 
 func retainedGitCommitCount(ctx context.Context, path string) (int, error) {

--- a/internal/workspace/preservation_test.go
+++ b/internal/workspace/preservation_test.go
@@ -5,9 +5,144 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
+
+func TestLocalGitCleanupChecksEveryWorkspace(t *testing.T) {
+	t.Parallel()
+	for _, record := range []string{"none", "ordinary", "preserved"} {
+		for _, work := range []string{"clean", "tracked", "staged", "untracked", "unpushed", "detached", "missing", "broken", "different branch", "no remote"} {
+			t.Run(record+"/"+work, func(t *testing.T) {
+				t.Parallel()
+				source := initSourceRepo(t)
+				if work != "no remote" {
+					runGit(t, source, "remote", "add", "origin", initBareRemote(t))
+					runGit(t, source, "push", "-u", "origin", "main")
+				}
+				backend, err := NewLocalGit(LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				issue := Issue{Identifier: "cleanup-safety"}
+				info, err := backend.Create(t.Context(), issue)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if record != "none" {
+					if err := backend.recordCleanupOwnership(t.Context(), info, issue, true); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if record == "preserved" {
+					if _, err := backend.PreserveIssue(t.Context(), issue); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if work == "detached" {
+					runGit(t, info.Path, "checkout", "--detach")
+				}
+				if work != "clean" && work != "no remote" && work != "broken" {
+					name := "README.md"
+					if work == "untracked" {
+						name = "implementation.go"
+					}
+					if err := os.WriteFile(filepath.Join(info.Path, name), []byte("unique work\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					if work != "tracked" && work != "untracked" {
+						runGit(t, info.Path, "add", name)
+						if work != "staged" {
+							runGit(t, info.Path, "commit", "-m", "unique work")
+						}
+					}
+				}
+				if work == "different branch" {
+					runGit(t, info.Path, "checkout", "--detach", "origin/main")
+				}
+				head := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
+				status := runGit(t, info.Path, "status", "--porcelain")
+				if work == "missing" {
+					if err := os.Rename(info.Path, filepath.Join(t.TempDir(), "moved")); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if work == "broken" {
+					if err := os.Rename(filepath.Join(info.Path, ".git"), filepath.Join(info.Path, "saved-git")); err != nil {
+						t.Fatal(err)
+					}
+				}
+				result, err := backend.CleanupIssue(t.Context(), issue)
+				if work == "clean" {
+					if err != nil || result.Worktrees != 1 || result.Branches != 1 {
+						t.Fatalf("cleanup = %+v, %v; want removed workspace and branch", result, err)
+					}
+					return
+				}
+				if !errors.Is(err, ErrWorkspacePreserved) || result.Worktrees != 0 || result.Branches != 0 {
+					t.Fatalf("cleanup = %+v, %v; want retained work", result, err)
+				}
+				if !branchExists(t, source, info.Branch) {
+					t.Fatal("cleanup deleted branch holding retained work")
+				}
+				if work != "missing" && work != "broken" {
+					if got := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD")); got != head {
+						t.Fatalf("head = %q, want %q", got, head)
+					}
+					if got := runGit(t, info.Path, "status", "--porcelain"); got != status {
+						t.Fatalf("status = %q, want %q", got, status)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestLocalGitCleanupChecksRemovalHooks(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+	for _, dirty := range []bool{false, true} {
+		t.Run(strconv.FormatBool(dirty), func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			publishCleanupSource(t, source)
+			trace := filepath.Join(t.TempDir(), "hook-ran")
+			backend, err := NewLocalGit(LocalGitOptions{
+				Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true,
+				Hooks: Hooks{BeforeRemove: "touch " + shellQuote(trace) + " && printf 'hook work' > README.md"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := Issue{Identifier: "cleanup-hook"}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if dirty {
+				if err := os.WriteFile(filepath.Join(info.Path, "README.md"), []byte("worker work"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			result, err := backend.CleanupIssue(t.Context(), issue)
+			if !errors.Is(err, ErrWorkspacePreserved) || result.Worktrees != 0 {
+				t.Fatalf("cleanup = %+v, %v; want preservation", result, err)
+			}
+			_, err = os.Stat(trace)
+			if dirty != errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("hook trace stat = %v, dirty = %t", err, dirty)
+			}
+			want := "hook work"
+			if dirty {
+				want = "worker work"
+			}
+			if got := readFile(t, filepath.Join(info.Path, "README.md")); got != want {
+				t.Fatalf("retained work = %q, want %q", got, want)
+			}
+		})
+	}
+}
 
 func TestLocalGitPreservesRevokedWorkAcrossCleanupAndRestart(t *testing.T) {
 	t.Parallel()

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -548,8 +548,12 @@ func (l *LocalGit) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult
 		return CleanupResult{}, err
 	}
 
+	return l.cleanupWorkspace(ctx, info, issue)
+}
+
+func (l *LocalGit) cleanupWorkspace(ctx context.Context, info Info, issue Issue) (CleanupResult, error) {
 	result := CleanupResult{Path: info.Path}
-	if err := l.checkPreservedWorkspace(ctx, info, issue); err != nil {
+	if err := l.checkWorkspaceCleanup(ctx, info); err != nil {
 		return result, err
 	}
 	exists, isDir, err := pathExists(info.Path)
@@ -573,9 +577,6 @@ func (l *LocalGit) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult
 		}
 		return result, nil
 	}
-	if err := l.recordCleanupOwnership(ctx, info, issue, isDir); err != nil {
-		return result, err
-	}
 	result.Processes = reapWorkspaceProcesses(ctx, info.Path, l.logger)
 	if isDir && l.isSourceWorktree(ctx, info.Path) {
 		if err := l.runHook(ctx, "before_remove", l.hooks.BeforeRemove, info, issue); err != nil {
@@ -583,6 +584,9 @@ func (l *LocalGit) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult
 		}
 	}
 
+	if err := l.beginWorkspaceCleanup(ctx, info, issue, isDir); err != nil {
+		return result, err
+	}
 	if err := l.removePath(ctx, info.Path); err != nil {
 		return result, err
 	}
@@ -1423,6 +1427,9 @@ func (l *LocalGit) deleteBranch(ctx context.Context, branch string) (bool, error
 	}
 	if !exists {
 		return false, nil
+	}
+	if err := l.checkCleanupBranch(ctx, branch); err != nil {
+		return false, err
 	}
 	_, err = l.runGit(ctx, "branch", "-D", branch)
 	return err == nil, err

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -369,6 +369,7 @@ func TestLocalGitCreateAndCleanupWithoutHooks(t *testing.T) {
 	t.Parallel()
 
 	source := initSourceRepo(t)
+	publishCleanupSource(t, source)
 	root := filepath.Join(t.TempDir(), "workspaces")
 
 	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
@@ -2154,6 +2155,7 @@ func TestLocalGitCleanupRemovesOnlyTargetWorktree(t *testing.T) {
 	skipWindows(t)
 
 	source := initSourceRepo(t)
+	publishCleanupSource(t, source)
 	root := filepath.Join(t.TempDir(), "workspaces")
 	tracePath := filepath.Join(t.TempDir(), "cleanup.trace")
 
@@ -2204,6 +2206,7 @@ func TestLocalGitCleanupRemediatesGeneratedCachePermissions(t *testing.T) {
 	enclosing := initSourceRepo(t)
 	source := filepath.Join(enclosing, "source")
 	initSourceRepoAt(t, source)
+	publishCleanupSource(t, source)
 	root := filepath.Join(enclosing, "workspaces")
 
 	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
@@ -2223,6 +2226,9 @@ func TestLocalGitCleanupRemediatesGeneratedCachePermissions(t *testing.T) {
 		restoreWritableTree(t, info.Path)
 	})
 
+	if err := ensureGitInfoExcludes(t.Context(), info.Path, []string{"tmp/"}); err != nil {
+		t.Fatal(err)
+	}
 	cacheDir := filepath.Join(info.Path, "tmp", "_validation-cache", "go-mod", "modernc.org", "libc@v1.73.4")
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		t.Fatalf("mkdir cache dir: %v", err)


### PR DESCRIPTION
## Summary

- Protect every Git workspace cleanup candidate from losing uncommitted files or commits absent from remote refs, regardless of ownership records or preservation flags. Recheck after removal hooks and before branch deletion, including when the workspace directory is missing.
- Discover unrecorded linked worktrees in the workspace root during residual reconciliation. Reclaim safe candidates, skip active issues/processes, and retain unsafe candidates with path diagnostics.
- Require a successful pre-removal safety check recorded durably before retrying partial deletions. Legacy residuals whose Git state cannot be inspected remain available for recovery.

Fixes #2218

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, first-viewport, or responsive visibility changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Reproduced deletion before the fix with table-driven cases for absent, ordinary, and preserved ownership records.
- [x] Focused cleanup tests cover clean, tracked, staged, untracked, unpushed, detached, missing-directory, broken-registration, and local-only work; removal hooks; orphan discovery; active exclusions; primary repository protection; and partial-removal recovery.
- [x] `make check` (race tests and all coverage floors passed; overall 79.9%, workspace 70.1%)
