### PR TITLE
feat(dispatch): reserve shared provider capacity

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -286,6 +286,13 @@ enroll`. The client renews this credential automatically. Its organization,
 machine ID and explicit native projects must match enrollment. See
 [runner onboarding and migration](hub-api.md#scoped-runner-onboarding).
 
+Enrolled native runners can opt into provider-aware dispatch with
+`client.provider_capacity_file`, an absolute path to a bounded JSON report file.
+The runner reads it on heartbeats and again before starting provider work. See
+[provider capacity reports](hub-api.md#provider-capacity-reports) for its safe
+schema, shared-account declarations and reservation semantics. This setting does
+not change backend credentials, model routes, effort defaults or fallback policy.
+
 ```yaml
 client:
   hub_url: https://hub.example.com

--- a/docs/hub-api.md
+++ b/docs/hub-api.md
@@ -663,3 +663,100 @@ scoped revision retrieval, backup-compatible migration and restart persistence.
 They do not claim that the future privileged purge/restore maintenance command is
 implemented. Until it is, operators must retain backups deliberately and must not
 disable triggers on a running Hub as a substitute for supported deletion.
+
+## Provider capacity reports
+
+Enrolled native runners can report provider capacity with an optional global
+client setting. Existing unconfigured runners retain their scheduling behavior.
+
+```yaml
+client:
+  hub_url: https://hub.example.com
+  identity_file: /absolute/private/runner/identity.json
+  organization_id: org_example
+  native_projects:
+    application: prj_example
+  provider_capacity_file: /absolute/private/runner/provider-capacity.json
+```
+
+The file is a JSON array written by an operator-managed local collector. Detent
+does not log into provider accounts or scrape billing pages to populate it. Use
+atomic file replacement when publishing a new observation. The collector maps
+each backend ID to the credentials already used by that local backend; reporting
+an alias never switches the backend's account. Each backend has exactly one local
+account in a report. Configure separate backend IDs for separately selected
+accounts through the existing agent routing configuration.
+
+```json
+[
+  {
+    "provider": "openai",
+    "backend": "codex",
+    "account_alias": "local-work",
+    "shared_account_alias": "team-subscription-a",
+    "models": ["gpt-5.6-sol", "gpt-6-astra"],
+    "max_concurrent": 2,
+    "availability": "unknown",
+    "observed_at": "2026-09-05T12:00:00Z"
+  }
+]
+```
+
+Only these fields and optional `reset_at` are accepted. Files are bounded to
+256 KiB, 32 backends and 128 model identifiers per backend. Aliases are opaque
+lowercase ASCII tokens, at most 64 characters; use no email addresses, API keys,
+login sessions, billing records or customer prompts. Provider/backend/model
+identifiers are bounded, case-sensitive tokens; use the same provider ID on every
+machine sharing an account. `models` must advertise the identifiers selected
+by local routing. An existing unpinned route uses the explicit `provider_default`
+capability; capacity never picks a different model or rewrites effort.
+
+`max_concurrent` is an operator-declared bound on simultaneous reserved runs,
+between 1 and 10000. It is not a token balance or an estimate of transferable
+credits. `availability` is `available`, `exhausted` or `unknown`. Observations at
+least two minutes old, observations in the future, and reset hints reached at
+equality become `unknown`, never automatically `available`. Unknown quota permits
+dispatch only within the declared concurrency bound and existing local brakes.
+An exhausted fresh observation waits for a refreshed report or its reset hint.
+
+Declare the same `provider` and `shared_account_alias` on every machine using the
+same provider account, even when local aliases or backend IDs differ. Hub scopes
+sharing to the organization, uses the lowest declared limit and honors exhaustion
+from any overlapping report. Distinct explicit aliases declare independent
+accounts. An omitted shared alias means sharing is unknown: its reports and
+reservations overlap every account of that provider in the organization. Separate
+local aliases or reports never imply independent capacity. Drain work before
+changing account mappings; existing leases retain their original reservation.
+
+Registration and heartbeats accept typed `provider_reports` on the native machine
+endpoints. Once a runner advertises reports, requests without selected candidates
+cannot bypass reservations. A missing/invalid configured report file defers
+dispatch; it does not silently disable capacity checks. Omitted heartbeat reports
+retain the last report, including its original observation time.
+
+`POST .../claims/preview` returns authorized candidates in the existing Hub queue
+order, in pages of up to 100 (`after`/`next` are opaque cursor values). The client
+uses the existing local role/model/override resolution, then includes
+`provider_candidates` (work item ID, revision and selected role/backend/model)
+in `POST .../claims`. Hub rechecks current issue revision, approved policy,
+organization/project authority, tags, fixed host, health, host capacity and
+provider compatibility inside the claim transaction. Capacity removes ineligible
+choices from that order; it does not reprioritize work or select a fallback model.
+The negotiated feature is `provider_capacity_reservations`.
+
+The claim response includes `provider_reservation`, pinned to the fenced lease.
+The client rechecks the local account and model immediately before `run.started`;
+Hub rechecks the shared pool while accepting the first ordered start. A changed
+identity or newly exhausted pool defers the start without spending the issue's
+failure budget. Existing local budgets, pools, host pressure and provider backoff
+still apply. Cancellation, failed preparation, hydration failure and normal
+release free capacity through the existing lease. Expiry frees abandoned
+reservations after restart; stale fencing tokens cannot release a successor's
+reservation. Lost acknowledgments remain idempotent. Capacity changes affect new
+starts and preserve active execution identity and history.
+
+These reservations coordinate enrolled Detent runs using reported accounts;
+external provider consumers still require fresh observations and local provider
+error handling. Fleet details show reports, shared usage and waiting reasons;
+run details show the selected role/backend/model/account and reason. `detent
+doctor` reports the same capacity view. There is no additional global banner.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/healthnotify"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -48,6 +49,7 @@ const (
 )
 
 type doctorCheck struct {
+	ProviderCapacity           []providercapacity.View                    `json:"provider_capacity,omitempty"`
 	Name                       string                                     `json:"name"`
 	Status                     doctorStatus                               `json:"status"`
 	Detail                     string                                     `json:"detail"`

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -37,6 +37,9 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	deps.pauseProjects = append([]globalconfig.Project(nil), cfg.Projects...)
 	deps.pauseGitHubToken = runtimeGlobalGitHubToken(githubToken)
 	checks := make([]doctorCheck, 0, len(cfg.Projects)*2)
+	if cfg.Client.ProviderCapacityFile != "" {
+		checks = append(checks, checkDoctorProviderCapacity(ctx, cfg))
+	}
 	for _, project := range cfg.Projects {
 		project.GlobalActiveHours = cfg.Global.ActiveHours
 		project.Identity = cfg.Global.Identity

--- a/internal/cli/doctor_provider_capacity.go
+++ b/internal/cli/doctor_provider_capacity.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+)
+
+func checkDoctorProviderCapacity(ctx context.Context, cfg globalconfig.Config) doctorCheck {
+	check := doctorCheck{Name: "Runner provider capacity", Status: doctorOK}
+	if _, err := providercapacity.Load(cfg.Client.ProviderCapacityFile); err != nil {
+		check.Status, check.Detail = doctorFail, err.Error()
+		check.Hint = "Publish a valid bounded provider report file; keep credentials in the local backend configuration."
+		return check
+	}
+	fleet, err := newHubRunnerFleet(cfg)
+	if err != nil {
+		check.Status, check.Detail = doctorFail, err.Error()
+		return check
+	}
+	view, err := fleet.Fleet(ctx)
+	if err != nil {
+		check.Status, check.Detail = doctorWarn, err.Error()
+		return check
+	}
+	var details []string
+	for _, runner := range view.Runners {
+		for _, capacity := range runner.ProviderCapacity {
+			check.ProviderCapacity = append(check.ProviderCapacity, capacity)
+			details = append(details, capacity.Summary())
+			if capacity.State != "available" || capacity.Used >= capacity.MaxConcurrent {
+				check.Status = doctorWarn
+			}
+		}
+	}
+	check.Detail = strings.Join(details, "; ")
+	if len(details) == 0 {
+		check.Status, check.Detail = doctorWarn, "Hub has not received a provider report from this runner"
+	}
+	return check
+}

--- a/internal/cli/doctor_provider_capacity_test.go
+++ b/internal/cli/doctor_provider_capacity_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+	"github.com/digitaldrywood/detent/internal/runnerauth"
+)
+
+func TestDoctorProviderCapacity(t *testing.T) {
+	t.Setenv("DETENT_TEST_PROVIDER_TOKEN", "test")
+	for _, test := range []struct {
+		name, state             string
+		used                    int
+		missing, offline, empty bool
+		want                    doctorStatus
+	}{
+		{name: "available", state: "available", want: doctorOK},
+		{name: "unknown", state: "unknown", want: doctorWarn},
+		{name: "exhausted", state: "exhausted", want: doctorWarn},
+		{name: "reserved", state: "available", used: 1, want: doctorWarn},
+		{name: "missing report", missing: true, want: doctorFail},
+		{name: "Hub outage", state: "available", offline: true, want: doctorWarn},
+		{name: "not registered", state: "available", empty: true, want: doctorWarn},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			report := providercapacity.Report{Provider: "openai", Backend: "codex", AccountAlias: "work", Models: []string{"sol"}, MaxConcurrent: 1, Availability: "unknown", ObservedAt: time.Now()}
+			path := filepath.Join(t.TempDir(), "report.json")
+			if !test.missing {
+				raw, err := json.Marshal([]providercapacity.Report{report})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, raw, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.offline {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				fleet := []runnerauth.Runner{{ProviderCapacity: []providercapacity.View{{Report: report, State: test.state, Used: test.used, Reason: "Capacity observation"}}}}
+				if test.empty {
+					fleet = nil
+				}
+				if err := json.NewEncoder(w).Encode(fleet); err != nil {
+					t.Error(err)
+				}
+			}))
+			t.Cleanup(server.Close)
+			cfg := globalconfig.Config{Client: globalconfig.HubClient{URL: server.URL, OrganizationID: "org_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", TokenEnvironment: "DETENT_TEST_PROVIDER_TOKEN", ProviderCapacityFile: path}}
+			check := checkDoctorProviderCapacity(t.Context(), cfg)
+			if check.Status != test.want || check.Detail == "" {
+				t.Fatalf("doctor = %+v", check)
+			}
+		})
+	}
+}

