### PR TITLE
fix(merge): prevent repeated green-head CI invalidation

### DIFF
--- a/.detent/skills/async-reservation-lifecycle-testing.md
+++ b/.detent/skills/async-reservation-lifecycle-testing.md
@@ -1,0 +1,16 @@
+---
+name: async-reservation-lifecycle-testing
+description: Verify bounded scheduler reservations across asynchronous worker completion, remote validation, filtered tracker snapshots, and restart.
+when_to_use: Use when a scheduler releases worker capacity during a remote wait but must retain exclusive ownership of a shared resource across retries.
+---
+
+# Asynchronous reservation lifecycle testing
+
+- Separate the worker slot and issue claim from the resource reservation. Assert that waits release execution capacity while competing users of the same resource remain deferred.
+- Drive a deterministic event sequence with an injected clock: select, mutate the remote head, fetch tracker state, process worker completion, finish validation, complete the item, and fetch again. Include the ordering where the remote mutation becomes visible before worker completion.
+- Make test fetches apply the production state filters. Completed or withdrawn items must disappear from the candidate stream; retaining every fixture item can hide a reservation that never releases.
+- Use recorded completion state or an explicit terminal cleanup boundary when an owner disappears from fetched candidates. Distinguish that from a temporary missing or degraded tracker response.
+- Keep the reservation deadline fixed across retries and worker-owned identity changes. Test expiry at equality, repeated refreshes, external identity changes, and successful admission of the next contender after release.
+- Test restart through the actual completion metadata writer and recovery reader. Reject expired, malformed, superseded, or mismatched records; restoration must preserve the original deadline.
+- Include independent resources and runnable implementation work in dispatch assertions, and require failed checks or conflicts to prevent the protected action.
+- Record both prior and current resource identities with the reason for retaining or releasing ownership so runtime history can distinguish required refreshes from avoidable invalidation.

--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -20,10 +20,34 @@ through the serialized worker. GitHub owns merge-group validation and batching;
 Detent keeps the issues in `Merging`, observes their queue entries, and
 reconciles them to `Done` after GitHub reports the PR merged. Without a native
 queue, a BEHIND PR whose existing head is mergeable and already has green
-required checks is merged directly against the current base without rewriting
-the checked head. Rebase is reserved for fallback cases; if a refreshed head
+required checks is submitted to the exact-head merge API without rewriting
+the checked head. If GitHub explicitly rejects an out-of-date base, Detent
+refreshes that head and waits for its required CI. Other refusals, including
+failed checks, conflicts, permissions, changed heads, and native queue
+requirements, do not authorize this refresh fallback. If a refreshed head
 is missing required contexts, Detent routes the issue to `Rework` instead of
 retrying an incomplete merge worker.
+
+A selected merge worker reserves its repository across CI waits for at most
+one hour from initial selection. Other same-repository retries cannot refresh
+or merge ahead of it during that reservation. Waiting releases the worker and
+issue claim, so implementation work and other repositories remain dispatchable
+under the configured capacity limits. Dependency priority and queue age select
+the next candidate after a reservation is released.
+
+The reservation deadline survives Detent-created head refreshes and restart;
+it is stored with the successful waiting work attempt. Failed checks, conflicts,
+withdrawal, approval or CI-trigger revocation, native queue handoff, and external
+head changes release it. An external base advance keeps the deadline and
+requires a fresh correctness check; strict protection may require another
+refresh. Missing or degraded tracker data cannot extend the deadline. Expiry
+releases the repository even if CI stalls, while the existing CI timeout handles
+the waiting issue. Recovery restores only an unexpired reservation whose latest
+terminal attempt and current PR still match. A released candidate cannot renew
+its own reservation before another candidate takes over. Recorded completion
+releases the reservation even after the tracker omits the completed issue from
+queue fetches. Diagnostics record
+reservation release reasons, head/base identities, and validation invalidation.
 
 Inside the serialized `Merging` lane, avoid duplicating the full local release
 gate when it does not buy new signal. If the PR already passed the pre-review

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -32,9 +32,10 @@ func ReportProgress(ctx context.Context) {
 }
 
 var (
-	ErrNotImplemented     = errors.New("connector operation not implemented")
-	ErrResourceExhausted  = errors.New("connector resource exhausted")
-	ErrStateUpdateBlocked = errors.New("issue state update blocked")
+	ErrNotImplemented           = errors.New("connector operation not implemented")
+	ErrResourceExhausted        = errors.New("connector resource exhausted")
+	ErrStateUpdateBlocked       = errors.New("issue state update blocked")
+	ErrPullRequestBaseOutOfDate = errors.New("pull request base is out of date")
 )
 
 type retryableError struct {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -4973,6 +4973,43 @@ func TestConnectorCreatePullRequestCommentUsesIssueCommentsEndpoint(t *testing.T
 	}
 }
 
