### PR TITLE
test(runner): stabilize Git wrapper invocation

### DIFF
--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1054,17 +1054,19 @@ if "%DETENT_TEST_PUSH_WRAPPER_FAIL%"=="1" (
 exit /b %errorlevel%
 `
 			}
-			if err := os.WriteFile(wrapperPath, []byte(wrapper), 0o700); err != nil {
+			if err := os.WriteFile(wrapperPath, []byte(wrapper), 0o600); err != nil {
 				t.Fatalf("write git wrapper: %v", err)
 			}
 
 			command := "git push origin " + pushRef
 			wrapperCommand := wrapperPath
-			actualCommand := `"$DETENT_TEST_GIT" push origin ` + pushRef
+			actualCommand := `sh "$DETENT_TEST_GIT" push origin ` + pushRef
 			if tt.laterFailure {
 				command += " && printf '%s\\n' 'later assertion failed' >&2 && exit 19"
 				actualCommand += " && printf '%s\\n' 'later assertion failed' >&2 && exit 19"
 			}
+			commandCtx, cancelCommand := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancelCommand()
 			var cmd *exec.Cmd
 			if runtime.GOOS == "windows" {
 				wrapperCommand, err = filepath.Rel(workspacePath, wrapperPath)
@@ -1075,9 +1077,9 @@ exit /b %errorlevel%
 				if tt.laterFailure {
 					actualCommand += " && echo later assertion failed 1>&2 && exit /b 19"
 				}
-				cmd = exec.CommandContext(t.Context(), "cmd.exe", "/d", "/s", "/c", actualCommand)
+				cmd = exec.CommandContext(commandCtx, "cmd.exe", "/d", "/s", "/c", actualCommand)
 			} else {
-				cmd = exec.CommandContext(t.Context(), "sh", "-c", actualCommand)
+				cmd = exec.CommandContext(commandCtx, "sh", "-c", actualCommand)
 			}
 			cmd.Dir = workspacePath
 			wrapperFailure := "0"


### PR DESCRIPTION
## Summary

- Run the generated POSIX Git fixture through `sh` so Linux does not execute the newly written script directly. A controlled reproduction with the script held open writable returned exit 126 / `Text file busy` through direct execution and the intended exit 23 through `sh`; the original CI writer/filesystem cause remains unknown.
- Store the wrapper without executable permission, so the existing scenarios guard against returning to direct execution. Keep Windows `cmd.exe`/`call`, private repositories and environments, exact exit 23/19 and fault-marker assertions, and all remote-head reconciliation checks. Bound each injected command to 30 seconds; add no retries or production changes.

Fixes #2230

## UI Surface Contract

- [x] N/A: test fixture only; no UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] No visual changes requiring browser verification.

## Test Plan

- [x] Controlled Linux launch reproduction: direct invocation fails with 126; explicit interpreter reaches injected exit 23 and marker with the same writable-open script.
- [x] Linux arm64, Go 1.26.8: `go test -race ./internal/runner -run '^TestReconcileFailedPushPublicationFromExactRemoteHead$' -count=50 -timeout=10m` (30.340s).
- [x] macOS: the same focused race test with `-count=20 -timeout=10m` (10.277s).
- [x] `make check`
- [x] [Current-head CI](https://github.com/digitaldrywood/detent/actions/runs/33980999538): all 11 checks passed, including Linux verification and macOS/Windows portability.