--- a/internal/cli/hub_client.go
+++ b/internal/cli/hub_client.go
@@ -11,6 +11,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/hubclient"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/runnerauth"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
@@ -64,8 +65,15 @@ func newHubScheduling(cfg globalconfig.Config, version string) (orchestrator.Sch
 	for name, id := range clientConfig.NativeProjects {
 		nativeProjects[name] = tracker.ProjectID(id)
 	}
+	var providerReports func() ([]providercapacity.Report, error)
+	if clientConfig.ProviderCapacityFile != "" {
+		providerReports = func() ([]providercapacity.Report, error) {
+			return providercapacity.Load(clientConfig.ProviderCapacityFile)
+		}
+	}
 	return hubclient.NewScheduler(client, hubclient.SchedulerConfig{
-		OrganizationID: tracker.OrganizationID(clientConfig.OrganizationID), NativeProjects: nativeProjects,
+		ProviderReports: providerReports,
+		OrganizationID:  tracker.OrganizationID(clientConfig.OrganizationID), NativeProjects: nativeProjects,
 		Machine: hubclient.Machine{
 			ID: tracker.MachineID(machineID), Hostname: hostname, DisplayName: displayName,
 			Capabilities: hubMachineCapabilities(cfg), Capacity: capacity, Version: strings.TrimSpace(version),

--- a/internal/config/global/hub_client.go
+++ b/internal/config/global/hub_client.go
@@ -16,6 +16,7 @@ const (
 )
 
 type HubClient struct {
+	ProviderCapacityFile     string            `yaml:"provider_capacity_file,omitempty"`
 	OrganizationID           string            `yaml:"organization_id,omitempty"`
 	NativeProjects           map[string]string `yaml:"native_projects,omitempty"`
 	URL                      string            `yaml:"hub_url,omitempty"`
@@ -30,7 +31,7 @@ type HubClient struct {
 }
 
 func (c HubClient) IsZero() bool {
-	return strings.TrimSpace(c.IdentityFile) == "" && strings.TrimSpace(c.OrganizationID) == "" && len(c.NativeProjects) == 0 && strings.TrimSpace(c.URL) == "" && strings.TrimSpace(c.TokenEnvironment) == "" &&
+	return strings.TrimSpace(c.ProviderCapacityFile) == "" && strings.TrimSpace(c.IdentityFile) == "" && strings.TrimSpace(c.OrganizationID) == "" && len(c.NativeProjects) == 0 && strings.TrimSpace(c.URL) == "" && strings.TrimSpace(c.TokenEnvironment) == "" &&
 		strings.TrimSpace(c.MachineID) == "" && strings.TrimSpace(c.DisplayName) == "" && c.Capacity == 0 &&
 		c.HeartbeatIntervalSeconds == 0 && c.LeaseTTLSeconds == 0 && c.RequestTimeoutMS == 0
 }
@@ -40,6 +41,7 @@ func (c HubClient) Configured() bool {
 }
 
 func (c HubClient) Normalized() HubClient {
+	c.ProviderCapacityFile = strings.TrimSpace(c.ProviderCapacityFile)
 	c.OrganizationID = strings.TrimSpace(c.OrganizationID)
 	c.URL = strings.TrimRight(strings.TrimSpace(c.URL), "/")
 	c.TokenEnvironment = strings.TrimSpace(c.TokenEnvironment)
@@ -81,6 +83,9 @@ func (c HubClient) Validate() []string {
 		return nil
 	}
 	var problems []string
+	if c.ProviderCapacityFile != "" && (!filepath.IsAbs(c.ProviderCapacityFile) || c.IdentityFile == "") {
+		problems = append(problems, "client.provider_capacity_file requires an absolute report path and an enrolled identity_file")
+	}
 	if c.IdentityFile != "" {
 		if !filepath.IsAbs(c.IdentityFile) {
 			problems = append(problems, "client.identity_file must be an absolute private path")
@@ -138,7 +143,7 @@ func hubClientRawErrors(value any) []string {
 		return []string{"client: must be a mapping"}
 	}
 	var problems []string
-	for _, name := range []string{"hub_url", "token_env", "identity_file", "machine_id", "display_name", "organization_id"} {
+	for _, name := range []string{"hub_url", "token_env", "identity_file", "provider_capacity_file", "machine_id", "display_name", "organization_id"} {
 		problems = append(problems, optionalStringTypeError(attrs, name)...)
 	}
 	for _, field := range []struct{ name, path string }{

--- a/internal/config/global/hub_client_test.go
+++ b/internal/config/global/hub_client_test.go
@@ -54,6 +54,12 @@ func TestHubRunnerIdentityConfiguration(t *testing.T) {
 		{"relative path", func(c *HubClient) { c.IdentityFile = "identity.json" }, false},
 		{"ambiguous token source", func(c *HubClient) { c.TokenEnvironment = "LEGACY_TOKEN" }, false},
 		{"no projects", func(c *HubClient) { c.NativeProjects = nil }, false},
+		{"provider reports", func(c *HubClient) { c.ProviderCapacityFile = filepath.Join(t.TempDir(), "reports.json") }, true},
+		{"relative provider reports", func(c *HubClient) { c.ProviderCapacityFile = "reports.json" }, false},
+		{"unenrolled provider reports", func(c *HubClient) {
+			c.ProviderCapacityFile = filepath.Join(t.TempDir(), "reports.json")
+			c.IdentityFile = ""
+		}, false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			config := HubClient{URL: "https://hub.example.test", IdentityFile: filepath.Join(t.TempDir(), "private", "identity.json"), OrganizationID: "org_example", NativeProjects: map[string]string{"local": "prj_example"}}

--- a/internal/hubclient/client.go
+++ b/internal/hubclient/client.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/runnerauth"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
@@ -41,13 +42,14 @@ type Client struct {
 }
 
 type Machine struct {
-	ID              tracker.MachineID `json:"id"`
-	Hostname        string            `json:"hostname"`
-	DisplayName     string            `json:"display_name,omitempty"`
-	Capabilities    map[string]any    `json:"capabilities,omitempty"`
-	Capacity        int               `json:"capacity"`
-	Version         string            `json:"version"`
-	LastHeartbeatAt time.Time         `json:"last_heartbeat_at,omitempty"`
+	ProviderReports []providercapacity.Report `json:"provider_reports,omitempty"`
+	ID              tracker.MachineID         `json:"id"`
+	Hostname        string                    `json:"hostname"`
+	DisplayName     string                    `json:"display_name,omitempty"`
+	Capabilities    map[string]any            `json:"capabilities,omitempty"`
+	Capacity        int                       `json:"capacity"`
+	Version         string                    `json:"version"`
+	LastHeartbeatAt time.Time                 `json:"last_heartbeat_at,omitempty"`
 }
 
 type MachineHeartbeat struct {

--- a/internal/hubclient/native.go
+++ b/internal/hubclient/native.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
@@ -29,7 +30,7 @@ func (c *NativeClient) base() string {
 	return "/api/v2/organizations/" + string(c.organization) + "/projects/" + string(c.project)
 }
 
-func (c *NativeClient) Negotiate(ctx context.Context) error {
+func (c *NativeClient) Negotiate(ctx context.Context, required ...string) error {
 	var capabilities struct {
 		ProtocolMajors []int    `json:"protocol_majors"`
 		EventSchemas   []int    `json:"event_schema_versions"`
@@ -43,6 +44,11 @@ func (c *NativeClient) Negotiate(ctx context.Context) error {
 	}
 	if !slices.Contains(capabilities.Features, "repository_policy") {
 		return errors.New("hub does not support approved repository policy; upgrade Hub before dispatch")
+	}
+	for _, feature := range required {
+		if !slices.Contains(capabilities.Features, feature) {
+			return errors.Join(ErrUnavailable, errors.New("Hub does not support the required "+feature+" capability"))
+		}
 	}
 	project, err := c.Project(ctx)
 	if err != nil {
@@ -177,14 +183,15 @@ func (c *NativeClient) AppendEvent(ctx context.Context, id tracker.NativeWorkIte
 
 func (c *NativeClient) RegisterMachine(ctx context.Context, machine Machine) error {
 	request := struct {
-		ID           tracker.MachineID `json:"id"`
-		Hostname     string            `json:"hostname"`
-		DisplayName  string            `json:"display_name"`
-		Capacity     int               `json:"capacity"`
-		Version      string            `json:"version"`
-		OS           string            `json:"os"`
-		Architecture string            `json:"architecture"`
-	}{machine.ID, machine.Hostname, machine.DisplayName, machine.Capacity, machine.Version, runtime.GOOS, runtime.GOARCH}
+		ProviderReports []providercapacity.Report `json:"provider_reports,omitempty"`
+		ID              tracker.MachineID         `json:"id"`
+		Hostname        string                    `json:"hostname"`
+		DisplayName     string                    `json:"display_name"`
+		Capacity        int                       `json:"capacity"`
+		Version         string                    `json:"version"`
+		OS              string                    `json:"os"`
+		Architecture    string                    `json:"architecture"`
+	}{machine.ProviderReports, machine.ID, machine.Hostname, machine.DisplayName, machine.Capacity, machine.Version, runtime.GOOS, runtime.GOARCH}
 	return c.client.request(ctx, http.MethodPost, c.base()+"/machines/register", request, nil)
 }
 

--- a/internal/hubclient/native_execution.go
+++ b/internal/hubclient/native_execution.go
@@ -146,6 +146,21 @@ func (e *nativeExecution) Validate(ctx context.Context) error {
 
 func (e *nativeExecution) Start(ctx context.Context, identity tracker.NativeExecutionIdentity) error {
 	e.mu.Lock()
+	if e.data.Identity != nil && e.data.Sequence > 0 {
+		defer e.mu.Unlock()
+		if *e.data.Identity != identity {
+			return errors.New("native execution identity changed during an attempt")
+		}
+		return e.flush(ctx)
+	}
+	e.mu.Unlock()
+	if err := e.Validate(ctx); err != nil {
+		return err
+	}
+	if err := e.validateProviderStart(identity); err != nil {
+		return err
+	}
+	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.data.Identity != nil {
 		if *e.data.Identity != identity {

--- a/internal/hubclient/native_scheduler.go
+++ b/internal/hubclient/native_scheduler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
@@ -34,9 +35,23 @@ func (s *Scheduler) ensureNativeMachine(ctx context.Context, source *NativeConne
 		return nil
 	}
 	if last.IsZero() {
-		if err := source.client.Negotiate(ctx); err != nil {
+		var required []string
+		if s.providerReports != nil {
+			required = append(required, tracker.NativeProviderCapacityCapability)
+		}
+		if err := source.client.Negotiate(ctx, required...); err != nil {
 			return err
 		}
+	}
+	if s.providerReports != nil {
+		reports, err := s.providerReports()
+		if err != nil {
+			return errors.Join(orchestrator.ErrSchedulingUnavailable, err)
+		}
+		if err := providercapacity.Validate(reports); err != nil {
+			return errors.Join(orchestrator.ErrSchedulingUnavailable, err)
+		}
+		s.machine.ProviderReports = reports
 	}
 	if s.client.runner != nil && !last.IsZero() {
 		if err := source.client.HeartbeatMachine(ctx, s.machine); err != nil {
@@ -60,12 +75,18 @@ func (s *Scheduler) fetchNativeCandidate(ctx context.Context, request orchestrat
 		return nil, err
 	}
 	claimStarted := s.now()
-	lease, err := source.client.Claim(ctx, tracker.NativeClaim{
+	claimRequest := tracker.NativeClaim{
 		PolicyID:  request.Policy.ID,
 		MachineID: s.machine.ID, SessionID: session, TTLSeconds: int64(s.leaseTTL / time.Second), ProtocolMajor: 2,
 		Capabilities: []string{"native_issues", "scoped_collaboration", tracker.NativeExecutionCapability}, WorkflowStates: request.WorkflowStates,
 		Authors: request.Filter.Authors, Assignees: request.Filter.Assignees, LabelInclude: request.Filter.LabelInclude, LabelExclude: request.Filter.LabelExclude,
-	})
+	}
+	var lease tracker.NativeLease
+	if s.providerReports != nil {
+		lease, err = s.claimProviderCandidate(ctx, request, source, claimRequest)
+	} else {
+		lease, err = source.client.Claim(ctx, claimRequest)
+	}
 	if errors.Is(err, ErrNoClaimableWork) {
 		return []connector.Issue{}, nil
 	}

--- a/internal/hubclient/provider_capacity.go
+++ b/internal/hubclient/provider_capacity.go
@@ -1,0 +1,94 @@
+package hubclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func (s *Scheduler) claimProviderCandidate(ctx context.Context, request orchestrator.SchedulingRequest, source *NativeConnector, claim tracker.NativeClaim) (tracker.NativeLease, error) {
+	if request.ProviderRequirement == nil {
+		return tracker.NativeLease{}, errors.Join(orchestrator.ErrSchedulingUnavailable, errors.New("provider dispatch needs the local runner's model resolver"))
+	}
+	preview := tracker.NativeCapacityPreview{NativeClaim: claim}
+	claim.Capabilities = append(claim.Capabilities, tracker.NativeProviderCapacityCapability)
+	var waiting error
+	for {
+		var page tracker.NativeCapacityPage
+		if err := source.client.client.request(ctx, http.MethodPost, source.client.base()+"/claims/preview", preview, &page); err != nil {
+			return tracker.NativeLease{}, err
+		}
+		if len(page.Items) > 100 {
+			return tracker.NativeLease{}, errors.Join(orchestrator.ErrSchedulingUnavailable, errors.New("provider candidate page exceeds the negotiated bound"))
+		}
+		claim.ProviderCandidates = nil
+		for _, issue := range page.Items {
+			requirement, err := request.ProviderRequirement(ctx, issueFromNative(issue))
+			if err != nil {
+				waiting = errors.Join(orchestrator.ErrSchedulingUnavailable, err)
+				continue
+			}
+			claim.ProviderCandidates = append(claim.ProviderCandidates, tracker.NativeCapacityCandidate{WorkItemID: issue.WorkItemID, Revision: issue.Revision, Requirement: requirement})
+		}
+		if len(claim.ProviderCandidates) != 0 {
+			lease, err := source.client.Claim(ctx, claim)
+			if err == nil {
+				if lease.ProviderReservation == nil {
+					return tracker.NativeLease{}, errors.Join(orchestrator.ErrSchedulingUnavailable, errors.New("hub omitted the required provider reservation"), source.client.Release(context.WithoutCancel(ctx), lease, "failed"))
+				}
+				return lease, nil
+			}
+			var failure *APIError
+			providerDeferred := errors.As(err, &failure) && failure != nil && (failure.Code == "provider_capacity" || failure.Code == "provider_incompatible" || failure.Code == "provider_candidate_changed")
+			if !errors.Is(err, ErrNoClaimableWork) && !providerDeferred {
+				return tracker.NativeLease{}, err
+			}
+			waiting = err
+		}
+		if page.Next == 0 {
+			if waiting != nil {
+				return tracker.NativeLease{}, waiting
+			}
+			return tracker.NativeLease{}, ErrNoClaimableWork
+		}
+		if page.Next == preview.After {
+			return tracker.NativeLease{}, errors.Join(orchestrator.ErrSchedulingUnavailable, errors.New("hub repeated provider candidate cursor"))
+		}
+		preview.After = page.Next
+	}
+}
+
+func (e *nativeExecution) validateProviderStart(identity tracker.NativeExecutionIdentity) error {
+	reservation := e.claim.lease.ProviderReservation
+	if reservation == nil {
+		if e.scheduler.providerReports != nil {
+			return e.unavailable(errors.New("provider reservation is missing"))
+		}
+		return nil
+	}
+	required := providercapacity.Requirement{Role: identity.Role, Backend: identity.Backend, Model: identity.Model}
+	if required != reservation.Requirement || e.scheduler.providerReports == nil {
+		return e.unavailable(errors.New("provider execution identity differs from its dispatch reservation"))
+	}
+	reports, err := e.scheduler.providerReports()
+	if err != nil {
+		return e.unavailable(err)
+	}
+	if err := providercapacity.Validate(reports); err != nil {
+		return e.unavailable(err)
+	}
+	for _, report := range reports {
+		if report.Supports(required) && report.Provider == reservation.Report.Provider && report.AccountAlias == reservation.Report.AccountAlias && report.SharedAccountAlias == reservation.Report.SharedAccountAlias {
+			if report.State(e.scheduler.now()) == "exhausted" || report.MaxConcurrent < reservation.Report.MaxConcurrent {
+				return errors.Join(runner.ErrExecutionAuthorityUnavailable, errors.New("provider capacity decreased after dispatch; release and wait"))
+			}
+			return nil
+		}
+	}
+	return e.unavailable(errors.New("local provider account or model capability changed after dispatch"))
+}

--- a/internal/hubclient/provider_capacity_test.go
+++ b/internal/hubclient/provider_capacity_test.go
@@ -1,0 +1,180 @@
+package hubclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/hubserver"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/runnerauth"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func TestProviderSchedulerEndToEnd(t *testing.T) {
+	t.Parallel()
+	service, err := hubserver.Open(t.Context(), hubserver.Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), InitialAdminToken: []byte("provider-test-admin")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := service.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	server := httptest.NewServer(service.Handler())
+	t.Cleanup(server.Close)
+	admin, err := New(Config{URL: server.URL, TokenSource: func() string { return "provider-test-admin" }, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var organizations tracker.Page[struct {
+		ID tracker.OrganizationID `json:"organization_id"`
+	}]
+	if err := admin.request(t.Context(), http.MethodGet, "/api/v2/organizations", nil, &organizations); err != nil {
+		t.Fatal(err)
+	}
+	organization := organizations.Items[0].ID
+	var project tracker.NativeProject
+	if err := admin.request(t.Context(), http.MethodPost, "/api/v2/organizations/"+string(organization)+"/projects", map[string]any{"name": "capacity", "idempotency_key": "capacity", "states": []tracker.NativeState{{Name: "Todo", Dispatchable: true}}}, &project); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "private", "identity.json")
+	file, err := runnerauth.Initialize(path, server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enrollment, err := admin.CreateRunnerEnrollment(t.Context(), organization, runnerauth.EnrollmentRequest{Binding: file.Identity.Binding, ProjectIDs: []tracker.ProjectID{project.ID}, Operations: []string{runnerauth.Read, runnerauth.Claim, runnerauth.Heartbeat, runnerauth.Events}, TTLSeconds: 60})
+	if err != nil {
+		t.Fatal(err)
+	}
+	machine := Machine{ID: file.Identity.MachineID, Hostname: "customer", DisplayName: "Runner", Capacity: 2, Version: "test"}
+	if _, err := EnrollRunner(t.Context(), path, organization, enrollment.Token, machine); err != nil {
+		t.Fatal(err)
+	}
+	client, err := New(Config{URL: server.URL, IdentityFile: path, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	native, err := admin.Native(organization, project.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor := clientTestPolicy()
+	if _, err := native.ApproveProjectPolicy(t.Context(), policy.Change{Policy: descriptor}); err != nil {
+		t.Fatal(err)
+	}
+	for _, title := range []string{"unsupported model", "compatible model"} {
+		if _, err := native.CreateIssue(t.Context(), tracker.CreateIssue{Mutation: tracker.Mutation{IdempotencyKey: title}, Title: title, State: "Todo"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	report := providercapacity.Report{Provider: "openai", Backend: "codex", AccountAlias: "work", SharedAccountAlias: "team", Models: []string{"sol"}, MaxConcurrent: 1, Availability: "available", ObservedAt: time.Now()}
+	scheduler, err := NewScheduler(client, SchedulerConfig{OrganizationID: organization, NativeProjects: map[string]tracker.ProjectID{"native": project.ID}, Machine: machine, HeartbeatInterval: 30 * time.Second, LeaseTTL: 90 * time.Second, ProviderReports: func() ([]providercapacity.Report, error) { return []providercapacity.Report{report}, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := orchestrator.SchedulingRequest{ProjectID: "native", Policy: descriptor, ProviderRequirement: func(_ context.Context, issue connector.Issue) (providercapacity.Requirement, error) {
+		model := "sol"
+		if issue.Title == "unsupported model" {
+			model = "astra"
+		}
+		return providercapacity.Requirement{Role: "code", Backend: "codex", Model: model}, nil
+	}}
+	candidates, err := scheduler.FetchCandidateIssues(t.Context(), request)
+	if err != nil || len(candidates) != 1 || candidates[0].Title != "compatible model" {
+		t.Fatalf("selection = %+v, %v", candidates, err)
+	}
+	issue := candidates[0]
+	if _, err := scheduler.AdoptClaim(t.Context(), issue, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	execution := scheduler.RunExecution(issue.ID)
+	if execution == nil {
+		t.Fatal("native claim has no execution lifecycle")
+	}
+	report.Availability = "exhausted"
+	if err := execution.Start(t.Context(), tracker.NativeExecutionIdentity{Role: "code", Backend: "codex", Model: "sol"}); !errors.Is(err, runner.ErrExecutionAuthorityUnavailable) {
+		t.Fatalf("changed local quota start = %v", err)
+	}
+	if err := scheduler.ReleaseClaim(t.Context(), issue.ID, "failed"); err != nil {
+		t.Fatal(err)
+	}
+	report.Availability = "available"
+	candidates, err = scheduler.FetchCandidateIssues(t.Context(), request)
+	if err != nil || len(candidates) != 1 {
+		t.Fatalf("released start did not free capacity: %v", err)
+	}
+	execution = scheduler.RunExecution(candidates[0].ID)
+	if execution == nil {
+		t.Fatal("reclaimed issue has no execution lifecycle")
+	}
+	identity := tracker.NativeExecutionIdentity{Role: "code", Backend: "codex", Model: "sol"}
+	transport := &executionTransport{next: client.httpClient.Transport}
+	client.httpClient.Transport = transport
+	t.Cleanup(func() { client.httpClient.Transport = transport.next })
+	transport.drop.Store(true)
+	if err := execution.Start(t.Context(), identity); !errors.Is(err, runner.ErrExecutionAuthorityUnavailable) {
+		t.Fatalf("lost start acknowledgment = %v", err)
+	}
+	report.Availability = "exhausted"
+	if err := execution.Start(t.Context(), identity); !errors.Is(err, runner.ErrExecutionAuthorityUnavailable) {
+		t.Fatalf("unacknowledged start skipped local quota revalidation: %v", err)
+	}
+	report.Availability = "available"
+	if err := execution.Start(t.Context(), identity); err != nil {
+		t.Fatal(err)
+	}
+	report.Availability = "exhausted"
+	if err := execution.Start(t.Context(), identity); err != nil {
+		t.Fatalf("active identity changed: %v", err)
+	}
+	if _, err := scheduler.FetchCandidateIssues(t.Context(), request); !errors.Is(err, orchestrator.ErrSchedulingUnavailable) {
+		t.Fatalf("incompatible capacity should defer scheduling: %v", err)
+	}
+	if err := scheduler.ReleaseClaim(t.Context(), candidates[0].ID, "completed"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLocalProviderRevalidation(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	requirement := providercapacity.Requirement{Role: "code", Backend: "codex", Model: "sol"}
+	report := providercapacity.Report{Provider: "openai", Backend: "codex", AccountAlias: "work", SharedAccountAlias: "team", Models: []string{"sol"}, MaxConcurrent: 1, Availability: "available", ObservedAt: now}
+	for _, test := range []struct {
+		name   string
+		change func(*providercapacity.Report)
+		model  string
+		want   bool
+	}{
+		{"same account", func(*providercapacity.Report) {}, "sol", true},
+		{"stale quota", func(r *providercapacity.Report) {
+			r.Availability = "exhausted"
+			r.ObservedAt = now.Add(-providercapacity.MaxAge)
+		}, "sol", true},
+		{"exhaustion", func(r *providercapacity.Report) { r.Availability = "exhausted" }, "sol", false},
+		{"account change", func(r *providercapacity.Report) { r.AccountAlias = "other" }, "sol", false},
+		{"shared pool change", func(r *providercapacity.Report) { r.SharedAccountAlias = "other" }, "sol", false},
+		{"model changed", func(*providercapacity.Report) {}, "astra", false},
+		{"invalid report", func(r *providercapacity.Report) { r.MaxConcurrent = 0 }, "sol", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			current := report
+			test.change(&current)
+			e := &nativeExecution{scheduler: &Scheduler{now: func() time.Time { return now }, providerReports: func() ([]providercapacity.Report, error) { return []providercapacity.Report{current}, nil }}, claim: nativeClaim{lease: tracker.NativeLease{ProviderReservation: &providercapacity.Reservation{Requirement: requirement, Report: report}}}}
+			err := e.validateProviderStart(tracker.NativeExecutionIdentity{Role: "code", Backend: "codex", Model: test.model})
+			if (err == nil) != test.want || err != nil && !errors.Is(err, runner.ErrExecutionAuthorityUnavailable) {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/hubclient/runner.go
+++ b/internal/hubclient/runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/apikey"
 	"github.com/digitaldrywood/detent/internal/instancelock"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/runnerauth"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
@@ -207,11 +208,12 @@ func RefreshRunner(ctx context.Context, path string, rotate bool) (identity runn
 
 func (c *NativeClient) HeartbeatMachine(ctx context.Context, machine Machine) error {
 	request := struct {
-		DisplayName  string `json:"display_name"`
-		Capacity     int    `json:"capacity"`
-		Version      string `json:"version"`
-		OS           string `json:"os"`
-		Architecture string `json:"architecture"`
-	}{machine.DisplayName, machine.Capacity, machine.Version, runtime.GOOS, runtime.GOARCH}
+		ProviderReports []providercapacity.Report `json:"provider_reports,omitempty"`
+		DisplayName     string                    `json:"display_name"`
+		Capacity        int                       `json:"capacity"`
+		Version         string                    `json:"version"`
+		OS              string                    `json:"os"`
+		Architecture    string                    `json:"architecture"`
+	}{machine.ProviderReports, machine.DisplayName, machine.Capacity, machine.Version, runtime.GOOS, runtime.GOARCH}
 	return c.client.request(ctx, http.MethodPost, c.base()+"/machines/"+url.PathEscape(string(machine.ID))+"/heartbeat", request, nil)
 }

--- a/internal/hubclient/scheduler.go
+++ b/internal/hubclient/scheduler.go
@@ -14,12 +14,14 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
 const hubWorkItemField = "detent_hub_work_item_id"
 
 type SchedulerConfig struct {
+	ProviderReports   func() ([]providercapacity.Report, error)
 	OrganizationID    tracker.OrganizationID
 	NativeProjects    map[string]tracker.ProjectID
 	Machine           Machine
@@ -30,6 +32,7 @@ type SchedulerConfig struct {
 }
 
 type Scheduler struct {
+	providerReports   func() ([]providercapacity.Report, error)
 	claimPolicies     map[string]claimPolicy
 	nativeProjects    map[string]*NativeConnector
 	nativeClaims      map[string]nativeClaim
@@ -67,8 +70,9 @@ func NewScheduler(client *Client, config SchedulerConfig) (*Scheduler, error) {
 		sessionID = randomSessionID
 	}
 	scheduler := &Scheduler{
-		claimPolicies: make(map[string]claimPolicy),
-		client:        client, machine: config.Machine, heartbeatInterval: config.HeartbeatInterval,
+		providerReports: config.ProviderReports,
+		claimPolicies:   make(map[string]claimPolicy),
+		client:          client, machine: config.Machine, heartbeatInterval: config.HeartbeatInterval,
 		leaseTTL: config.LeaseTTL, now: now, sessionID: sessionID, claims: make(map[string]tracker.Lease),
 		nativeProjects: make(map[string]*NativeConnector), nativeClaims: make(map[string]nativeClaim), nativeHeartbeats: make(map[tracker.ProjectID]time.Time),
 	}
@@ -357,7 +361,7 @@ func routingDeferred(err error) bool {
 		return false
 	}
 	switch failure.Code {
-	case "selector_no_match", "runner_disabled", "runner_draining", "runner_offline", "runner_capacity", "host_capacity", "project_access_denied", "claim_not_permitted":
+	case "provider_capacity", "provider_incompatible", "provider_candidate_changed", "selector_no_match", "runner_disabled", "runner_draining", "runner_offline", "runner_capacity", "host_capacity", "project_access_denied", "claim_not_permitted":
 		return true
 	default:
 		return false

--- a/internal/hubserver/api_worker.go
+++ b/internal/hubserver/api_worker.go
@@ -35,17 +35,18 @@ type claimAPIRequest struct {
 }
 
 type claimCandidateQuery struct {
-	PolicyID       string
-	RequirePolicy  bool
-	NativeScope    *nativeScope
-	RepositoryIDs  []tracker.RepositoryID
-	Repositories   []string
-	WorkflowStates []string
-	Authors        []string
-	Assignees      []string
-	LabelInclude   []string
-	LabelExclude   []string
-	Scope          string
+	ProviderCandidates []tracker.NativeCapacityCandidate
+	PolicyID           string
+	RequirePolicy      bool
+	NativeScope        *nativeScope
+	RepositoryIDs      []tracker.RepositoryID
+	Repositories       []string
+	WorkflowStates     []string
+	Authors            []string
+	Assignees          []string
+	LabelInclude       []string
+	LabelExclude       []string
+	Scope              string
 }
 
 type renewLeaseAPIRequest struct {
@@ -355,6 +356,7 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 	if err != nil {
 		return tracker.Lease{}, err
 	}
+	var providerWait error
 	for _, id := range ids {
 		if request.WorkItemID > 0 && id != request.WorkItemID {
 			continue
@@ -368,6 +370,17 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 				return tracker.Lease{}, fmt.Errorf("%w: work item %d is held by lease %s", tracker.ErrLeaseConflict, id, current.session.ID)
 			}
 			continue
+		}
+		reservation, reserved, err := selectProviderCapacity(ctx, tx, query, id, now)
+		if err != nil {
+			if errors.Is(err, ErrNoClaimableWork) {
+				continue
+			}
+			if isProviderWait(err) {
+				providerWait = err
+				continue
+			}
+			return tracker.Lease{}, err
 		}
 		request.WorkItemID = id
 		lease, err = d.claimInTransaction(ctx, tx, request, now)
@@ -384,10 +397,18 @@ func (d *database) claimNext(ctx context.Context, request tracker.ClaimRequest, 
 				return tracker.Lease{}, err
 			}
 		}
+		if reserved && query.NativeScope != nil {
+			if err := writeProviderReservation(ctx, tx, lease.ID, query.NativeScope.organization, reservation); err != nil {
+				return tracker.Lease{}, err
+			}
+		}
 		if err := tx.Commit(); err != nil {
 			return tracker.Lease{}, fmt.Errorf("commit hub claim next: %w", err)
 		}
 		return lease, nil
+	}
+	if providerWait != nil {
+		return tracker.Lease{}, providerWait
 	}
 	return tracker.Lease{}, ErrNoClaimableWork
 }

--- a/internal/hubserver/database_test.go
+++ b/internal/hubserver/database_test.go
@@ -81,6 +81,7 @@ func TestOpenCreatesHubSchemaAndConfiguresSQLite(t *testing.T) {
 		"lease_runners",
 		"policy_revisions",
 		"project_policies",
+		"provider_reservations",
 		"machines",
 		"native_attempts",
 		"native_attempt_events",

--- a/internal/hubserver/migrate.go
+++ b/internal/hubserver/migrate.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	hubSchemaTable         = "hub_schema_version"
-	supportedSchemaVersion = int64(13)
+	supportedSchemaVersion = int64(14)
 )
 
 //go:embed migrations/*.sql

--- a/internal/hubserver/migrations/00014_provider_capacity.sql
+++ b/internal/hubserver/migrations/00014_provider_capacity.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+ALTER TABLE runner_identities ADD COLUMN provider_reports_json TEXT NOT NULL DEFAULT '[]';
+
+CREATE TABLE provider_reservations (
+    lease_id TEXT PRIMARY KEY REFERENCES leases(lease_id),
+    organization_id TEXT NOT NULL REFERENCES organizations(id),
+    pool TEXT NOT NULL,
+    reservation_json TEXT NOT NULL
+);
+
+CREATE INDEX provider_reservations_pool ON provider_reservations(organization_id, pool);
+
+-- +goose Down
+DROP TABLE provider_reservations;
+ALTER TABLE runner_identities DROP COLUMN provider_reports_json;

--- a/internal/hubserver/native_api.go
+++ b/internal/hubserver/native_api.go
@@ -93,6 +93,7 @@ func (s *Service) registerNativeRoutes(e *echo.Echo) {
 	e.GET(nativeBase+"/work-items/:item/versions/:revision", s.getNativeVersion, read)
 	e.GET(nativeBase+"/work-items/:item/comments/:comment/versions/:revision", s.getNativeVersion, read)
 	e.POST(nativeBase+"/claims", s.claimNativeIssue, worker)
+	e.POST(nativeBase+"/claims/preview", s.previewProviderCandidates, worker)
 	e.POST(nativeBase+"/leases/:lease/renew", s.renewNativeLease, worker)
 	e.POST(nativeBase+"/leases/:lease/release", s.releaseNativeLease, worker)
 	e.POST(nativeBase+"/machines/register", s.registerNativeMachine, worker)

--- a/internal/hubserver/native_attempts.go
+++ b/internal/hubserver/native_attempts.go
@@ -140,6 +140,9 @@ func recordNativeAttempt(ctx context.Context, tx *sql.Tx, scope nativeScope, ite
 		if event.Type != "run.started" || data.Sequence != 1 {
 			return false, nativeExecutionConflict("An attempt must begin with run.started at sequence 1")
 		}
+		if err := validateProviderAttempt(ctx, tx, scope, data, now); err != nil {
+			return false, err
+		}
 		var conflicts int
 		if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM native_attempts WHERE lease_id = ? OR (run_id = ? AND work_item_id != ?)`, data.LeaseID, data.RunID, item).Scan(&conflicts); err != nil {
 			return false, err

--- a/internal/hubserver/native_events.go
+++ b/internal/hubserver/native_events.go
@@ -102,6 +102,13 @@ func (s *Service) appendNativeRunEvent(c echo.Context) error {
 				}{true}, nil
 			}
 		} else {
+			_, reserved, err := readProviderReservation(ctx, tx, request.Data.LeaseID)
+			if err != nil {
+				return nil, err
+			}
+			if reserved {
+				return nil, nativeInvalid("Provider reservations require ordered execution events")
+			}
 			var ordered int
 			if err := tx.QueryRowContext(ctx, "SELECT count(*) FROM native_attempts WHERE id = ? OR lease_id = ?", request.Data.AttemptID, request.Data.LeaseID).Scan(&ordered); err != nil {
 				return nil, err

--- a/internal/hubserver/native_projects.go
+++ b/internal/hubserver/native_projects.go
@@ -31,7 +31,7 @@ func (s *Service) nativeCapabilities(c echo.Context) error {
 		Features        []string `json:"features"`
 		MaxRequestBytes int      `json:"max_request_bytes"`
 		MaxPageSize     int      `json:"max_page_size"`
-	}{serverID, []int{1, 2}, []int{1}, []string{"native_issues", "scoped_collaboration", "revision_conflicts", "idempotent_mutations", "scoped_runner_identity", "repository_policy", tracker.NativeExecutionCapability}, maxAPIRequestBodyBytes, maxAPIPageLimit})
+	}{serverID, []int{1, 2}, []int{1}, []string{"native_issues", "scoped_collaboration", "revision_conflicts", "idempotent_mutations", "scoped_runner_identity", "repository_policy", tracker.NativeExecutionCapability, tracker.NativeProviderCapacityCapability}, maxAPIRequestBodyBytes, maxAPIPageLimit})
 }
 
 func (s *Service) nativeOrganizations(c echo.Context) error {

--- a/internal/hubserver/native_worker.go
+++ b/internal/hubserver/native_worker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
@@ -61,11 +62,14 @@ func (s *Service) claimNativeIssue(c echo.Context) error {
 	if err := decodeAPIJSON(c, &request); err != nil {
 		return invalidAPIRequest(c, err)
 	}
+	if err := validateProviderCandidates(request.ProviderCandidates); err != nil {
+		return s.nativeAPIError(c, err)
+	}
 	if request.ProtocolMajor != tracker.NativeProtocolMajor || !slices.Contains(request.Capabilities, "scoped_collaboration") || !slices.Contains(request.Capabilities, "native_issues") {
 		return s.nativeAPIError(c, nativeInvalid("Native protocol and required collaboration capabilities must be negotiated"))
 	}
 	for _, capability := range request.Capabilities {
-		if !slices.Contains([]string{"native_issues", "scoped_collaboration", "revision_conflicts", "idempotent_mutations", tracker.NativeExecutionCapability}, capability) {
+		if !slices.Contains([]string{"native_issues", "scoped_collaboration", "revision_conflicts", "idempotent_mutations", tracker.NativeExecutionCapability, tracker.NativeProviderCapacityCapability}, capability) {
 			return s.nativeAPIError(c, nativeInvalid("Unknown required capability"))
 		}
 	}
@@ -85,7 +89,7 @@ func (s *Service) claimNativeIssue(c echo.Context) error {
 		}
 	}
 	lease, err := s.database.claimNext(c.Request().Context(), tracker.ClaimRequest{WorkItemID: id, MachineID: request.MachineID, SessionID: request.SessionID, TTL: ttl}, claimCandidateQuery{
-		PolicyID: request.PolicyID, RequirePolicy: true,
+		PolicyID: request.PolicyID, RequirePolicy: true, ProviderCandidates: request.ProviderCandidates,
 		NativeScope: &scope, Scope: string(scope.project), WorkflowStates: request.WorkflowStates, Authors: request.Authors, Assignees: request.Assignees, LabelInclude: request.LabelInclude, LabelExclude: request.LabelExclude,
 	}, s.config.ReconcileInterval)
 	if err != nil {
@@ -103,7 +107,15 @@ func (s *Service) respondNativeLease(c echo.Context, scope nativeScope, lease tr
 	if err := s.database.db.QueryRowContext(c.Request().Context(), "SELECT native_id FROM issues WHERE id = ? AND organization_id = ? AND project_id = ?", lease.WorkItemID, scope.organization, scope.project).Scan(&id); err != nil {
 		return s.nativeAPIError(c, err)
 	}
-	return c.JSON(http.StatusOK, tracker.NativeLease{ServerTime: s.config.now().UTC(), PolicyID: policyID, ID: lease.ID, WorkItemID: id, MachineID: lease.Machine.ID, SessionID: lease.SessionID, FencingToken: lease.FencingToken, AcquiredAt: lease.AcquiredAt, RenewedAt: lease.RenewedAt, ExpiresAt: lease.ExpiresAt})
+	reservation, reserved, err := readProviderReservation(c.Request().Context(), s.database.db, lease.ID)
+	if err != nil {
+		return s.nativeAPIError(c, err)
+	}
+	var providerReservation *providercapacity.Reservation
+	if reserved {
+		providerReservation = &reservation
+	}
+	return c.JSON(http.StatusOK, tracker.NativeLease{ProviderReservation: providerReservation, ServerTime: s.config.now().UTC(), PolicyID: policyID, ID: lease.ID, WorkItemID: id, MachineID: lease.Machine.ID, SessionID: lease.SessionID, FencingToken: lease.FencingToken, AcquiredAt: lease.AcquiredAt, RenewedAt: lease.RenewedAt, ExpiresAt: lease.ExpiresAt})
 }
 
 func (s *Service) requireNativeLease(c echo.Context) error {
@@ -149,13 +161,14 @@ func (s *Service) releaseNativeLease(c echo.Context) error {
 
 func (s *Service) registerNativeMachine(c echo.Context) error {
 	var request struct {
-		ID           tracker.MachineID `json:"id"`
-		Hostname     string            `json:"hostname"`
-		DisplayName  string            `json:"display_name"`
-		Capacity     int               `json:"capacity"`
-		Version      string            `json:"version"`
-		OS           string            `json:"os,omitempty"`
-		Architecture string            `json:"architecture,omitempty"`
+		ID              tracker.MachineID         `json:"id"`
+		Hostname        string                    `json:"hostname"`
+		DisplayName     string                    `json:"display_name"`
+		Capacity        int                       `json:"capacity"`
+		Version         string                    `json:"version"`
+		OS              string                    `json:"os,omitempty"`
+		Architecture    string                    `json:"architecture,omitempty"`
+		ProviderReports []providercapacity.Report `json:"provider_reports,omitempty"`
 	}
 	if err := decodeAPIJSON(c, &request); err != nil {
 		return invalidAPIRequest(c, err)
@@ -170,8 +183,14 @@ func (s *Service) registerNativeMachine(c echo.Context) error {
 	}
 	if scope.credential.Runner.RunnerID != "" {
 		return s.runnerTransaction(c, http.StatusOK, func(ctx context.Context, tx *sql.Tx, now time.Time) (any, error) {
-			return request, updateRunnerHeartbeat(ctx, tx, scope, request.Capacity, request.OS, request.Architecture, now)
+			if err := updateRunnerHeartbeat(ctx, tx, scope, request.Capacity, request.OS, request.Architecture, now); err != nil {
+				return nil, err
+			}
+			return request, updateProviderReports(ctx, tx, scope, request.ProviderReports, now)
 		})
+	}
+	if len(request.ProviderReports) != 0 {
+		return s.nativeAPIError(c, nativeInvalid("Provider reports require an enrolled runner"))
 	}
 	result, err := s.database.db.ExecContext(c.Request().Context(), `INSERT INTO machines (id, hostname, display_name, capacity, version, last_heartbeat_at, registered_at, updated_at, organization_id, token_id)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/internal/hubserver/provider_candidates.go
+++ b/internal/hubserver/provider_candidates.go
@@ -1,0 +1,74 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func (s *Service) previewProviderCandidates(c echo.Context) error {
+	var request tracker.NativeCapacityPreview
+	if err := decodeAPIJSON(c, &request); err != nil {
+		return invalidAPIRequest(c, err)
+	}
+	return s.runnerTransaction(c, http.StatusOK, func(ctx context.Context, tx *sql.Tx, now time.Time) (any, error) {
+		scope := nativeRequestScope(c)
+		if scope.credential.Runner.RunnerID == "" {
+			return nil, nativeInvalid("Provider selection requires an enrolled runner")
+		}
+		if err := requireRunnerAuthority(ctx, tx, scope, now); err != nil {
+			return nil, err
+		}
+		if err := authorizeClaimScope(ctx, tx, tracker.ClaimRequest{MachineID: request.MachineID}, &scope); err != nil {
+			return nil, err
+		}
+		query := claimCandidateQuery{PolicyID: request.PolicyID, RequirePolicy: true, NativeScope: &scope, Scope: string(scope.project)}
+		if _, err := validateClaimPolicy(ctx, tx, query, request.MachineID); err != nil {
+			return nil, err
+		}
+		if err := validateRunnerDispatch(ctx, tx, scope, now); err != nil {
+			return nil, err
+		}
+		ids, err := claimCandidateIDs(ctx, tx, query, nil, nil, normalizedQueryStrings(request.WorkflowStates), normalizedQueryStrings(request.Authors), normalizedQueryStrings(request.Assignees), normalizedQueryStrings(request.LabelInclude), normalizedQueryStrings(request.LabelExclude), nil)
+		if err != nil {
+			return nil, err
+		}
+		page := tracker.NativeCapacityPage{Items: []tracker.NativeIssue{}}
+		started := request.After == 0
+		for _, id := range ids {
+			if !started {
+				started = id == request.After
+				continue
+			}
+			lease, found, err := readUnreleasedLease(ctx, tx, id)
+			if err != nil {
+				return nil, err
+			}
+			if found && lease.session.ExpiresAt.After(now) {
+				continue
+			}
+			var native string
+			if err := tx.QueryRowContext(ctx, "SELECT native_id FROM issues WHERE id = ?", id).Scan(&native); err != nil {
+				return nil, err
+			}
+			issue, _, err := readNativeIssue(ctx, tx, scope, native)
+			if err != nil {
+				return nil, err
+			}
+			page.Items = append(page.Items, issue)
+			if len(page.Items) == 100 {
+				page.Next = id
+				break
+			}
+		}
+		if !started {
+			return nil, providerWait("provider_candidate_changed", "Queue changed during provider selection; refresh the candidate page")
+		}
+		return page, nil
+	})
+}

--- a/internal/hubserver/provider_capacity.go
+++ b/internal/hubserver/provider_capacity.go
@@ -1,0 +1,256 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func providerWait(code, message string) error {
+	return &nativeError{Code: code, Message: message, status: http.StatusConflict}
+}
+
+func isProviderWait(err error) bool {
+	var failure *nativeError
+	return errors.As(err, &failure) && failure != nil && (failure.Code == "provider_capacity" || failure.Code == "provider_incompatible" || failure.Code == "provider_candidate_changed")
+}
+
+func validateProviderCandidates(candidates []tracker.NativeCapacityCandidate) error {
+	if len(candidates) > 100 {
+		return nativeInvalid("Provider selection is limited to 100 candidates per page")
+	}
+	seen := make(map[tracker.NativeWorkItemID]bool)
+	for _, candidate := range candidates {
+		if candidate.WorkItemID == "" || candidate.Revision <= 0 || seen[candidate.WorkItemID] {
+			return nativeInvalid("Provider candidates require distinct work items and positive revisions")
+		}
+		if err := candidate.Requirement.Validate(); err != nil {
+			return nativeInvalid(err.Error())
+		}
+		seen[candidate.WorkItemID] = true
+	}
+	return nil
+}
+
+func updateProviderReports(ctx context.Context, tx *sql.Tx, scope nativeScope, reports []providercapacity.Report, now time.Time) error {
+	if reports == nil {
+		return nil
+	}
+	if err := providercapacity.Validate(reports); err != nil {
+		return nativeInvalid(err.Error())
+	}
+	if len(reports) == 0 {
+		return nativeInvalid("An enabled provider reporter must retain at least one backend")
+	}
+	previous, err := readProviderReports(ctx, tx, scope.credential.Runner.RunnerID)
+	if err != nil {
+		return err
+	}
+	for i, report := range reports {
+		for _, prior := range previous {
+			if prior.Backend != report.Backend || prior.Provider != report.Provider || prior.AccountAlias != report.AccountAlias || prior.SharedAccountAlias != report.SharedAccountAlias || prior.ObservedAt.After(now) {
+				continue
+			}
+			if report.ObservedAt.After(now) || prior.ObservedAt.After(report.ObservedAt) || prior.ObservedAt.Equal(report.ObservedAt) && prior.Availability == "exhausted" && report.Availability != "exhausted" {
+				reports[i] = prior
+			}
+		}
+	}
+	raw, err := json.Marshal(reports)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, "UPDATE runner_identities SET provider_reports_json = ? WHERE id = ? AND organization_id = ?", string(raw), scope.credential.Runner.RunnerID, scope.organization)
+	return err
+}
+
+func readProviderReports(ctx context.Context, query nativeQueryer, runner string) ([]providercapacity.Report, error) {
+	var raw string
+	if err := query.QueryRowContext(ctx, "SELECT provider_reports_json FROM runner_identities WHERE id = ?", runner).Scan(&raw); err != nil {
+		return nil, err
+	}
+	var reports []providercapacity.Report
+	err := json.Unmarshal([]byte(raw), &reports)
+	return reports, err
+}
+
+func sharedProviderAccount(a, b providercapacity.Report) bool {
+	return a.Provider == b.Provider && (a.SharedAccountAlias == "" || b.SharedAccountAlias == "" || a.SharedAccountAlias == b.SharedAccountAlias)
+}
+
+func providerView(ctx context.Context, query nativeQueryer, organization tracker.OrganizationID, report providercapacity.Report, now time.Time) (providercapacity.View, error) {
+	view := providercapacity.View{Report: report, State: report.State(now), Reason: "Bounded concurrency available; quota is an observation, not transferable credit"}
+	rows, err := query.QueryContext(ctx, "SELECT provider_reports_json FROM runner_identities WHERE organization_id = ?", organization)
+	if err != nil {
+		return view, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var raw string
+		var reports []providercapacity.Report
+		if err := rows.Scan(&raw); err != nil {
+			return view, err
+		}
+		if err := json.Unmarshal([]byte(raw), &reports); err != nil {
+			return view, err
+		}
+		for _, other := range reports {
+			if !sharedProviderAccount(report, other) {
+				continue
+			}
+			view.MaxConcurrent = min(view.MaxConcurrent, other.MaxConcurrent)
+			if other.State(now) == "exhausted" {
+				view.State = "exhausted"
+				if other.ResetAt.After(view.ResetAt) {
+					view.ResetAt = other.ResetAt
+				}
+			} else if other.State(now) == "unknown" && view.State != "exhausted" {
+				view.State = "unknown"
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return view, err
+	}
+	if err := rows.Close(); err != nil {
+		return view, err
+	}
+	rows, err = query.QueryContext(ctx, `SELECT p.reservation_json, l.expires_at FROM provider_reservations p JOIN leases l ON l.lease_id = p.lease_id WHERE p.organization_id = ? AND l.released_at IS NULL`, organization)
+	if err != nil {
+		return view, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var raw, expiry string
+		var reservation providercapacity.Reservation
+		if err := rows.Scan(&raw, &expiry); err != nil {
+			return view, err
+		}
+		end, err := parseTimeValue(expiry)
+		if err != nil {
+			return view, err
+		}
+		if !end.After(now) {
+			continue
+		}
+		if err := json.Unmarshal([]byte(raw), &reservation); err != nil {
+			return view, err
+		}
+		if sharedProviderAccount(report, reservation.Report) {
+			view.Used++
+			view.MaxConcurrent = min(view.MaxConcurrent, reservation.Report.MaxConcurrent)
+		}
+	}
+	switch {
+	case view.State == "exhausted":
+		view.Reason = "Provider account is exhausted; wait for a fresh observation or reset hint"
+	case view.Used >= view.MaxConcurrent:
+		view.Reason = "Shared provider concurrency is fully reserved; wait for lease release or expiry"
+	case view.State == "unknown":
+		view.Reason = "Quota is unknown or stale; only the declared concurrency bound is available"
+	}
+	return view, rows.Err()
+}
+
+func selectProviderCapacity(ctx context.Context, tx *sql.Tx, query claimCandidateQuery, id tracker.WorkItemID, now time.Time) (providercapacity.Reservation, bool, error) {
+	if query.NativeScope == nil || query.NativeScope.credential.Runner.RunnerID == "" {
+		if len(query.ProviderCandidates) != 0 {
+			return providercapacity.Reservation{}, false, nativeInvalid("Provider selection requires an enrolled runner")
+		}
+		return providercapacity.Reservation{}, false, nil
+	}
+	reports, err := readProviderReports(ctx, tx, query.NativeScope.credential.Runner.RunnerID)
+	if err != nil {
+		return providercapacity.Reservation{}, false, err
+	}
+	if len(reports) == 0 && len(query.ProviderCandidates) == 0 {
+		return providercapacity.Reservation{}, false, nil
+	}
+	var native tracker.NativeWorkItemID
+	var revision tracker.Revision
+	if err := tx.QueryRowContext(ctx, "SELECT native_id, revision FROM issues WHERE id = ?", id).Scan(&native, &revision); err != nil {
+		return providercapacity.Reservation{}, false, err
+	}
+	for _, candidate := range query.ProviderCandidates {
+		if candidate.WorkItemID != native {
+			continue
+		}
+		if candidate.Revision != revision {
+			return providercapacity.Reservation{}, false, providerWait("provider_candidate_changed", "Work item changed after local model selection; refresh before claiming")
+		}
+		for _, report := range reports {
+			if !report.Supports(candidate.Requirement) {
+				continue
+			}
+			view, err := providerView(ctx, tx, query.NativeScope.organization, report, now)
+			if err != nil {
+				return providercapacity.Reservation{}, false, err
+			}
+			if view.State == "exhausted" || view.Used >= view.MaxConcurrent {
+				return providercapacity.Reservation{}, false, providerWait("provider_capacity", view.Reason)
+			}
+			return providercapacity.Reservation{Requirement: candidate.Requirement, Report: report, Reason: view.Reason}, true, nil
+		}
+		return providercapacity.Reservation{}, false, providerWait("provider_incompatible", "Runner does not advertise the selected backend and model; model and host requirements remain fixed")
+	}
+	if len(query.ProviderCandidates) != 0 {
+		return providercapacity.Reservation{}, false, ErrNoClaimableWork
+	}
+	return providercapacity.Reservation{}, false, providerWait("provider_incompatible", "Work item needs local model selection before a provider reservation can be claimed")
+}
+
+func writeProviderReservation(ctx context.Context, tx *sql.Tx, lease tracker.LeaseID, organization tracker.OrganizationID, reservation providercapacity.Reservation) error {
+	raw, err := json.Marshal(reservation)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, "INSERT INTO provider_reservations (lease_id, organization_id, pool, reservation_json) VALUES (?, ?, ?, ?)", lease, organization, reservation.Report.Pool(), string(raw))
+	return err
+}
+
+func readProviderReservation(ctx context.Context, query nativeQueryer, lease tracker.LeaseID) (providercapacity.Reservation, bool, error) {
+	var raw string
+	if err := query.QueryRowContext(ctx, "SELECT reservation_json FROM provider_reservations WHERE lease_id = ?", lease).Scan(&raw); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return providercapacity.Reservation{}, false, nil
+		}
+		return providercapacity.Reservation{}, false, err
+	}
+	var reservation providercapacity.Reservation
+	err := json.Unmarshal([]byte(raw), &reservation)
+	return reservation, err == nil, err
+}
+
+func validateProviderAttempt(ctx context.Context, tx *sql.Tx, scope nativeScope, data tracker.NativeRunData, now time.Time) error {
+	reservation, found, err := readProviderReservation(ctx, tx, data.LeaseID)
+	if err != nil || !found {
+		return err
+	}
+	if data.Identity == nil || reservation.Requirement != (providercapacity.Requirement{Role: data.Identity.Role, Backend: data.Identity.Backend, Model: data.Identity.Model}) {
+		return providerWait("provider_incompatible", "Execution identity must match the reserved role, backend and model")
+	}
+	reports, err := readProviderReports(ctx, tx, scope.credential.Runner.RunnerID)
+	if err != nil {
+		return err
+	}
+	for _, report := range reports {
+		if !report.Supports(reservation.Requirement) || report.Provider != reservation.Report.Provider || report.AccountAlias != reservation.Report.AccountAlias || report.SharedAccountAlias != reservation.Report.SharedAccountAlias {
+			continue
+		}
+		view, err := providerView(ctx, tx, scope.organization, report, now)
+		if err != nil {
+			return err
+		}
+		if view.State == "exhausted" || view.Used > view.MaxConcurrent {
+			return providerWait("provider_capacity", "Provider capacity changed after reservation; release the lease and wait")
+		}
+		return nil
+	}
+	return providerWait("provider_incompatible", "Provider account or capability changed after reservation")
+}

--- a/internal/hubserver/provider_capacity_test.go
+++ b/internal/hubserver/provider_capacity_test.go
@@ -1,0 +1,349 @@
+package hubserver
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+	"github.com/digitaldrywood/detent/internal/runnerauth"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func capacityReport(now time.Time) providercapacity.Report {
+	return providercapacity.Report{Provider: "openai", Backend: "codex", AccountAlias: "local", SharedAccountAlias: "team", Models: []string{"test-model"}, MaxConcurrent: 1, Availability: "available", ObservedAt: now}
+}
+
+func publishCapacity(t *testing.T, f nativeFixture, r runnerFixture, reports ...providercapacity.Report) {
+	t.Helper()
+	response := performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/machines/"+string(r.binding.MachineID)+"/heartbeat", r.redemption.Credential,
+		map[string]any{"display_name": "runner", "capacity": 8, "version": "test", "provider_reports": reports})
+	requireNativeStatus(t, response, http.StatusNoContent)
+}
+
+func providerClaim(r runnerFixture, issue tracker.NativeIssue, session string) tracker.NativeClaim {
+	return tracker.NativeClaim{PolicyID: hubTestPolicy().ID, WorkItemID: issue.WorkItemID, MachineID: r.binding.MachineID, SessionID: session, TTLSeconds: 90,
+		ProtocolMajor: 2, Capabilities: []string{"native_issues", "scoped_collaboration", tracker.NativeExecutionCapability},
+		ProviderCandidates: []tracker.NativeCapacityCandidate{{WorkItemID: issue.WorkItemID, Revision: issue.Revision, Requirement: providercapacity.Requirement{Role: "implement", Backend: "codex", Model: "test-model"}}}}
+}
+
+func TestProviderCapacityClaimObservations(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		change func(*providercapacity.Report, *tracker.NativeClaim)
+		want   int
+	}{
+		{"available", func(*providercapacity.Report, *tracker.NativeClaim) {}, http.StatusOK},
+		{"unknown", func(r *providercapacity.Report, _ *tracker.NativeClaim) { r.Availability = "unknown" }, http.StatusOK},
+		{"stale exhaustion", func(r *providercapacity.Report, _ *tracker.NativeClaim) {
+			r.Availability = "exhausted"
+			r.ObservedAt = r.ObservedAt.Add(-providercapacity.MaxAge)
+		}, http.StatusOK},
+		{"future observation", func(r *providercapacity.Report, _ *tracker.NativeClaim) {
+			r.Availability = "exhausted"
+			r.ObservedAt = r.ObservedAt.Add(time.Second)
+		}, http.StatusOK},
+		{"exhausted", func(r *providercapacity.Report, _ *tracker.NativeClaim) { r.Availability = "exhausted" }, http.StatusConflict},
+		{"reset", func(r *providercapacity.Report, _ *tracker.NativeClaim) {
+			r.Availability = "exhausted"
+			r.ResetAt = r.ObservedAt
+			r.ObservedAt = r.ObservedAt.Add(-time.Minute)
+		}, http.StatusOK},
+		{"explicit model unavailable", func(_ *providercapacity.Report, c *tracker.NativeClaim) {
+			c.ProviderCandidates[0].Requirement.Model = "expensive"
+		}, http.StatusConflict},
+		{"wrong backend", func(_ *providercapacity.Report, c *tracker.NativeClaim) {
+			c.ProviderCandidates[0].Requirement.Backend = "other"
+		}, http.StatusConflict},
+		{"changed issue", func(_ *providercapacity.Report, c *tracker.NativeClaim) { c.ProviderCandidates[0].Revision++ }, http.StatusConflict},
+		{"missing requirements", func(_ *providercapacity.Report, c *tracker.NativeClaim) { c.ProviderCandidates = nil }, http.StatusConflict},
+		{"invalid requirements", func(_ *providercapacity.Report, c *tracker.NativeClaim) {
+			c.ProviderCandidates[0].Requirement.Model = ""
+		}, http.StatusUnprocessableEntity},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+			f := newNativeFixture(t, openTestService(t, Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }}), "", "provider")
+			r := prepareRunner(t, f, runnerauth.Read, runnerauth.Claim, runnerauth.Heartbeat, runnerauth.Events)
+			r.enroll(t)
+			approveHubTestPolicy(t, f.service, f.base+"/policy", hubTestPolicy())
+			issue := f.create(t, "work")
+			report := capacityReport(now)
+			claim := providerClaim(r, issue, "work")
+			test.change(&report, &claim)
+			publishCapacity(t, f, r, report)
+			response := performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", r.redemption.Credential, claim)
+			requireNativeStatus(t, response, test.want)
+			var count int
+			if err := f.service.database.db.QueryRowContext(t.Context(), "SELECT count(*) FROM provider_reservations").Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if test.want != http.StatusOK {
+				if count != 0 {
+					t.Fatal("failed claim retained reservation")
+				}
+				return
+			}
+			var lease tracker.NativeLease
+			decodeHubResponse(t, response, &lease)
+			if count != 1 || lease.ProviderReservation == nil || lease.ProviderReservation.Model != "test-model" {
+				t.Fatalf("lease = %+v", lease)
+			}
+			response = performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", r.redemption.Credential, claim)
+			requireNativeStatus(t, response, http.StatusOK)
+			var repeated tracker.NativeLease
+			decodeHubResponse(t, response, &repeated)
+			if repeated.ID != lease.ID || repeated.ProviderReservation.Model != lease.ProviderReservation.Model {
+				t.Fatal("idempotent claim changed reservation")
+			}
+		})
+	}
+}
+
+func TestProviderSharedCapacityConcurrentRecovery(t *testing.T) {
+	t.Parallel()
+	for _, sharing := range []string{"declared", "unknown", "mixed"} {
+		t.Run(sharing, func(t *testing.T) {
+			now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+			cfg := Config{DatabasePath: filepath.Join(t.TempDir(), "hub.db"), now: func() time.Time { return now }}
+			f := newNativeFixture(t, openTestService(t, cfg), "", "shared-provider")
+			approveHubTestPolicy(t, f.service, f.base+"/policy", hubTestPolicy())
+			runners := make([]runnerFixture, 2)
+			for i := range runners {
+				runners[i] = prepareRunner(t, f, runnerauth.Read, runnerauth.Claim, runnerauth.Heartbeat, runnerauth.Events)
+				runners[i].enroll(t)
+				report := capacityReport(now)
+				report.AccountAlias = fmt.Sprintf("local-%d", i)
+				if sharing == "unknown" || sharing == "mixed" && i == 1 {
+					report.SharedAccountAlias = ""
+				}
+				publishCapacity(t, f, runners[i], report)
+			}
+			type result struct {
+				status, runner int
+				lease          tracker.NativeLease
+			}
+			outcomes := make(chan result, 8)
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for i := range 8 {
+				issue := f.create(t, fmt.Sprintf("work-%d", i))
+				wg.Go(func() {
+					<-start
+					response := performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", runners[i%2].redemption.Credential, providerClaim(runners[i%2], issue, fmt.Sprintf("session-%d", i)))
+					outcome := result{status: response.Code, runner: i % 2}
+					if response.Code == http.StatusOK {
+						decodeHubResponse(t, response, &outcome.lease)
+					}
+					outcomes <- outcome
+				})
+			}
+			close(start)
+			wg.Wait()
+			close(outcomes)
+			var winner result
+			count := 0
+			for outcome := range outcomes {
+				if outcome.status == http.StatusOK {
+					count++
+					winner = outcome
+				} else if outcome.status != http.StatusConflict {
+					t.Fatalf("status = %d", outcome.status)
+				}
+			}
+			if count != 1 {
+				t.Fatalf("concurrent reservations = %d, want 1", count)
+			}
+			if err := f.service.Close(); err != nil {
+				t.Fatal(err)
+			}
+			f.service = openTestService(t, cfg)
+			response := performHubAPIRequest(t, f.service, http.MethodGet, runners[0].base+"/runners", testHubAdminToken, nil)
+			requireNativeStatus(t, response, http.StatusOK)
+			var fleet []runnerauth.Runner
+			decodeHubResponse(t, response, &fleet)
+			for _, r := range fleet {
+				if len(r.ProviderCapacity) != 1 || r.ProviderCapacity[0].Used != 1 {
+					t.Fatalf("restart capacity = %+v", r.ProviderCapacity)
+				}
+			}
+			blockedIssue := f.create(t, "blocked")
+			claim := providerClaim(runners[1-winner.runner], blockedIssue, "blocked")
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", runners[1-winner.runner].redemption.Credential, claim), http.StatusConflict)
+			now = now.Add(90 * time.Second)
+			response = performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", runners[1-winner.runner].redemption.Credential, claim)
+			requireNativeStatus(t, response, http.StatusOK)
+			var successor tracker.NativeLease
+			decodeHubResponse(t, response, &successor)
+			if successor.FencingToken <= winner.lease.FencingToken {
+				t.Fatal("recovery reused fencing token")
+			}
+			path := f.base + "/leases/" + string(winner.lease.ID) + "/release"
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, runners[winner.runner].redemption.Credential, tracker.NativeLeaseMutation{FencingToken: winner.lease.FencingToken, Reason: "released"}), http.StatusConflict)
+			path = f.base + "/leases/" + string(successor.ID) + "/release"
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, runners[1-winner.runner].redemption.Credential, tracker.NativeLeaseMutation{FencingToken: successor.FencingToken, Reason: "cancelled"}), http.StatusNoContent)
+			claim.SessionID = "after-cancel"
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", runners[1-winner.runner].redemption.Credential, claim), http.StatusOK)
+		})
+	}
+}
+
+func TestProviderStartRevalidation(t *testing.T) {
+	t.Parallel()
+	for _, change := range []string{"exhausted", "model", "account", "active"} {
+		t.Run(change, func(t *testing.T) {
+			f := newNativeFixture(t, nil, "", "revalidation")
+			r := prepareRunner(t, f, runnerauth.Read, runnerauth.Claim, runnerauth.Heartbeat, runnerauth.Events)
+			r.enroll(t)
+			approveHubTestPolicy(t, f.service, f.base+"/policy", hubTestPolicy())
+			report := capacityReport(f.service.config.now())
+			publishCapacity(t, f, r, report)
+			issue := f.create(t, "work")
+			response := performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", r.redemption.Credential, providerClaim(r, issue, "session"))
+			requireNativeStatus(t, response, http.StatusOK)
+			var lease tracker.NativeLease
+			decodeHubResponse(t, response, &lease)
+			event := nativeStartedEvent(lease)
+			path := f.base + "/work-items/" + string(issue.WorkItemID) + "/events"
+			if change == "active" {
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, r.redemption.Credential, event), http.StatusOK)
+			}
+			switch change {
+			case "exhausted", "active":
+				report.Availability = "exhausted"
+			case "model":
+				event.Data.Identity.Model = "expensive"
+			case "account":
+				report.AccountAlias = "changed"
+			}
+			publishCapacity(t, f, r, report)
+			if change == "active" {
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, r.redemption.Credential, event), http.StatusOK)
+				event.Type, event.IdempotencyKey, event.Data.Sequence = "run.checkpointed", "checkpoint", 2
+				event.Data.Handoff = nativeTestCheckpoint()
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, r.redemption.Credential, event), http.StatusOK)
+			} else {
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, r.redemption.Credential, event), http.StatusConflict)
+			}
+		})
+	}
+}
+
+func TestProviderQueueOrderAndSelectors(t *testing.T) {
+	t.Parallel()
+	f := newNativeFixture(t, nil, "", "fairness")
+	r := prepareRunner(t, f, runnerauth.Read, runnerauth.Claim, runnerauth.Heartbeat)
+	r.enroll(t)
+	approveHubTestPolicy(t, f.service, f.base+"/policy", hubTestPolicy())
+	report := capacityReport(f.service.config.now())
+	publishCapacity(t, f, r, report)
+	issues := []tracker.NativeIssue{f.create(t, "unsupported urgent"), f.create(t, "compatible high"), f.create(t, "compatible normal")}
+	claim := providerClaim(r, issues[0], "fair")
+	claim.WorkItemID = ""
+	claim.ProviderCandidates = nil
+	for i := len(issues) - 1; i >= 0; i-- {
+		issue := issues[i]
+		if _, err := f.service.database.db.ExecContext(t.Context(), "UPDATE queue_entries SET priority_override = ? WHERE issue_id = (SELECT id FROM issues WHERE native_id = ?)", i, issue.WorkItemID); err != nil {
+			t.Fatal(err)
+		}
+		candidate := providerClaim(r, issue, "").ProviderCandidates[0]
+		if i == 0 {
+			candidate.Requirement.Model = "unsupported"
+		}
+		claim.ProviderCandidates = append(claim.ProviderCandidates, candidate)
+	}
+	response := performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims/preview", r.redemption.Credential, tracker.NativeCapacityPreview{NativeClaim: claim})
+	requireNativeStatus(t, response, http.StatusOK)
+	var page tracker.NativeCapacityPage
+	decodeHubResponse(t, response, &page)
+	if len(page.Items) != 3 || page.Items[0].WorkItemID != issues[0].WorkItemID || page.Items[1].WorkItemID != issues[1].WorkItemID {
+		t.Fatalf("preview reordered candidates: %+v", page)
+	}
+	response = performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", r.redemption.Credential, claim)
+	requireNativeStatus(t, response, http.StatusOK)
+	var lease tracker.NativeLease
+	decodeHubResponse(t, response, &lease)
+	if lease.WorkItemID != issues[1].WorkItemID {
+		t.Fatal("capacity changed existing priority order")
+	}
+	requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/leases/"+string(lease.ID)+"/release", r.redemption.Credential, tracker.NativeLeaseMutation{FencingToken: lease.FencingToken, Reason: "completed"}), http.StatusNoContent)
+	descriptor := hubTestPolicy()
+	descriptor.Requirements.MachineID = string(runnerauth.NewBinding().MachineID)
+	descriptor = descriptor.WithID()
+	response = performHubAPIRequest(t, f.service, http.MethodPut, f.base+"/policy", testHubAdminToken, map[string]any{"expected_policy_id": hubTestPolicy().ID, "policy": descriptor})
+	requireNativeStatus(t, response, http.StatusOK)
+	claim.PolicyID, claim.SessionID = descriptor.ID, "wrong-host"
+	for _, path := range []string{"/claims", "/claims/preview"} {
+		response = performHubAPIRequest(t, f.service, http.MethodPost, f.base+path, r.redemption.Credential, claim)
+		requireNativeStatus(t, response, http.StatusConflict)
+		var failure nativeError
+		decodeHubResponse(t, response, &failure)
+		if failure.Code != "selector_no_match" {
+			t.Fatalf("fixed host lost authority: %s", failure.Code)
+		}
+	}
+}
+
+func TestProviderOlderReportsCannotRestoreQuota(t *testing.T) {
+	t.Parallel()
+	f := newNativeFixture(t, nil, "", "observations")
+	r := prepareRunner(t, f, runnerauth.Read, runnerauth.Claim, runnerauth.Heartbeat)
+	r.enroll(t)
+	report := capacityReport(f.service.config.now().Add(-time.Second))
+	report.Availability = "exhausted"
+	publishCapacity(t, f, r, report)
+	for _, age := range []time.Duration{0, -time.Second, time.Hour} {
+		stale := report
+		stale.ObservedAt = stale.ObservedAt.Add(age)
+		stale.Availability = "available"
+		publishCapacity(t, f, r, stale)
+		stored, err := readProviderReports(t.Context(), f.service.database.db, r.binding.RunnerID)
+		if err != nil || len(stored) != 1 || stored[0].Availability != "exhausted" || !stored[0].ObservedAt.Equal(report.ObservedAt) {
+			t.Fatalf("stale observation replaced exhaustion: %+v, %v", stored, err)
+		}
+	}
+}
+
+func TestProviderPoolIsolation(t *testing.T) {
+	t.Parallel()
+	f := newNativeFixture(t, nil, "", "isolation")
+	r := prepareRunner(t, f, runnerauth.Read, runnerauth.Claim, runnerauth.Heartbeat)
+	r.enroll(t)
+	approveHubTestPolicy(t, f.service, f.base+"/policy", hubTestPolicy())
+	report := capacityReport(f.service.config.now())
+	publishCapacity(t, f, r, report)
+	issue := f.create(t, "reserved")
+	requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", r.redemption.Credential, providerClaim(r, issue, "reserved")), http.StatusOK)
+	for _, test := range []struct {
+		name, provider, shared string
+		otherOrganization      bool
+		used                   int
+	}{
+		{"same pool", "openai", "team", false, 1},
+		{"explicit independent account", "openai", "independent", false, 0},
+		{"unknown sharing", "openai", "", false, 1},
+		{"other provider", "anthropic", "team", false, 0},
+		{"other organization", "openai", "team", true, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			other := report
+			other.Provider, other.SharedAccountAlias, other.MaxConcurrent = test.provider, test.shared, 3
+			organization := f.project.OrganizationID
+			if test.otherOrganization {
+				organization = "org_other"
+			}
+			view, err := providerView(t.Context(), f.service.database.db, organization, other, f.service.config.now())
+			if err != nil || view.Used != test.used {
+				t.Fatalf("view = %+v, %v", view, err)
+			}
+			if test.used != 0 && view.MaxConcurrent != 1 {
+				t.Fatal("did not preserve the conservative shared bound")
+			}
+		})
+	}
+}

--- a/internal/hubserver/runner_identity.go
+++ b/internal/hubserver/runner_identity.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/apikey"
 	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/runnerauth"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
@@ -29,7 +30,7 @@ func runnerOperationAllowed(c echo.Context, operations []string) bool {
 		return false
 	case c.Request().Method == http.MethodGet:
 		operation = runnerauth.Read
-	case path == nativeBase+"/claims", path == nativeBase+"/leases/:lease/renew", path == nativeBase+"/leases/:lease/release", path == nativeBase+"/leases/:lease/validate":
+	case path == nativeBase+"/claims", path == nativeBase+"/claims/preview", path == nativeBase+"/leases/:lease/renew", path == nativeBase+"/leases/:lease/release", path == nativeBase+"/leases/:lease/validate":
 		operation = runnerauth.Claim
 	case path == nativeBase+"/machines/register", path == nativeBase+"/machines/:machine/heartbeat":
 		operation = runnerauth.Heartbeat
@@ -159,11 +160,12 @@ func recordRunnerEvent(ctx context.Context, tx *sql.Tx, runner, actor, kind stri
 
 func (s *Service) heartbeatNativeMachine(c echo.Context) error {
 	var request struct {
-		DisplayName  string `json:"display_name"`
-		Capacity     int    `json:"capacity"`
-		Version      string `json:"version"`
-		OS           string `json:"os,omitempty"`
-		Architecture string `json:"architecture,omitempty"`
+		ProviderReports []providercapacity.Report `json:"provider_reports,omitempty"`
+		DisplayName     string                    `json:"display_name"`
+		Capacity        int                       `json:"capacity"`
+		Version         string                    `json:"version"`
+		OS              string                    `json:"os,omitempty"`
+		Architecture    string                    `json:"architecture,omitempty"`
 	}
 	if err := decodeAPIJSON(c, &request); err != nil {
 		return invalidAPIRequest(c, err)
@@ -177,7 +179,13 @@ func (s *Service) heartbeatNativeMachine(c echo.Context) error {
 	}
 	return s.runnerTransaction(c, http.StatusNoContent, func(ctx context.Context, tx *sql.Tx, now time.Time) (any, error) {
 		if scope.credential.Runner.RunnerID != "" {
-			return struct{}{}, updateRunnerHeartbeat(ctx, tx, scope, request.Capacity, request.OS, request.Architecture, now)
+			if err := updateRunnerHeartbeat(ctx, tx, scope, request.Capacity, request.OS, request.Architecture, now); err != nil {
+				return nil, err
+			}
+			return struct{}{}, updateProviderReports(ctx, tx, scope, request.ProviderReports, now)
+		}
+		if len(request.ProviderReports) != 0 {
+			return nil, nativeInvalid("Provider reports require an enrolled runner")
 		}
 		result, err := tx.ExecContext(ctx, `UPDATE machines SET display_name = ?, capacity = ?, version = ?, last_heartbeat_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND token_id = ?`, request.DisplayName, request.Capacity, request.Version, formatHubTime(now), formatHubTime(now), c.Param("machine"), scope.organization, scope.credential.ID)
 		return struct{}{}, requireRunnerUpdate(result, err)

--- a/internal/hubserver/runner_routing.go
+++ b/internal/hubserver/runner_routing.go
@@ -89,7 +89,33 @@ LEFT JOIN project_policies pp ON pp.scope = lp.scope WHERE l.machine_id = ? AND 
 			}
 		}
 	}
-	return r, rows.Err()
+	if err := rows.Err(); err != nil {
+		return r, err
+	}
+	if err := rows.Close(); err != nil {
+		return r, err
+	}
+	reports, err := readProviderReports(ctx, db, id)
+	if err != nil {
+		return r, err
+	}
+	for _, report := range reports {
+		view, err := providerView(ctx, db, organization, report, now)
+		if err != nil {
+			return r, err
+		}
+		r.ProviderCapacity = append(r.ProviderCapacity, view)
+	}
+	for i := range r.Leases {
+		reservation, reserved, err := readProviderReservation(ctx, db, r.Leases[i].ID)
+		if err != nil {
+			return r, err
+		}
+		if reserved {
+			r.Leases[i].ProviderReservation = &reservation
+		}
+	}
+	return r, nil
 }
 
 func (s *Service) getRunnerRouting(c echo.Context) error {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hostpressure"
 	"github.com/digitaldrywood/detent/internal/policy"
 	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -176,11 +177,12 @@ type ClaimingConfig struct {
 }
 
 type SchedulingRequest struct {
-	Policy         policy.Descriptor
-	ProjectID      string
-	Repository     string
-	WorkflowStates []string
-	Filter         connector.IssueFilterHint
+	ProviderRequirement func(context.Context, connector.Issue) (providercapacity.Requirement, error)
+	Policy              policy.Descriptor
+	ProjectID           string
+	Repository          string
+	WorkflowStates      []string
+	Filter              connector.IssueFilterHint
 }
 
 type SchedulingSource interface {
@@ -297,6 +299,7 @@ type Orchestrator struct {
 	activity                *activity.Broker
 	release                 releasepkg.Coordinator
 	capacityController      runpkg.CapacityController
+	providerCapacity        runpkg.ProviderCapacityResolver
 	capacityStatus          runpkg.CapacityStatusController
 	validatorCapacity       runpkg.ValidatorCapacityController
 	recoveryInspector       runpkg.BlockedRecoveryInspector
@@ -466,6 +469,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		securityAuditor = candidate
 	}
 	var capacityController runpkg.CapacityController
+	var providerCapacity runpkg.ProviderCapacityResolver
+	if candidate, ok := runner.(runpkg.ProviderCapacityResolver); ok {
+		providerCapacity = candidate
+	}
 	if candidate, ok := runner.(runpkg.CapacityController); ok {
 		capacityController = candidate
 	}
@@ -676,6 +683,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		newStalenessNotifier:    newStalenessNotifier,
 		projectID:               cfg.Project.ID,
 		capacityController:      capacityController,
+		providerCapacity:        providerCapacity,
 		capacityStatus:          capacityStatus,
 		validatorCapacity:       validatorCapacity,
 		recoveryInspector:       blockedRecoveryInspector,

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -524,13 +526,19 @@ func (o *Orchestrator) fetchCandidateIssuesForTick(ctx context.Context, state *S
 		return []connector.Issue{}, nil
 	}
 	if o.scheduling != nil {
-		return o.scheduling.FetchCandidateIssues(ctx, SchedulingRequest{
+		request := SchedulingRequest{
 			Policy:         o.cfg.Policy,
 			ProjectID:      o.cfg.Project.ID,
 			Repository:     o.cfg.SchedulingRepository,
 			WorkflowStates: states,
 			Filter:         o.authorizationFilterHint(),
-		})
+		}
+		if resolver := o.providerCapacity; resolver != nil {
+			request.ProviderRequirement = func(ctx context.Context, issue connector.Issue) (providercapacity.Requirement, error) {
+				return resolver.DispatchCapacity(ctx, runpkg.RunRequest{Issue: issue, Mode: o.dispatchMode(ctx, state, issue), SelectorContext: o.selectorContext()})
+			}
+		}
+		return o.scheduling.FetchCandidateIssues(ctx, request)
 	}
 	if fetcher, ok := o.connector.(connector.CandidateIssuesFilterFetcher); ok {
 		return fetcher.FetchCandidateIssuesByStatesWithFilter(ctx, states, o.authorizationFilterHint())

--- a/internal/providercapacity/capacity.go
+++ b/internal/providercapacity/capacity.go
@@ -1,0 +1,126 @@
+package providercapacity
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"slices"
+	"time"
+)
+
+const MaxAge = 2 * time.Minute
+
+var token = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.:/-]{0,127}$`)
+var alias = regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]{0,63}$`)
+
+type Requirement struct {
+	Role    string `json:"role"`
+	Backend string `json:"backend"`
+	Model   string `json:"model"`
+}
+
+type Report struct {
+	Provider           string    `json:"provider"`
+	Backend            string    `json:"backend"`
+	AccountAlias       string    `json:"account_alias"`
+	SharedAccountAlias string    `json:"shared_account_alias,omitempty"`
+	Models             []string  `json:"models"`
+	MaxConcurrent      int       `json:"max_concurrent"`
+	Availability       string    `json:"availability"`
+	ObservedAt         time.Time `json:"observed_at"`
+	ResetAt            time.Time `json:"reset_at,omitzero"`
+}
+
+type Reservation struct {
+	Requirement
+	Report Report `json:"report"`
+	Reason string `json:"reason"`
+}
+
+type View struct {
+	Report
+	Used   int    `json:"used"`
+	State  string `json:"state"`
+	Reason string `json:"reason"`
+}
+
+func (r Requirement) Validate() error {
+	if !token.MatchString(r.Role) || !token.MatchString(r.Backend) || !token.MatchString(r.Model) {
+		return errors.New("provider requirement needs bounded role, backend and model identifiers")
+	}
+	return nil
+}
+
+func Validate(reports []Report) error {
+	if len(reports) > 32 {
+		return errors.New("provider reports are limited to 32 backends")
+	}
+	seen := make(map[string]bool)
+	for _, r := range reports {
+		if !token.MatchString(r.Provider) || !token.MatchString(r.Backend) || !alias.MatchString(r.AccountAlias) || r.SharedAccountAlias != "" && !alias.MatchString(r.SharedAccountAlias) {
+			return errors.New("provider reports need bounded provider/backend identifiers and opaque account aliases")
+		}
+		if seen[r.Backend] {
+			return errors.New("each backend must identify exactly one local account")
+		}
+		seen[r.Backend] = true
+		if r.MaxConcurrent < 1 || r.MaxConcurrent > 10000 || len(r.Models) == 0 || len(r.Models) > 128 {
+			return errors.New("provider reports need 1 to 128 models and a concurrency limit between 1 and 10000")
+		}
+		for _, model := range r.Models {
+			if !token.MatchString(model) {
+				return errors.New("provider model identifiers must be bounded tokens")
+			}
+		}
+		if !slices.Contains([]string{"unknown", "available", "exhausted"}, r.Availability) || r.ObservedAt.IsZero() || !r.ResetAt.IsZero() && !r.ResetAt.After(r.ObservedAt) {
+			return errors.New("provider reports need an observation time, valid availability and a later reset hint")
+		}
+	}
+	return nil
+}
+
+func Load(path string) (reports []Report, resultErr error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.New("provider capacity report file is unavailable")
+	}
+	defer func() { resultErr = errors.Join(resultErr, file.Close()) }()
+	decoder := json.NewDecoder(io.LimitReader(file, 256*1024+1))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&reports); err != nil {
+		return nil, errors.New("provider capacity report file must contain only the supported report fields")
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return nil, errors.New("provider capacity report file contains trailing data")
+	}
+	if len(reports) == 0 {
+		return nil, errors.New("provider capacity report file must contain at least one backend")
+	}
+	return reports, Validate(reports)
+}
+
+func (r Report) Pool() string {
+	if r.SharedAccountAlias == "" {
+		return r.Provider + "/unknown"
+	}
+	return r.Provider + "/shared/" + r.SharedAccountAlias
+}
+
+func (r Report) State(now time.Time) string {
+	if now.Before(r.ObservedAt) || !now.Before(r.ObservedAt.Add(MaxAge)) || !r.ResetAt.IsZero() && !now.Before(r.ResetAt) {
+		return "unknown"
+	}
+	return r.Availability
+}
+
+func (r Report) Supports(requirement Requirement) bool {
+	return r.Backend == requirement.Backend && slices.Contains(r.Models, requirement.Model)
+}
+
+func (v View) Summary() string {
+	return fmt.Sprintf("%s / %s · account %s · %s · %d / %d reserved · %s", v.Provider, v.Backend, v.AccountAlias, v.State, v.Used, v.MaxConcurrent, v.Reason)
+}

--- a/internal/providercapacity/capacity_test.go
+++ b/internal/providercapacity/capacity_test.go
@@ -1,0 +1,145 @@
+package providercapacity
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testReport() Report {
+	return Report{Provider: "openai", Backend: "codex", AccountAlias: "work", SharedAccountAlias: "team", Models: []string{"sol"}, MaxConcurrent: 2, Availability: "available", ObservedAt: time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)}
+}
+
+func TestReportObservation(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name, state, want string
+		age, reset        time.Duration
+	}{
+		{"available", "available", "available", 0, 0},
+		{"unknown", "unknown", "unknown", 0, 0},
+		{"exhausted", "exhausted", "exhausted", time.Second, time.Minute},
+		{"stale available", "available", "unknown", MaxAge, 0},
+		{"stale exhausted", "exhausted", "unknown", MaxAge, time.Hour},
+		{"future observation", "available", "unknown", -time.Second, 0},
+		{"reset equality", "exhausted", "unknown", time.Minute, time.Minute},
+		{"reset past", "available", "unknown", time.Minute, time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := testReport()
+			r.Availability = test.state
+			if test.reset != 0 {
+				r.ResetAt = r.ObservedAt.Add(test.reset)
+			}
+			if got := r.State(r.ObservedAt.Add(test.age)); got != test.want {
+				t.Fatalf("state = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReportValidation(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		change func(*Report)
+	}{
+		{"provider", func(r *Report) { r.Provider = "account@example.com" }},
+		{"backend", func(r *Report) { r.Backend = "two words" }},
+		{"account", func(r *Report) { r.AccountAlias = "email@example.com" }},
+		{"shared account", func(r *Report) { r.SharedAccountAlias = strings.Repeat("a", 65) }},
+		{"zero concurrency", func(r *Report) { r.MaxConcurrent = 0 }},
+		{"oversized concurrency", func(r *Report) { r.MaxConcurrent = 10001 }},
+		{"missing models", func(r *Report) { r.Models = nil }},
+		{"too many models", func(r *Report) { r.Models = make([]string, 129) }},
+		{"invalid model", func(r *Report) { r.Models = []string{"raw prompt"} }},
+		{"availability", func(r *Report) { r.Availability = "unlimited" }},
+		{"missing observation", func(r *Report) { r.ObservedAt = time.Time{} }},
+		{"reset before observation", func(r *Report) { r.ResetAt = r.ObservedAt.Add(-time.Second) }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := testReport()
+			test.change(&r)
+			if Validate([]Report{r}) == nil {
+				t.Fatal("accepted invalid report")
+			}
+		})
+	}
+	if err := Validate([]Report{testReport()}); err != nil {
+		t.Fatal(err)
+	}
+	for _, reports := range [][]Report{{testReport(), testReport()}, make([]Report, 33)} {
+		if Validate(reports) == nil {
+			t.Fatal("accepted duplicate or excessive backends")
+		}
+	}
+}
+
+func TestLoadReports(t *testing.T) {
+	t.Parallel()
+	raw, err := json.Marshal([]Report{testReport()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name, raw string
+		valid     bool
+	}{
+		{"valid", string(raw), true},
+		{"empty", "[]", false},
+		{"null", "null", false},
+		{"syntax", "[", false},
+		{"trailing", string(raw) + " {}", false},
+		{"secret field", strings.Replace(string(raw), "\"provider\":", "\"api_key\":\"private\",\"provider\":", 1), false},
+		{"invalid bound", strings.Replace(string(raw), "\"max_concurrent\":2", "\"max_concurrent\":0", 1), false},
+		{"oversized", strings.Repeat(" ", 256*1024) + string(raw), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "reports.json")
+			if err := os.WriteFile(path, []byte(test.raw), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(path)
+			if (err == nil) != test.valid {
+				t.Fatalf("Load() = %v", err)
+			}
+			if err != nil && strings.Contains(err.Error(), "private") {
+				t.Fatal("report error leaked input")
+			}
+		})
+	}
+	if _, err := Load(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("missing file accepted")
+	}
+}
+
+func TestProviderCompatibility(t *testing.T) {
+	t.Parallel()
+	r := testReport()
+	for _, test := range []struct {
+		requirement      Requirement
+		valid, supported bool
+	}{
+		{Requirement{Role: "code", Backend: "codex", Model: "sol"}, true, true},
+		{Requirement{Role: "plan", Backend: "codex", Model: "astra"}, true, false},
+		{Requirement{Role: "code", Backend: "claude", Model: "sol"}, true, false},
+		{Requirement{Role: "code", Backend: "codex", Model: ""}, false, false},
+	} {
+		if (test.requirement.Validate() == nil) != test.valid || r.Supports(test.requirement) != test.supported {
+			t.Fatalf("invalid compatibility: %+v", test)
+		}
+	}
+	if r.Pool() != "openai/shared/team" {
+		t.Fatal(r.Pool())
+	}
+	r.SharedAccountAlias = ""
+	if r.Pool() != "openai/unknown" {
+		t.Fatal(r.Pool())
+	}
+	if got := (View{Report: r, State: "unknown", Reason: "stale"}).Summary(); !strings.Contains(got, "stale") || !strings.Contains(got, "0 / 2") {
+		t.Fatal(got)
+	}
+}

--- a/internal/runner/provider_capacity.go
+++ b/internal/runner/provider_capacity.go
@@ -1,0 +1,28 @@
+package runner
+
+import (
+	"context"
+
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+)
+
+type ProviderCapacityResolver interface {
+	DispatchCapacity(context.Context, RunRequest) (providercapacity.Requirement, error)
+}
+
+func (r *Runner) DispatchCapacity(ctx context.Context, req RunRequest) (providercapacity.Requirement, error) {
+	workflow, runtime, _, _ := r.runtimeSnapshot()
+	role := runRole(req.Mode, req.Issue)
+	selection, backend, _, err := runtime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), runtime.effectiveRunRole(role))
+	if err != nil {
+		return providercapacity.Requirement{}, err
+	}
+	effort, field := workflow.Config.Agent.Effort.Resolve(role)
+	override := resolveAgentOverride(ctx, req.Issue, "", selection.Model, role, agentEffortCandidate{Field: field, Effort: effort}, backend)
+	model := effectiveModel("", override.Model, runtime.defaultModelForRole(role))
+	if model == "" {
+		model = "provider_default"
+	}
+	result := providercapacity.Requirement{Role: role, Backend: selection.BackendID, Model: model}
+	return result, result.Validate()
+}

--- a/internal/runner/provider_capacity_test.go
+++ b/internal/runner/provider_capacity_test.go
@@ -1,0 +1,56 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+func TestDispatchCapacityPreservesRouting(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name, state, mode, body, modelOverride, routeModel, wantModel, wantRole string
+		catalogErr                                                              error
+	}{
+		{name: "configured model", routeModel: "sol", wantModel: "sol", wantRole: RoleCode},
+		{name: "issue field", modelOverride: "astra", wantModel: "astra", wantRole: RoleCode},
+		{name: "route precedes field", modelOverride: "astra", routeModel: "sol", wantModel: "sol", wantRole: RoleCode},
+		{name: "explicit body model", routeModel: "sol", body: "```detent-agent\nschema: 1\nmodel: astra\neffort: high\n```", wantModel: "astra", wantRole: RoleCode},
+		{name: "effort does not upgrade", routeModel: "sol", body: "```detent-agent\nschema: 1\neffort: xhigh\n```", wantModel: "sol", wantRole: RoleCode},
+		{name: "retired override retains configured fallback", routeModel: "sol", body: "```detent-agent\nschema: 1\nmodel: retired\n```", wantModel: "sol", wantRole: RoleCode},
+		{name: "catalog failure retains configured fallback", routeModel: "sol", body: "```detent-agent\nschema: 1\nmodel: astra\n```", catalogErr: errors.New("offline"), wantModel: "sol", wantRole: RoleCode},
+		{name: "provider default remains explicit", wantModel: "provider_default", wantRole: RoleCode},
+		{name: "plan role", mode: RunModePlan, routeModel: "sol", wantModel: "plan-model", wantRole: RolePlan},
+		{name: "merge role fallback", state: "Merging", routeModel: "sol", wantModel: "sol", wantRole: RoleMerge},
+		{name: "rework role", state: "Rework", routeModel: "sol", wantModel: "sol", wantRole: RoleRework},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			backend := &catalogAgentBackend{models: []AgentModel{{ID: "sol", Model: "sol", SupportedReasoningEfforts: []string{"high", "xhigh"}}, {ID: "astra", Model: "astra", SupportedReasoningEfforts: []string{"high"}}, {ID: "retired", Model: "retired", Upgrade: "astra"}}, err: test.catalogErr}
+			router, err := NewRouter([]Route{{BackendID: "code", Default: true, Model: test.routeModel}, {BackendID: "plan", Role: RolePlan, Default: true, Model: "plan-model"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := &Runner{agentRuntime: agentRuntime{router: router, backends: map[string]AgentBackend{"code": backend, "plan": backend}, backendConfigs: map[string]config.AgentBackend{"code": {ID: "code"}, "plan": {ID: "plan"}}}}
+			issue := connector.Issue{State: test.state, Description: test.body, ModelOverride: test.modelOverride}
+			result, err := r.DispatchCapacity(t.Context(), RunRequest{Issue: issue, Mode: test.mode, SelectorContext: selector.Context{}})
+			if err != nil || result.Role != test.wantRole || result.Model != test.wantModel {
+				t.Fatalf("requirement = %+v, %v", result, err)
+			}
+			if issue.ModelOverride != test.modelOverride || issue.Description != test.body {
+				t.Fatal("capacity selection mutated issue policy")
+			}
+		})
+	}
+}
+
+func TestDispatchCapacityMissingRoute(t *testing.T) {
+	t.Parallel()
+	r := &Runner{}
+	if _, err := r.DispatchCapacity(t.Context(), RunRequest{}); !errors.Is(err, ErrMissingAgentRoutes) {
+		t.Fatal(err)
+	}
+}

--- a/internal/runnerauth/routing.go
+++ b/internal/runnerauth/routing.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
@@ -32,6 +33,7 @@ type HostChange struct {
 }
 
 type Runner struct {
+	ProviderCapacity []providercapacity.View `json:"provider_capacity,omitempty"`
 	Binding
 	Routing
 	OrganizationID   tracker.OrganizationID `json:"organization_id"`
@@ -52,13 +54,14 @@ type Runner struct {
 }
 
 type RunnerLease struct {
-	ID         tracker.LeaseID          `json:"lease_id"`
-	WorkItemID tracker.NativeWorkItemID `json:"work_item_id"`
-	Title      string                   `json:"title"`
-	ProjectID  tracker.ProjectID        `json:"project_id"`
-	Policy     policy.Descriptor        `json:"policy"`
-	ExpiresAt  time.Time                `json:"expires_at"`
-	Exclusions []Exclusion              `json:"exclusions"`
+	ProviderReservation *providercapacity.Reservation `json:"provider_reservation,omitempty"`
+	ID                  tracker.LeaseID               `json:"lease_id"`
+	WorkItemID          tracker.NativeWorkItemID      `json:"work_item_id"`
+	Title               string                        `json:"title"`
+	ProjectID           tracker.ProjectID             `json:"project_id"`
+	Policy              policy.Descriptor             `json:"policy"`
+	ExpiresAt           time.Time                     `json:"expires_at"`
+	Exclusions          []Exclusion                   `json:"exclusions"`
 }
 
 type Exclusion struct {
@@ -145,6 +148,14 @@ func (r Runner) Exclusions(project tracker.ProjectID, requirements policy.Requir
 	}
 	if !activeLease && r.Used >= min(r.CapacityLimit, r.ReportedCapacity) {
 		add("runner_capacity", "Runner capacity is full or paused")
+	}
+	if !activeLease && len(r.ProviderCapacity) > 0 {
+		available := slices.ContainsFunc(r.ProviderCapacity, func(view providercapacity.View) bool {
+			return view.State != "exhausted" && view.Used < view.MaxConcurrent
+		})
+		if !available {
+			add("provider_capacity", "All reported provider accounts are exhausted or fully reserved; work stays queued")
+		}
 	}
 	return result
 }

--- a/internal/runnerauth/routing_test.go
+++ b/internal/runnerauth/routing_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
@@ -67,6 +68,18 @@ func TestRunnerEligibility(t *testing.T) {
 		{"runner full", func(r *Runner) { r.Used = 2 }, policy.Requirements{}, false, "runner_capacity"},
 		{"reported pause", func(r *Runner) { r.ReportedCapacity = 0 }, policy.Requirements{}, false, "runner_capacity"},
 		{"active retains slot", func(r *Runner) { r.Used = 2; r.HostUsed = 2 }, policy.Requirements{}, true, ""},
+		{"provider exhausted", func(r *Runner) {
+			r.ProviderCapacity = []providercapacity.View{{Report: providercapacity.Report{MaxConcurrent: 2}, State: "exhausted"}}
+		}, policy.Requirements{}, false, "provider_capacity"},
+		{"provider fully reserved", func(r *Runner) {
+			r.ProviderCapacity = []providercapacity.View{{Report: providercapacity.Report{MaxConcurrent: 2}, State: "available", Used: 2}}
+		}, policy.Requirements{}, false, "provider_capacity"},
+		{"provider unknown", func(r *Runner) {
+			r.ProviderCapacity = []providercapacity.View{{Report: providercapacity.Report{MaxConcurrent: 2}, State: "unknown"}}
+		}, policy.Requirements{}, false, ""},
+		{"active provider exhaustion", func(r *Runner) {
+			r.ProviderCapacity = []providercapacity.View{{Report: providercapacity.Report{MaxConcurrent: 2}, State: "exhausted"}}
+		}, policy.Requirements{}, true, ""},
 		{"rename", func(r *Runner) { r.DisplayName = "New name"; r.HostDisplayName = "New host" }, policy.Requirements{RunnerID: "runner_a", MachineID: "machine_a"}, false, ""},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/tracker/native.go
+++ b/internal/tracker/native.go
@@ -1,8 +1,14 @@
 package tracker
 
-import "time"
+import (
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/providercapacity"
+)
 
 const NativeProtocolMajor = 2
+
+const NativeProviderCapacityCapability = "provider_capacity_reservations"
 
 type OrganizationID string
 type ProjectID string
@@ -182,31 +188,49 @@ type NativeProject struct {
 }
 
 type NativeClaim struct {
-	PolicyID       string           `json:"policy_id"`
-	WorkItemID     NativeWorkItemID `json:"work_item_id,omitempty"`
-	MachineID      MachineID        `json:"machine_id"`
-	SessionID      string           `json:"session_id"`
-	TTLSeconds     int64            `json:"ttl_seconds"`
-	ProtocolMajor  int              `json:"protocol_major"`
-	Capabilities   []string         `json:"capabilities"`
-	WorkflowStates []string         `json:"workflow_states,omitempty"`
-	Authors        []string         `json:"authors,omitempty"`
-	Assignees      []string         `json:"assignees,omitempty"`
-	LabelInclude   []string         `json:"label_include,omitempty"`
-	LabelExclude   []string         `json:"label_exclude,omitempty"`
+	ProviderCandidates []NativeCapacityCandidate `json:"provider_candidates,omitempty"`
+	PolicyID           string                    `json:"policy_id"`
+	WorkItemID         NativeWorkItemID          `json:"work_item_id,omitempty"`
+	MachineID          MachineID                 `json:"machine_id"`
+	SessionID          string                    `json:"session_id"`
+	TTLSeconds         int64                     `json:"ttl_seconds"`
+	ProtocolMajor      int                       `json:"protocol_major"`
+	Capabilities       []string                  `json:"capabilities"`
+	WorkflowStates     []string                  `json:"workflow_states,omitempty"`
+	Authors            []string                  `json:"authors,omitempty"`
+	Assignees          []string                  `json:"assignees,omitempty"`
+	LabelInclude       []string                  `json:"label_include,omitempty"`
+	LabelExclude       []string                  `json:"label_exclude,omitempty"`
 }
 
 type NativeLease struct {
-	ServerTime   time.Time        `json:"server_time"`
-	PolicyID     string           `json:"policy_id"`
-	ID           LeaseID          `json:"lease_id"`
-	WorkItemID   NativeWorkItemID `json:"work_item_id"`
-	MachineID    MachineID        `json:"machine_id"`
-	SessionID    string           `json:"session_id"`
-	FencingToken FencingToken     `json:"fencing_token,string"`
-	AcquiredAt   time.Time        `json:"acquired_at"`
-	RenewedAt    time.Time        `json:"renewed_at"`
-	ExpiresAt    time.Time        `json:"expires_at"`
+	ProviderReservation *providercapacity.Reservation `json:"provider_reservation,omitempty"`
+	ServerTime          time.Time                     `json:"server_time"`
+	PolicyID            string                        `json:"policy_id"`
+	ID                  LeaseID                       `json:"lease_id"`
+	WorkItemID          NativeWorkItemID              `json:"work_item_id"`
+	MachineID           MachineID                     `json:"machine_id"`
+	SessionID           string                        `json:"session_id"`
+	FencingToken        FencingToken                  `json:"fencing_token,string"`
+	AcquiredAt          time.Time                     `json:"acquired_at"`
+	RenewedAt           time.Time                     `json:"renewed_at"`
+	ExpiresAt           time.Time                     `json:"expires_at"`
+}
+
+type NativeCapacityCandidate struct {
+	WorkItemID  NativeWorkItemID             `json:"work_item_id"`
+	Revision    Revision                     `json:"revision,string"`
+	Requirement providercapacity.Requirement `json:"requirement"`
+}
+
+type NativeCapacityPreview struct {
+	NativeClaim
+	After WorkItemID `json:"after,omitempty"`
+}
+
+type NativeCapacityPage struct {
+	Items []NativeIssue `json:"items"`
+	Next  WorkItemID    `json:"next,omitempty"`
 }
 
 type NativeLeaseMutation struct {

--- a/internal/web/runner_fleet_test.go
+++ b/internal/web/runner_fleet_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/providercapacity"
 	"github.com/digitaldrywood/detent/internal/runnerauth"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/tracker"
@@ -134,6 +135,12 @@ func TestRunnerFleetViews(t *testing.T) {
 		}, "?project=repository-a", "runner_offline", true},
 		{"no matching tags", func(p *runnerFleetProbe) { p.requirements.RequiredTags = []string{"linux"} }, "?project=repository-a", "selector_no_match", true},
 		{"read only", func(p *runnerFleetProbe) { p.fleet.Editable = false }, "", "Mac builder", false},
+		{"provider exhaustion", func(p *runnerFleetProbe) {
+			p.fleet.Runners[0].ProviderCapacity = []providercapacity.View{{Report: providercapacity.Report{Provider: "openai", Backend: "codex", AccountAlias: "work", Models: []string{"sol"}, MaxConcurrent: 2, ObservedAt: time.Now(), ResetAt: time.Now().Add(time.Hour)}, State: "exhausted", Reason: "Provider account is exhausted"}}
+		}, "", "Provider account is exhausted", true},
+		{"provider selection", func(p *runnerFleetProbe) {
+			p.fleet.Runners[0].Leases = []runnerauth.RunnerLease{{ID: "lease", Title: "Selected work", ProviderReservation: &providercapacity.Reservation{Requirement: providercapacity.Requirement{Role: "code", Backend: "codex", Model: "sol"}, Report: providercapacity.Report{AccountAlias: "work"}, Reason: "Quota is unknown"}}}
+		}, "", "Quota is unknown", true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/web/templates/runner_fleet.templ
+++ b/internal/web/templates/runner_fleet.templ
@@ -75,6 +75,17 @@ templ runnerFleetCard(r runnerauth.Runner, view RunnerFleetData) {
 			<dt class="text-sec">Stable runner</dt><dd class="break-all font-mono text-sec">{ r.RunnerID }</dd>
 			<dt class="text-sec">Stable host</dt><dd class="break-all font-mono text-sec">{ string(r.MachineID) }</dd>
 		</dl>
+		for _, capacity := range r.ProviderCapacity {
+			<details class="border-t border-line pt-3" data-provider-capacity={ capacity.Backend }>
+				<summary class="cursor-pointer break-words text-xs text-text">{ capacity.Summary() }</summary>
+				<p class="mt-2 break-words text-xs text-sec">Models: { strings.Join(capacity.Models, ", ") }</p>
+				<p class="mt-2 break-words text-xs text-sec">Shared account: { runnerRequirement(capacity.SharedAccountAlias, "Unknown; conservatively shared within this provider") }</p>
+				<p class="mt-2 text-xs text-sec">Observed: { capacity.ObservedAt.UTC().Format("2006-01-02 15:04:05 UTC") }</p>
+				if !capacity.ResetAt.IsZero() {
+					<p class="mt-2 text-xs text-sec">Reset hint: { capacity.ResetAt.UTC().Format("2006-01-02 15:04:05 UTC") }</p>
+				}
+			</details>
+		}
 		if view.Eligibility != nil {
 			if len(view.exclusions(r.RunnerID)) == 0 {
 				<p class="text-xs text-text" data-eligible>Eligible for this project</p>
@@ -120,6 +131,9 @@ templ runnerFleetCard(r runnerauth.Runner, view RunnerFleetData) {
 					<dt class="text-sec">Exact host</dt><dd class="break-all font-mono text-text">{ runnerRequirement(lease.Policy.Requirements.MachineID, "Any authorized host") }</dd>
 					<dt class="text-sec">Lease expires</dt><dd class="text-text">{ lease.ExpiresAt.UTC().Format("2006-01-02 15:04:05 UTC") }</dd>
 				</dl>
+				if reservation := lease.ProviderReservation; reservation != nil {
+					<p class="mt-2 break-words text-xs text-text" data-provider-selection>{ reservation.Role } · { reservation.Backend } · { reservation.Model } · account { reservation.Report.AccountAlias }: { reservation.Reason }</p>
+				}
 				if len(lease.Exclusions) == 0 {
 					<p class="mt-2 text-xs text-text">Current authority permits this active run.</p>
 				}

--- a/internal/web/templates/runner_fleet_templ.go
+++ b/internal/web/templates/runner_fleet_templ.go
@@ -475,74 +475,168 @@ func runnerFleetCard(r runnerauth.Runner, view RunnerFleetData) templ.Component 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		for _, capacity := range r.ProviderCapacity {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<details class=\"border-t border-line pt-3\" data-provider-capacity=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(capacity.Backend)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 79, Col: 87}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\"><summary class=\"cursor-pointer break-words text-xs text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var29 string
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(capacity.Summary())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 80, Col: 86}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</summary><p class=\"mt-2 break-words text-xs text-sec\">Models: ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(strings.Join(capacity.Models, ", "))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 81, Col: 94}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</p><p class=\"mt-2 break-words text-xs text-sec\">Shared account: ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var31 string
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(runnerRequirement(capacity.SharedAccountAlias, "Unknown; conservatively shared within this provider"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 82, Col: 168}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</p><p class=\"mt-2 text-xs text-sec\">Observed: ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var32 string
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(capacity.ObservedAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 83, Col: 108}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if !capacity.ResetAt.IsZero() {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<p class=\"mt-2 text-xs text-sec\">Reset hint: ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var33 string
+				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(capacity.ResetAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 85, Col: 108}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</details> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
 		if view.Eligibility != nil {
 			if len(view.exclusions(r.RunnerID)) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<p class=\"text-xs text-text\" data-eligible>Eligible for this project</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<p class=\"text-xs text-text\" data-eligible>Eligible for this project</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			for _, reason := range view.exclusions(r.RunnerID) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<p class=\"text-xs text-text\" data-exclusion=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<p class=\"text-xs text-text\" data-exclusion=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var28 string
-				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Code)
+				var templ_7745c5c3_Var34 string
+				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Code)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 83, Col: 61}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 94, Col: 61}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var29 string
-				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Message)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 83, Col: 80}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</p>")
+				var templ_7745c5c3_Var35 string
+				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Message)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 94, Col: 80}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
 		if view.Fleet.Editable {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<details class=\"border-t border-line pt-3\"><summary class=\"cursor-pointer text-xs font-semibold text-accent\">Edit runner and host</summary><form class=\"mt-3 grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2\" hx-post=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<details class=\"border-t border-line pt-3\"><summary class=\"cursor-pointer text-xs font-semibold text-accent\">Edit runner and host</summary><form class=\"mt-3 grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2\" hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs("/fleet/runners/" + r.RunnerID)
+			var templ_7745c5c3_Var36 string
+			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs("/fleet/runners/" + r.RunnerID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 89, Col: 107}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 100, Col: 107}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" hx-target=\"#runner-fleet-feedback\" hx-swap=\"innerHTML\"><input type=\"hidden\" name=\"revision\" value=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var31 string
-			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatInt(r.Revision, 10))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 90, Col: 83}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\" hx-target=\"#runner-fleet-feedback\" hx-swap=\"innerHTML\"><input type=\"hidden\" name=\"revision\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\">")
+			var templ_7745c5c3_Var37 string
+			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatInt(r.Revision, 10))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 101, Col: 83}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -554,66 +648,66 @@ func runnerFleetCard(r runnerauth.Runner, view RunnerFleetData) templ.Component 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">State<select name=\"state\" class=\"rounded border border-line bg-elev p-2 text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">State<select name=\"state\" class=\"rounded border border-line bg-elev p-2 text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, state := range []string{"active", "draining", "disabled"} {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<option value=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<option value=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var32 string
-				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(state)
+				var templ_7745c5c3_Var38 string
+				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(state)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 95, Col: 28}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 106, Col: 28}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if r.State == state {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, " selected")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, " selected")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, ">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, ">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var33 string
-				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(state)
+				var templ_7745c5c3_Var39 string
+				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(state)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 95, Col: 69}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 106, Col: 69}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</option>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</option>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</select></label> <label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">Runner capacity limit<input class=\"rounded border border-line bg-elev p-2 text-text\" name=\"capacity_limit\" type=\"number\" min=\"0\" max=\"10000\" required value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</select></label> <label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">Runner capacity limit<input class=\"rounded border border-line bg-elev p-2 text-text\" name=\"capacity_limit\" type=\"number\" min=\"0\" max=\"10000\" required value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var34 string
-			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(r.CapacityLimit))
+			var templ_7745c5c3_Var40 string
+			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(r.CapacityLimit))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 98, Col: 252}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 109, Col: 252}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\"></label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\"></label>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -621,33 +715,33 @@ func runnerFleetCard(r runnerauth.Runner, view RunnerFleetData) templ.Component 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<div class=\"flex items-end\"><button class=\"rounded border border-line bg-elev px-3 py-2 text-xs font-semibold text-text\" type=\"submit\">Save runner</button></div></form><p class=\"mt-3 text-xs text-sec\">Drain allows active runs to finish. Disabling or removing required tags or access stops new work and interrupts affected runs.</p><form class=\"mt-3 grid min-w-0 grid-cols-1 gap-3 border-t border-line pt-3 sm:grid-cols-2\" hx-post=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<div class=\"flex items-end\"><button class=\"rounded border border-line bg-elev px-3 py-2 text-xs font-semibold text-text\" type=\"submit\">Save runner</button></div></form><p class=\"mt-3 text-xs text-sec\">Drain allows active runs to finish. Disabling or removing required tags or access stops new work and interrupts affected runs.</p><form class=\"mt-3 grid min-w-0 grid-cols-1 gap-3 border-t border-line pt-3 sm:grid-cols-2\" hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var35 string
-			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs("/fleet/hosts/" + string(r.MachineID))
+			var templ_7745c5c3_Var41 string
+			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs("/fleet/hosts/" + string(r.MachineID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 103, Col: 140}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 114, Col: 140}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" hx-target=\"#runner-fleet-feedback\" hx-swap=\"innerHTML\"><input type=\"hidden\" name=\"revision\" value=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var36 string
-			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatInt(r.HostRevision, 10))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 104, Col: 87}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" hx-target=\"#runner-fleet-feedback\" hx-swap=\"innerHTML\"><input type=\"hidden\" name=\"revision\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\">")
+			var templ_7745c5c3_Var42 string
+			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.FormatInt(r.HostRevision, 10))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 115, Col: 87}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -655,190 +749,261 @@ func runnerFleetCard(r runnerauth.Runner, view RunnerFleetData) templ.Component 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">Capacity shared by all runners<input class=\"rounded border border-line bg-elev p-2 text-text\" name=\"capacity\" type=\"number\" min=\"0\" max=\"10000\" required value=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var37 string
-			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(r.HostCapacity))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 106, Col: 254}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\"></label> <button class=\"w-fit rounded border border-line bg-elev px-3 py-2 text-xs font-semibold text-text\" type=\"submit\">Save host</button></form></details> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		for _, lease := range r.Leases {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<details class=\"border-t border-line pt-3\" data-run-eligibility=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var38 string
-			templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(string(lease.ID))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 112, Col: 85}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\"><summary class=\"cursor-pointer text-xs font-semibold text-text\">Run: ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var39 string
-			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(lease.Title)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 113, Col: 86}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</summary><dl class=\"mt-3 grid min-w-0 grid-cols-1 gap-1 text-xs sm:grid-cols-[8rem_1fr]\"><dt class=\"text-sec\">Work item</dt><dd class=\"break-all font-mono text-text\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var40 string
-			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(string(lease.WorkItemID))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 115, Col: 108}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</dd><dt class=\"text-sec\">Policy</dt><dd class=\"break-all font-mono text-text\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var41 string
-			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(lease.Policy.ID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 116, Col: 96}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</dd><dt class=\"text-sec\">Policy revision</dt><dd class=\"break-all font-mono text-text\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var42 string
-			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(lease.Policy.SourceRevision)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 117, Col: 117}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</dd><dt class=\"text-sec\">Required tags</dt><dd class=\"break-words text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">Capacity shared by all runners<input class=\"rounded border border-line bg-elev p-2 text-text\" name=\"capacity\" type=\"number\" min=\"0\" max=\"10000\" required value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var43 string
-			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(runnerRequirement(strings.Join(lease.Policy.Requirements.RequiredTags, ", "), "None"))
+			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(r.HostCapacity))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 118, Col: 165}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 117, Col: 254}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</dd><dt class=\"text-sec\">Exact runner</dt><dd class=\"break-all font-mono text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\"></label> <button class=\"w-fit rounded border border-line bg-elev px-3 py-2 text-xs font-semibold text-text\" type=\"submit\">Save host</button></form></details> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, lease := range r.Leases {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<details class=\"border-t border-line pt-3\" data-run-eligibility=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var44 string
-			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(runnerRequirement(lease.Policy.Requirements.RunnerID, "Any authorized runner"))
+			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(string(lease.ID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 119, Col: 165}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 123, Col: 85}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</dd><dt class=\"text-sec\">Exact host</dt><dd class=\"break-all font-mono text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "\"><summary class=\"cursor-pointer text-xs font-semibold text-text\">Run: ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var45 string
-			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(runnerRequirement(lease.Policy.Requirements.MachineID, "Any authorized host"))
+			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(lease.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 120, Col: 162}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 124, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</dd><dt class=\"text-sec\">Lease expires</dt><dd class=\"text-text\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</summary><dl class=\"mt-3 grid min-w-0 grid-cols-1 gap-1 text-xs sm:grid-cols-[8rem_1fr]\"><dt class=\"text-sec\">Work item</dt><dd class=\"break-all font-mono text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var46 string
-			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(lease.ExpiresAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(string(lease.WorkItemID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 121, Col: 123}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 126, Col: 108}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</dd></dl>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</dd><dt class=\"text-sec\">Policy</dt><dd class=\"break-all font-mono text-text\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			var templ_7745c5c3_Var47 string
+			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(lease.Policy.ID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 127, Col: 96}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</dd><dt class=\"text-sec\">Policy revision</dt><dd class=\"break-all font-mono text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var48 string
+			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(lease.Policy.SourceRevision)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 128, Col: 117}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</dd><dt class=\"text-sec\">Required tags</dt><dd class=\"break-words text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var49 string
+			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(runnerRequirement(strings.Join(lease.Policy.Requirements.RequiredTags, ", "), "None"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 129, Col: 165}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</dd><dt class=\"text-sec\">Exact runner</dt><dd class=\"break-all font-mono text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var50 string
+			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(runnerRequirement(lease.Policy.Requirements.RunnerID, "Any authorized runner"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 130, Col: 165}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</dd><dt class=\"text-sec\">Exact host</dt><dd class=\"break-all font-mono text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var51 string
+			templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(runnerRequirement(lease.Policy.Requirements.MachineID, "Any authorized host"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 131, Col: 162}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</dd><dt class=\"text-sec\">Lease expires</dt><dd class=\"text-text\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var52 string
+			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(lease.ExpiresAt.UTC().Format("2006-01-02 15:04:05 UTC"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 132, Col: 123}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</dd></dl>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if reservation := lease.ProviderReservation; reservation != nil {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<p class=\"mt-2 break-words text-xs text-text\" data-provider-selection>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var53 string
+				templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(reservation.Role)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 93}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, " · ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var54 string
+				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(reservation.Backend)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 120}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, " · ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var55 string
+				templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(reservation.Model)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 145}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, " · account ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var56 string
+				templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(reservation.Report.AccountAlias)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 192}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, ": ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var57 string
+				templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(reservation.Reason)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 216}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
 			if len(lease.Exclusions) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<p class=\"mt-2 text-xs text-text\">Current authority permits this active run.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<p class=\"mt-2 text-xs text-text\">Current authority permits this active run.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			for _, reason := range lease.Exclusions {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "<p class=\"mt-2 text-xs text-text\" data-exclusion=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<p class=\"mt-2 text-xs text-text\" data-exclusion=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var47 string
