### PR TITLE
fix(orchestrator): reject invalid rework waits

### DIFF
--- a/internal/explain/model.go
+++ b/internal/explain/model.go
@@ -222,13 +222,21 @@ type PullRequest struct {
 }
 
 type Gate struct {
-	State       GateState   `json:"state"`
-	SourceState SourceState `json:"source_state"`
-	EvidenceID  string      `json:"evidence_id,omitempty"`
-	Source      string      `json:"source,omitempty"`
-	ObservedAt  *time.Time  `json:"observed_at,omitempty"`
-	Failures    []string    `json:"failures"`
-	Running     []string    `json:"running"`
+	CIState        string      `json:"ci_state,omitempty"`
+	Reason         string      `json:"reason,omitempty"`
+	MergeableState string      `json:"mergeable_state,omitempty"`
+	HeadSHA        string      `json:"head_sha,omitempty"`
+	BaseSHA        string      `json:"base_sha,omitempty"`
+	AuditRunID     int64       `json:"audit_run_id,omitempty"`
+	AuditReason    string      `json:"audit_reason,omitempty"`
+	HumanAction    string      `json:"human_action,omitempty"`
+	State          GateState   `json:"state"`
+	SourceState    SourceState `json:"source_state"`
+	EvidenceID     string      `json:"evidence_id,omitempty"`
+	Source         string      `json:"source,omitempty"`
+	ObservedAt     *time.Time  `json:"observed_at,omitempty"`
+	Failures       []string    `json:"failures"`
+	Running        []string    `json:"running"`
 }
 
 type SourceStatus struct {

--- a/internal/explain/required_gate_test.go
+++ b/internal/explain/required_gate_test.go
@@ -1,0 +1,44 @@
+package explain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestRequiredGateSeparatesCIFromAggregateEvidence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		required     *telemetry.RequiredGate
+		mergeability string
+		want         GateState
+	}{
+		{name: "exact head audit failure", required: &telemetry.RequiredGate{PRNumber: 11, HeadSHA: "head", BaseSHA: "base", State: "failed", Reason: "security_audit_findings", AuditRunID: 13, AuditReason: "unresolved_findings"}, want: GateFailed},
+		{name: "cached pass with current conflict", required: &telemetry.RequiredGate{PRNumber: 11, HeadSHA: "head", BaseSHA: "base", State: "passed", Reason: "ready"}, mergeability: "dirty", want: GateFailed},
+		{name: "conflict", mergeability: "dirty", want: GateFailed},
+		{name: "conflicting", mergeability: "conflicting", want: GateFailed},
+		{name: "capability blocker", required: &telemetry.RequiredGate{PRNumber: 11, HeadSHA: "head", BaseSHA: "base", State: "failed", Reason: "workpad_blocker", HumanAction: "Restore worker-github-cli-auth."}, want: GateFailed},
+		{name: "missing audit", required: &telemetry.RequiredGate{PRNumber: 11, HeadSHA: "head", BaseSHA: "base", State: "pending", Reason: "security_audit_missing"}, want: GatePending},
+		{name: "stale audit failure", required: &telemetry.RequiredGate{PRNumber: 11, HeadSHA: "old", BaseSHA: "base", State: "failed", Reason: "security_audit_findings"}, want: GatePending},
+		{name: "passed configured gate", required: &telemetry.RequiredGate{PRNumber: 11, HeadSHA: "head", BaseSHA: "base", State: "passed", Reason: "ready"}, want: GatePassed},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 5, 19, 18, 8, 0, time.UTC)
+			issue := telemetry.Issue{ID: "issue-1", ProjectID: "detent", PullRequest: &telemetry.PullRequest{Number: 11, HeadSHA: "head", BaseSHA: "base", CIStatus: "success", MergeableState: tt.mergeability}, RequiredGate: tt.required}
+			reader := &evidenceReader{observation: liveIssueObservation(now, issue)}
+			got, err := newTestService(now, reader).Explain(t.Context(), Query{ProjectID: "detent", IssueID: "issue-1"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.RequiredGate.State != tt.want || got.RequiredGate.CIState != "success" {
+				t.Fatalf("required gate = %#v, want aggregate %s and CI success", got.RequiredGate, tt.want)
+			}
+			if tt.required != nil && tt.required.HeadSHA == "head" && (got.RequiredGate.AuditRunID != tt.required.AuditRunID || got.RequiredGate.HumanAction != tt.required.HumanAction) {
+				t.Fatalf("missing evidence: %#v", got.RequiredGate)
+			}
+		})
+	}
+}

--- a/internal/explain/select.go
+++ b/internal/explain/select.go
@@ -910,12 +910,42 @@ func gateFromSnapshot(collected collectedEvidence) (Gate, bool) {
 		}
 	}
 	gate.Running = append(gate.Running, pr.RunningChecks...)
