### PR TITLE
fix(ci): skip triggers for green PR heads

### DIFF
--- a/docs/retrospection.md
+++ b/docs/retrospection.md
@@ -81,7 +81,13 @@ as the final CI trigger after the latest push. This preserves label ordering
 when a project uses additional CI lane labels. Merging workers also reapply it
 immediately after deterministic head-changing pushes and whenever current-head
 hydration reports required checks as missing, including after a rebase or
-another merge advances the base. Trigger events use a shared lock and persisted
+another merge advances the base. Before scheduling a trigger, Detent refreshes
+the current head's check-runs and commit statuses. When every configured required
+check has succeeded, it skips reapplication even after a restart or a reported
+push. Explicit forced reapplication still repairs CI label ordering. Failed or
+unavailable hydration defers the trigger; streamed no-op push output does not
+count as a head-changing push. Scheduling logs include the reason and current
+required-check states. Trigger events use a shared lock and persisted
 timestamp per repository and are spaced by
 `ci_trigger_label_stagger_seconds` (a positive value, default `15`) to avoid a
 self-hosted CI stampede. `detent doctor` warns when it finds a label-gated

--- a/internal/orchestrator/ci_trigger_label_test.go
+++ b/internal/orchestrator/ci_trigger_label_test.go
@@ -1,0 +1,149 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/synctest"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+)
+
+func TestScheduleCITriggerLabelCurrentHeadChecks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		checks        []connector.PullRequestCheck
+		failures      []connector.PullRequestCheck
+		required      []string
+		head          string
+		hydrationErr  error
+		unavailable   string
+		afterHeadPush bool
+		forceReapply  bool
+		wantReapply   bool
+		wantReason    string
+	}{
+		{
+			name:       "green commit status after restart",
+			checks:     []connector.PullRequestCheck{{Name: "Full CI", Status: "success", Conclusion: "success"}},
+			wantReason: "required_checks_green",
+		},
+		{
+			name:          "green check run after reported push",
+			checks:        []connector.PullRequestCheck{{Name: "Full CI", Status: "completed", Conclusion: "success"}},
+			afterHeadPush: true,
+			wantReason:    "required_checks_green",
+		},
+		{
+			name:         "force preserves label ordering repair",
+			checks:       []connector.PullRequestCheck{{Name: "Full CI", Status: "success", Conclusion: "success"}},
+			forceReapply: true, wantReapply: true, wantReason: "forced_reapply",
+		},
+		{
+			name: "new head lacks old head success",
+			head: "new-head", afterHeadPush: true, wantReapply: true, wantReason: "after_head_push",
+		},
+		{
+			name: "missing required status", wantReapply: true, wantReason: "required_checks_not_green",
+		},
+		{
+			name:        "failed status can retry",
+			checks:      []connector.PullRequestCheck{{Name: "Full CI", Status: "failure", Conclusion: "failure"}},
+			wantReapply: true, wantReason: "required_checks_not_green",
+		},
+		{
+			name:        "pending status is not green",
+			checks:      []connector.PullRequestCheck{{Name: "Full CI", Status: "pending", Conclusion: "pending"}},
+			wantReapply: true, wantReason: "required_checks_not_green",
+		},
+		{
+			name:        "skipped check is not green",
+			checks:      []connector.PullRequestCheck{{Name: "Full CI", Status: "completed", Conclusion: "skipped"}},
+			wantReapply: true, wantReason: "required_checks_not_green",
+		},
+		{
+			name:        "required failure overrides green inventory",
+			checks:      []connector.PullRequestCheck{{Name: "Full CI", Status: "completed", Conclusion: "success"}},
+			failures:    []connector.PullRequestCheck{{Name: "Full CI", Status: "in_progress"}},
+			wantReapply: true, wantReason: "required_checks_not_green",
+		},
+		{
+			name:        "unrelated green check is insufficient",
+			checks:      []connector.PullRequestCheck{{Name: "Lint", Status: "completed", Conclusion: "success"}},
+			wantReapply: true, wantReason: "required_checks_not_green",
+		},
+		{
+			name:        "every configured check must pass",
+			required:    []string{"Full CI", "Security"},
+			checks:      []connector.PullRequestCheck{{Name: "Full CI", Status: "success", Conclusion: "success"}},
+			wantReapply: true, wantReason: "required_checks_not_green",
+		},
+		{
+			name:     "all configured checks pass",
+			required: []string{"Full CI", "Security"},
+			checks: []connector.PullRequestCheck{
+				{Name: "Full CI", Status: "success", Conclusion: "success"},
+				{Name: "Security", Status: "completed", Conclusion: "success"},
+			},
+			wantReason: "required_checks_green",
+		},
+		{
+			name:         "hydration error does not spend CI",
+			hydrationErr: errors.New("unavailable"), wantReason: "pull_request_refresh_failed",
+		},
+		{
+			name:        "deferred hydration does not spend CI",
+			unavailable: connector.PullRequestHydrationReasonRESTBudgetReserved, wantReason: "pull_request_hydration_unavailable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				issue := connector.Issue{
+					ID: "issue-2250", Identifier: "digitaldrywood/detent#2250", PRRepository: "digitaldrywood/detent",
+					PullRequest: &connector.PullRequest{
+						Number: 2250, HeadSHA: "old-head", State: "OPEN", CIStatus: "success",
+						Checks: []connector.PullRequestCheck{{Name: "Full CI", Status: "success", Conclusion: "success"}},
+					},
+				}
+				fresh := cloneIssue(issue)
+				fresh.PullRequest.Checks = tt.checks
+				fresh.PullRequest.RequiredCheckFailures = tt.failures
+				fresh.PullRequest.HydrationUnavailableReason = tt.unavailable
+				if tt.head != "" {
+					fresh.PullRequest.HeadSHA = tt.head
+				}
+				tracker := &autoPromoteTickMergeConnector{
+					hydratedIssues: []connector.Issue{fresh}, hydrateErr: tt.hydrationErr,
+				}
+				var logs mergeFastPathLockedBuffer
+				required := tt.required
+				if required == nil {
+					required = []string{"Full CI"}
+				}
+				orch := &Orchestrator{
+					cfg: Config{AutoPromote: AutoPromoteConfig{Gate: gate.Config{
+						RequiredStatusChecks: required, CITriggerLabel: "run-full-ci",
+					}}},
+					connector: tracker, logger: slog.New(slog.NewTextHandler(&logs, nil)),
+				}
+				got := orch.scheduleCITriggerLabel(context.Background(), issue, []string{"Full CI"}, 1, tt.afterHeadPush, tt.forceReapply)
+				synctest.Wait()
+				if got != tt.wantReapply || (len(tracker.relabels) == 1) != tt.wantReapply {
+					t.Fatalf("scheduled = %v, label events = %d, want reapply %v", got, len(tracker.relabels), tt.wantReapply)
+				}
+				if !strings.Contains(logs.String(), "reason="+tt.wantReason) {
+					t.Fatalf("logs = %s, want reason %s", logs.String(), tt.wantReason)
+				}
+				if tt.wantReapply && !strings.Contains(logs.String(), "required_check_states=") {
+					t.Fatalf("logs = %s, want current required-check states", logs.String())
+				}
+			})
+		})
+	}
+}

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1561,8 +1561,8 @@ func TestHandleRunResultRefreshesNewPullRequestBeforeCITrigger(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for new-PR trigger-label reapplication")
 	}
