### PR TITLE
test(cli): isolate doctor health probe listener

### DIFF
--- a/.detent/skills/wildcard-loopback-test-isolation.md
+++ b/.detent/skills/wildcard-loopback-test-isolation.md
@@ -1,0 +1,15 @@
+---
+name: wildcard-loopback-test-isolation
+description: Diagnose HTTP test EOFs or wrong responses when a wildcard listener is probed through loopback on macOS.
+when_to_use: Use when parallel HTTP tests intermittently reach the wrong handler or lose a connection while the intended wildcard server remains alive.
+---
+
+# Verify ownership of the probe address
+
+- Compare the listener address with the client's actual destination. A listener on `0.0.0.0:0` does not necessarily reserve the assigned port on `127.0.0.1`. macOS can allow both listeners simultaneously; verify the host behavior with `net.Listen` before assigning causality.
+- Hold both listeners on the same explicit ephemeral port. Give their handlers distinguishable responses, then probe loopback to establish which listener receives the connection. Keep every socket outside production ports.
+- Reproduce a close-before-response EOF with the shadowing loopback handler and `panic(http.ErrAbortHandler)`. To exercise `httptest.Server.Close` itself, wrap the loopback listener's `Accept`: read the request with `http.ReadRequest`, signal receipt, and wait on a channel released by the wrapper's `Close`. Close the shadow server after receipt. Reading the request before closing avoids an unread-data TCP reset obscuring the EOF sequence.
+- Keep the evidence boundary explicit: reproducing a possible interleaving establishes a failure mechanism, not proof that an untraced historical failure used that interleaving. Shared transport cleanup and ambient authentication are separate hypotheses.
+- For tests of wildcard-to-loopback URL mapping, bind the HTTP fixture to the exact loopback destination. Inject the occupied bind result through the existing listener dependency, asserting that production requested the configured wildcard address. This separates platform bind rules from HTTP health classification.
+- Assert that binding another listener to the fixture's probe address fails as occupied. Demonstrate this assertion failing against the original wildcard fixture, then passing with the loopback fixture. Keep real connection-close and incomplete-response cases classified as failures; do not add generic EOF retries.
+- When supplying an existing listener to `httptest.Server`, construct the server with that listener and its `http.Server` configuration. Replacing `NewUnstartedServer().Listener` without closing the original discards a live socket.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -5266,7 +5266,6 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 	tests := []struct {
 		name       string
 		host       string
-		listenHost string
 		statusCode int
 		body       string
 		want       doctorStatus
@@ -5275,7 +5274,6 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 		{
 			name:       "healthy running detent on wildcard host",
 			host:       "0.0.0.0",
-			listenHost: "0.0.0.0",
 			statusCode: http.StatusOK,
 			body:       `{"status":"ok","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},"budgets":[{"project_id":"detent","enabled":true,"per_day_max_usd":250,"per_issue_max_usd":25}]}`,
 			want:       doctorWarn,
@@ -5292,7 +5290,6 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 		{
 			name:       "unhealthy detent service",
 			host:       "127.0.0.1",
-			listenHost: "127.0.0.1",
 			statusCode: http.StatusOK,
 			body:       `{"status":"error","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"}}`,
 			want:       doctorFail,
@@ -5305,7 +5302,6 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 		{
 			name:       "non-detent service",
 			host:       "127.0.0.1",
-			listenHost: "127.0.0.1",
 			statusCode: http.StatusOK,
 			body:       `{"status":"ok"}`,
 			want:       doctorFail,
@@ -5318,7 +5314,6 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 		{
 			name:       "generic health service",
 			host:       "127.0.0.1",
-			listenHost: "127.0.0.1",
 			statusCode: http.StatusOK,
 			body:       `{"status":"ok","mode":"ready","checks":{}}`,
 			want:       doctorFail,
@@ -5334,14 +5329,78 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			port := occupiedDoctorPort(t, tt.listenHost, tt.statusCode, tt.body)
+			port := occupiedDoctorPort(t, doctorHealthProbeHost(tt.host), tt.statusCode, tt.body)
+			probeAddr := net.JoinHostPort(doctorHealthProbeHost(tt.host), strconv.Itoa(port))
+			var listenConfig net.ListenConfig
+			shadow, err := listenConfig.Listen(t.Context(), "tcp", probeAddr)
+			if err == nil {
+				if closeErr := shadow.Close(); closeErr != nil {
+					t.Errorf("Close() shadow listener error = %v", closeErr)
+				}
+				t.Fatalf("health fixture does not reserve probe address %s", probeAddr)
+			}
+			if !doctorListenErrIndicatesOccupied(err) {
+				t.Fatalf("Listen(%q) error = %v, want occupied address", probeAddr, err)
+			}
 			got := checkDoctorServerPort(context.Background(), BootConfig{Host: tt.host, Port: &port}, doctorDeps{
-				listen: net.Listen,
+				listen: func(network, address string) (net.Listener, error) {
+					wantAddr := net.JoinHostPort(tt.host, strconv.Itoa(port))
+					if network != "tcp" || address != wantAddr {
+						t.Fatalf("listen(%q, %q), want tcp, %q", network, address, wantAddr)
+					}
+					return listenConfig.Listen(t.Context(), network, probeAddr)
+				},
 			})
 			if got.Status != tt.want {
 				t.Fatalf("Status = %s, want %s: %+v", got.Status, tt.want, got)
 			}
 			for _, want := range tt.wantDetail {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorServerPortRejectsHealthProbeEOF(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantDetail string
+	}{
+		{
+			name: "connection closes before response",
+			handler: func(http.ResponseWriter, *http.Request) {
+				panic(http.ErrAbortHandler)
+			},
+			wantDetail: "could not be reached",
+		},
+		{
+			name: "incomplete health response",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				if _, err := io.WriteString(w, `{"status":`); err != nil {
+					t.Errorf("WriteString() error = %v", err)
+				}
+			},
+			wantDetail: "did not return Detent health",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(tt.handler)
+			t.Cleanup(server.Close)
+			port := doctorPortFromAddr(t, server.Listener.Addr())
+			got := checkDoctorServerPort(t.Context(), BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{})
+			if got.Status != doctorFail {
+				t.Fatalf("Status = %s, want %s: %+v", got.Status, doctorFail, got)
+			}
+			for _, want := range []string{tt.wantDetail, "EOF"} {
 				if !strings.Contains(got.Detail, want) {
 					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
 				}
@@ -6694,7 +6753,7 @@ func occupiedDoctorPort(t *testing.T, host string, statusCode int, body string) 
 	}
 	port := doctorPortFromAddr(t, listener.Addr())
 
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := &httptest.Server{Listener: listener, Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/health" {
 			http.NotFound(w, r)
 			return
@@ -6704,8 +6763,7 @@ func occupiedDoctorPort(t *testing.T, host string, statusCode int, body string) 
 		if _, err := w.Write([]byte(body)); err != nil {
 			t.Errorf("Write() error = %v", err)
 		}
-	}))
-	server.Listener = listener
+	})}}
 	server.Start()
 	t.Cleanup(server.Close)
 


### PR DESCRIPTION
## Summary

- Reserve the doctor test's actual loopback probe address. On macOS, wildcard and loopback listeners can share a TCP port, allowing another parallel test's listener to shadow the healthy fixture. A controlled shadow-listener close reproduced the reported EOF; the historical failure's exact interleaving was not recorded.
- Assert exclusive ownership of the probe address and verify the configured wildcard bind address through listener injection. Preserve healthy WARN and unhealthy/non-Detent FAIL assertions, and add real HTTP connection-close and incomplete-response cases that remain FAIL on EOF.
- Avoid discarding the helper's preallocated httptest listener and record the reusable diagnostic method in a skill draft.

Fixes #2224

## UI Surface Contract

- [x] N/A: test and diagnostic guidance changes only.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Probe-address reservation assertion fails against the original wildcard fixture and passes with loopback reservation.
- [x] Unchanged baseline: focused coverage x200 and full CLI coverage x5 pass.
- [x] Updated focused port tests x20 and focused race tests x100 pass on Go 1.27.1 and Go 1.26.6.
- [x] `make check` (80.1% coverage; package/file floors pass)