+func TestConnectorMergePullRequestClassifiesBaseRefusal(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		status  int
+		message string
+		want    bool
+	}{
+		{"strict protection", 405, "Head branch is out of date. Review and try the merge again.", true},
+		{"base race", 405, "Base branch was modified. Review and try the merge again.", true},
+		{"required failure", 405, "Required status check Test is failing.", false},
+		{"native queue", 405, "Pull request must be merged using the merge queue.", false},
+		{"conflict", 405, "Pull Request is not mergeable", false},
+		{"changed head", 409, "Head branch is out of date.", false},
+		{"permission", 403, "Head branch is out of date.", false},
+		{"transient", 502, "Head branch is out of date.", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body, err := json.Marshal(map[string]string{"message": tt.message})
+			if err != nil {
+				t.Fatal(err)
+			}
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{method: http.MethodPut, path: "/repos/example/repo/pulls/42/merge", status: tt.status, body: string(body)}})
+			c := newGitHubTestConnector(t, server, Config{})
+			err = c.MergePullRequest(t.Context(), "example/repo", 42, "checked-head", "squash")
+			if errors.Is(err, connector.ErrPullRequestBaseOutOfDate) != tt.want {
+				t.Fatalf("error = %v, want base refusal %t", err, tt.want)
+			}
+			var status *StatusError
+			if !errors.As(err, &status) || status.StatusCode != tt.status {
+				t.Fatalf("lost original status: %v", err)
+			}
+		})
+	}
+}
+
 func TestConnectorMergePullRequestUsesConfiguredMethod(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -533,6 +533,13 @@ func (c *Connector) MergePullRequest(ctx context.Context, repository string, num
 	}
 	var response restPullRequestMergeResponse
 	if err := c.client.REST(ctx, http.MethodPut, restPullRequestMergePath(repo, number), body, &response); err != nil {
+		var status *StatusError
+		if errors.As(err, &status) && status.StatusCode == http.StatusMethodNotAllowed {
+			message := strings.ToLower(status.Body)
+			if strings.Contains(message, "head branch is out of date") || strings.Contains(message, "base branch was modified") {
+				return fmt.Errorf("merge github pull request: %w: %w", connector.ErrPullRequestBaseOutOfDate, err)
+			}
+		}
 		return fmt.Errorf("merge github pull request: %w", err)
 	}
 	if !response.Merged {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1477,6 +1477,9 @@ func activeMergeWorkerRepositories(state *State) map[string]struct{} {
 		repositories = consumeActiveMergeWorkerRepository(repositories, claimed.Issue)
 	}
 	for _, retry := range state.Retry {
+		if reservation := state.mergeReservations[mergeWorkerRepositoryKey(retry.Issue)]; reservation.IssueID == retry.Issue.ID && reservation.ReleasedReason != "" {
+			continue
+		}
 		repositories = consumeActiveMergeWorkerRepository(repositories, retry.Issue)
 	}
 	if len(repositories) == 0 {
@@ -1521,9 +1524,7 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 		return nil
 	}
 	o.logMergeWorkerQueueCycle(state, issues, now)
-	if stickyMergingIssueID(state, issues, now, o.cfg.MergeFairnessAge) != "" {
-		return nil
-	}
+	stickyID := stickyMergingIssueID(state, issues, now, o.cfg.MergeFairnessAge)
 	candidates := o.staleMergingQueueDispatchCandidates(state, issues, now)
 	if len(candidates) == 0 {
 		return nil
@@ -1531,6 +1532,9 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 	out := make([]connector.Issue, 0, len(candidates))
 	selectedByState := map[string]int{}
 	for _, issue := range candidates {
+		if mergeFairnessBlocks(state, stickyID, issue, now) {
+			continue
+		}
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
 			continue
@@ -1757,6 +1761,9 @@ func stickyMergingIssueID(state *State, issues []connector.Issue, now time.Time,
 		if refreshed, ok := current[issueID]; ok {
 			issue = refreshed
 		}
+		if reservation := state.mergeReservations[mergeWorkerRepositoryKey(issue)]; reservation.IssueID == issueID {
+			return
+		}
 		if !mergeWorkerIssueAged(issue, now, fairnessAge) {
 			return
 		}
@@ -1813,12 +1820,16 @@ func mergeWorkerHeadReady(issue connector.Issue) bool {
 }
 
 func (o *Orchestrator) staleMergingQueueDispatchCandidates(state *State, issues []connector.Issue, now time.Time) []connector.Issue {
+	o.reconcileMergeReservations(state, issues, now)
 	candidates := []connector.Issue{}
 	consumedRepositories := activeMergeWorkerRepositories(state)
 	for _, issue := range staleMergingQueueIssues(issues, o.cfg, state, now) {
 		issueID := strings.TrimSpace(issue.ID)
 		repository := mergeWorkerRepositoryKey(issue)
 		if staleMergingPullRequestDispatchActive(state, issueID) {
+			if reservation := state.mergeReservations[repository]; reservation.IssueID == issueID && reservation.ReleasedReason != "" {
+				continue
+			}
 			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
 			continue
 		}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -764,6 +764,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	delete(state.ReapedWorkspaces, issue.ID)
 	delete(state.Completed, issue.ID)
 
+	reservation := reserveMergeCandidate(state, issue, now)
 	request := RunRequest{
 		ProjectID:           strings.TrimSpace(o.cfg.Project.ID),
 		Issue:               issue,
@@ -782,6 +783,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		OnOverrideRejected:  o.agentOverrideRejectionHandler(runCtx, issue),
 		ProgressProbe:       o.sessionProgressProbe(issue),
 		MergePrecheck:       cloneMergePrecheck(queuedRetry.MergePrecheck),
+		MergeRefreshHeadSHA: reservation.RefreshHeadSHA,
 		ForgeRetry:          cloneForgeRetry(queuedRetry.ForgeRetry),
 	}
 	o.attachHumanPrerequisiteTool(&request)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -67,6 +67,7 @@ func (p dispatchPlanner) plan(
 ) DispatchPlan {
 	p.now = now
 	state.ensureInitialized(p.cfg)
+	reconcileMergeReservations(state, candidates, p.cfg, now)
 	p.trackOwnershipAttentionCandidates(state, candidates, now)
 
 	plannedCandidates := cloneIssues(candidates)
@@ -99,7 +100,15 @@ func (p dispatchPlanner) plan(
 		if correctableDispatchEscalated(state, issue.ID, dispatchSkipOwnershipAssigneeRequired) {
 			continue
 		}
-		if mergePriority.stickyIssueID != "" && mergeWorkerIssue(issue) && strings.TrimSpace(issue.ID) != mergePriority.stickyIssueID {
+		if reservation, blocked := mergeReservationBlocks(state, issue, now); blocked {
+			logDecision(dispatchPlanDecision{
+				Issue: issue, QueuePosition: queuePosition,
+				SkipReason: "merge_ci_reservation",
+				SkipDetail: "reserved for " + reservation.IssueID + " head=" + reservation.HeadSHA + " base=" + reservation.BaseSHA + " until=" + reservation.ExpiresAt.Format(time.RFC3339),
+			})
+			continue
+		}
+		if mergeFairnessBlocks(state, mergePriority.stickyIssueID, issue, now) {
 			logDecision(dispatchPlanDecision{
 				Issue:         issue,
 				QueuePosition: queuePosition,
@@ -415,6 +424,7 @@ func (p dispatchPlanner) newDispatchAction(
 
 func (p dispatchPlanner) markDispatched(state *State, action dispatchAction, now time.Time) {
 	issue := cloneIssue(action.issue)
+	reserveMergeCandidate(state, issue, now)
 	state.Running[issue.ID] = Running{
 		Issue:             issue,
 		Attempt:           action.attempt,

--- a/internal/orchestrator/merge_fast_path_test.go
+++ b/internal/orchestrator/merge_fast_path_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
-func TestMergingFastPathBehindReadyRefreshesThenMerges(t *testing.T) {
+func TestMergingFastPathBehindReadyPreservesCheckedHead(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 26, 13, 20, 0, 0, time.UTC)
@@ -86,6 +86,11 @@ func TestMergingFastPathBehindReadyRefreshesThenMerges(t *testing.T) {
 		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	state := newState(cfg)
+	previous := cloneIssue(issue)
+	previous.ID = "previous-candidate"
+	reservation := reserveMergeCandidate(&state, previous, now.Add(-mergeWorkerCurrentHeadCIWaitTimeout))
+	reservation.RefreshHeadSHA = issue.PullRequest.HeadSHA
+	state.mergeReservations[reservation.Repository] = reservation
 	orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{issue}, now)
 
 	completion := receiveMergeFastPathCompletion(t, orch.runResults)
@@ -97,14 +102,14 @@ func TestMergingFastPathBehindReadyRefreshesThenMerges(t *testing.T) {
 	}
 	orch.handleRunResult(context.Background(), &state, completion)
 
-	if got := workspaceBackend.createCalls.Load(); got != 1 {
-		t.Fatalf("Create() calls = %d, want 1", got)
+	if got := workspaceBackend.createCalls.Load(); got != 0 {
+		t.Fatalf("Create() calls = %d, want 0", got)
 	}
-	if got := workspaceBackend.prepareCalls.Load(); got != 1 {
-		t.Fatalf("PrepareMerge() calls = %d, want 1", got)
+	if got := workspaceBackend.prepareCalls.Load(); got != 0 {
+		t.Fatalf("PrepareMerge() calls = %d, want 0", got)
 	}
-	if got := workspaceBackend.afterRunCalls.Load(); got != 1 {
-		t.Fatalf("AfterRun() calls = %d, want 1", got)
+	if got := workspaceBackend.afterRunCalls.Load(); got != 0 {
+		t.Fatalf("AfterRun() calls = %d, want 0", got)
 	}
 	if got := agentBackend.calls.Load(); got != 0 {
 		t.Fatalf("AgentBackend.RunTurn() calls = %d, want 0", got)
@@ -871,8 +876,8 @@ func TestMergingFastPathCleanPrecheckWaitsForCurrentHeadCI(t *testing.T) {
 	if retry.Wait.Kind != retryWaitCurrentHeadCI || retry.Wait.PollCount != 1 {
 		t.Fatalf("Retry[%q].Wait = %#v, want first current-head CI poll", issue.ID, retry.Wait)
 	}
-	if _, ok := state.Claimed[issue.ID]; !ok {
-		t.Fatalf("Claimed[%q] missing while waiting for CI", issue.ID)
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] retained while waiting for CI", issue.ID)
 	}
 }
 

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -50,6 +50,9 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 	stickyIssueID := stickyMergingIssueID(state, out, now, o.cfg.MergeFairnessAge)
 
 	for _, candidate := range staleMergingQueueIssues(out, o.cfg, state, now) {
+		if _, reserved := mergeReservationBlocks(state, candidate, now); reserved {
+			continue
+		}
 		issueID := strings.TrimSpace(candidate.ID)
 		if !nativeMergeQueueCandidate(candidate, o.cfg) || staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
@@ -58,7 +61,7 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			applyNativeMergeQueueEntry(out, issueID, cached.Entry)
 			continue
 		}
-		if stickyIssueID != "" && issueID != stickyIssueID {
+		if mergeFairnessBlocks(state, stickyIssueID, candidate, now) {
 			continue
 		}
 

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -102,20 +102,48 @@ func TestDelegateNativeMergeQueueIssuesHonorsAgedHeadReservation(t *testing.T) {
 	})
 
 	tests := []struct {
-		name  string
-		setup func(*State)
+		name           string
+		setup          func(*State)
+		sameRepository bool
+		wantEnqueued   int
 	}{
 		{
-			name: "running aged head",
+			name:         "running aged head allows other repository",
+			wantEnqueued: 1,
 			setup: func(state *State) {
 				state.Running[aged.ID] = Running{Issue: aged, StartedAt: now.Add(-time.Minute)}
 			},
 		},
 		{
-			name: "retrying aged head",
+			name:         "retrying aged head allows other repository",
+			wantEnqueued: 1,
 			setup: func(state *State) {
 				state.Retry[aged.ID] = Retry{Issue: aged, DueAt: now.Add(time.Minute)}
 			},
+		},
+		{
+			name:           "running aged head protects same repository",
+			sameRepository: true,
+			setup: func(state *State) {
+				state.Running[aged.ID] = Running{Issue: aged, StartedAt: now.Add(-time.Minute)}
+			},
+		},
+		{
+			name:           "retrying aged head protects same repository",
+			sameRepository: true,
+			setup: func(state *State) {
+				state.Retry[aged.ID] = Retry{Issue: aged, DueAt: now.Add(time.Minute)}
+			},
+		},
+		{
+			name:           "CI reservation protects same repository",
+			sameRepository: true,
+			setup:          func(state *State) { reserveMergeCandidate(state, aged, now) },
+		},
+		{
+			name:         "CI reservation allows other repository",
+			wantEnqueued: 1,
+			setup:        func(state *State) { reserveMergeCandidate(state, aged, now) },
 		},
 	}
 
@@ -131,15 +159,20 @@ func TestDelegateNativeMergeQueueIssuesHonorsAgedHeadReservation(t *testing.T) {
 			orch := &Orchestrator{cfg: cfg, connector: tracker}
 			state := newState(cfg)
 			tt.setup(&state)
+			recent := cloneIssue(recent)
+			if tt.sameRepository {
+				recent.PRRepository = aged.PRRepository
+			}
 
 			queued := orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{aged, recent}, now)
 
-			if len(tracker.enqueued) != 0 || tracker.inspections != 0 {
-				t.Fatalf("native queue activity = enqueued %#v, inspections %d; want none", tracker.enqueued, tracker.inspections)
+			if len(tracker.enqueued) != tt.wantEnqueued || tracker.inspections != tt.wantEnqueued {
+				t.Fatalf("native queue activity = enqueued %#v, inspections %d; want %d", tracker.enqueued, tracker.inspections, tt.wantEnqueued)
 			}
 			for _, issue := range queued {
-				if issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil {
-					t.Fatalf("issue %q merge queue entry = %#v, want none", issue.ID, issue.PullRequest.MergeQueueEntry)
+				wantEntry := issue.ID == recent.ID && tt.wantEnqueued == 1
+				if gotEntry := issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil; gotEntry != wantEntry {
+					t.Fatalf("issue %q has entry = %t, want %t", issue.ID, gotEntry, wantEntry)
 				}
 			}
 		})

--- a/internal/orchestrator/merge_reservation.go
+++ b/internal/orchestrator/merge_reservation.go
@@ -1,0 +1,242 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+const mergeReservationMetadataKey = "merge_reservation"
+
+type mergeReservation struct {
+	IssueID        string    `json:"issue_id"`
+	Repository     string    `json:"repository"`
+	HeadSHA        string    `json:"head_sha"`
+	BaseSHA        string    `json:"base_sha"`
+	StartedAt      time.Time `json:"started_at"`
+	ExpiresAt      time.Time `json:"expires_at"`
+	ReleasedReason string    `json:"released_reason,omitempty"`
+	RefreshHeadSHA string    `json:"refresh_head_sha,omitempty"`
+}
+
+func reserveMergeCandidate(state *State, issue connector.Issue, now time.Time) mergeReservation {
+	repository := mergeWorkerRepositoryKey(issue)
+	if !mergeWorkerIssue(issue) || repository == "" || issue.PullRequest == nil || issue.PullRequest.HeadSHA == "" {
+		return mergeReservation{}
+	}
+	if state.mergeReservations == nil {
+		state.mergeReservations = map[string]mergeReservation{}
+	}
+	if reservation := state.mergeReservations[repository]; reservation.IssueID == issue.ID {
+		return reservation
+	}
+	reservation := mergeReservation{
+		IssueID: issue.ID, Repository: repository,
+		HeadSHA: strings.TrimSpace(issue.PullRequest.HeadSHA), BaseSHA: strings.TrimSpace(issue.PullRequest.BaseSHA),
+		StartedAt: now.UTC(), ExpiresAt: now.Add(mergeWorkerCurrentHeadCIWaitTimeout).UTC(),
+	}
+	state.mergeReservations[repository] = reservation
+	return reservation
+}
+
+func mergeReservationBlocks(state *State, issue connector.Issue, now time.Time) (mergeReservation, bool) {
+	if state == nil || !mergeWorkerIssue(issue) {
+		return mergeReservation{}, false
+	}
+	for _, running := range state.Running {
+		if mergeWorkerIssue(running.Issue) && running.Issue.ID != issue.ID && mergeWorkerRepositoryKey(running.Issue) == mergeWorkerRepositoryKey(issue) {
+			return mergeReservation{IssueID: running.Issue.ID, Repository: mergeWorkerRepositoryKey(issue)}, true
+		}
+	}
+	reservation := state.mergeReservations[mergeWorkerRepositoryKey(issue)]
+	return reservation, reservation.IssueID != "" && reservation.IssueID != issue.ID &&
+		reservation.ReleasedReason == "" && now.Before(reservation.ExpiresAt)
+}
+
+func mergeFairnessBlocks(state *State, stickyID string, issue connector.Issue, now time.Time) bool {
+	if stickyID == "" || stickyID == issue.ID || !mergeWorkerIssue(issue) {
+		return false
+	}
+	if reservation := state.mergeReservations[mergeWorkerRepositoryKey(issue)]; reservation.IssueID != "" && reservation.ReleasedReason == "" && now.Before(reservation.ExpiresAt) {
+		return false
+	}
+	if running, ok := state.Running[stickyID]; ok {
+		return mergeWorkerRepositoryKey(running.Issue) == mergeWorkerRepositoryKey(issue)
+	}
+	if retry, ok := state.Retry[stickyID]; ok {
+		return mergeWorkerRepositoryKey(retry.Issue) == mergeWorkerRepositoryKey(issue)
+	}
+	return false
+}
+
+func reconcileMergeReservations(state *State, issues []connector.Issue, cfg Config, now time.Time) []mergeReservation {
+	current := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		current[issue.ID] = issue
+	}
+	var released []mergeReservation
+	for repository, reservation := range state.mergeReservations {
+		if reservation.ReleasedReason != "" {
+			continue
+		}
+		reason := ""
+		issue, present := current[reservation.IssueID]
+		if !present {
+			if completed, ok := state.Completed[reservation.IssueID]; ok {
+				issue, present = completed.Issue, true
+			}
+		}
+		_, running := state.Running[reservation.IssueID]
+		switch {
+		case !now.Before(reservation.ExpiresAt):
+			reason = "expired"
+		case present && workspaceIssueTerminal(issue, cfg.TerminalStates):
+			reason = "completed"
+		case present && (!mergeWorkerIssue(issue) || issue.Closed):
+			reason = "withdrawn"
+		case present && issue.PullRequest != nil && !pullRequestHydrationBlocksProgress(issue.PullRequest):
+			pr := issue.PullRequest
+			switch {
+			case normalizePullRequestState(pr.State) != "open" || pr.Draft:
+				reason = "withdrawn"
+			case mergeWorkerRepositoryKey(issue) != repository:
+				reason = "repository_changed"
+			case strings.TrimSpace(pr.HeadSHA) != reservation.HeadSHA && !running:
+				reason = "head_changed"
+			case staleMergingCIRed(pr.CIStatus) || len(pr.RequiredCheckFailures) > 0 && !mergeWorkerProgrammaticMergeWaiting(issue):
+				reason = "required_checks_failed"
+			case strings.EqualFold(pr.MergeableState, "dirty"):
+				reason = "conflict"
+			case pr.MergeQueueEntry != nil:
+				reason = "native_queue"
+			default:
+				if _, revoked := mergeApprovalLabelRevoked(issue, cfg); revoked {
+					reason = "approval_withdrawn"
+				} else if _, revoked := mergeCITriggerLabelRevoked(issue, cfg); revoked {
+					reason = "ci_trigger_withdrawn"
+				}
+			}
+		}
+		if reason != "" {
+			reservation.ReleasedReason = reason
+			state.mergeReservations[repository] = reservation
+			released = append(released, reservation)
+		}
+	}
+	return released
+}
+
+func (o *Orchestrator) reconcileMergeReservations(state *State, issues []connector.Issue, now time.Time) {
+	for _, reservation := range reconcileMergeReservations(state, issues, o.cfg, now) {
+		if o.logger != nil {
+			issue := connector.Issue{ID: reservation.IssueID}
+			for _, current := range issues {
+				if current.ID == reservation.IssueID {
+					issue = current
+					break
+				}
+			}
+			o.logger.Info("merge_reservation_released", mergeWorkerLogAttrs(issue,
+				"repository", reservation.Repository, "reason", reservation.ReleasedReason,
+				"reserved_head_sha", reservation.HeadSHA, "reserved_base_sha", reservation.BaseSHA,
+				"expires_at", reservation.ExpiresAt, "prior_validation_invalidated", reservation.ReleasedReason == "head_changed")...)
+		}
+	}
+}
+
+func (o *Orchestrator) recordMergeReservationWait(state *State, issue connector.Issue, now time.Time) mergeReservation {
+	reservation := reserveMergeCandidate(state, issue, now)
+	if reservation.IssueID == "" {
+		return reservation
+	}
+	if o.logger != nil {
+		o.logger.Info("merge_reservation_wait", mergeWorkerLogAttrs(issue,
+			"reserved_head_sha", reservation.HeadSHA, "reserved_base_sha", reservation.BaseSHA,
+			"expires_at", reservation.ExpiresAt,
+			"prior_validation_invalidated", reservation.HeadSHA != issue.PullRequest.HeadSHA)...)
+	}
+	reservation.HeadSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
+	reservation.BaseSHA = strings.TrimSpace(issue.PullRequest.BaseSHA)
+	reservation.RefreshHeadSHA = ""
+	state.mergeReservations[reservation.Repository] = reservation
+	return reservation
+}
+
+func (o *Orchestrator) recoverMergeReservations(state *State, attempts []store.WorkAttempt, issues []connector.Issue, now time.Time) {
+	current := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		current[issue.ID] = issue
+	}
+	latest := latestStoreTerminalAttemptsByIssue(attempts)
+	for _, attempt := range latest {
+		var metadata struct {
+			Reservation mergeReservation `json:"merge_reservation"`
+		}
+		if json.Unmarshal([]byte(attempt.WorkerMetadataJSON), &metadata) != nil {
+			continue
+		}
+		reservation := metadata.Reservation
+		if reservation.IssueID != attempt.IssueID || reservation.Repository == "" || reservation.HeadSHA == "" ||
+			reservation.StartedAt.IsZero() || reservation.StartedAt.After(now) || reservation.ReleasedReason != "" || !now.Before(reservation.ExpiresAt) ||
+			reservation.ExpiresAt.After(reservation.StartedAt.Add(mergeWorkerCurrentHeadCIWaitTimeout)) ||
+			attempt.Phase != "waiting" || attempt.TerminalState != store.WorkAttemptTerminalSuccess {
+			continue
+		}
+		issue := current[reservation.IssueID]
+		if issue.ID != reservation.IssueID || mergeWorkerRepositoryKey(issue) != reservation.Repository || issue.PullRequest == nil || pullRequestHydrationBlocksProgress(issue.PullRequest) {
+			continue
+		}
+		validation := State{mergeReservations: map[string]mergeReservation{reservation.Repository: reservation}}
+		o.reconcileMergeReservations(&validation, []connector.Issue{issue}, now)
+		if validation.mergeReservations[reservation.Repository].ReleasedReason != "" {
+			continue
+		}
+		if state.mergeReservations == nil {
+			state.mergeReservations = map[string]mergeReservation{}
+		}
+		if existing := state.mergeReservations[reservation.Repository]; existing.IssueID != "" && existing.ReleasedReason == "" && now.Before(existing.ExpiresAt) && !reservation.StartedAt.Before(existing.StartedAt) {
+			continue
+		}
+		state.mergeReservations[reservation.Repository] = reservation
+		state.Retry[issue.ID] = Retry{Issue: cloneIssue(issue), Attempt: attempt.AttemptNumber,
+			DueAt: now, WorkerHost: attempt.WorkerHost, Error: mergeWorkerCurrentHeadCIWaitReason(issue),
+			Wait: RetryWait{Kind: retryWaitCurrentHeadCI, StartedAt: reservation.StartedAt}}
+		state.MergeTimings[issue.ID] = MergeTiming{CIWaitStartedAt: reservation.StartedAt, CIWaitHeadSHA: reservation.HeadSHA}
+		if o.logger != nil {
+			o.logger.Info("merge_reservation_restored", mergeWorkerLogAttrs(issue, "expires_at", reservation.ExpiresAt)...)
+		}
+	}
+}
+
+func (o *Orchestrator) restoreDurableMergeReservations(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
+	if o.workAttempts == nil {
+		return
+	}
+	if state.mergeRecoveryChecked == nil {
+		state.mergeRecoveryChecked = map[string]bool{}
+	}
+	for _, issue := range issues {
+		if !mergeWorkerIssue(issue) || state.mergeRecoveryChecked[issue.ID] || issue.PullRequest == nil || pullRequestHydrationBlocksProgress(issue.PullRequest) {
+			continue
+		}
+		if reservation := state.mergeReservations[mergeWorkerRepositoryKey(issue)]; reservation.IssueID == issue.ID {
+			state.mergeRecoveryChecked[issue.ID] = true
+			continue
+		}
+		attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+			ProjectID: o.cfg.Project.ID, IssueID: issue.ID, Limit: 1,
+		})
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("merge_reservation_recovery_failed", "issue_id", issue.ID, "error", err)
+			}
+			continue
+		}
+		state.mergeRecoveryChecked[issue.ID] = true
+		o.recoverMergeReservations(state, attempts, []connector.Issue{issue}, now)
+	}
+}

--- a/internal/orchestrator/merge_reservation_test.go
+++ b/internal/orchestrator/merge_reservation_test.go
@@ -1,0 +1,480 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestMergeCIWaitReservesRepositoryBeforeFairnessAge(t *testing.T) {
+	t.Parallel()
+	for _, ci := range []string{"pending", "success"} {
+		t.Run(ci, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 15, 13, 37, 0, time.UTC)
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents:        3,
+				MaxConcurrentAgentsByState: map[string]int{"Merging": 1},
+				ActiveStates:               []string{"Todo", "Merging"},
+				TerminalStates:             []string{"Done"},
+				MergeFastPathEnabled:       true,
+				MergeFairnessAge:           2 * time.Hour,
+				ContinuationRetryDelay:     time.Second,
+			})
+			orch := Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			selected := nativeMergeQueueTestIssue(2221, "pending")
+			selected.StageUpdatedAt = timePointer(now.Add(-3 * time.Minute))
+			selected.PullRequest.HeadSHA = "validated-prerequisite-head"
+			selected.PullRequest.BaseSHA = "base-before-other-merge"
+			other := nativeMergeQueueTestIssue(2220, "success")
+			other.StageUpdatedAt = timePointer(now.Add(-15 * time.Minute))
+			state.Retry[other.ID] = Retry{Issue: other, Attempt: 2, DueAt: now}
+			orch.waitForMergeWorkerCurrentHeadCI(t.Context(), &state,
+				runpkg.Completion{IssueID: selected.ID, CompletedAt: now},
+				Running{Issue: selected, Attempt: 1}, selected)
+			selected.PullRequest.CIStatus = ci
+			plan := newDispatchPlanner(cfg).plan(&state, []connector.Issue{other, selected}, now.Add(time.Minute), dispatchPlanHooks{})
+			for _, dispatch := range plan.Dispatches {
+				if dispatch.IssueID == other.ID {
+					t.Fatal("another same-repository retry advanced the base during the selected head's CI reservation")
+				}
+			}
+			if ci == "success" && (len(plan.Dispatches) != 1 || plan.Dispatches[0].IssueID != selected.ID) {
+				t.Fatalf("dispatches = %#v, want selected candidate after asynchronous CI completion", plan.Dispatches)
+			}
+		})
+	}
+}
+
+func TestMergeReservationLifecycle(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 5, 15, 0, 0, 0, time.UTC)
+	for _, tt := range []struct {
+		name    string
+		mutate  func(*connector.Issue)
+		elapsed time.Duration
+		reason  string
+	}{
+		{name: "pending CI"},
+		{name: "green CI", mutate: func(i *connector.Issue) { i.PullRequest.CIStatus = "success" }},
+		{name: "external base advance", mutate: func(i *connector.Issue) {
+			i.PullRequest.BaseSHA = "external-base"
+			i.PullRequest.MergeableState = "behind"
+		}},
+		{name: "external head change", mutate: func(i *connector.Issue) { i.PullRequest.HeadSHA = "external-head" }, reason: "head_changed"},
+		{name: "failed checks", mutate: func(i *connector.Issue) { i.PullRequest.CIStatus = "failure" }, reason: "required_checks_failed"},
+		{name: "conflict", mutate: func(i *connector.Issue) { i.PullRequest.MergeableState = "dirty" }, reason: "conflict"},
+		{name: "withdrawal", mutate: func(i *connector.Issue) { i.State = "Rework" }, reason: "withdrawn"},
+		{name: "closed", mutate: func(i *connector.Issue) { i.PullRequest.State = "closed" }, reason: "withdrawn"},
+		{name: "draft", mutate: func(i *connector.Issue) { i.PullRequest.Draft = true }, reason: "withdrawn"},
+		{name: "native queue", mutate: func(i *connector.Issue) {
+			i.PullRequest.MergeQueueEntry = &connector.PullRequestMergeQueueEntry{ID: "entry"}
+		}, reason: "native_queue"},
+		{name: "stalled CI expires", elapsed: mergeWorkerCurrentHeadCIWaitTimeout, reason: "expired"},
+		{name: "degraded hydration bounded", mutate: func(i *connector.Issue) { i.PullRequest.HydrationDegradedReason = "unavailable" }},
+		{name: "degraded hydration expires", mutate: func(i *connector.Issue) { i.PullRequest.HydrationDegradedReason = "unavailable" }, elapsed: mergeWorkerCurrentHeadCIWaitTimeout, reason: "expired"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+			state := newState(cfg)
+			issue := nativeMergeQueueTestIssue(2221, "pending")
+			other := nativeMergeQueueTestIssue(2220, "success")
+			original := reserveMergeCandidate(&state, issue, now)
+			if tt.mutate != nil {
+				tt.mutate(&issue)
+			}
+			var logs bytes.Buffer
+			orch := Orchestrator{cfg: cfg, logger: slog.New(slog.NewTextHandler(&logs, nil))}
+			orch.reconcileMergeReservations(&state, []connector.Issue{issue, other}, now.Add(tt.elapsed))
+			reservation, blocked := mergeReservationBlocks(&state, other, now.Add(tt.elapsed))
+			if blocked != (tt.reason == "") || reservation.ReleasedReason != tt.reason {
+				t.Fatalf("reservation = %#v, blocked = %t, want reason %q", reservation, blocked, tt.reason)
+			}
+			if tt.reason != "" && !strings.Contains(logs.String(), "reason="+tt.reason) {
+				t.Fatalf("missing release reason in %s", logs.String())
+			}
+			if !reservation.ExpiresAt.Equal(original.ExpiresAt) {
+				t.Fatal("reservation deadline moved")
+			}
+		})
+	}
+}
+
+func TestMergeReservationAllowsIndependentWork(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 5, 15, 0, 0, 0, time.UTC)
+	for _, age := range []time.Duration{time.Minute, 3 * time.Hour} {
+		t.Run(age.String(), func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 3, MaxConcurrentAgentsByState: map[string]int{"Merging": 1}, ActiveStates: []string{"Merging", "Todo"}, TerminalStates: []string{"Done"}})
+			state := newState(cfg)
+			waiting := nativeMergeQueueTestIssue(2221, "pending")
+			waiting.StageUpdatedAt = timePointer(now.Add(-age))
+			reserveMergeCandidate(&state, waiting, now)
+			state.Retry[waiting.ID] = Retry{Issue: waiting, Attempt: 1, DueAt: now.Add(time.Minute), Wait: RetryWait{Kind: retryWaitCurrentHeadCI, StartedAt: now}}
+			other := nativeMergeQueueTestIssue(2220, "success")
+			other.PRRepository = "example/other"
+			implementation := dispatchTestIssue("implementation", "Todo")
+			plan := newDispatchPlanner(cfg).plan(&state, []connector.Issue{waiting, other, implementation}, now, dispatchPlanHooks{})
+			if len(plan.Dispatches) != 2 {
+				t.Fatalf("dispatches = %#v, want unrelated merge and implementation", plan.Dispatches)
+			}
+			if _, held := state.Running[waiting.ID]; held {
+				t.Fatal("CI wait holds worker slot")
+			}
+		})
+	}
+}
+
+func TestMergeReservationTracksWorkerPushWithoutRenewal(t *testing.T) {
+	t.Parallel()
+	for _, expired := range []bool{false, true} {
+		t.Run(fmt.Sprintf("expired=%t", expired), func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 15, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Merging"}})
+			state := newState(cfg)
+			issue := nativeMergeQueueTestIssue(2221, "success")
+			original := reserveMergeCandidate(&state, issue, now)
+			state.Running[issue.ID] = Running{Issue: cloneIssue(issue), Mode: runpkg.RunModeMerge}
+			issue.PullRequest.HeadSHA = "worker-pushed-head"
+			issue.PullRequest.CIStatus = "pending"
+			elapsed := time.Minute
+			if expired {
+				elapsed = mergeWorkerCurrentHeadCIWaitTimeout
+			}
+			orch := Orchestrator{cfg: cfg}
+			orch.reconcileMergeReservations(&state, []connector.Issue{issue}, now.Add(elapsed))
+			delete(state.Running, issue.ID)
+			reservation := orch.recordMergeReservationWait(&state, issue, now.Add(elapsed))
+			other := nativeMergeQueueTestIssue(2220, "success")
+			if _, blocked := mergeReservationBlocks(&state, other, now.Add(elapsed)); blocked == expired {
+				t.Fatalf("blocked = %t after worker push, expired = %t", blocked, expired)
+			}
+			if reservation.HeadSHA != issue.PullRequest.HeadSHA || reservation.ExpiresAt != original.ExpiresAt {
+				t.Fatalf("reservation = %#v, want pushed head and original deadline", reservation)
+			}
+		})
+	}
+}
+
+func TestMergeReservationRecoversCurrentWaitingHead(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 5, 15, 0, 0, 0, time.UTC)
+	for _, tt := range []struct {
+		name   string
+		mutate func(*connector.Issue, *store.WorkAttempt)
+		want   bool
+	}{
+		{name: "pending", want: true},
+		{name: "green after restart", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.PullRequest.CIStatus = "success" }, want: true},
+		{name: "external base advance", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.PullRequest.BaseSHA = "external" }, want: true},
+		{name: "head changed", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.PullRequest.HeadSHA = "changed" }},
+		{name: "withdrawn", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.State = "Rework" }},
+		{name: "failed", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.PullRequest.CIStatus = "failure" }},
+		{name: "newer completed attempt", mutate: func(_ *connector.Issue, a *store.WorkAttempt) { a.Phase = "completed" }},
+		{name: "malformed metadata", mutate: func(_ *connector.Issue, a *store.WorkAttempt) { a.WorkerMetadataJSON = "{" }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+			state := newState(cfg)
+			issue := nativeMergeQueueTestIssue(2221, "pending")
+			reservation := reserveMergeCandidate(&state, issue, now.Add(-10*time.Minute))
+			attempt := store.WorkAttempt{ID: 1, IssueID: issue.ID, Phase: "waiting", Status: store.WorkAttemptStatusTerminal, TerminalState: store.WorkAttemptTerminalSuccess, AttemptNumber: 2, CompletedAt: now.Add(-9 * time.Minute), WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{mergeReservationMetadataKey: reservation})}
+			if tt.mutate != nil {
+				tt.mutate(&issue, &attempt)
+			}
+			tracker := &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}}
+			orch := Orchestrator{cfg: cfg, connector: tracker}
+			restarted := newState(cfg)
+			orch.recoverMergeReservations(&restarted, []store.WorkAttempt{attempt}, []connector.Issue{issue}, now)
+			_, restored := restarted.Retry[issue.ID]
+			if restored != tt.want {
+				t.Fatalf("restored = %t, want %t", restored, tt.want)
+			}
+			if restored && restarted.mergeReservations[reservation.Repository].ExpiresAt != reservation.ExpiresAt {
+				t.Fatal("restart renewed reservation")
+			}
+		})
+	}
+}
+
+func TestMergeReservationExpiryAdmitsNextCandidate(t *testing.T) {
+	t.Parallel()
+	for _, retryQueued := range []bool{false, true} {
+		t.Run(fmt.Sprintf("retry=%t", retryQueued), func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 15, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 3, ActiveStates: []string{"Merging"}, MergeFastPathEnabled: true})
+			orch := Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			waiting := nativeMergeQueueTestIssue(2221, "pending")
+			waiting.StageUpdatedAt = timePointer(now.Add(-3 * time.Hour))
+			reserveMergeCandidate(&state, waiting, now.Add(-mergeWorkerCurrentHeadCIWaitTimeout))
+			state.Retry[waiting.ID] = Retry{Issue: waiting, Attempt: 1, DueAt: now, Wait: RetryWait{Kind: retryWaitCurrentHeadCI, StartedAt: now.Add(-mergeWorkerCurrentHeadCIWaitTimeout)}}
+			other := nativeMergeQueueTestIssue(2220, "success")
+			if retryQueued {
+				state.Retry[other.ID] = Retry{Issue: other, Attempt: 1, DueAt: now}
+			} else {
+				candidates := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{waiting, other}, now)
+				if len(candidates) != 1 || candidates[0].ID != other.ID {
+					t.Fatalf("candidates = %#v, want next candidate after expiry", candidates)
+				}
+			}
+			plan := newDispatchPlanner(cfg).plan(&state, []connector.Issue{waiting, other}, now, dispatchPlanHooks{})
+			if len(plan.Dispatches) != 1 || plan.Dispatches[0].IssueID != other.ID {
+				t.Fatalf("dispatches = %#v, want next candidate after expiry", plan.Dispatches)
+			}
+		})
+	}
+}
+
+func TestMergeReservationPersistsAndRestoresWait(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		age     time.Duration
+		refresh bool
+		want    bool
+	}{
+		{name: "CI wait", age: time.Minute, want: true},
+		{name: "base refresh refusal", age: time.Minute, refresh: true, want: true},
+		{name: "expired", age: mergeWorkerCurrentHeadCIWaitTimeout},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 15, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Merging"}, MergeFastPathEnabled: true})
+			state := newState(cfg)
+			issue := nativeMergeQueueTestIssue(2221, "pending")
+			attempts := &recordingWorkAttemptStore{}
+			tracker := &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}}
+			orch := Orchestrator{cfg: cfg, workAttempts: attempts, connector: tracker}
+			running := Running{Issue: issue, Attempt: 2, WorkAttemptID: 1}
+			event := runpkg.Completion{IssueID: issue.ID, CompletedAt: now}
+			if tt.refresh {
+				issue.PullRequest.CIStatus = "success"
+				issue.PullRequest.MergeableState = "behind"
+				tracker.err = connector.ErrPullRequestBaseOutOfDate
+				event.Result = runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, Output: runpkg.RunOutputMergeFastPathCheckedHead}
+				if !orch.completeProgrammaticMergeWorkerResult(t.Context(), &state, event, running, issue) {
+					t.Fatal("base refusal was not handled")
+				}
+			} else {
+				orch.waitForMergeWorkerCurrentHeadCI(t.Context(), &state, event, running, issue)
+			}
+			if len(attempts.completions) != 1 {
+				t.Fatalf("completions = %d, want 1", len(attempts.completions))
+			}
+			completion := attempts.completions[0]
+			attempts.history = []store.WorkAttempt{{ID: 1, IssueID: issue.ID, Phase: completion.Phase, Status: completion.Status, TerminalState: completion.TerminalState, AttemptNumber: 2, CompletedAt: now, WorkerMetadataJSON: completion.WorkerMetadataJSON}}
+			restarted := newState(cfg)
+			orch.restoreDurableMergeReservations(t.Context(), &restarted, []connector.Issue{issue}, now.Add(tt.age))
+			other := nativeMergeQueueTestIssue(2220, "success")
+			reservation, blocked := mergeReservationBlocks(&restarted, other, now.Add(tt.age))
+			if blocked != tt.want {
+				t.Fatalf("blocked = %t, want %t, metadata: %s", blocked, tt.want, completion.WorkerMetadataJSON)
+			}
+			if tt.want && (reservation.ExpiresAt != now.Add(mergeWorkerCurrentHeadCIWaitTimeout) || (reservation.RefreshHeadSHA != "") != tt.refresh) {
+				t.Fatalf("restored reservation = %#v", reservation)
+			}
+			orch.restoreDurableMergeReservations(t.Context(), &restarted, []connector.Issue{issue}, now.Add(tt.age))
+			if len(attempts.historyQueries) != 1 {
+				t.Fatalf("repeated recovery queries = %d, want 1", len(attempts.historyQueries))
+			}
+		})
+	}
+}
+
+func TestMergeReservationNeverBypassesUnsafeHead(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		mutate func(*connector.PullRequest)
+	}{
+		{name: "failed required check", mutate: func(pr *connector.PullRequest) { pr.CIStatus = "failure" }},
+		{name: "required failure despite green aggregate", mutate: func(pr *connector.PullRequest) {
+			pr.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "test", Conclusion: "failure"}}
+		}},
+		{name: "conflict", mutate: func(pr *connector.PullRequest) { pr.MergeableState = "dirty" }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 15, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Merging", "Rework"}, MergeFastPathEnabled: true})
+			state := newState(cfg)
+			issue := nativeMergeQueueTestIssue(2221, "success")
+			reserveMergeCandidate(&state, issue, now)
+			tt.mutate(issue.PullRequest)
+			tracker := &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}}
+			orch := Orchestrator{cfg: cfg, connector: tracker}
+			event := runpkg.Completion{IssueID: issue.ID, CompletedAt: now, Request: runpkg.RunRequest{Mode: runpkg.RunModeMerge}, Result: runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, Output: runpkg.RunOutputMergeFastPathCheckedHead}}
+			if !orch.completeProgrammaticMergeWorkerResult(t.Context(), &state, event, Running{Issue: issue, Attempt: 1}, issue) {
+				t.Fatal("unsafe result not handled")
+			}
+			if len(tracker.merges) != 0 {
+				t.Fatal("unsafe head reached merge API")
+			}
+		})
+	}
+}
+
+func TestMergeTrainDrainsWithoutAvoidableCIInvalidation(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		strict        bool
+		external      bool
+		wantRefreshes map[int]int
+	}{
+		{name: "legal checked heads", wantRefreshes: map[int]int{}},
+		{name: "strict protection", strict: true, wantRefreshes: map[int]int{2221: 1, 2220: 1}},
+		{name: "external base advance during CI", strict: true, external: true, wantRefreshes: map[int]int{2221: 2, 2220: 1}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 15, 12, 53, 0, time.UTC)
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 3, MaxConcurrentAgentsByState: map[string]int{"Merging": 1}, ActiveStates: []string{"Merging", "Todo"}, TerminalStates: []string{"Done"}, MergeFastPathEnabled: true, PrioritizeUnblockers: true, ContinuationRetryDelay: time.Second, FailureRetryBaseDelay: time.Second})
+			selected := nativeMergeQueueTestIssue(2221, "success")
+			selected.StageUpdatedAt = timePointer(now.Add(-3 * time.Minute))
+			other := nativeMergeQueueTestIssue(2220, "success")
+			other.StageUpdatedAt = timePointer(now.Add(-15 * time.Minute))
+			for _, issue := range []*connector.Issue{&selected, &other} {
+				issue.PullRequest.BaseSHA = "old-base"
+				issue.PullRequest.MergeableState = "behind"
+			}
+			tracker := &mergeTrainConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{selected, other}}}, base: "base-0", strict: tt.strict, pending: map[string]int{}}
+			backend := &mergeTrainWorkspace{mergeFastPathWorkspace: &mergeFastPathWorkspace{info: workspace.Info{Path: t.TempDir(), Branch: "detent/test"}}, tracker: tracker, refreshes: map[int]int{}}
+			runner, err := runpkg.NewRunner(runpkg.Dependencies{Workflow: workflowconfig.Workflow{}, Workspace: backend, AgentBackend: &mergeFastPathAgentBackend{}, Now: func() time.Time { return now }, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var logs bytes.Buffer
+			orch := Orchestrator{cfg: cfg, connector: tracker, logger: slog.New(slog.NewTextHandler(&logs, nil))}
+			state := newState(cfg)
+			state.Retry[other.ID] = Retry{Issue: cloneIssue(other), Attempt: 2, DueAt: now}
+			advanced := false
+			for tick := 0; tick < 40 && len(tracker.merged) < 2; tick++ {
+				for index := range tracker.stateIssues {
+					issue := &tracker.stateIssues[index]
+					if remaining := tracker.pending[issue.ID]; remaining > 0 {
+						tracker.pending[issue.ID]--
+						if remaining == 1 {
+							issue.PullRequest.CIStatus = "success"
+						}
+					}
+					if issue.PullRequest.BaseSHA != tracker.base {
+						issue.PullRequest.MergeableState = "behind"
+					} else {
+						issue.PullRequest.MergeableState = "clean"
+					}
+				}
+				if tt.external && !advanced && tracker.pending[selected.ID] > 0 {
+					tracker.base = "external-base"
+					advanced = true
+				}
+				candidates := cloneIssues(issuesInStates(tracker.stateIssues, []string{"Merging"}))
+				for n := range 3 {
+					candidates = append(candidates, rankingDependencyIssue(fmt.Sprintf("dependent-%d", n), "Todo", selected.ID))
+				}
+				plan := newDispatchPlanner(cfg).plan(&state, candidates, now, dispatchPlanHooks{})
+				for _, dispatch := range plan.Dispatches {
+					running := state.Running[dispatch.IssueID]
+					if !mergeWorkerIssue(running.Issue) {
+						t.Fatalf("dependent dispatched before prerequisite: %#v", dispatch)
+					}
+					reservation := state.mergeReservations[mergeWorkerRepositoryKey(running.Issue)]
+					request := runpkg.RunRequest{Issue: running.Issue, Mode: runpkg.RunModeMerge, Attempt: running.Attempt, StartedAt: now, MergeRefreshHeadSHA: reservation.RefreshHeadSHA}
+					running.Mode = runpkg.RunModeMerge
+					state.Running[dispatch.IssueID] = running
+					result, runErr := runner.Run(t.Context(), request)
+					if runErr != nil {
+						t.Fatal(runErr)
+					}
+					orch.handleRunResult(t.Context(), &state, runpkg.Completion{IssueID: dispatch.IssueID, CompletedAt: now, Request: request, Result: result})
+				}
+				if len(state.Running) > 0 || len(state.Claimed) > 0 {
+					t.Fatal("merge CI wait retained a worker or claim")
+				}
+				now = now.Add(time.Minute)
+			}
+			if !reflect.DeepEqual(tracker.merged, []int{2221, 2220}) {
+				t.Fatalf("merged = %v, want prerequisite then other; logs: %s", tracker.merged, logs.String())
+			}
+			if !reflect.DeepEqual(backend.refreshes, tt.wantRefreshes) {
+				t.Fatalf("refreshes = %v, want %v", backend.refreshes, tt.wantRefreshes)
+			}
+			if tt.strict && !strings.Contains(logs.String(), "reason=merge_api_rejected_out_of_date_base") {
+				t.Fatalf("missing required-refresh diagnostics: %s", logs.String())
+			}
+		})
+	}
+}
+
+type mergeTrainConnector struct {
+	*autoPromoteTickMergeConnector
+	base    string
+	strict  bool
+	merged  []int
+	pending map[string]int
+}
+
+func (c *mergeTrainConnector) MergePullRequest(ctx context.Context, repository string, number int, headSHA, method string) error {
+	for _, issue := range c.stateIssues {
+		if pullRequestNumber(issue) != number {
+			continue
+		}
+		if issue.PullRequest.HeadSHA != headSHA || !mergeWorkerCIGreen(issue.PullRequest.CIStatus) || len(issue.PullRequest.RequiredCheckFailures) > 0 {
+			return errors.New("unsafe merge attempted")
+		}
+		if c.strict && issue.PullRequest.BaseSHA != c.base {
+			return connector.ErrPullRequestBaseOutOfDate
+		}
+		if err := c.autoPromoteTickMergeConnector.MergePullRequest(ctx, repository, number, headSHA, method); err != nil {
+			return err
+		}
+		c.merged = append(c.merged, number)
+		c.base = fmt.Sprintf("merged-%d", number)
+		return nil
+	}
+	return errors.New("pull request missing")
+}
+
+type mergeTrainWorkspace struct {
+	*mergeFastPathWorkspace
+	tracker   *mergeTrainConnector
+	refreshes map[int]int
+}
+
+func (w *mergeTrainWorkspace) PrepareMerge(_ context.Context, _ workspace.Info, target workspace.Issue, _ workspace.MergePrepareOptions) (workspace.MergePrepareResult, error) {
+	for index := range w.tracker.stateIssues {
+		issue := &w.tracker.stateIssues[index]
+		if issue.ID != target.ID {
+			continue
+		}
+		w.refreshes[issue.PullRequest.Number]++
+		issue.PullRequest.HeadSHA = fmt.Sprintf("refreshed-%d-%d", issue.PullRequest.Number, w.refreshes[issue.PullRequest.Number])
+		issue.PullRequest.BaseSHA = w.tracker.base
+		issue.PullRequest.CIStatus = "pending"
+		issue.PullRequest.MergeableState = "clean"
+		w.tracker.pending[issue.ID] = 4
+		return workspace.MergePrepareResult{Status: workspace.MergePrepareStatusClean, HeadChanged: true}, nil
+	}
+	return workspace.MergePrepareResult{}, errors.New("pull request missing")
+}