+	gate.CIState = pr.CIStatus
+	gate.MergeableState = pr.MergeableState
+	if required := issue.RequiredGate; required != nil && required.PRNumber == pr.Number &&
+		required.HeadSHA == strings.TrimSpace(pr.HeadSHA) && required.BaseSHA == strings.TrimSpace(pr.BaseSHA) {
+		gate.State = GateState(required.State)
+		gate.Reason = required.Reason
+		gate.HeadSHA = required.HeadSHA
+		gate.BaseSHA = required.BaseSHA
+		gate.AuditRunID = required.AuditRunID
+		gate.AuditReason = required.AuditReason
+		gate.HumanAction = required.HumanAction
+		if gate.State == GateFailed {
+			gate.Failures = append(gate.Failures, required.Reason)
+		}
+	} else if issue.RequiredGate != nil {
+		gate.State = GatePending
+		gate.Reason = "gate_evidence_stale"
+	}
 	if strings.TrimSpace(pr.HydrationUnavailableReason) != "" || strings.TrimSpace(pr.HydrationDegradedReason) != "" {
 		gate.State = GateUnavailable
 		return gate, true
 	}
 	if len(gate.Failures) > 0 {
 		gate.State = GateFailed
+		if len(pr.RequiredCheckFailures) > 0 {
+			gate.Reason = "ci_not_green"
+		}
+		return gate, true
+	}
+	if strings.EqualFold(strings.TrimSpace(pr.MergeableState), "dirty") || strings.EqualFold(strings.TrimSpace(pr.MergeableState), "conflicting") {
+		gate.State = GateFailed
+		gate.Reason = "merge_conflicts"
+		gate.Failures = append(gate.Failures, "merge_conflicts")
+		return gate, true
+	}
+	if issue.RequiredGate != nil {
 		return gate, true
 	}
 	gate.State = normalizedGateState(pr.CIStatus)

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -15,6 +15,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/securityaudit"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
@@ -287,7 +288,11 @@ func (o *Orchestrator) restoreDurableGateWaitCompletions(
 	state *State,
 	issues []connector.Issue,
 ) {
-	if o == nil || state == nil || o.workAttempts == nil {
+	if o == nil || state == nil {
+		return
+	}
+	issues = o.refreshRequiredGateEvidence(ctx, state, issues)
+	if o.workAttempts == nil {
 		return
 	}
 	autoCfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
@@ -300,7 +305,11 @@ func (o *Orchestrator) restoreDurableGateWaitCompletions(
 		if issueID == "" {
 			continue
 		}
-		if _, ok := state.Completed[issueID]; ok {
+		if completed, ok := state.Completed[issueID]; ok {
+			if completed.GateWaitReason == completedReworkGateWaitReason &&
+				(!completedReworkGateWaitEvidenceCurrent(completed, issue) || !o.reworkGateWaitCurrent(ctx, issue)) {
+				delete(state.Completed, issueID)
+			}
 			continue
 		}
 		completion, operational := operationalCompletionFromIssue(issue)
@@ -342,11 +351,20 @@ func (o *Orchestrator) latestSuccessfulGateWaitAttempt(
 	if o == nil || o.workAttempts == nil {
 		return store.WorkAttempt{}, false, nil
 	}
+	if normalizeState(issue.State) == normalizeState(normalizeAutoPromoteConfig(o.cfg.AutoPromote).ReworkState) && !o.reworkGateWaitCurrent(ctx, issue) {
+		return store.WorkAttempt{}, false, nil
+	}
 	attempts, err := o.recentAgentTerminalAttempts(ctx, issue)
 	if err != nil {
 		return store.WorkAttempt{}, false, err
 	}
 	for _, attempt := range attempts {
+		if normalizeState(issue.State) == normalizeState(normalizeAutoPromoteConfig(o.cfg.AutoPromote).ReworkState) {
+			if record, ok := implementProgressRecordFromAttempt(attempt); ok && normalizeState(record.TrackerState) == normalizeState(issue.State) &&
+				attempt.TerminalState != store.WorkAttemptTerminalSuccess {
+				return store.WorkAttempt{}, false, nil
+			}
+		}
 		if attempt.TerminalState != store.WorkAttemptTerminalSuccess {
 			continue
 		}
@@ -447,23 +465,14 @@ func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connecto
 	gateWaitReason := strings.TrimSpace(gateWaitRecord.Reason)
 	if gateWaitReason == completedReworkGateWaitReason {
 		if normalizeState(issue.State) != normalizeState(reworkState) ||
+			strings.TrimSpace(record.WorkpadStatus) == workpad.StatusBlocked || strings.TrimSpace(record.HumanAction) != "" ||
+			!reworkGateWaitPullRequestReady(issue) || reworkGateWaitWorkpadBlocked(issue) ||
 			normalizeState(record.TrackerState) != normalizeState(issue.State) ||
 			record.WorkspaceDiffStats.FilesChanged != 0 ||
 			record.WorkspaceDiffStats.AddedLines != 0 ||
 			record.WorkspaceDiffStats.RemovedLines != 0 ||
 			record.WorkspaceDiffStats.UnpushedCommits != 0 ||
 			strings.TrimSpace(record.WorkspaceDiffStats.Status) == "" {
-			return false
-		}
-		currentSummary := AutoPromoteSummaryFromIssue(issue)
-		currentSignature := autoPromoteReworkSignatureFromIssue(issue, currentSummary)
-		if autoPromoteHasNewStrings(record.CurrentSignature.FailedChecks, currentSignature.FailedChecks) {
-			return false
-		}
-		if !autoPromoteMergeConflicts(gateWaitRecord.MergeableState) && autoPromoteMergeConflicts(currentSummary.MergeableState) {
-			return false
-		}
-		if autoPromoteHasNewFinding(gateWaitRecord.P1Findings, currentSummary.P1Findings) {
 			return false
 		}
 		if issue.StageUpdatedAt != nil && issue.StageUpdatedAt.After(attempt.CompletedAt) {
@@ -511,6 +520,9 @@ func completedReworkGateWaitProgress(
 		normalizeState(dispatchState) != normalizeState(autoCfg.ReworkState) ||
 		!autoPromoteReworkGateWaitTrackedIssue(decision.Issue, cfg, autoCfg) ||
 		decision.Block || decision.DependencyDeferral ||
+		decision.WorkpadStatus != workpad.StatusComplete || decision.HumanAction != "" || decision.Warning != "" ||
+		!reworkGateWaitWorkpadComplete(decision.Issue) || !reworkGateWaitPullRequestReady(decision.Issue) ||
+		!reworkGateWaitAuditReady(cfg.AutoPromote.Gate, decision.SecurityAudit) ||
 		!implementProgressSignatureUsable(decision.CurrentSignature) ||
 		!implementProgressOperationalWorkspaceClean(decision.WorkspaceDiffStats) {
 		return decision, ""
@@ -630,6 +642,9 @@ func autoPromoteCompletedReworkGateWaitCurrent(
 }
 
 func completedReworkGateWaitEvidenceCurrent(completed Completed, issue connector.Issue) bool {
+	if !reworkGateWaitPullRequestReady(issue) || reworkGateWaitWorkpadBlocked(issue) {
+		return false
+	}
 	previous := completed.gateWaitEvidence
 	if strings.TrimSpace(previous.ID) == "" {
 		previous = completed.Issue
@@ -644,47 +659,40 @@ func completedReworkGateWaitEvidenceCurrent(completed Completed, issue connector
 	if issue.StageUpdatedAt != nil && !completed.CompletedAt.IsZero() && issue.StageUpdatedAt.After(completed.CompletedAt) {
 		return false
 	}
-	previousSummary := AutoPromoteSummaryFromIssue(previous)
-	currentSummary := AutoPromoteSummaryFromIssue(issue)
-	if autoPromoteHasNewStrings(previousSummary.FailedChecks, currentSummary.FailedChecks) {
+	return true
+}
+
+func (o *Orchestrator) reworkGateWaitCurrent(ctx context.Context, issue connector.Issue) bool {
+	if !reworkGateWaitPullRequestReady(issue) || reworkGateWaitWorkpadBlocked(issue) {
 		return false
 	}
-	if !autoPromoteMergeConflicts(previousSummary.MergeableState) && autoPromoteMergeConflicts(currentSummary.MergeableState) {
+	refreshed, current := o.refreshImplementCompletionIssue(ctx, issue)
+	return current && reworkGateWaitWorkpadComplete(refreshed) &&
+		reworkGateWaitAuditReady(o.cfg.AutoPromote.Gate, o.securityAuditEvaluation(ctx, refreshed))
+}
+
+func reworkGateWaitWorkpadComplete(issue connector.Issue) bool {
+	signal, ok := autoPromoteIssueWorkpadSignal(issue)
+	return ok && signal != nil && signal.Invalid == nil && signal.Source == workpad.SourceStructured &&
+		strings.TrimSpace(signal.Status) == workpad.StatusComplete && len(signal.Blockers) == 0 && strings.TrimSpace(signal.HumanAction) == ""
+}
+
+func reworkGateWaitWorkpadBlocked(issue connector.Issue) bool {
+	signal, ok := autoPromoteIssueWorkpadSignal(issue)
+	return ok && signal != nil && !reworkGateWaitWorkpadComplete(issue)
+}
+
+func reworkGateWaitPullRequestReady(issue connector.Issue) bool {
+	if issue.PullRequest == nil || implementProgressHydrationUnavailableReason(issue.PullRequest) != "" {
 		return false
 	}
-	return !autoPromoteHasNewFinding(previousSummary.P1Findings, currentSummary.P1Findings)
+	summary := AutoPromoteSummaryFromIssue(issue)
+	return !issue.PullRequest.Draft && !autoPromoteMergeConflicts(summary.MergeableState) && len(summary.P1Findings) == 0 &&
+		len(summary.UnresolvedReviewThreads) == 0 && len(summary.FailedChecks) == 0
 }
 
-func autoPromoteHasNewStrings(previous []string, current []string) bool {
-	previous = uniqueStrings(previous)
-	for _, value := range uniqueStrings(current) {
-		if !slices.Contains(previous, value) {
-			return true
-		}
-	}
-	return false
-}
-
-func autoPromoteHasNewFinding(previous []AutoPromoteFinding, current []AutoPromoteFinding) bool {
-	known := make(map[string]struct{}, len(previous))
-	for _, finding := range previous {
-		known[autoPromoteFindingKey(finding)] = struct{}{}
-	}
-	for _, finding := range current {
-		if _, ok := known[autoPromoteFindingKey(finding)]; !ok {
-			return true
-		}
-	}
-	return false
-}
-
-func autoPromoteFindingKey(finding AutoPromoteFinding) string {
-	return strings.Join([]string{
-		strings.TrimSpace(finding.Body),
-		strings.TrimSpace(finding.URL),
-		strings.TrimSpace(finding.Path),
-		strconv.Itoa(finding.Line),
-	}, "\x00")
+func reworkGateWaitAuditReady(cfg gate.Config, evaluation securityaudit.Evaluation) bool {
+	return !gate.Effective(cfg).SecurityAudit.Enabled || evaluation.Allowed || evaluation.Reason == securityaudit.ReasonMissing
 }
 
 func autoPromoteActiveGateEligibleIssue(

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1196,6 +1196,7 @@ func TestRestoreDurableReworkGateWaitCompletion(t *testing.T) {
 				CIStatus:       "success",
 			})
 			issue.State = "Rework"
+			issue.Comments = []connector.IssueComment{{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```"}}
 			recordedIssue := cloneIssue(issue)
 			if tt.prepareIssue != nil {
 				tt.prepareIssue(&issue)
@@ -1203,7 +1204,7 @@ func TestRestoreDurableReworkGateWaitCompletion(t *testing.T) {
 			signature := autoPromoteReworkSignature{PRNumber: 2030, HeadSHA: "same-head", FailedChecks: tt.recordedFailures}
 			attempt := successfulReworkGateWaitAttempt(now.Add(-2*time.Minute), recordedIssue, signature, tt.includeMarker)
 			attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{attempt}}
-			orch := &Orchestrator{cfg: cfg, workAttempts: attempts}
+			orch := &Orchestrator{cfg: cfg, workAttempts: attempts, connector: &implementProgressConnector{refreshed: issue}}
 			state := newState(cfg)
 
 			orch.restoreDurableGateWaitCompletions(t.Context(), &state, []connector.Issue{issue})

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1133,6 +1133,9 @@ func TestDispatchableCompletedReworkGateWaitEvidence(t *testing.T) {
 			prepareComplete: func(issue *connector.Issue) {
 				issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "completed", Conclusion: "failure"}}
 			},
+			prepareCurrent: func(issue *connector.Issue) {
+				issue.PullRequest.RequiredCheckFailures = nil
+			},
 		},
 		{
 			name: "lane movement permits dispatch",

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/securityaudit"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
@@ -44,6 +45,7 @@ type implementCompletionProgressDecision struct {
 	WorkspaceDiffStats     DiffStats
 	ConsecutiveNoProgress  int
 	WorkpadStatus          string
+	SecurityAudit          securityaudit.Evaluation
 	HumanAction            string
 	TrackerState           string
 	ConsecutiveHumanAction int
@@ -346,6 +348,11 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 	decision.Issue = issue
 	decision.TrackerState = strings.TrimSpace(issue.State)
 	decision.WorkspaceDiffStats = implementProgressReconcilePullRequestEvidence(running.DiffStats, issue.PullRequest)
+	if workpadCurrent {
+		decision.WorkpadStatus = implementProgressArtifactSnapshotFromIssue(issue, true).WorkpadStatus
+		_, decision.HumanAction = implementProgressBlockedHumanAction(issue)
+	}
+	decision.SecurityAudit = o.securityAuditEvaluation(ctx, issue)
 	if workpadCurrent && !pullRequestMerged(issue.PullRequest) && implementProgressDiffStatsClean(decision.WorkspaceDiffStats) && decision.WorkspaceDiffStats.UnpushedCommits == 0 && len(decision.WorkspaceDiffStats.CommitsNotInPullRequest) == 0 {
 		blockers, rejected, deferred := o.evaluateImplementDependencyDeferral(ctx, issue)
 		decision.DependencyBlockers = blockers
@@ -383,6 +390,24 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		return decision
 	}
 	previous, ok := latestImplementProgressSignature(attempts)
+	if decision.WorkpadStatus == workpad.StatusBlocked {
+		decision.Outcome = store.WorkAttemptTerminalNoProgress
+		decision.Reason = "workpad_blocked"
+		decision.ConsecutiveNoProgress = 1 + consecutiveImplementNoProgressAttempts(attempts, signature)
+		decision.Block = decision.NoProgressLimit > 0 && decision.ConsecutiveNoProgress >= decision.NoProgressLimit
+		if decision.Block {
+			decision.BlockReason = noProgressLimitReason
+		}
+		if decision.HumanAction != "" {
+			decision.ConsecutiveHumanAction = 1 + consecutiveImplementBlockedHumanActionAttempts(attempts, decision.HumanAction, decision.TrackerState)
+			decision.Block = decision.ConsecutiveHumanAction >= workpadBlockedUnactionedLimit
+			if decision.Block {
+				decision.Reason = workpadBlockedUnactionedReason
+				decision.BlockReason = workpadBlockedUnactionedReason
+			}
+		}
+		return decision
+	}
 	if ok {
 		decision.PreviousSignature = previous
 		decision.PreviousSignatureFound = true
@@ -620,6 +645,16 @@ func implementProgressBlockedHumanAction(issue connector.Issue) (string, string)
 		return "", ""
 	}
 	humanAction := strings.TrimSpace(signal.HumanAction)
+	if humanAction == "" {
+		for _, blocker := range signal.Blockers {
+			if blocker.Owner == workpad.BlockerOwnerHuman {
+				humanAction = firstNonBlank(blocker.Reason, blocker.Ref, blocker.Identifier)
+				if humanAction != "" {
+					break
+				}
+			}
+		}
+	}
 	if humanAction == "" {
 		return "", ""
 	}

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1143,6 +1143,7 @@ func TestHandleRunResultDoesNotSupersedeReworkPullRequestUpdates(t *testing.T) {
 	completedIssue.State = "Rework"
 	replacementIssue := cloneIssue(completedIssue)
 	replacementIssue.PullRequest.HeadSHA = "replacement-head"
+	replacementIssue.Comments = []connector.IssueComment{{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```"}}
 	signature := autoPromoteReworkSignature{PRNumber: 1070, HeadSHA: "completed-head"}
 	tests := []struct {
 		name   string
@@ -1161,7 +1162,7 @@ func TestHandleRunResultDoesNotSupersedeReworkPullRequestUpdates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tracker := &implementProgressConnector{hydrated: replacementIssue}
+			tracker := &implementProgressConnector{hydrated: replacementIssue, refreshed: replacementIssue}
 			attempts := &implementProgressAttemptStore{history: []store.WorkAttempt{
 				successfulReworkGateWaitAttempt(base.Add(-2*time.Minute), completedIssue, signature, true),
 			}}
@@ -1261,7 +1262,8 @@ func TestHandleRunResultHoldsCompletedReworkGateWait(t *testing.T) {
 
 			issue := implementProgressIssue("same-head")
 			issue.State = "Rework"
-			tracker := &implementProgressConnector{hydrated: issue}
+			issue.Comments = []connector.IssueComment{{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```"}}
+			tracker := &implementProgressConnector{hydrated: issue, refreshed: issue}
 			attempts := &implementProgressAttemptStore{history: tt.history, completionErr: tt.completionErr}
 			cfg := normalizeConfig(Config{
 				Project: scheduler.ProjectCandidate{ID: "detent"},
@@ -1291,6 +1293,7 @@ func TestHandleRunResultHoldsCompletedReworkGateWait(t *testing.T) {
 				DispatchSourceState: "Rework",
 				StartedAt:           base.Add(-time.Minute),
 				DiffStats:           DiffStats{Status: "clean"},
+				DispatchProgress:    implementProgressArtifactSnapshotFromIssue(issue, true),
 			}
 			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: base.Add(-time.Minute)}
 

--- a/internal/orchestrator/required_gate.go
+++ b/internal/orchestrator/required_gate.go
@@ -1,0 +1,84 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/securityaudit"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func (o *Orchestrator) refreshRequiredGateEvidence(ctx context.Context, state *State, issues []connector.Issue) []connector.Issue {
+	issues = cloneIssues(issues)
+	now := time.Now()
+	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	state.RequiredGates = make(map[string]telemetry.RequiredGate, len(issues))
+	for i, issue := range issues {
+		if issue.PullRequest == nil {
+			continue
+		}
+		if normalizeState(issue.State) == normalizeState(normalizeAutoPromoteConfig(o.cfg.AutoPromote).ReworkState) {
+			if refreshed, current := o.refreshImplementCompletionIssue(ctx, issue); current {
+				issue = refreshed
+				issues[i] = refreshed
+			}
+		}
+		summary := AutoPromoteSummaryFromIssue(issue)
+		summary.SecurityAudit = o.securityAuditEvaluation(ctx, issue)
+		if gate.Effective(cfg.Gate).Validator.Enabled {
+			summary.Validator, _, _ = o.validatorStageResult(ctx, issue)
+		}
+		summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(state, issue.ID, cfg, now)
+		state.RequiredGates[issue.ID] = requiredGateFromSummary(issue, summary, cfg, now)
+	}
+	return issues
+}
+
+func requiredGateFromSummary(issue connector.Issue, summary AutoPromoteSummary, cfg AutoPromoteConfig, now time.Time) telemetry.RequiredGate {
+	decision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(summary), now, gate.EvaluationOptions{
+		QuietDuration:              cfg.QuietDuration,
+		AutomatedReviewWaitExpired: summary.AutomatedReviewWaitExpired,
+	})
+	result := telemetry.RequiredGate{State: "pending", Reason: string(decision.Reason), CIState: summary.CIStatus,
+		MergeableState: summary.MergeableState, AuditRunID: summary.SecurityAudit.RunID, AuditReason: summary.SecurityAudit.Reason}
+	if issue.PullRequest != nil {
+		result.PRNumber = issue.PullRequest.Number
+		result.HeadSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
+		result.BaseSHA = strings.TrimSpace(issue.PullRequest.BaseSHA)
+	}
+	switch decision.Action {
+	case gate.ActionPass:
+		result.State = "passed"
+	case gate.ActionRework:
+		result.State = "failed"
+	}
+	if gate.Effective(cfg.Gate).SecurityAudit.Enabled && !summary.SecurityAudit.Allowed && summary.SecurityAudit.Reason != securityaudit.ReasonMissing {
+		result.State = "failed"
+		result.Reason = string(AutoPromoteReasonSecurityAuditFailed)
+		if summary.SecurityAudit.Reason == securityaudit.ReasonUnresolvedFindings {
+			result.Reason = string(AutoPromoteReasonSecurityAuditFindings)
+		}
+	}
+	if len(summary.FailedChecks) > 0 || autoPromoteMergeConflicts(summary.MergeableState) || len(summary.UnresolvedReviewThreads) > 0 {
+		result.State = "failed"
+		result.Reason = string(AutoPromoteReasonCINotGreen)
+		if autoPromoteMergeConflicts(summary.MergeableState) {
+			result.Reason = string(AutoPromoteReasonMergeConflicts)
+		} else if len(summary.UnresolvedReviewThreads) > 0 {
+			result.Reason = string(AutoPromoteReasonUnresolvedReviewThreads)
+		}
+	}
+	if reworkGateWaitWorkpadBlocked(issue) {
+		result.State = "failed"
+		result.Reason = string(AutoPromoteReasonWorkpadBlocker)
+		_, result.HumanAction = implementProgressBlockedHumanAction(issue)
+	}
+	if summary.PullRequestHydrationUnavailableReason != "" || summary.PullRequestHydrationDegradedReason != "" {
+		result.State = "unavailable"
+		result.Reason = string(AutoPromoteReasonPullRequestHydrationUnavailable)
+	}
+	return result
+}

--- a/internal/orchestrator/required_gate_test.go
+++ b/internal/orchestrator/required_gate_test.go
@@ -1,0 +1,123 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/securityaudit"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+func TestRequiredGateReportsConfiguredEvidence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		prepare func(*connector.Issue, *AutoPromoteSummary)
+		state   string
+		reason  string
+	}{
+		{name: "passed", state: "passed", reason: string(gate.ReasonReady)},
+		{name: "audit missing", prepare: func(_ *connector.Issue, s *AutoPromoteSummary) {
+			s.SecurityAudit = securityaudit.Evaluation{Reason: securityaudit.ReasonMissing}
+		}, state: "pending", reason: string(gate.ReasonSecurityAuditMissing)},
+		{name: "audit failed", prepare: func(_ *connector.Issue, s *AutoPromoteSummary) {
+			s.SecurityAudit = securityaudit.Evaluation{RunID: 13, Reason: securityaudit.ReasonFailed}
+		}, state: "failed", reason: string(gate.ReasonSecurityAuditFailed)},
+		{name: "audit findings", prepare: func(_ *connector.Issue, s *AutoPromoteSummary) {
+			s.SecurityAudit = securityaudit.Evaluation{RunID: 13, Reason: securityaudit.ReasonUnresolvedFindings}
+		}, state: "failed", reason: string(gate.ReasonSecurityAuditFindings)},
+		{name: "dirty", prepare: func(_ *connector.Issue, s *AutoPromoteSummary) { s.MergeableState = "dirty" }, state: "failed", reason: string(AutoPromoteReasonMergeConflicts)},
+		{name: "review thread", prepare: func(_ *connector.Issue, s *AutoPromoteSummary) {
+			s.UnresolvedReviewThreads = []connector.PullRequestReviewThread{{}}
+		}, state: "failed", reason: string(AutoPromoteReasonUnresolvedReviewThreads)},
+		{name: "CI failed", prepare: func(_ *connector.Issue, s *AutoPromoteSummary) { s.FailedChecks = []string{"Test"} }, state: "failed", reason: string(AutoPromoteReasonCINotGreen)},
+		{name: "hydration unavailable", prepare: func(_ *connector.Issue, s *AutoPromoteSummary) {
+			s.PullRequestHydrationUnavailableReason = "unavailable"
+		}, state: "unavailable", reason: string(AutoPromoteReasonPullRequestHydrationUnavailable)},
+		{name: "capability blocked", prepare: func(i *connector.Issue, _ *AutoPromoteSummary) {
+			i.Comments = nil
+			i.WorkpadSignal = &workpad.Signal{Source: workpad.SourceStructured, Status: workpad.StatusBlocked, HumanAction: "Restore worker-github-cli-auth."}
+		}, state: "failed", reason: string(AutoPromoteReasonWorkpadBlocker)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := reworkGateWaitTestIssue(workpad.StatusComplete)
+			summary := AutoPromoteSummaryFromIssue(issue)
+			summary.SecurityAudit = securityaudit.Evaluation{Allowed: true, Reason: securityaudit.ReasonReady}
+			if tt.prepare != nil {
+				tt.prepare(&issue, &summary)
+			}
+			cfg := gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false), SecurityAudit: gate.SecurityAuditConfig{Enabled: true}}
+			got := requiredGateFromSummary(issue, summary, AutoPromoteConfig{Gate: cfg}, time.Now())
+			if got.State != tt.state || got.Reason != tt.reason || got.CIState != "success" || got.HeadSHA != issue.PullRequest.HeadSHA {
+				t.Fatalf("required gate = %#v, want %s/%s with green CI and exact head", got, tt.state, tt.reason)
+			}
+			if tt.name == "capability blocked" && got.HumanAction == "" {
+				t.Fatal("capability recovery requirement missing")
+			}
+		})
+	}
+}
+
+func TestRequiredGateSnapshotBindsExactPullRequest(t *testing.T) {
+	t.Parallel()
+	issue := reworkGateWaitTestIssue(workpad.StatusComplete)
+	for _, tt := range []struct {
+		name   string
+		change func(*telemetry.RequiredGate)
+		want   bool
+	}{
+		{name: "exact head", want: true},
+		{name: "old head", change: func(g *telemetry.RequiredGate) { g.HeadSHA = "old" }},
+		{name: "old base", change: func(g *telemetry.RequiredGate) { g.BaseSHA = "old" }},
+		{name: "different PR", change: func(g *telemetry.RequiredGate) { g.PRNumber++ }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			required := telemetry.RequiredGate{State: "failed", PRNumber: issue.PullRequest.Number, HeadSHA: issue.PullRequest.HeadSHA, BaseSHA: issue.PullRequest.BaseSHA, AuditRunID: 13}
+			if tt.change != nil {
+				tt.change(&required)
+			}
+			state := newState(normalizeConfig(Config{}))
+			state.RequiredGates = map[string]telemetry.RequiredGate{issue.ID: required}
+			snapshots := []telemetry.Issue{{ID: issue.ID}}
+			state.applyAutoPromoteDecisionSnapshots(snapshots, []connector.Issue{issue}, time.Now())
+			if (snapshots[0].RequiredGate != nil) != tt.want {
+				t.Fatalf("snapshot = %#v, want evidence %t", snapshots[0], tt.want)
+			}
+		})
+	}
+}
+
+func TestRequiredGateRetainsConfiguredPassiveWaits(t *testing.T) {
+	t.Parallel()
+	issue := reworkGateWaitTestIssue(workpad.StatusComplete)
+	now := time.Date(2026, 9, 5, 19, 18, 8, 0, time.UTC)
+	for _, tt := range []struct {
+		name string
+		cfg  AutoPromoteConfig
+		want string
+	}{
+		{name: "review quiet window", cfg: AutoPromoteConfig{QuietDuration: time.Minute, Gate: gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)}}, want: string(gate.ReasonAutomatedReviewNotQuiet)},
+		{name: "validator missing", cfg: AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false), Validator: gate.ValidatorConfig{Enabled: true}}}, want: string(gate.ReasonValidatorMissing)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			summary := AutoPromoteSummaryFromIssue(issue)
+			summary.LastActivityAt = &now
+			got := requiredGateFromSummary(issue, summary, tt.cfg, now)
+			if got.State != "pending" || got.Reason != tt.want {
+				t.Fatalf("gate=%#v, want pending/%s", got, tt.want)
+			}
+			orch := &Orchestrator{cfg: Config{AutoPromote: tt.cfg}, connector: &implementProgressConnector{refreshed: issue}}
+			state := newState(orch.cfg)
+			orch.refreshRequiredGateEvidence(t.Context(), &state, []connector.Issue{issue})
+			if state.RequiredGates[issue.ID].State == "passed" {
+				t.Fatalf("passive wait passed: %#v", state.RequiredGates[issue.ID])
+			}
+		})
+	}
+}

--- a/internal/orchestrator/rework_gate_wait_test.go
+++ b/internal/orchestrator/rework_gate_wait_test.go
@@ -1,0 +1,378 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/securityaudit"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+func TestReworkGateWaitRejectsActionableCompletion(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		status       string
+		mergeability string
+		humanAction  string
+	}{
+		{name: "recorded auth blocker and dirty PR", status: workpad.StatusBlocked, mergeability: "dirty", humanAction: "Restore worker-github-cli-auth under the configured credential policy."},
+		{name: "dirty PR with completed Workpad", status: workpad.StatusComplete, mergeability: "dirty"},
+		{name: "clean PR with incomplete Workpad", status: workpad.StatusInProgress, mergeability: "clean"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := implementProgressIssue("same-head")
+			issue.State = "Rework"
+			issue.PullRequest.MergeableState = tt.mergeability
+			issue.WorkpadSignal = &workpad.Signal{Source: workpad.SourceStructured, Status: tt.status, HumanAction: tt.humanAction}
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Rework"}, AutoPromote: AutoPromoteConfig{Enabled: true, GateWaitState: autoPromoteGateWaitSource, Gate: gate.Config{Kind: gate.KindCommand}}})
+			decision := implementCompletionProgressDecision{Issue: issue, Outcome: store.WorkAttemptTerminalNoProgress, WorkpadStatus: tt.status, Reason: "unchanged_signature_clean_diff", CurrentSignature: autoPromoteReworkSignature{PRNumber: 1070, HeadSHA: "same-head"}, WorkspaceDiffStats: DiffStats{Status: "clean"}}
+			got, reason := completedReworkGateWaitProgress(Running{Issue: issue}, decision, cfg, FinalStateCompleted)
+			if reason != "" || got.Outcome == store.WorkAttemptTerminalSuccess {
+				t.Fatalf("actionable completion became successful wait: outcome=%s reason=%s", got.Outcome, reason)
+			}
+		})
+	}
+}
+
+func TestReworkGateWaitHistoryCannotResurrectSupersededWait(t *testing.T) {
+	t.Parallel()
+	issue := reworkGateWaitTestIssue(workpad.StatusComplete)
+	now := time.Date(2026, 9, 5, 19, 18, 8, 0, time.UTC)
+	valid := successfulReworkGateWaitAttempt(now, issue, autoPromoteReworkSignature{PRNumber: int64(issue.PullRequest.Number), HeadSHA: issue.PullRequest.HeadSHA}, true)
+	failed := valid
+	failed.TerminalState = store.WorkAttemptTerminalNoProgress
+	for _, tt := range []struct {
+		name    string
+		history []store.WorkAttempt
+		err     error
+		want    bool
+	}{
+		{name: "newer no progress supersedes wait", history: []store.WorkAttempt{failed, valid}},
+		{name: "ignore unrelated failed plan", history: []store.WorkAttempt{{TerminalState: store.WorkAttemptTerminalFailure}, valid}, want: true},
+		{name: "history unavailable", err: errors.New("history unavailable")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			orch := &Orchestrator{cfg: normalizeConfig(Config{ActiveStates: []string{"Rework"}, AutoPromote: AutoPromoteConfig{Enabled: true, GateWaitState: autoPromoteGateWaitSource, Gate: gate.Config{Kind: gate.KindCommand}}}), connector: &implementProgressConnector{refreshed: issue}, workAttempts: &recordingWorkAttemptStore{history: tt.history, historyErr: tt.err}, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			_, ok, err := orch.latestSuccessfulGateWaitAttempt(t.Context(), issue)
+			if ok != tt.want || !errors.Is(err, tt.err) {
+				t.Fatalf("found=%t err=%v, want=%t/%v", ok, err, tt.want, tt.err)
+			}
+			state := State{}
+			orch.restoreDurableGateWaitCompletions(t.Context(), &state, []connector.Issue{{}, issue})
+			if _, restored := state.Completed[issue.ID]; restored != tt.want {
+				t.Fatalf("restored=%t, want=%t", restored, tt.want)
+			}
+		})
+	}
+}
+
+func TestReworkGateWaitRejectsMismatchedDurableEvidence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		mutate func(*connector.Issue, *store.WorkAttempt)
+	}{
+		{name: "missing PR", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.PullRequest = nil }},
+		{name: "missing PR number", mutate: func(i *connector.Issue, _ *store.WorkAttempt) {
+			i.PullRequest.Number = 0
+			i.PRNumber = nil
+			i.PullRequest.URL = ""
+		}},
+		{name: "different attempt PR", mutate: func(_ *connector.Issue, a *store.WorkAttempt) { a.PRNumber = new(int64(999)) }},
+		{name: "different signature PR", mutate: func(i *connector.Issue, a *store.WorkAttempt) {
+			a.PRNumber = nil
+			i.PullRequest.Number = 999
+			i.PRNumber = new(999)
+		}},
+		{name: "malformed wait metadata", mutate: func(_ *connector.Issue, a *store.WorkAttempt) { a.WorkerMetadataJSON = "{" }},
+		{name: "unavailable PR hydration", mutate: func(i *connector.Issue, _ *store.WorkAttempt) {
+			i.PullRequest.HydrationUnavailableReason = "unavailable"
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := reworkGateWaitTestIssue(workpad.StatusComplete)
+			attempt := successfulReworkGateWaitAttempt(time.Now(), issue, autoPromoteReworkSignature{PRNumber: int64(issue.PullRequest.Number), HeadSHA: issue.PullRequest.HeadSHA}, true)
+			tt.mutate(&issue, &attempt)
+			if gateWaitAttemptMatchesPullRequest(attempt, issue, "Rework") {
+				t.Fatal("mismatched durable completion was restored")
+			}
+			if tt.name == "malformed wait metadata" {
+				if _, ok := completionGateWaitRecordFromAttempt(attempt); ok {
+					t.Fatal("malformed metadata accepted")
+				}
+			}
+		})
+	}
+}
+
+func TestGateWaitHelpersTolerateMissingState(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	var orch *Orchestrator
+	orch.restoreDurableGateWaitCompletions(ctx, nil, nil)
+	if attempts, err := orch.recentAgentTerminalAttempts(ctx, connector.Issue{}); err != nil || len(attempts) != 0 {
+		t.Fatalf("attempts=%v err=%v", attempts, err)
+	}
+	if autoPromoteCompletedFinalState(nil, "issue") != "" || autoPromoteOperationalCompletionAccepted(nil, "issue") || autoPromoteReviewWaitExpired(nil, "issue", AutoPromoteConfig{}, time.Now()) || autoPromoteIssueCompleted(nil, "issue") {
+		t.Fatal("absent state supplied completion evidence")
+	}
+	if autoPromoteActiveGatePendingIssue(connector.Issue{}, nil, Config{}, AutoPromoteConfig{}) {
+		t.Fatal("absent state supplied gate wait")
+	}
+	recordAutoPromoteSnapshotDecision(nil, "issue", AutoPromoteDecision{})
+	state := newState(normalizeConfig(Config{}))
+	recordAutoPromoteSnapshotDecision(&state, "", AutoPromoteDecision{})
+	state.AutoPromoteDecisions["issue"] = autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen)
+	recordAutoPromoteSnapshotDecision(&state, "issue", autoPromoteDecision(AutoPromoteActionPromote, AutoPromoteReasonReady))
+	if len(state.AutoPromoteDecisions) != 0 {
+		t.Fatal("superseded wait remains visible")
+	}
+}
+
+func reworkGateWaitTestIssue(status string) connector.Issue {
+	issue := securityAuditTestIssue()
+	issue.AssignedToWorker = true
+	issue.State = "Rework"
+	issue.PullRequest.State = "OPEN"
+	issue.PullRequest.MergeableState = "clean"
+	issue.PullRequest.CIStatus = "success"
+	issue.Comments = []connector.IssueComment{{Body: fmt.Sprintf("## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: %s\nblockers: []\nhuman_action: null\n```", status)}}
+	return issue
+}
+
+func assertReworkGateWaitSafety(t *testing.T, stateIndex uint8, mergeIndex uint8, severityIndex uint8, metadata bool) {
+	t.Helper()
+	statuses := []string{workpad.StatusComplete, workpad.StatusBlocked, workpad.StatusInProgress, ""}
+	mergeabilities := []string{"clean", "dirty", "conflicting"}
+	severities := []string{"p1", "p2", "p3", ""}
+	status := statuses[int(stateIndex)%len(statuses)]
+	mergeability := mergeabilities[int(mergeIndex)%len(mergeabilities)]
+	severity := severities[int(severityIndex)%len(severities)]
+	issue := reworkGateWaitTestIssue(status)
+	issue.PullRequest.MergeableState = mergeability
+	issue.WorkpadSignal = &workpad.Signal{Source: workpad.SourceStructured, Status: status}
+	run := securityAuditPassingRun(issue)
+	if severity != "" {
+		run.Verdict = securityaudit.VerdictFail
+		run.Findings = []securityaudit.Finding{{ID: "repair", Severity: severity}}
+	}
+	key := securityaudit.Key{ProjectID: run.ProjectID, Repository: run.Repository, PRNumber: run.PRNumber, BaseSHA: run.BaseSHA, HeadSHA: run.HeadSHA}
+	audit := securityaudit.Evaluate(run, nil, key, run.ServiceIdentity, []string{"p1", "p2"})
+	cfg := normalizeConfig(Config{ActiveStates: []string{"Rework"}, AutoPromote: AutoPromoteConfig{Enabled: true, GateWaitState: autoPromoteGateWaitSource, Gate: gate.Config{Kind: gate.KindCommand, SecurityAudit: gate.SecurityAuditConfig{Enabled: true, BlockOn: []string{"p1", "p2"}}}}})
+	decision := implementCompletionProgressDecision{Issue: issue, Outcome: store.WorkAttemptTerminalNoProgress, WorkpadStatus: status, SecurityAudit: audit, CurrentSignature: autoPromoteReworkSignature{PRNumber: int64(issue.PullRequest.Number), HeadSHA: issue.PullRequest.HeadSHA}, WorkspaceDiffStats: DiffStats{Status: "clean"}}
+	if !metadata {
+		decision.WorkpadStatus = ""
+	}
+	got, reason := completedReworkGateWaitProgress(Running{Issue: issue}, decision, cfg, FinalStateCompleted)
+	wantWait := metadata && status == workpad.StatusComplete && mergeability == "clean" && (severity == "" || severity == "p3")
+	if (reason != "") != wantWait || (got.Outcome == store.WorkAttemptTerminalSuccess) != wantWait {
+		t.Fatalf("status=%s mergeability=%s severity=%s metadata=%t: outcome=%s reason=%s wantWait=%t", status, mergeability, severity, metadata, got.Outcome, reason, wantWait)
+	}
+}
+
+func TestReworkGateWaitSafetyMatrix(t *testing.T) {
+	t.Parallel()
+	for state := range uint8(4) {
+		for merge := range uint8(3) {
+			for severity := range uint8(4) {
+				for _, metadata := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%d_%d_%d_%t", state, merge, severity, metadata), func(t *testing.T) {
+						t.Parallel()
+						assertReworkGateWaitSafety(t, state, merge, severity, metadata)
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestReworkGateWaitReloadReconcilesRepairs(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		mergeability string
+		severity     string
+		status       string
+		wantWait     bool
+	}{
+		{name: "valid completed wait", mergeability: "clean", status: workpad.StatusComplete, wantWait: true},
+		{name: "dirty to dirty", mergeability: "dirty", status: workpad.StatusComplete},
+		{name: "configured P2 remains unresolved", mergeability: "clean", severity: "p2", status: workpad.StatusComplete},
+		{name: "nonblocking P3", mergeability: "clean", severity: "p3", status: workpad.StatusComplete, wantWait: true},
+		{name: "blocked Workpad", mergeability: "clean", status: workpad.StatusBlocked},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			issue := reworkGateWaitTestIssue(tt.status)
+			issue.PullRequest.MergeableState = tt.mergeability
+			now := time.Date(2026, 9, 5, 19, 18, 8, 0, time.UTC)
+			attempt := successfulReworkGateWaitAttempt(now, issue, autoPromoteReworkSignature{PRNumber: int64(issue.PullRequest.Number), HeadSHA: issue.PullRequest.HeadSHA}, true)
+			path := filepath.Join(t.TempDir(), "restart.db")
+			db, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			id, err := db.StartWorkAttempt(ctx, store.WorkAttemptStart{ProjectID: "detent", IssueID: issue.ID, Identifier: issue.Identifier, IssueURL: issue.URL, WorkerType: "agent", Lane: "Rework", StartedAt: attempt.StartedAt, PRNumber: attempt.PRNumber})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := db.CompleteWorkAttempt(ctx, store.WorkAttemptCompletion{AttemptID: id, CompletedAt: now, TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: attempt.WorkerMetadataJSON}); err != nil {
+				t.Fatal(err)
+			}
+			run := securityAuditPassingRun(issue)
+			run.RecordedAt = now
+			if tt.severity != "" {
+				run.Verdict = securityaudit.VerdictFail
+				run.Findings = []securityaudit.Finding{{ID: "repair", Severity: tt.severity, Body: "Repair the configured blocking finding."}}
+			}
+			if _, err := db.RecordSecurityAuditRun(ctx, run); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			db, err = store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+			orch := securityAuditTestOrchestrator(db)
+			orch.cfg.ActiveStates = []string{"Todo", "In Progress", "Rework"}
+			orch.cfg.AutoPromote.Enabled = true
+			orch.cfg.AutoPromote.GateWaitState = autoPromoteGateWaitSource
+			orch.cfg.AutoPromote.Gate.SecurityAudit.BlockOn = []string{"p1", "p2"}
+			orch.cfg = normalizeConfig(orch.cfg)
+			orch.connector = &implementProgressConnector{hydrated: issue, refreshed: issue}
+			orch.workAttempts = db
+			for _, cached := range []bool{false, true} {
+				state := newState(orch.cfg)
+				if cached {
+					state.Completed[issue.ID] = completedFromGateWaitAttempt(issue, attempt)
+				}
+				orch.restoreDurableGateWaitCompletions(ctx, &state, []connector.Issue{issue})
+				decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now.Add(time.Hour), "")
+				if wait := decision.reason == dispatchSkipAwaitingGate; wait != tt.wantWait || decision.dispatchable == tt.wantWait {
+					t.Fatalf("cached=%t dispatch=%#v, want wait=%t", cached, decision, tt.wantWait)
+				}
+				if tt.severity == "p2" && state.RequiredGates[issue.ID].State != "failed" {
+					t.Fatalf("audit gate = %#v", state.RequiredGates[issue.ID])
+				}
+			}
+		})
+	}
+}
+
+func TestReworkCapabilityBlockerIsBoundedWithDependentTodo(t *testing.T) {
+	t.Parallel()
+	for _, humanAction := range []bool{true, false} {
+		t.Run(fmt.Sprintf("explicit_human_action_%t", humanAction), func(t *testing.T) {
+			t.Parallel()
+			issue := reworkGateWaitTestIssue(workpad.StatusBlocked)
+			action := "Restore worker-github-cli-auth under the configured credential policy."
+			declaration := "human_action: " + action
+			if !humanAction {
+				declaration = "human_action: null\nblockers:\n  - reason: " + action + "\n    owner: human\n    recheck_interval: tick"
+			}
+			issue.Comments[0].Body = "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\n" + declaration + "\n```"
+			issue.PullRequest.MergeableState = "dirty"
+			tracker := &implementProgressConnector{hydrated: issue, refreshed: issue}
+			attempts := &implementProgressAttemptStore{}
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Todo", "In Progress", "Rework"}, TerminalStates: []string{"Done"}, AutoPromote: AutoPromoteConfig{Enabled: true, GateWaitState: autoPromoteGateWaitSource, NoProgressLimit: 3, Gate: gate.Config{Kind: gate.KindCommand}}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			state := newState(cfg)
+			for n := 1; n <= workpadBlockedUnactionedLimit; n++ {
+				now := time.Date(2026, 9, 5, 19, n, 0, 0, time.UTC)
+				state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: int64(n), Mode: runpkg.RunModeImplement, StartedAt: now.Add(-time.Minute), DiffStats: DiffStats{Status: "clean"}}
+				orch.handleRunResult(context.Background(), &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: now, Request: runpkg.RunRequest{Mode: runpkg.RunModeImplement}, Result: runpkg.RunResult{FinalState: FinalStateCompleted, DiffStats: DiffStats{Status: "clean"}}})
+				completion := attempts.completions[len(attempts.completions)-1]
+				if completion.TerminalState != store.WorkAttemptTerminalNoProgress {
+					t.Fatalf("terminal state = %s", completion.TerminalState)
+				}
+				attempt := store.WorkAttempt{ID: int64(n), TerminalState: completion.TerminalState, WorkerMetadataJSON: completion.WorkerMetadataJSON}
+				if completionGateWaitReasonFromAttempt(attempt) != "" {
+					t.Fatal("capability blocker became a wait")
+				}
+				record, ok := implementProgressRecordFromAttempt(attempt)
+				if !ok || record.HumanAction != action {
+					t.Fatalf("lost human action: %#v", record)
+				}
+				attempts.history = append([]store.WorkAttempt{attempt}, attempts.history...)
+			}
+			if len(tracker.updates) == 0 || tracker.updates[len(tracker.updates)-1].state != blockedStatusState {
+				t.Fatalf("updates = %#v", tracker.updates)
+			}
+			if len(tracker.comments) == 0 || !strings.Contains(tracker.comments[len(tracker.comments)-1].body, action) {
+				t.Fatal("park lost recovery requirement")
+			}
+			child := dispatchTestIssue("child", "Todo")
+			child.BlockedBy = []connector.BlockedRef{{Identifier: issue.Identifier, State: "Blocked"}}
+			decision := orch.dispatchPlanner().dispatchableIssueDecision(child, &state, false, time.Now(), "")
+			if decision.dispatchable || decision.reason != dispatchSkipBlockedByDependency {
+				t.Fatalf("dependent Todo dispatch=%#v", decision)
+			}
+		})
+	}
+}
+
+func TestReworkGateWaitRejectsDirtyToDirtyEvidence(t *testing.T) {
+	t.Parallel()
+	issue := implementProgressIssue("same-head")
+	issue.State = "Rework"
+	issue.PullRequest.MergeableState = "dirty"
+	issue.WorkpadSignal = &workpad.Signal{Source: workpad.SourceStructured, Status: workpad.StatusBlocked, HumanAction: "Restore worker-github-cli-auth."}
+	attempt := successfulReworkGateWaitAttempt(time.Now(), issue, autoPromoteReworkSignature{PRNumber: 1070, HeadSHA: "same-head"}, true)
+	if gateWaitAttemptMatchesPullRequest(attempt, issue, "Rework") {
+		t.Fatal("dirty-to-dirty durable completion remains eligible after restart")
+	}
+	if completedReworkGateWaitEvidenceCurrent(completedFromGateWaitAttempt(issue, attempt), issue) {
+		t.Fatal("dirty-to-dirty in-memory completion remains eligible")
+	}
+}
+
+func TestInvalidReworkWaitPreservesIndependentParks(t *testing.T) {
+	t.Parallel()
+	for _, reason := range []string{spendProgressReason, dispatchLoopDetectedReason} {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
+			issue := reworkGateWaitTestIssue(workpad.StatusComplete)
+			issue.PullRequest.MergeableState = "dirty"
+			now := time.Date(2026, 9, 5, 19, 18, 8, 0, time.UTC)
+			attempt := successfulReworkGateWaitAttempt(now, issue, autoPromoteReworkSignature{PRNumber: int64(issue.PullRequest.Number), HeadSHA: issue.PullRequest.HeadSHA}, true)
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Rework"}, AutoPromote: AutoPromoteConfig{Enabled: true, GateWaitState: autoPromoteGateWaitSource, Gate: gate.Config{Kind: gate.KindCommand}}})
+			orch := &Orchestrator{cfg: cfg, connector: &implementProgressConnector{refreshed: issue}, workAttempts: &recordingWorkAttemptStore{history: []store.WorkAttempt{attempt}}}
+			state := newState(cfg)
+			state.Completed[issue.ID] = completedFromGateWaitAttempt(issue, attempt)
+			state.Blocked[issue.ID] = Blocked{Issue: issue, Reason: reason}
+			orch.restoreDurableGateWaitCompletions(t.Context(), &state, []connector.Issue{issue})
+			if _, exists := state.Completed[issue.ID]; exists {
+				t.Fatal("invalid completion survived")
+			}
+			if state.Blocked[issue.ID].Reason != reason {
+				t.Fatal("independent park was cleared")
+			}
+			if decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, ""); decision.dispatchable || decision.reason == dispatchSkipAwaitingGate {
+				t.Fatalf("dispatch=%#v", decision)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -33,6 +33,7 @@ func (s *releaseErrorSafetyScheduler) ReleaseSlot(slot scheduler.Slot) error {
 }
 
 func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
+	f.Add(0, 0, 0, "", "blocked", int64(1), "same-head", "p2", int64(1), "same-head", "completed_rework_gate_wait", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, true, uint8(17))
 	f.Add(0, 0, 0, "", "```detent-human\nschema: 1\n```", int64(1), "head", "Depends on: owner/repo#1 #2", int64(1), "head", "", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, uint8(0))
 	f.Add(0, 0, 0, "", "```detent-human\nschema: invalid\n", int64(1), "head", "Depends on: #1bad https://github.com/owner/repo/issues/0", int64(1), "head", "", int64(0), int64(0), false, int64(0), int64(0), int64(0), false, false, uint8(0))
 	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true, false, uint8(0))
@@ -69,6 +70,7 @@ func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
 		tracked bool,
 		gateScenario uint8,
 	) {
+		assertReworkGateWaitSafety(t, gateScenario%4, gateScenario/4%3, gateScenario/12%4, tracked)
 		assertHumanDependencyBoundary(t, status, leftChecks)
 		diffStats := DiffStats{
 			FilesChanged: filesChanged,

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -537,6 +537,11 @@ func (s State) applyAutoPromoteDecisionSnapshots(snapshots []telemetry.Issue, is
 			return
 		}
 		issueID := strings.TrimSpace(issues[i].ID)
+		if required, ok := s.RequiredGates[issueID]; ok && issues[i].PullRequest != nil &&
+			required.PRNumber == issues[i].PullRequest.Number && required.HeadSHA == strings.TrimSpace(issues[i].PullRequest.HeadSHA) &&
+			required.BaseSHA == strings.TrimSpace(issues[i].PullRequest.BaseSHA) {
+			snapshots[i].RequiredGate = &required
+		}
 		decision, ok := s.AutoPromoteDecisions[issueID]
 		if !ok {
 			if !s.shouldComputeAutoPromoteSnapshotDecision(issues[i]) {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -71,6 +71,7 @@ type State struct {
 	BoardIssues              []connector.Issue
 	Pipeline                 []connector.Issue
 	AutoPromoteDecisions     map[string]AutoPromoteDecision
+	RequiredGates            map[string]telemetry.RequiredGate
 	Running                  map[string]Running
 	WorkAttempts             []telemetry.WorkAttempt
 	SchedulerDecisions       []telemetry.SchedulerDecision
@@ -475,6 +476,7 @@ func (s State) clone() State {
 		BoardIssues:              cloneIssues(s.BoardIssues),
 		Pipeline:                 cloneIssues(s.Pipeline),
 		AutoPromoteDecisions:     cloneAutoPromoteDecisions(s.AutoPromoteDecisions),
+		RequiredGates:            maps.Clone(s.RequiredGates),
 		WorkAttempts:             cloneTelemetryWorkAttempts(s.WorkAttempts),
 		SchedulerDecisions:       cloneTelemetrySchedulerDecisions(s.SchedulerDecisions),
 		DispatchEscalations:      maps.Clone(s.DispatchEscalations),

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1105,6 +1105,7 @@ type Issue struct {
 	LeaseExpiresAt        *time.Time             `json:"lease_expires_at,omitempty"`
 	LeaseStale            bool                   `json:"lease_stale,omitempty"`
 	GatePending           bool                   `json:"gate_pending,omitempty"`
+	RequiredGate          *RequiredGate          `json:"required_gate,omitempty"`
 	CreatedAt             *time.Time             `json:"created_at,omitempty"`
 	UpdatedAt             *time.Time             `json:"updated_at,omitempty"`
 	StageUpdatedAt        *time.Time             `json:"stage_updated_at,omitempty"`
@@ -1113,6 +1114,19 @@ type Issue struct {
 	RuntimeIdentity       agentidentity.Identity `json:"runtime_identity,omitzero"`
 	ParkSummary           ParkSummary            `json:"park_summary,omitzero"`
 	CompletionProgress    CompletionProgress     `json:"completion_progress,omitzero"`
+}
+
+type RequiredGate struct {
+	State          string `json:"state"`
+	Reason         string `json:"reason,omitempty"`
+	PRNumber       int    `json:"pr_number,omitempty"`
+	HeadSHA        string `json:"head_sha,omitempty"`
+	BaseSHA        string `json:"base_sha,omitempty"`
+	CIState        string `json:"ci_state,omitempty"`
+	MergeableState string `json:"mergeable_state,omitempty"`
+	AuditRunID     int64  `json:"audit_run_id,omitempty"`
+	AuditReason    string `json:"audit_reason,omitempty"`
+	HumanAction    string `json:"human_action,omitempty"`
 }
 
 type CompletionProgress struct {

--- a/scripts/coverage-exceptions.txt
+++ b/scripts/coverage-exceptions.txt
@@ -2,6 +2,7 @@
 github.com/digitaldrywood/detent/internal/config/cmd/configdoc 0 # Config documentation command wiring delegates to the tested generator package.
 github.com/digitaldrywood/detent/internal/admission/dependencies.go 90
 github.com/digitaldrywood/detent/internal/admission/manager.go 90 # Safety-critical admission capacity gate and cleanup.
+github.com/digitaldrywood/detent/internal/orchestrator/autopromote_tick.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/backend_capacity.go 90 # Safety-critical backend capacity brake.
 github.com/digitaldrywood/detent/internal/connector/human.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/dependency_autounblock.go 90
@@ -11,6 +12,8 @@ github.com/digitaldrywood/detent/internal/orchestrator/human_prerequisite.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/implement_dependency_deferral.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/implement_progress.go 90 # Safety-critical no-progress brake.
 github.com/digitaldrywood/detent/internal/orchestrator/ranking.go 90 # Safety-critical dispatch ranking.
+github.com/digitaldrywood/detent/internal/orchestrator/required_gate.go 90
+github.com/digitaldrywood/detent/internal/orchestrator/snapshot.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/spend_progress.go 90 # Safety-critical spend progress brake.
 github.com/digitaldrywood/detent/internal/scheduler/global_gate.go 90 # Safety-critical fleet-wide dispatch gate.
 github.com/digitaldrywood/detent/internal/scheduler/pool_registry.go 90 # Safety-critical agent-pool dispatch control.


### PR DESCRIPTION
## Summary

- Require current completed Workpad evidence and no actionable repairs before deduplicating a successful Rework completion. Human capability blockers retain bounded non-success outcomes and explicit recovery requirements.
- Reconcile invalid durable waits across restart, including unchanged conflicts and configured P2 audit findings, while preserving dependency gates and independent parks.
- Report the configured aggregate gate separately from CI, with current PR base/head, trusted audit run, conflict, and human-action evidence.

Fixes #2247

## UI Surface Contract

- [x] N/A: no layout, density, first-viewport, or responsive visibility changes.
- [x] No persistent top-of-screen messaging added.
- [x] No visual changes; operator explanation JSON is verified with service tests.

## Test Plan

- [x] Reproduce blocked/dirty unchanged-head completion and durable dirty-to-dirty waiting before the fix.
- [x] Table-driven regressions, real SQLite close/reopen, configured P2/P3 audit behavior, capability/dependency handling, independent parks, and aggregate gate explanations.
- [x] Deterministic safety fuzz seed and 30-second fuzz run.
- [x] `make check` with race tests, NilAway, and package/exact-file coverage gates.
- [x] At least 90% exact-file coverage for changed completion/gate controls, enforced by coverage ratchets.
