### PR TITLE
fix(diagnostics): clarify direct dependent counts

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -396,7 +396,9 @@ Use `tracker.authorization.labels.*`, `projects[].authorization`, and
 `agent.dispatch_priority_by_label` for selecting or ranking work by ordinary
 labels such as `documentation`, `bug`, or `enhancement`.
 `agent.prioritize_unblockers` defaults to `true` and ranks an unlabeled issue
-ahead of otherwise-equal peers when it directly unblocks waiting work. State,
+ahead of otherwise-equal peers based on its number of directly dependent blocked
+issues. These issues may still have other unfinished prerequisites; the count
+does not predict how many issues become runnable. State,
 tracker priority, and every configured dispatch-label tier remain higher.
 
 The fleet `/kanban` board stays read-only, as do observer dashboards and

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -187,9 +187,9 @@ func (o *Orchestrator) escalateCorrectableDispatchDecision(state *State, now tim
 
 func unblockerDecisionReason(count int) string {
 	if count == 1 {
-		return "unblocks_1_issue"
+		return "prerequisite_for_1_blocked_issue"
 	}
-	return fmt.Sprintf("unblocks_%d_issues", count)
+	return fmt.Sprintf("prerequisite_for_%d_blocked_issues", count)
 }
 
 func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome string, decision scheduler.DispatchGateDecision, projectStats projectStateSlotStats) {

--- a/internal/orchestrator/ranking_test.go
+++ b/internal/orchestrator/ranking_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -292,38 +293,55 @@ func TestAnnotateUnblockerCountsIsInputOrderIndependent(t *testing.T) {
 func TestDispatchPlannerRecordsUnblockerSelectionReason(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-	cfg := normalizeConfig(Config{
-		MaxConcurrentAgents:  1,
-		ActiveStates:         []string{"Todo", "Blocked"},
-		TerminalStates:       []string{"Done"},
-		PrioritizeUnblockers: true,
-	})
-	blocker := rankingIssue("blocker", "Todo", 0, now.Add(-time.Hour))
-	peer := rankingIssue("older-peer", "Todo", 0, now.Add(-4*time.Hour))
-	blocker.Title = "Dependency blocker"
-	peer.Title = "Older peer"
-	dependent := rankingDependencyIssue("dependent", "Blocked", blocker.ID)
-	state := newState(cfg)
-	state.Blocked[dependent.ID] = Blocked{Issue: dependent, Source: BlockedSourceDependency}
+	for _, tt := range []struct {
+		name              string
+		count             int
+		otherPrerequisite bool
+		wantReason        string
+	}{
+		{name: "single remaining prerequisite", count: 1, wantReason: "prerequisite_for_1_blocked_issue"},
+		{name: "three dependents with unfinished prerequisites", count: 3, otherPrerequisite: true, wantReason: "prerequisite_for_3_blocked_issues"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents:  1,
+				ActiveStates:         []string{"Todo", "Blocked"},
+				TerminalStates:       []string{"Done"},
+				PrioritizeUnblockers: true,
+			})
+			blocker := rankingIssue("blocker", "Todo", 0, now.Add(-time.Hour))
+			peer := rankingIssue("older-peer", "Todo", 0, now.Add(-4*time.Hour))
+			blocker.Title = "Dependency blocker"
+			peer.Title = "Older peer"
+			state := newState(cfg)
+			for index := range tt.count {
+				dependent := rankingDependencyIssue(fmt.Sprintf("dependent-%d", index), "Blocked", blocker.ID)
+				if tt.otherPrerequisite {
+					dependent.BlockedBy = append(dependent.BlockedBy, connector.BlockedRef{ID: "other", State: "Blocked"})
+				}
+				state.Blocked[dependent.ID] = Blocked{Issue: dependent, Source: BlockedSourceDependency}
+			}
 
-	var decisions []dispatchPlanDecision
-	newDispatchPlanner(cfg).plan(&state, []connector.Issue{peer, blocker}, now, dispatchPlanHooks{
-		decision: func(decision dispatchPlanDecision) {
-			decisions = append(decisions, decision)
-		},
-	})
+			var decisions []dispatchPlanDecision
+			newDispatchPlanner(cfg).plan(&state, []connector.Issue{peer, blocker}, now, dispatchPlanHooks{
+				decision: func(decision dispatchPlanDecision) {
+					decisions = append(decisions, decision)
+				},
+			})
 
-	if len(decisions) != 2 {
-		t.Fatalf("decisions = %d, want 2", len(decisions))
-	}
-	if !decisions[0].Selected || decisions[0].Issue.ID != blocker.ID || decisions[0].UnblockerCount != 1 {
-		t.Fatalf("first decision = %#v, want selected blocker with one dependent", decisions[0])
-	}
-	orch := Orchestrator{cfg: cfg}
-	orch.logDispatchPlanDecision(context.Background(), &state, now, decisions[0])
-	if len(state.SchedulerDecisions) != 1 || state.SchedulerDecisions[0].Reason != "unblocks_1_issue" {
-		t.Fatalf("scheduler decisions = %#v, want unblocker reason", state.SchedulerDecisions)
+			if len(decisions) != 2 {
+				t.Fatalf("decisions = %d, want 2", len(decisions))
+			}
+			if !decisions[0].Selected || decisions[0].Issue.ID != blocker.ID || decisions[0].UnblockerCount != tt.count {
+				t.Fatalf("first decision = %#v, want selected blocker with expected dependent count", decisions[0])
+			}
+			orch := Orchestrator{cfg: cfg}
+			orch.logDispatchPlanDecision(context.Background(), &state, now, decisions[0])
+			if len(state.SchedulerDecisions) != 1 || state.SchedulerDecisions[0].Reason != tt.wantReason {
+				t.Fatalf("scheduler decisions = %#v, want unblocker reason", state.SchedulerDecisions)
+			}
+		})
 	}
 }
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -1746,7 +1746,7 @@ func boardCardPriority(card projectKanbanCard) (string, string, string, bool) {
 		badge = card.DispatchPriorityLabel
 	}
 	if badge == "" && card.UnblockerCount > 0 {
-		badge = "unblocker"
+		badge = "prerequisite"
 	}
 	details := make([]string, 0, 3)
 	if card.PriorityRank > 0 {
@@ -1770,9 +1770,9 @@ func boardCardPriority(card projectKanbanCard) (string, string, string, bool) {
 
 func unblockerPriorityDetail(count int) string {
 	if count == 1 {
-		return "Unblocks 1 issue."
+		return "Prerequisite for 1 blocked issue."
 	}
-	return "Unblocks " + strconv.Itoa(count) + " issues."
+	return "Prerequisite for " + strconv.Itoa(count) + " blocked issues."
 }
 
 // boardCardExtra picks the single allowed extra signal, most urgent first:

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -724,14 +724,14 @@ func TestBoardCardPriority(t *testing.T) {
 		{
 			name:       "derived unblocker boost",
 			card:       projectKanbanCard{UnblockerCount: 3},
-			wantBadge:  "unblocker",
-			wantDetail: "Unblocks 3 issues.",
+			wantBadge:  "prerequisite",
+			wantDetail: "Prerequisite for 3 blocked issues.",
 		},
 		{
 			name:       "single derived dependent",
 			card:       projectKanbanCard{UnblockerCount: 1},
-			wantBadge:  "unblocker",
-			wantDetail: "Unblocks 1 issue.",
+			wantBadge:  "prerequisite",
+			wantDetail: "Prerequisite for 1 blocked issue.",
 		},
 		{
 			name: "unprioritized",
@@ -3484,8 +3484,8 @@ func TestBoardSnapshotRendersUnblockerPriorityDetail(t *testing.T) {
 	for _, want := range []string{
 		`data-board-priority`,
 		`data-help-scope="dispatch-priority"`,
-		`data-help-description="Unblocks 2 issues."`,
-		`unblocker`,
+		`data-help-description="Prerequisite for 2 blocked issues."`,
+		`prerequisite`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("unblocker board snapshot missing %q:\n%s", want, html)
@@ -4591,6 +4591,18 @@ func TestBoardCardSheetPreservesSupportingValues(t *testing.T) {
 			}
 			if strings.Contains(html, "md:truncate") {
 				t.Fatal("sheet core truncates supporting values")
+			}
+		})
+	}
+}
+
+func TestSchedulerDecisionHistoricalReasonsRemainReadable(t *testing.T) {
+	t.Parallel()
+	for _, reason := range []string{"unblocks_1_issue", "unblocks_3_issues", "prerequisite_for_1_blocked_issue", "prerequisite_for_3_blocked_issues"} {
+		t.Run(reason, func(t *testing.T) {
+			row := telemetry.SchedulerDecision{Reason: reason}
+			if got := schedulerDecisionReasonLabel(row); got != reason {
+				t.Fatalf("reason label = %q, want %q", got, reason)
 			}
 		})
 	}

--- a/internal/web/templates/work_data.go
+++ b/internal/web/templates/work_data.go
@@ -186,7 +186,7 @@ func workItemPriority(card projectKanbanCard) (string, string, int) {
 		name = strings.ToLower(strings.TrimSpace(card.DispatchPriorityLabel))
 	}
 	if name == "" && card.UnblockerCount > 0 {
-		name = "unblocker"
+		name = "prerequisite"
 	}
 	if name == "" {
 		return "Unset", "unset", rank

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -469,17 +469,17 @@ test("boosted card explains its direct downstream count", async ({ page }) => {
     hasText: "Add screenshot manifest smoke test",
   });
   const badge = card.locator('[data-board-priority]', {
-    hasText: "unblocker",
+    hasText: "prerequisite",
   });
   await expect(badge).toHaveAttribute(
     "data-help-description",
-    "Unblocks 2 issues.",
+    "Prerequisite for 2 blocked issues.",
   );
   await badge.hover();
   await badge.dispatchEvent("pointerover", { pointerType: "mouse" });
   const tooltip = page.locator("body > #help-tooltip");
   await expect(tooltip).toBeVisible();
-  await expect(tooltip).toContainText("Unblocks 2 issues");
+  await expect(tooltip).toContainText("Prerequisite for 2 blocked issues");
 });
 
 test("board elevated blockers render one compact opt-in alert", async ({


### PR DESCRIPTION
## Summary

- Describe the ranking count as a prerequisite for blocked issues in scheduler reasons, card badges, hover details, and documentation. Dependents can still have other unfinished prerequisites.
- Preserve direct-dependent ranking, priority ordering, and verbatim readability of historical scheduler decisions. Cover both three dependents with other unfinished prerequisites and a single remaining prerequisite.

Fixes #2245

## UI Surface Contract

- [x] N/A: this is the wording correction requested by the issue, with no layout or responsive visibility changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Chrome DevTools verified the prerequisite badge and visible “Prerequisite for 2 blocked issues.” tooltip on an isolated random-port demo. The focused Playwright hover test also passed.

## Test Plan

- [x] Reproduced the misleading scheduler reason with the new table-driven regression before fixing it.
- [x] Focused Go regression, existing ranking, singular/plural card and historical reason display tests.
- [x] Focused Playwright boosted-card test.
- [x] `make check`: all checks passed; 80.0% coverage and configured package/file floors passed.