--- a/internal/orchestrator/merge_timing.go
+++ b/internal/orchestrator/merge_timing.go
@@ -147,7 +147,8 @@ func (o *Orchestrator) markMergeStarted(state *State, issue connector.Issue, now
 	timing := o.markMergeWorkerSlotAcquired(state, issue, now)
 	timing.MergeStartedAt = now.UTC()
 	baseRefreshStarted := issue.PullRequest != nil &&
-		strings.EqualFold(strings.TrimSpace(issue.PullRequest.MergeableState), "behind")
+		strings.EqualFold(strings.TrimSpace(issue.PullRequest.MergeableState), "behind") &&
+		(!mergeWorkerProgrammaticMergeReady(issue) || state.mergeReservations[mergeWorkerRepositoryKey(issue)].RefreshHeadSHA == issue.PullRequest.HeadSHA)
 	if baseRefreshStarted {
 		timing.BaseRefreshStartedAt = timing.MergeStartedAt
 		timing.BaseRefreshFinishedAt = time.Time{}

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -300,9 +300,10 @@ func TestDispatchReadyIssuesMergeFairnessReservation(t *testing.T) {
 			wantReadyReason:  mergeSelectionReasonClean,
 		},
 		{
-			name:            "aged retry reserves lane after invalidation",
-			enteredAt:       now.Add(-threshold),
-			wantReadyReason: dispatchSkipMergeFairnessReserved,
+			name:             "aged retry allows another repository",
+			enteredAt:        now.Add(-threshold),
+			wantReadyRunning: true,
+			wantReadyReason:  mergeSelectionReasonClean,
 		},
 	}
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1593,6 +1593,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		return true
 	}
 	if event.Result.PullRequestHeadPushed {
+		o.recordMergeReservationWait(state, issue, event.CompletedAt)
 		triggerPending := false
 		if !event.Result.CITriggerLabelReapplied {
 			triggerPending = o.scheduleCITriggerLabel(ctx, issue, gate.Effective(o.cfg.AutoPromote.Gate).RequiredStatusChecks, running.Attempt, true, false)
@@ -1674,6 +1675,24 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	number := pullRequestNumber(issue)
 	headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA)
 	if err := merger.MergePullRequest(ctx, repository, number, headSHA, o.cfg.MergeMethod); err != nil {
+		if errors.Is(err, connector.ErrPullRequestBaseOutOfDate) &&
+			event.Result.Output == runpkg.RunOutputMergeFastPathCheckedHead &&
+			strings.EqualFold(issue.PullRequest.MergeableState, "behind") {
+			reservation := reserveMergeCandidate(state, issue, event.CompletedAt)
+			reservation.RefreshHeadSHA = headSHA
+			state.mergeReservations[reservation.Repository] = reservation
+			running.Issue = issue
+			o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess,
+				"", "", "waiting", "base refresh required by merge API", map[string]any{mergeReservationMetadataKey: reservation})
+			o.releaseTerminalAttemptClaim(ctx, state, issue, event.CompletedAt)
+			o.scheduleRetry(state, issue, nextAttempt(running.Attempt), event.CompletedAt, "base refresh required by merge API", true, running.WorkerHost)
+			if o.logger != nil {
+				o.logger.Info("merge_base_refresh_required", mergeWorkerLogAttrs(issue,
+					"reason", "merge_api_rejected_out_of_date_base", "error", err,
+					"prior_validation_invalidated", true, "reservation_expires_at", reservation.ExpiresAt)...)
+			}
+			return true
+		}
 		running.Issue = issue
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "programmatic_merge_failed", err)
 		return true
