### PR TITLE
test(git): isolate fixture author configuration

### DIFF
--- a/.detent/skills/inherited-git-fixture-isolation.md
+++ b/.detent/skills/inherited-git-fixture-isolation.md
@@ -1,0 +1,15 @@
+---
+name: inherited-git-fixture-isolation
+description: Diagnose Git fixtures that mutate a source repository through inherited environment settings.
+when_to_use: Use when fixture identities or Git mutations escape temporary repositories, especially in hooks or linked worktrees.
+---
+
+# Isolate Git fixture subprocesses
+
+- Inspect the origins of user.name and user.email read-only. Record inherited Git variable names without printing possible credential values. Do not attribute an existing override to a helper without evidence.
+- Build a disposable source repository and linked worktree. Run the suspect fixture command with inherited GIT_DIR, GIT_COMMON_DIR, and GIT_CONFIG separately. A working directory or git -C does not override these routing settings.
+- Compare the disposable source/common config byte-for-byte before and after each case. Never reproduce by targeting the real shared repository.
+- When an entire test package owns temporary Git fixtures, clear inherited GIT_* variables in TestMain before any tests run. This also protects application subprocesses and hook commands reached by tests. Preserve non-Git environment settings and allow individual tests to set explicit Git variables afterward.
+- Exercise the real fixture helper in a child test executable, injecting hostile Git settings only into that child. Starting the child from a disposable linked worktree tests both startup isolation and common-directory resolution without mutating the parallel parent environment.
+- Cover routing variables, config file and command-config injection, index/worktree overrides, and author overrides. Assert fixture ownership and commit identity as well as unchanged source config. Give each case its own disposable source.
+- Prove the regression fails before the fix, run focused race tests, and run the repository gate. Keep historical attribution separate from a verified reproduction mechanism.

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -32,11 +32,15 @@ import (
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/testenv"
 	"github.com/digitaldrywood/detent/internal/tui"
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
 func TestMain(m *testing.M) {
+	if err := testenv.ClearGitEnvironment(); err != nil {
+		panic(err)
+	}
 	if err := os.Unsetenv("DETENT_API_TOKEN"); err != nil {
 		panic("clear DETENT_API_TOKEN: " + err.Error())
 	}

--- a/internal/intake/scanner_test.go
+++ b/internal/intake/scanner_test.go
@@ -7,7 +7,16 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/digitaldrywood/detent/internal/testenv"
 )
+
+func TestMain(m *testing.M) {
+	if err := testenv.ClearGitEnvironment(); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
 
 func TestStaleTODOScanner(t *testing.T) {
 	tests := []struct {

--- a/internal/orchestrator/leak_test.go
+++ b/internal/orchestrator/leak_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 
 	"go.uber.org/goleak"
+
+	"github.com/digitaldrywood/detent/internal/testenv"
 )
 
 func TestMain(m *testing.M) {
+	if err := testenv.ClearGitEnvironment(); err != nil {
+		panic(err)
+	}
 	goleak.VerifyTestMain(m)
 }

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -22,6 +22,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
 	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/testenv"
 )
 
 const (
@@ -31,6 +32,9 @@ const (
 )
 
 func TestMain(m *testing.M) {
+	if err := testenv.ClearGitEnvironment(); err != nil {
+		panic(err)
+	}
 	switch os.Getenv(workflowGitHelperModeEnv) {
 	case "git":
 		os.Exit(runWorkflowGitParentHelper())

--- a/internal/runner/leak_test.go
+++ b/internal/runner/leak_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 
 	"go.uber.org/goleak"
+
+	"github.com/digitaldrywood/detent/internal/testenv"
 )
 
 func TestMain(m *testing.M) {
+	if err := testenv.ClearGitEnvironment(); err != nil {
+		panic(err)
+	}
 	goleak.VerifyTestMain(m)
 }

--- a/internal/testenv/git.go
+++ b/internal/testenv/git.go
@@ -1,0 +1,19 @@
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ClearGitEnvironment() error {
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "GIT_") {
+			if err := os.Unsetenv(key); err != nil {
+				return fmt.Errorf("clear %s: %w", key, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/testenv/git_test.go
+++ b/internal/testenv/git_test.go
@@ -1,0 +1,53 @@
+package testenv
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestClearGitEnvironment(t *testing.T) {
+	for _, entry := range os.Environ() {
+		key, value, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "GIT_") {
+			t.Setenv(key, value)
+		}
+	}
+
+	tests := []struct {
+		key     string
+		removed bool
+	}{
+		{key: "GIT_DIR", removed: true},
+		{key: "GIT_COMMON_DIR", removed: true},
+		{key: "GIT_WORK_TREE", removed: true},
+		{key: "GIT_INDEX_FILE", removed: true},
+		{key: "GIT_OBJECT_DIRECTORY", removed: true},
+		{key: "GIT_ALTERNATE_OBJECT_DIRECTORIES", removed: true},
+		{key: "GIT_CONFIG", removed: true},
+		{key: "GIT_CONFIG_PARAMETERS", removed: true},
+		{key: "GIT_CONFIG_COUNT", removed: true},
+		{key: "GIT_CONFIG_KEY_0", removed: true},
+		{key: "GIT_CONFIG_VALUE_0", removed: true},
+		{key: "GIT_AUTHOR_NAME", removed: true},
+		{key: "GIT_COMMITTER_EMAIL", removed: true},
+		{key: "DETENT_TEST_KEEP_ENV"},
+	}
+	for _, tt := range tests {
+		t.Setenv(tt.key, "inherited value")
+	}
+	if err := ClearGitEnvironment(); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			value, present := os.LookupEnv(tt.key)
+			if present == tt.removed {
+				t.Fatalf("environment variable present = %t, want %t", present, !tt.removed)
+			}
+			if !tt.removed && value != "inherited value" {
+				t.Fatalf("preserved value = %q, want inherited value", value)
+			}
+		})
+	}
+}

--- a/internal/workspace/git_environment_test.go
+++ b/internal/workspace/git_environment_test.go
@@ -1,0 +1,89 @@
+package workspace
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitFixtureEnvironmentIsolation(t *testing.T) {
+	if os.Getenv("DETENT_TEST_GIT_FIXTURE_CHILD") == "1" {
+		fixture := initSourceRepo(t)
+		common := strings.TrimSpace(runGit(t, fixture, "rev-parse", "--path-format=absolute", "--git-common-dir"))
+		if got, want := mustCanonicalExistingPath(t, common), mustCanonicalExistingPath(t, filepath.Join(fixture, ".git")); got != want {
+			t.Fatalf("fixture common directory = %q, want %q", got, want)
+		}
+		if got := strings.TrimSpace(runGit(t, fixture, "log", "-1", "--format=%an <%ae>")); got != "Test User <test@example.com>" {
+			t.Fatalf("fixture author = %q", got)
+		}
+		return
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		variables []string
+	}{
+		{name: "linked worktree cwd"},
+		{name: "linked git directory", variables: []string{"GIT_DIR"}},
+		{name: "common directory", variables: []string{"GIT_COMMON_DIR"}},
+		{name: "config file", variables: []string{"GIT_CONFIG"}},
+		{name: "worktree and index", variables: []string{"GIT_WORK_TREE", "GIT_INDEX_FILE"}},
+		{name: "linked worktree hook", variables: []string{"GIT_DIR", "GIT_COMMON_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"}},
+		{name: "config parameters", variables: []string{"GIT_CONFIG_PARAMETERS"}},
+		{name: "config entries", variables: []string{"GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0"}},
+		{name: "author identity", variables: []string{"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := initSourceRepo(t)
+			runGit(t, source, "config", "user.name", "Source Owner")
+			runGit(t, source, "config", "user.email", "source@example.com")
+			linked := filepath.Join(t.TempDir(), "linked")
+			runGit(t, source, "worktree", "add", "-b", "linked", linked)
+			common := filepath.Join(source, ".git")
+			configPath := filepath.Join(common, "config")
+			values := map[string]string{
+				"GIT_DIR":               linkedWorktreeGitDir(t, linked),
+				"GIT_COMMON_DIR":        common,
+				"GIT_CONFIG":            configPath,
+				"GIT_WORK_TREE":         source,
+				"GIT_INDEX_FILE":        filepath.Join(common, "index"),
+				"GIT_CONFIG_PARAMETERS": "'core.bare=true'",
+				"GIT_CONFIG_COUNT":      "1",
+				"GIT_CONFIG_KEY_0":      "core.bare",
+				"GIT_CONFIG_VALUE_0":    "true",
+				"GIT_AUTHOR_NAME":       "Inherited Author",
+				"GIT_AUTHOR_EMAIL":      "inherited@example.com",
+			}
+			before, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.CommandContext(t.Context(), executable, "-test.run=^TestGitFixtureEnvironmentIsolation$")
+			cmd.Dir = linked
+			cmd.Env = append(os.Environ(), "DETENT_TEST_GIT_FIXTURE_CHILD=1")
+			for _, key := range tt.variables {
+				cmd.Env = append(cmd.Env, key+"="+values[key])
+			}
+			output, runErr := cmd.CombinedOutput()
+			after, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Error("fixture setup changed source/common repository configuration")
+			}
+			if runErr != nil {
+				t.Fatalf("fixture child: %v\n%s", runErr, output)
+			}
+		})
+	}
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -14,11 +14,16 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/testenv"
 )
 
 const workspacePackageDefaultParallelism = "1"
 
 func TestMain(m *testing.M) {
+	if err := testenv.ClearGitEnvironment(); err != nil {
+		panic(err)
+	}
 	if !hasExplicitTestParallelism(os.Args[1:]) {
 		if err := flag.Set("test.parallel", workspacePackageDefaultParallelism); err != nil {
 			fmt.Fprintf(os.Stderr, "configure workspace test parallelism: %v\n", err)


### PR DESCRIPTION
## Summary

- Prevent inherited Git repository, configuration, index, and identity variables from redirecting disposable test fixtures into the shared source repository. Clear them before tests start in every package that creates Git fixtures.
- Add standard-library table-driven coverage that invokes the real fixture setup from disposable linked worktrees and checks fixture ownership, author identity, and byte-identical source/common configuration. The escape mechanism is reproduced; the historical writer of the existing override remains unknown.

Fixes #2231

## UI Surface Contract

- [x] N/A: this change has no UI surface or layout changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Reproduced source/common configuration mutations before the fix using inherited GIT_DIR, GIT_COMMON_DIR, and GIT_CONFIG in disposable repositories.
- [x] Focused regression tests and affected-package race tests pass.
- [x] `make check`
- [x] Verified the real shared repository configuration remains byte-identical after validation.
