### PR TITLE
test(cli): isolate demo HTTP client cleanup

### DIFF
--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -1779,8 +1779,9 @@ func waitForDashboard(t *testing.T, url string, done <-chan error) string {
 func waitForDashboardContext(t *testing.T, ctx context.Context, url string, done <-chan error) string {
 	t.Helper()
 
-	client := http.Client{Timeout: time.Second}
-	body, err := awaitDashboard(ctx, &client, url, done)
+	client := newRuntimeHTTPClient()
+	defer client.CloseIdleConnections()
+	body, err := awaitDashboard(ctx, client, url, done)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -422,7 +422,8 @@ func waitForIsolatedRuntimeURL(t *testing.T, output *lockedBuffer, done <-chan e
 func waitForDashboardHeader(t *testing.T, rawURL string, done <-chan error, scenario string) string {
 	t.Helper()
 
-	client := http.Client{Timeout: time.Second}
+	client := newRuntimeHTTPClient()
+	defer client.CloseIdleConnections()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -465,7 +466,8 @@ func waitForDashboardHeader(t *testing.T, rawURL string, done <-chan error, scen
 func postRuntimeRefresh(t *testing.T, url string, done <-chan error) {
 	t.Helper()
 
-	client := http.Client{Timeout: time.Second}
+	client := newRuntimeHTTPClient()
+	defer client.CloseIdleConnections()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -529,7 +531,8 @@ func waitForDashboardConditionWithRefresh(
 func postRuntimeKanbanForm(t *testing.T, rawURL string, done <-chan error, form url.Values) string {
 	t.Helper()
 
-	client := http.Client{Timeout: time.Second}
+	client := newRuntimeHTTPClient()
+	defer client.CloseIdleConnections()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -587,4 +590,8 @@ func boardStateCountFromBody(t *testing.T, body string, state string) int {
 		}
 	}
 	return 0
+}
+
+func newRuntimeHTTPClient() *http.Client {
+	return &http.Client{Transport: &http.Transport{}, Timeout: time.Second}
 }

--- a/internal/cli/dev_runtime_shutdown_test.go
+++ b/internal/cli/dev_runtime_shutdown_test.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+func TestRuntimeCanceledDialShutdown(t *testing.T) {
+	tests := []struct {
+		name            string
+		closeClient     bool
+		closeBeforeDial bool
+		wantErr         error
+	}{
+		{name: "retained connection expires web shutdown", wantErr: context.DeadlineExceeded},
+		{name: "close completed dial before runtime cancellation", closeClient: true, wantErr: context.Canceled},
+		{name: "close pending dial before runtime cancellation", closeClient: true, closeBeforeDial: true, wantErr: context.Canceled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				server, err := web.NewServer(web.Config{Mode: web.ModeOnboarding}, web.Dependencies{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				clientConn, serverConn := net.Pipe()
+				defer clientConn.Close()
+				defer serverConn.Close()
+				listener := &runtimePipeListener{connections: make(chan net.Conn, 1), closed: make(chan struct{})}
+				listener.connections <- serverConn
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				runtimeDone := make(chan error, 1)
+				go func() { runtimeDone <- serve(ctx, server, listener) }()
+
+				dialStarted := make(chan struct{})
+				releaseDial := make(chan struct{})
+				transport := &http.Transport{
+					DialContext: func(context.Context, string, string) (net.Conn, error) {
+						close(dialStarted)
+						<-releaseDial
+						return clientConn, nil
+					},
+				}
+				defer transport.CloseIdleConnections()
+				client := &http.Client{Transport: transport}
+				requestCtx, cancelRequest := context.WithCancel(context.Background())
+				defer cancelRequest()
+				request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, "http://runtime.test/health", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				requestDone := make(chan error, 1)
+				go func() {
+					response, err := client.Do(request)
+					if response != nil {
+						_ = response.Body.Close()
+					}
+					requestDone <- err
+				}()
+				<-dialStarted
+				cancelRequest()
+				if err := <-requestDone; !errors.Is(err, context.Canceled) {
+					t.Fatalf("request error = %v, want context canceled", err)
+				}
+				if tt.closeBeforeDial {
+					client.CloseIdleConnections()
+				}
+				close(releaseDial)
+				synctest.Wait()
+				if tt.closeClient && !tt.closeBeforeDial {
+					client.CloseIdleConnections()
+					synctest.Wait()
+				}
+				cancel()
+				if err := <-runtimeDone; !errors.Is(err, tt.wantErr) {
+					t.Fatalf("serve() error = %v, want %v", err, tt.wantErr)
+				}
+			})
+		})
+	}
+}
+
+func TestRuntimeHTTPHelpersCloseConnections(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		request func(*testing.T, string, <-chan error)
+	}{
+		{name: "dashboard", status: http.StatusOK, request: func(t *testing.T, rawURL string, done <-chan error) {
+			waitForDashboard(t, rawURL, done)
+		}},
+		{name: "scenario", status: http.StatusOK, request: func(t *testing.T, rawURL string, done <-chan error) {
+			waitForDashboardHeader(t, rawURL, done, "example")
+		}},
+		{name: "refresh", status: http.StatusAccepted, request: postRuntimeRefresh},
+		{name: "kanban", status: http.StatusOK, request: func(t *testing.T, rawURL string, done <-chan error) {
+			postRuntimeKanbanForm(t, rawURL, done, url.Values{"project_id": {"example"}})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			closed := make(chan struct{})
+			var closeOnce sync.Once
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+				if state == http.StateClosed {
+					closeOnce.Do(func() { close(closed) })
+				}
+			}
+			server.Start()
+			defer server.Close()
+			tt.request(t, server.URL, make(chan error))
+			select {
+			case <-closed:
+			case <-time.After(10 * time.Second):
+				t.Fatal("HTTP helper returned without closing its connection")
+			}
+		})
+	}
+}
+
+func TestRuntimeHTTPClientOwnsTransport(t *testing.T) {
+	first := newRuntimeHTTPClient()
+	defer first.CloseIdleConnections()
+	second := newRuntimeHTTPClient()
+	defer second.CloseIdleConnections()
+	if first.Transport == nil || second.Transport == nil || first.Transport == second.Transport || first.Transport == http.DefaultTransport || second.Transport == http.DefaultTransport {
+		t.Fatal("runtime HTTP clients must own independent transports")
+	}
+}
+
+type runtimePipeListener struct {
+	connections chan net.Conn
+	closed      chan struct{}
+	closeOnce   sync.Once
+}
+
+func (l *runtimePipeListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.connections:
+		return conn, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *runtimePipeListener) Close() error {
+	l.closeOnce.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (*runtimePipeListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)}
+}


### PR DESCRIPTION
## Summary

- Give isolated-runtime HTTP test helpers independent transports and close their connections before runtime cancellation. Keep the existing strict cancellation assertion and runtime join.
- Reproduce a request canceled during dialing with standard-library virtual time and in-memory connections. Retaining the late connection makes the real web shutdown return a deadline error; closing completed or pending dials preserves cancellation. Add regression checks for helper connection closure and transport ownership.
- The historical failure cannot be tied to a specific connection from its log alone; the regression demonstrates a matching shutdown mechanism without weakening production errors.

Fixes #2219

## UI Surface Contract

- [x] N/A: test-only changes; no UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Baseline demo race test: five repetitions passed.
- [x] Ownership regression failed against the original nil-transport client pattern.
- [x] Ten race repetitions of deterministic shutdown, client ownership, helper cleanup, demo actions, and persistence-join tests passed.
- [x] `make check` passed on retry. The first run exposed unrelated installer timeouts; five isolated repetitions passed and follow-up #2222 tracks the failure.

- [x] Entire CLI package: `go test -race ./internal/cli -count=10 -timeout=30m` passed (522.821s). The initial repetition command reached the default aggregate 10m timeout; individual test deadlines were unchanged.
- [x] All eleven current-head CI checks passed, including Linux/macOS/Windows verification, Browser Visual, Security, and release snapshot.