@@ -1740,9 +1759,12 @@ func (o *Orchestrator) waitForMergeWorkerCurrentHeadCI(
 	}
 	retryError := mergeWorkerCurrentHeadCIWaitReason(issue)
 	exceeded := o.mergeWorkerCurrentHeadCIWaitExceeded(state, issue, event.CompletedAt)
+	reservation := o.recordMergeReservationWait(state, issue, event.CompletedAt)
 	running.Issue = issue
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
-	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", retryError)
+	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", retryError,
+		map[string]any{mergeReservationMetadataKey: reservation})
+	o.releaseTerminalAttemptClaim(ctx, state, issue, event.CompletedAt)
 	o.scheduleRetry(state, issue, attempt, event.CompletedAt, retryError, true, running.WorkerHost)
 	retry := state.Retry[issue.ID]
 	retry.Wait = RetryWait{
@@ -1951,7 +1973,9 @@ func (o *Orchestrator) waitForMergeWorkerRetry(
 ) {
 	running.Issue = issue
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
-	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", retryError)
+	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", retryError,
+		map[string]any{mergeReservationMetadataKey: state.mergeReservations[mergeWorkerRepositoryKey(issue)]})
+	o.releaseTerminalAttemptClaim(ctx, state, issue, event.CompletedAt)
 	if attempt < 1 {
 		attempt = 1
 	}
@@ -2067,7 +2091,7 @@ func mergeWorkerProgrammaticMergeReady(issue connector.Issue) bool {
 	default:
 		return false
 	}
-	if !mergeWorkerCIGreen(pullRequest.CIStatus) {
+	if !mergeWorkerCIGreen(pullRequest.CIStatus) || len(pullRequest.RequiredCheckFailures) > 0 || pullRequest.MergeQueueEntry != nil {
 		return false
 	}
 	return pullRequestRepository(issue) != "" &&

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -81,6 +81,8 @@ type State struct {
 	Completed                map[string]Completed
 	Retry                    map[string]Retry
 	MergeTimings             map[string]MergeTiming
+	mergeReservations        map[string]mergeReservation
+	mergeRecoveryChecked     map[string]bool
 	mergeSlotAcquisitions    []mergeSlotAcquisition
 	mergeSlotWarnings        map[string]time.Time
 	nativeMergeQueueEntries  map[string]nativeMergeQueueEntry
@@ -482,6 +484,8 @@ func (s State) clone() State {
 		Completed:                make(map[string]Completed, len(s.Completed)),
 		Retry:                    make(map[string]Retry, len(s.Retry)),
 		MergeTimings:             maps.Clone(s.MergeTimings),
+		mergeReservations:        maps.Clone(s.mergeReservations),
+		mergeRecoveryChecked:     maps.Clone(s.mergeRecoveryChecked),
 		mergeSlotAcquisitions:    append([]mergeSlotAcquisition(nil), s.mergeSlotAcquisitions...),
 		mergeSlotWarnings:        maps.Clone(s.mergeSlotWarnings),
 		nativeMergeQueueEntries:  cloneNativeMergeQueueEntries(s.nativeMergeQueueEntries),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -146,6 +146,8 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	fetched.candidates = overlayIssueStateSnapshots(fetched.candidates, terminalRetryTransitions)
 	fetched.status = overlayIssueStateSnapshots(fetched.status, terminalRetryTransitions)
 	o.observePullRequestHydrationSkips(mergeIssueSlices(fetched.candidates, fetched.status))
+	o.restoreDurableMergeReservations(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now)
+	o.reconcileMergeReservations(state, mergeIssueSlices(fetched.candidates, fetched.status), now)
 	o.restoreDurableGateWaitCompletions(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status))
 	fetched = filterReconciledTickIssues(state, fetched, o.reconcileOperatorStopHolds(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now))
 	fetched = filterReconciledTickIssues(state, fetched, o.reconcileMergeDurationHolds(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now))

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -746,7 +746,11 @@ func mergeFastPathCheckedHead(issue connector.Issue) bool {
 	if !strings.EqualFold(strings.TrimSpace(pullRequest.State), "open") || pullRequest.Draft {
 		return false
 	}
-	if !strings.EqualFold(strings.TrimSpace(pullRequest.MergeableState), "clean") {
+	mergeable := strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
+	if mergeable != "clean" && mergeable != "behind" {
+		return false
+	}
+	if pullRequest.HydrationUnavailableReason != "" || pullRequest.HydrationDegradedReason != "" || len(pullRequest.RequiredCheckFailures) > 0 || pullRequest.MergeQueueEntry != nil {
 		return false
 	}
 	if strings.TrimSpace(pullRequest.HeadSHA) == "" {
@@ -1350,10 +1354,14 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	workflow, agentRuntime, budgetChecker, dispatchEstimator := r.runtimeSnapshot()
 	forgeHost := forgeavailability.HostFromEndpoint(workflow.Config.Tracker.Endpoint)
 	mode := normalizeRunMode(req.Mode)
-	if mode == RunModeMerge && mergeFastPathCheckedHead(req.Issue) {
+	if mode == RunModeMerge && mergeFastPathCheckedHead(req.Issue) && req.MergeRefreshHeadSHA != req.Issue.PullRequest.HeadSHA {
 		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_checked_head",
 			telemetry.WorkAttemptIDKey, req.WorkAttemptID,
 			"workspace_branch", strings.TrimSpace(req.Issue.BranchName),
+			"head_sha", req.Issue.PullRequest.HeadSHA,
+			"base_sha", req.Issue.PullRequest.BaseSHA,
+			"reason", "preserve_green_head_for_merge_api",
+			"prior_validation_invalidated", false,
 		)
 		return RunResult{
 			FinalState: FinalStateCompleted,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -3502,7 +3502,15 @@ func TestMergeFastPathCheckedHead(t *testing.T) {
 	}{
 		{name: "current green head", want: true},
 		{name: "normalized current head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = " CLEAN " }, want: true},
-		{name: "behind green head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = "behind" }},
+		{name: "behind green head", mutate: func(pr *connector.PullRequest) { pr.MergeableState = "behind" }, want: true},
+		{name: "required failure despite aggregate green", mutate: func(pr *connector.PullRequest) {
+			pr.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Conclusion: "failure"}}
+		}},
+		{name: "native queue entry", mutate: func(pr *connector.PullRequest) {
+			pr.MergeQueueEntry = &connector.PullRequestMergeQueueEntry{ID: "queue"}
+		}},
+		{name: "degraded hydration", mutate: func(pr *connector.PullRequest) { pr.HydrationDegradedReason = "unavailable" }},
+		{name: "conflict", mutate: func(pr *connector.PullRequest) { pr.MergeableState = "dirty" }},
 		{name: "pending checks", mutate: func(pr *connector.PullRequest) { pr.CIStatus = "pending" }},
 		{name: "draft", mutate: func(pr *connector.PullRequest) { pr.Draft = true }},
 		{name: "closed", mutate: func(pr *connector.PullRequest) { pr.State = "closed" }},

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -595,6 +595,7 @@ type RunRequest struct {
 	AgentToolHandler          AgentToolHandler
 	AcquireModelPermit        ModelPermitAcquirer
 	MergePrecheck             *MergePrecheck
+	MergeRefreshHeadSHA       string
 	ForgeRetry                *ForgeRetry
 	sessionBrake              *sessionBrakeController
 	workerGitHubActor         connector.IssueActor


### PR DESCRIPTION
## Summary

- Preserve green, mergeable BEHIND heads for the exact-SHA merge API. Refresh only when GitHub explicitly refuses an out-of-date base, then require CI on the refreshed head.
- Reserve the selected candidate's repository across CI waits so other queued retries cannot repeatedly invalidate its checks. Release worker claims during waits and bound the reservation to one hour without renewing it across head refreshes or restart.
- Restore eligible reservations from work-attempt metadata; release on expiry, failed checks, conflicts, withdrawal, or external head changes. Keep native queue delegation and record refresh/release reasons with head and base identities.

- Add a skill draft for testing asynchronous reservations with realistic tracker filtering and persisted recovery.

Fixes #2226

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, viewport, or responsive changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Focused merge, runner, and GitHub connector tests.
- [x] Deterministic multi-candidate train: zero refreshes with relaxed protection, one per candidate with strict protection, and one additional required refresh after an external base advance.
- [x] Worker-push race, completion omitted from tracker fetches, expiry allowing the next candidate, restart from persisted wait metadata, independent implementation/repository dispatch, and refusal of failing checks/conflicts.
- [x] Safety-boundary fuzz: all 13 seeds and 1,371,352 executions over 30 seconds.
- [x] `make check` (80.0% total coverage; package and exact-file floors met)