-	if tracker.hydrations != 1 {
-		t.Fatalf("hydrations = %d, want 1", tracker.hydrations)
+	if tracker.hydrations != 2 {
+		t.Fatalf("hydrations = %d, want 2", tracker.hydrations)
 	}
 }
 
@@ -1647,8 +1647,8 @@ func TestHandleRunResultRefreshesStalePullRequestAfterHydrationFailure(t *testin
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for refreshed-head trigger-label reapplication")
 	}
-	if tracker.hydrations != 2 {
-		t.Fatalf("hydrations = %d, want completion hydration plus push refresh attempt", tracker.hydrations)
+	if tracker.hydrations != 3 {
+		t.Fatalf("hydrations = %d, want completion hydration, push refresh, and trigger refresh", tracker.hydrations)
 	}
 }
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -2201,6 +2201,38 @@ func (o *Orchestrator) scheduleCITriggerLabel(ctx context.Context, issue connect
 		}
 		return false
 	}
+	if len(cfg.RequiredStatusChecks) > 0 {
+		hydrator, ok := o.connector.(connector.PullRequestHydrator)
+		if !ok {
+			if o.logger != nil {
+				o.logger.Info("ci_trigger_label_skipped", append(attrs, "reason", "hydration_unsupported")...)
+			}
+			return false
+		}
+		refreshed, err := hydrator.HydratePullRequest(ctx, issue)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("ci_trigger_label_skipped", append(attrs, "reason", "pull_request_refresh_failed", "error", err)...)
+			}
+			return false
+		}
+		issue = refreshed
+		attrs = mergeWorkerLogAttrs(issue, "required_checks", strings.Join(checkNames, ","))
+		if pullRequestHydrationBlocksProgress(issue.PullRequest) {
+			if o.logger != nil {
+				o.logger.Info("ci_trigger_label_skipped", append(attrs, "reason", "pull_request_hydration_unavailable")...)
+			}
+			return false
+		}
+	}
+	checkStates, green := ciTriggerRequiredCheckStates(issue.PullRequest, cfg.RequiredStatusChecks)
+	attrs = append(attrs, "required_check_states", checkStates, "after_head_push", afterHeadPush, "force_reapply", forceReapply)
+	if green && !forceReapply {
+		if o.logger != nil {
+			o.logger.Info("ci_trigger_label_skipped", append(attrs, "reason", "required_checks_green")...)
+		}
+		return false
+	}
 	repository := pullRequestRepository(issue)
 	number := pullRequestNumber(issue)
 	headSHA := ""