-				templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Code)
+				var templ_7745c5c3_Var58 string
+				templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Code)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 127, Col: 67}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 141, Col: 67}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var48 string
-				templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Message)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 127, Col: 86}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</p>")
+				var templ_7745c5c3_Var59 string
+				templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(reason.Message)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 141, Col: 86}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</details>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</details>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -862,51 +1027,51 @@ func runnerTextField(label, name, value string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var49 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var49 == nil {
-			templ_7745c5c3_Var49 = templ.NopComponent
+		templ_7745c5c3_Var60 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var60 == nil {
+			templ_7745c5c3_Var60 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "<label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<label class=\"flex min-w-0 flex-col gap-1 text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var50 string
-		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		var templ_7745c5c3_Var61 string
+		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 149, Col: 68}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<input class=\"min-w-0 rounded border border-line bg-elev p-2 text-text\" name=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var51 string
-		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(name)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 153}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<input class=\"min-w-0 rounded border border-line bg-elev p-2 text-text\" name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "\" value=\"")
+		var templ_7745c5c3_Var62 string
+		templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 149, Col: 153}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var52 string
-		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(value)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 135, Col: 169}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "\"></label>")
+		var templ_7745c5c3_Var63 string
+		templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 149, Col: 169}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "\"></label>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -930,25 +1095,25 @@ func RunnerFleetFeedback(message string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var53 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var53 == nil {
-			templ_7745c5c3_Var53 = templ.NopComponent
+		templ_7745c5c3_Var64 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var64 == nil {
+			templ_7745c5c3_Var64 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "<p role=\"alert\" class=\"rounded-card border border-line bg-surface p-3 text-sm text-text\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<p role=\"alert\" class=\"rounded-card border border-line bg-surface p-3 text-sm text-text\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var54 string
-		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+		var templ_7745c5c3_Var65 string
+		templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 139, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/runner_fleet.templ`, Line: 153, Col: 99}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

Compatible native runners can currently claim work without coordinating provider accounts shared across machines. Add opt-in capacity reporting and lease-backed reservations so exhausted or fully reserved accounts leave work queued while existing model choices, access rules, fixed-host requirements, and local safety brakes remain authoritative.

- Read bounded, credential-free reports from an operator-managed local JSON file. Opaque shared aliases identify account pools; undeclared sharing is conservative. Stale/future/reset observations become unknown, and declared concurrency is never treated as transferable token credit.
- Resolve role/backend/model through existing local routing, retain Hub queue order, and reserve shared capacity atomically with fenced leases. Revalidate locally and at Hub before startup; cover failed starts, lost acknowledgments, cancellation, expiry, and restart recovery.
- Show report freshness, shared usage, selection and waiting reasons in fleet/run details and doctor. Document report schema, alias ownership, and collector responsibilities.

Prerequisites #2185/#2236 and #2186/#2237 are merged in the base. #2175 model policy remains outside this change. Live model/account configuration was not changed.

Fixes #2198

## UI Surface Contract

- [x] The issue explicitly authorizes capacity and selection reasons in fleet/run details and doctor output.
- [x] No persistent top-of-screen messaging was added.
- [x] Chrome DevTools verified expanded reports and selected-run details on the real server-rendered UI using an isolated ephemeral server. Desktop and 390px mobile views were readable; mobile scrollWidth equaled innerWidth (390px). Preview servers shut down cleanly.

## Test Plan

- [x] `make generate`
- [x] Focused table-driven capacity, model/fallback, concurrent shared-account, fairness, lease recovery, local revalidation, acknowledgment-loss, doctor and UI tests.
- [x] `make check` on final contents: build, lint, vet, NilAway, race tests, 80.0% overall coverage and configured file/package floors. Provider capacity package: 100% coverage.
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`: 13 initial seeds, 592,354 executions passed. Named safety-critical brake files are unchanged.
- [x] Configured gosec scan and its eight-run determinism check passed.
- [x] Current-head Linux Security CI passed. Local `make security` reports pre-existing GO-2026-5970 in unchanged x/text v0.37.0, including when targeting Linux. Separate Backlog follow-up #2238 records the unresolved reachability discrepancy and patched dependency update; this is not a PR dependency. No security gate was weakened.
- [x] All 11 current-head GitHub checks passed: [CI run 33996176746](https://github.com/digitaldrywood/detent/actions/runs/33996176746), including Linux race verification, Windows/macOS portability, full Browser Visual, Security, coverage, lint, release snapshot and smoke checks.