@@ -2252,10 +2284,44 @@ func (o *Orchestrator) scheduleCITriggerLabel(ctx context.Context, issue connect
 	o.ciTriggerLabelHeads[key] = ciTriggerLabelHead{HeadSHA: headSHA, Pending: true}
 	o.ciTriggerLabelMu.Unlock()
 	if o.logger != nil {
-		o.logger.Info("ci_trigger_label_scheduled", append(attrs, "stagger", stagger, "attempt", attempt)...)
+		reason := "required_checks_not_green"
+		if forceReapply {
+			reason = "forced_reapply"
+		} else if afterHeadPush {
+			reason = "after_head_push"
+		}
+		o.logger.Info("ci_trigger_label_scheduled", append(attrs, "reason", reason, "stagger", stagger, "attempt", attempt)...)
 	}
 	go o.reapplyMergeWorkerCITriggerLabel(ctx, reapplier, key, headSHA, repository, number, label, stagger, attrs)
 	return true
+}
+
+func ciTriggerRequiredCheckStates(pr *connector.PullRequest, required []string) ([]connector.PullRequestCheck, bool) {
+	required = gate.NormalizeRequiredStatusChecks(required)
+	checks := make(map[string]connector.PullRequestCheck)
+	if pr != nil {
+		for _, check := range pr.Checks {
+			checks[strings.TrimSpace(check.Name)] = check
+		}
+		for _, check := range pr.RequiredCheckFailures {
+			checks[strings.TrimSpace(check.Name)] = check
+		}
+	}
+	states := make([]connector.PullRequestCheck, 0, len(required))
+	green := len(required) > 0
+	for _, name := range required {
+		check, ok := checks[name]
+		if !ok {
+			check = connector.PullRequestCheck{Name: name, Status: "missing", Conclusion: "missing"}
+		}
+		status := strings.ToLower(strings.TrimSpace(check.Status))
+		if !strings.EqualFold(strings.TrimSpace(check.Conclusion), "success") ||
+			(status != "success" && status != "completed") {
+			green = false
+		}
+		states = append(states, check)
+	}
+	return states, green
 }
 
 func (o *Orchestrator) commentObservedLaneTransition(

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -4216,7 +4216,7 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 			delete(p.deliverableFailures, "push")
 			p.deliverableSuccesses["push"] = true
 			p.deliverableSuccesses["forge_write"] = true
-			if gitPushChanged(update, invocation.command) {
+			if gitPushChanged(update, invocation.command, invocation.output) {
 				p.successfulPushes++
 				p.ciTriggerLabelValid = false
 			}
@@ -4231,7 +4231,7 @@ func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
 			p.deliverableSuccesses["push"] = true
 			p.deliverableSuccesses["ci_trigger_label"] = true
 			p.deliverableSuccesses["forge_write"] = true
-			if gitPushChanged(update, invocation.command) {
+			if gitPushChanged(update, invocation.command, invocation.output) {
 				p.successfulPushes++
 			}
 			p.ciTriggerPushSequence = p.successfulPushes
@@ -4578,11 +4578,11 @@ func commandFlagValue(fields []string, flag string) (string, bool) {
 	return "", false
 }
 
-func gitPushChanged(update AgentUpdate, command string) bool {
+func gitPushChanged(update AgentUpdate, command string, streamedOutput string) bool {
 	if gitPushCommandCount(command) != 1 {
 		return true
 	}
-	output := strings.ToLower(strings.Join([]string{update.Delta, update.BackendErrorMessage, update.BackendErrorBody}, " "))
+	output := strings.ToLower(strings.Join([]string{streamedOutput, update.Delta, update.BackendErrorMessage, update.BackendErrorBody}, " "))
 	return !strings.Contains(output, "everything up-to-date") && !strings.Contains(output, "everything up to date")
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -526,6 +526,24 @@ func TestRunAgentTurnFailsForUnrecoveredDeliverableCommandError(t *testing.T) {
 			wantPullRequestHeadPushed: true,
 		},
 		{
+			name: "streamed no-op push does not change head",
+			updates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "push", Tool: "commandExecution", Delta: "git push origin HEAD"},
+				{Type: AgentUpdateToolOutput, ItemID: "push", Tool: "commandExecution", Delta: "Everything up-to-date"},
+				{Type: AgentUpdateToolCompleted, ItemID: "push", Tool: "commandExecution", Status: "completed"},
+				{Type: AgentUpdateTurnCompleted, Status: "completed"},
+			},
+		},
+		{
+			name: "streamed no-op combined push does not change head",
+			updates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "push", Tool: "commandExecution", Delta: "git push origin HEAD && detent ci-trigger-label --repository digitaldrywood/detent --pull-request 1212 --label ci:ready"},
+				{Type: AgentUpdateToolOutput, ItemID: "push", Tool: "commandExecution", Delta: "Everything up-to-date"},
+				{Type: AgentUpdateToolCompleted, ItemID: "push", Tool: "commandExecution", Status: "completed", Delta: "label reapplied"},
+				{Type: AgentUpdateTurnCompleted, Status: "completed"},
+			},
+		},
+		{
 			name: "CI trigger label after latest push records delivery",
 			updates: []AgentUpdate{
 				{Type: AgentUpdateToolStarted, ItemID: "push", Tool: "commandExecution", Delta: "git push -u origin HEAD"},


### PR DESCRIPTION
## Summary

- Refresh current-head required checks before scheduling CI trigger labels. Already-green heads now skip reapplication even with an empty deduplication map; explicit forced retries remain available. Failed or unavailable hydration suppresses label mutation.
- Include streamed tool output when detecting no-op pushes, and log scheduling reasons with the required-check states.

Fixes #2250

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] No visual changes requiring browser verification.

## Test Plan

- [x] Reproduced green-head label emission and streamed no-op push misclassification with failing table-driven regressions before fixing them.
- [x] Focused orchestrator, runner, and GitHub hydration tests pass, covering required commit statuses/check-runs, multiple required contexts, changed heads, forced retries, and hydration failures.
- [x] `make check` passes: build, lint, vet, NilAway, race suite, 80.1% total coverage, and package/file coverage floors.
