### PR TITLE
feat(agents): add inherited Sol-first selection

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -781,6 +781,8 @@
 #   # agents.backends | type: list<object> | default: [] | required: No | validation: None
 #   backends:
 #     -
+#       # agents.backends[].disabled | type: boolean | default: false when configured | required: No | validation: None
+#       disabled: false
 #       # agents.backends[].id | type: string | default: none | required: Conditional | validation: is required
 #       id: null
 #       # agents.backends[].kind | type: string | default: none | required: Conditional | validation: is required
@@ -835,6 +837,8 @@
 #   # agents.routes | type: list<object> | default: [] | required: No | validation: None
 #   routes:
 #     -
+#       # agents.routes[].disabled | type: boolean | default: false when configured | required: No | validation: None
+#       disabled: false
 #       # agents.routes[].name | type: string | default: none | required: No | validation: None
 #       name: null
 #       # agents.routes[].role | type: string | default: none | required: No | validation: None
@@ -872,6 +876,82 @@
 #         and: []
 #         # agents.routes[].selector.or | type: list<mapping> | default: [] | required: No | validation: None
 #         or: []
+#   # agents.model_selection | type: object | default: see child fields | required: No | validation: None
+#   model_selection:
+#     # agents.model_selection.enabled | type: boolean | default: none | required: No | validation: None
+#     enabled: null
+#     # agents.model_selection.preset | type: string | default: none | required: No | validation: must be sol_first or empty
+#     preset: null
+#     # agents.model_selection.normal_model | type: string | default: none | required: Conditional | validation: is required when enabled
+#     normal_model: null
+#     # agents.model_selection.complex_model | type: string | default: none | required: Conditional | validation: is required when enabled
+#     complex_model: null
+#     # agents.model_selection.backend_kinds | type: list<string> | default: none | required: No | validation: None
+#     backend_kinds: null
+#     # agents.model_selection.default_level | type: string | default: none | required: Conditional | validation: is required when enabled; must reference a configured level
+#     default_level: null
+#     # agents.model_selection.levels | type: mapping<string, mapping> | default: {} | required: No | validation: None
+#     levels:
+#       # agents.model_selection.levels.<name> | type: object | default: backend-dependent | required: No | validation: None
+#       <name>:
+#         # agents.model_selection.levels.<name>.model | type: string | default: backend-dependent | required: No | validation: None
+#         model: null
+#         # agents.model_selection.levels.<name>.effort | type: string | default: none for Claude Code | required: No | validation: None
+#         effort: null
+#     # agents.model_selection.stages | type: mapping<string, mapping> | default: {} | required: No | validation: None
+#     stages:
+#       # agents.model_selection.stages.<name> | type: object | default: backend-dependent | required: No | validation: None
+#       <name>:
+#         # agents.model_selection.stages.<name>.model | type: string | default: backend-dependent | required: No | validation: None
+#         model: null
+#         # agents.model_selection.stages.<name>.effort | type: string | default: none for Claude Code | required: No | validation: None
+#         effort: null
+#         # agents.model_selection.stages.<name>.level | type: string | default: backend-dependent | required: No | validation: None
+#         level: null
+#         # agents.model_selection.stages.<name>.issue_complexity | type: boolean | default: backend-dependent | required: No | validation: None
+#         issue_complexity: null
+#     # agents.model_selection.rules | type: list<object> | default: none | required: No | validation: None
+#     rules:
+#       -
+#         # agents.model_selection.rules[].name | type: string | default: none | required: No | validation: None
+#         name: null
+#         # agents.model_selection.rules[].disabled | type: boolean | default: none | required: No | validation: None
+#         disabled: null
+#         # agents.model_selection.rules[].level | type: string | default: none | required: No | validation: None
+#         level: null
+#         # agents.model_selection.rules[].roles | type: list<string> | default: none | required: No | validation: None
+#         roles: null
+#         # agents.model_selection.rules[].selector | type: object | default: none | required: No | validation: None
+#         selector:
+#           # agents.model_selection.rules[].selector.assignee_in | type: list<string> | default: none | required: No | validation: None
+#           assignee_in: null
+#           # agents.model_selection.rules[].selector.author_in | type: list<string> | default: none | required: No | validation: None
+#           author_in: null
+#           # agents.model_selection.rules[].selector.priority_in | type: list<integer> | default: none | required: No | validation: None
+#           priority_in: null
+#           # agents.model_selection.rules[].selector.labels | type: object | default: none | required: No | validation: None
+#           labels:
+#             # agents.model_selection.rules[].selector.labels.include | type: list<string> | default: none | required: No | validation: None
+#             include: null
+#             # agents.model_selection.rules[].selector.labels.exclude | type: list<string> | default: none | required: No | validation: None
+#             exclude: null
+#           # agents.model_selection.rules[].selector.fields | type: list<object> | default: none | required: No | validation: None
+#           fields:
+#             -
+#               # agents.model_selection.rules[].selector.fields[].name | type: string | default: none | required: No | validation: None
+#               name: null
+#               # agents.model_selection.rules[].selector.fields[].value | type: string | default: none | required: No | validation: None
+#               value: null
+#           # agents.model_selection.rules[].selector.and | type: list<mapping> | default: none | required: No | validation: None
+#           and: null
+#           # agents.model_selection.rules[].selector.or | type: list<mapping> | default: none | required: No | validation: None
+#           or: null
+#         # agents.model_selection.rules[].efforts | type: list<string> | default: none | required: No | validation: None
+#         efforts: null
+#     # agents.model_selection.unavailable | type: string | default: none | required: No | validation: must be fallback or fail
+#     unavailable: null
+#     # agents.model_selection.fallback_order | type: list<string> | default: none | required: No | validation: None
+#     fallback_order: null
 # # codex | type: object | default: see child fields | required: No | validation: agents.backends.protocol must be app-server for codex
 # codex:
 #   # codex.command | type: string | default: "codex app-server" | required: No | validation: is required

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -67,8 +67,9 @@ INSERT INTO codex_sessions (
   provider_session_id,
   resumed_from_session_id,
   orphan_recovery_outcome,
-  orphan_recovery_fallback_reason
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  orphan_recovery_fallback_reason,
+  runtime_identity_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: BackfillSessionProjectID :execrows
@@ -125,7 +126,8 @@ SET agent_backend_id = COALESCE(sqlc.narg(agent_backend_id), agent_backend_id),
     reasoning_effort_provenance = sqlc.narg(reasoning_effort_provenance),
     service_tier = sqlc.narg(service_tier),
     service_tier_provenance = sqlc.narg(service_tier_provenance),
-    identity_observed_at = sqlc.narg(identity_observed_at)
+    identity_observed_at = sqlc.narg(identity_observed_at),
+    runtime_identity_json = sqlc.narg(runtime_identity_json)
 WHERE id = sqlc.arg(id);
 
 -- name: UpdateCodexSessionProviderIdentity :execrows
@@ -195,6 +197,7 @@ SELECT
   CAST(COALESCE(s.agent_backend_id, '') AS TEXT) AS agent_backend_id,
   CAST(COALESCE(s.agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(COALESCE(s.agent_role, '') AS TEXT) AS agent_role,
+  CAST(COALESCE(s.runtime_identity_json, '') AS TEXT) AS runtime_identity_json,
   CAST(COALESCE(w.worker_type, '') AS TEXT) AS worker_type,
   CAST(COALESCE(w.worker_host, '') AS TEXT) AS worker_host,
   CAST(COALESCE(w.lane, '') AS TEXT) AS lane,
@@ -227,6 +230,7 @@ SELECT
   CAST(COALESCE(s.agent_backend_id, '') AS TEXT) AS agent_backend_id,
   CAST(COALESCE(s.agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(COALESCE(s.agent_role, '') AS TEXT) AS agent_role,
+  CAST(COALESCE(s.runtime_identity_json, '') AS TEXT) AS runtime_identity_json,
   CAST(s.completed_at AS TEXT) AS completed_at
 FROM codex_sessions AS s
 JOIN work_attempts AS w ON w.id = s.work_attempt_id
@@ -274,6 +278,7 @@ SELECT
   CAST(COALESCE(agent_backend_id, '') AS TEXT) AS agent_backend_id,
   CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(COALESCE(agent_role, '') AS TEXT) AS agent_role,
+  CAST(COALESCE(runtime_identity_json, '') AS TEXT) AS runtime_identity_json,
   CAST(completed_at AS TEXT) AS completed_at
 FROM codex_sessions
 WHERE completed_at IS NOT NULL

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,6 +10,9 @@ Detent has two configuration layers:
 This page is the single reference for both configuration layers. Project
 configuration is documented below after the host-wide settings.
 
+For instance backend/route inheritance and the opt-in `sol_first` model-selection
+preset, see [Instance agent defaults](multi-project.md#instance-agent-defaults-and-sol-first-selection).
+
 ## Repository policy with Hub execution
 
 Connecting a project to Hub preserves its repository definition. The customer
@@ -860,6 +863,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `agents` | `object` | `see child fields` | No | None |
 | `agents.backends` | `list<object>` | `[]` | No | None |
 | `agents.backends[].command` | `string` | `none` | Conditional | is required |
+| `agents.backends[].disabled` | `boolean` | `false when configured` | No | None |
 | `agents.backends[].id` | `string` | `none` | Conditional | is required |
 | `agents.backends[].kind` | `string` | `none` | Conditional | is required |
 | `agents.backends[].options` | `mapping` | `see child fields` | No | None |
@@ -884,9 +888,47 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `agents.backends[].options.turn_timeout_ms` | `integer` | `Codex: 3600000; Claude Code: 0` | No | must be greater than or equal to 0 |
 | `agents.backends[].protocol` | `string` | `none` | No | must be app-server for codex<br>must be headless for claude_code |
 | `agents.backends[].provider` | `string` | `none` | No | must be a sanitized label containing only letters, numbers, dots, underscores, or hyphens |
+| `agents.model_selection` | `object` | `see child fields` | No | None |
+| `agents.model_selection.backend_kinds` | `list<string>` | `none` | No | None |
+| `agents.model_selection.complex_model` | `string` | `none` | Conditional | is required when enabled |
+| `agents.model_selection.default_level` | `string` | `none` | Conditional | is required when enabled<br>must reference a configured level |
+| `agents.model_selection.enabled` | `boolean` | `none` | No | None |
+| `agents.model_selection.fallback_order` | `list<string>` | `none` | No | None |
+| `agents.model_selection.levels` | `mapping<string, mapping>` | `{}` | No | None |
+| `agents.model_selection.levels.<name>` | `object` | `backend-dependent` | No | None |
+| `agents.model_selection.levels.<name>.effort` | `string` | `none for Claude Code` | No | None |
+| `agents.model_selection.levels.<name>.model` | `string` | `backend-dependent` | No | None |
+| `agents.model_selection.normal_model` | `string` | `none` | Conditional | is required when enabled |
+| `agents.model_selection.preset` | `string` | `none` | No | must be sol_first or empty |
+| `agents.model_selection.rules` | `list<object>` | `none` | No | None |
+| `agents.model_selection.rules[].disabled` | `boolean` | `none` | No | None |
+| `agents.model_selection.rules[].efforts` | `list<string>` | `none` | No | None |
+| `agents.model_selection.rules[].level` | `string` | `none` | No | None |
+| `agents.model_selection.rules[].name` | `string` | `none` | No | None |
+| `agents.model_selection.rules[].roles` | `list<string>` | `none` | No | None |
+| `agents.model_selection.rules[].selector` | `object` | `none` | No | None |
+| `agents.model_selection.rules[].selector.and` | `list<mapping>` | `none` | No | None |
+| `agents.model_selection.rules[].selector.assignee_in` | `list<string>` | `none` | No | None |
+| `agents.model_selection.rules[].selector.author_in` | `list<string>` | `none` | No | None |
+| `agents.model_selection.rules[].selector.fields` | `list<object>` | `none` | No | None |
+| `agents.model_selection.rules[].selector.fields[].name` | `string` | `none` | No | None |
+| `agents.model_selection.rules[].selector.fields[].value` | `string` | `none` | No | None |
+| `agents.model_selection.rules[].selector.labels` | `object` | `none` | No | None |
+| `agents.model_selection.rules[].selector.labels.exclude` | `list<string>` | `none` | No | None |
+| `agents.model_selection.rules[].selector.labels.include` | `list<string>` | `none` | No | None |
+| `agents.model_selection.rules[].selector.or` | `list<mapping>` | `none` | No | None |
+| `agents.model_selection.rules[].selector.priority_in` | `list<integer>` | `none` | No | None |
+| `agents.model_selection.stages` | `mapping<string, mapping>` | `{}` | No | None |
+| `agents.model_selection.stages.<name>` | `object` | `backend-dependent` | No | None |
+| `agents.model_selection.stages.<name>.effort` | `string` | `none for Claude Code` | No | None |
+| `agents.model_selection.stages.<name>.issue_complexity` | `boolean` | `backend-dependent` | No | None |
+| `agents.model_selection.stages.<name>.level` | `string` | `backend-dependent` | No | None |
+| `agents.model_selection.stages.<name>.model` | `string` | `backend-dependent` | No | None |
+| `agents.model_selection.unavailable` | `string` | `none` | No | must be fallback or fail |
 | `agents.routes` | `list<object>` | `[]` | No | None |
 | `agents.routes[].backend` | `string` | `none` | Conditional | is required<br>must reference a configured backend |
 | `agents.routes[].default` | `boolean` | `false when configured` | No | None |
+| `agents.routes[].disabled` | `boolean` | `false when configured` | No | None |
 | `agents.routes[].model` | `string` | `none` | No | None |
 | `agents.routes[].model_field` | `string` | `none` | No | None |
 | `agents.routes[].name` | `string` | `none` | No | None |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -509,3 +509,20 @@ REST telemetry distinguishes `total_requests`, `conditional_requests`,
 `not_modified_requests`, and `billable_requests`. Endpoint contributors expose
 the same breakdown, and the REST rate-limit card's cycle cost uses billable
 requests rather than free `304` checks.
+
+
+## Optional fleet model preset
+
+To make existing and newly onboarded projects use Sol for ordinary work and
+Astra for explicitly complex work, configure `global.agents.model_selection.preset:
+sol_first` in the instance configuration. This defaults omitted effort to medium
+(or high for very complex work) and preserves explicit issue model/effort fields.
+Create `complexity:complex` and `complexity:very-complex` repository labels for
+operators who want those signals, plus `design` if using an inherited Claude
+selector. Generic `enhancement` does not select Astra. Projects inherit each
+omitted setting; `agents.model_selection.enabled: false` opts out.
+
+See the [fleet activation and inheritance examples](multi-project.md#instance-agent-defaults-and-sol-first-selection)
+for full precedence, custom rules, fallback, ambient Claude authentication,
+project opt-out, and pricing limitations. Run `detent doctor` to inspect effective
+settings before dispatching new work.

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -599,3 +599,222 @@ The dashboard and `/api/v1/state` surface each instance identity, authorization
 scope, owner, lease renewal time, lease expiry, and selected model usage, which
 lets operators verify that scoped instances are not contending for the same
 work.
+
+
+## Instance agent defaults and Sol-first selection
+
+Enable the recommended preset once in the instance's `global.yaml`. Existing
+projects and future registrations inherit it without editing their definitions:
+
+```yaml
+global:
+  agents:
+    model_selection:
+      preset: sol_first
+```
+
+This is opt-in. Existing pinned models remain pinned. The preset sets normal
+work to `gpt-5.6-sol` at medium effort; complex work to `gpt-6-astra` at medium;
+and very complex work to Astra at high. It never automatically assigns max.
+Explicit issue effort, including low, xhigh, and max, is retained when supported.
+A provider default changing to Astra does not affect enabled automatic selection.
+
+Host backend and route defaults use the same schema as project `agents`. For
+example, share a Claude design selector alongside each project's Codex default:
+
+```yaml
+global:
+  agents:
+    backends:
+      - id: design
+        kind: claude_code
+        command: /opt/detent/bin/claude-wrapper
+    routes:
+      - name: design
+        backend: design
+        model: sonnet
+        selector:
+          labels:
+            include: [design]
+    model_selection:
+      preset: sol_first
+```
+
+The absolute wrapper command is supported, as is `command: claude`. Authenticate
+Claude Code on the host using its ambient authentication before enabling the
+route. This configuration neither copies credentials nor changes subscription
+billing. The preset's `backend_kinds: [codex]` excludes Claude. The selector's
+explicit `sonnet` remains authoritative for design work.
+
+Backends merge by ID and routes by name. Project entries replace an inherited
+entry as a whole; omitted entries inherit. Project selectors are evaluated in
+project order before inherited selectors in instance order. A project default
+route takes precedence over an instance default for the same role, even when
+named differently. Legacy projects retain their implicit Codex backend and
+default route. Inherited entries require names/IDs. Referenced disabled or missing
+backends make the effective configuration invalid.
+
+A project can opt out of a selector without copying the instance configuration:
+
+```yaml
+agents:
+  routes:
+    - name: design
+      disabled: true
+```
+
+Use `disabled: true` on a backend ID to remove that inherited backend too, and
+remove/disable any routes referencing it. `agents.backends: []` clears inherited
+backends and restores the legacy project Codex backend; `agents.routes: []`
+clears inherited routes and restores the implicit project default route. Disabling
+the named `default` route explicitly suppresses that implicit route.
+
+To migrate repeated `detent.local.yaml` overlays, copy the common backend and
+named selector to `global.agents`, verify with `detent doctor`, then remove each
+redundant project entry. Keep per-project defaults and deliberate deviations.
+During onboarding, create the `design` label in each repository that will use the
+selector; issue labels are not created by loading configuration. Projects with
+pinned models must remove those pins to use automatic selection.
+
+### Policy overrides and clearing
+
+Every policy field inherits independently: preset, enable flag, normal/complex
+models, eligible backend kinds, default level, level model/effort defaults, stage
+model/effort/complexity defaults, ordered rules, unavailable behavior, and fallback
+order. The same `agents.model_selection` schema works in a project's
+`detent.yaml` or `detent.local.yaml`:
+
+```yaml
+agents:
+  model_selection:
+    complex_model: gpt-6-astra
+    levels:
+      very_complex:
+        effort: high
+    stages:
+      validator:
+        model: normal
+        effort: medium
+    unavailable: fallback
+    fallback_order: [normal]
+```
+
+Omission inherits. `enabled: false` disables automatic selection for that project.
+`preset: ""` removes the inherited preset; a fully custom enabled policy must then
+provide normal/complex models, a default level, level defaults, and unavailable
+behavior. `normal` and `complex` in level/stage models and fallback entries refer
+to the configured normal/complex model; any other nonempty string is a literal
+backend model ID. No model catalog choice is inferred from cost or provider order.
+
+`levels` and `stages` merge by name and then by individual field. Explicit `{}`
+clears the corresponding map. Clearing all levels requires disabling the policy
+or supplying a replacement default level. Empty stage model/effort/level strings
+remove that stage override and use the selected level's defaults. Missing stages
+or `issue_complexity: false` do not consume issue-wide complexity signals.
+
+`backend_kinds: []` makes no backend eligible. `fallback_order: []` permits no
+fallback. `rules: []` clears all complexity rules. Nonempty rule lists merge by
+rule name: replacement retains its order, new names append, and `disabled: true`
+disables a named inherited rule. A replacement rule is a complete rule, not a
+field patch. The first matching enabled rule wins. To reorder rules, clear them
+at the instance and supply a complete project list (or use a custom empty preset).
+YAML null is omission, not a clearing operation.
+
+Pricing uses the existing external pricing-file format. Set
+`global.budget.pricing_path: /absolute/path/models.yaml` for an instance default;
+project `budget.pricing_path` overrides it independently. An explicit empty
+project path selects the embedded table. Other budget fields, limits, and
+subscription enforcement are unchanged. Use absolute instance pricing paths so
+projects do not interpret the same relative path from different working directories.
+
+### Complexity and independent precedence
+
+The preset recognizes these deterministic signals; it does not inspect prose or
+make a classification-model call:
+
+| Signal | Automatic model | Default effort |
+| --- | --- | --- |
+| Missing metadata, simple/basic work, or generic `enhancement` alone | Sol | medium |
+| `complexity:complex` for substantive feature/implementation work | Astra | medium |
+| `complexity:very-complex` for subsystems, difficult architecture, state, concurrency, or recovery | Astra | high |
+| Explicit applicable issue xhigh/max, with model omitted | Astra | explicit effort retained |
+
+Priority, entering Rework, waiting for CI, provider errors, and host/backend
+effort defaults are not complexity signals in the preset. Label substantive work
+intentionally; a trivial enhancement needs no complexity label. Code, plan, and
+rework consume issue-wide signals. Routine, merge, validator, and security-audit
+stage defaults suppress issue-wide complexity. A role-specific effort signal or a
+rule with an explicit `roles` list can select complexity for just that stage.
+For example, a custom rule can match issue fields without upgrading every stage:
+
+```yaml
+agents:
+  model_selection:
+    rules:
+      - name: complex-validator
+        roles: [validator]
+        level: complex
+        selector:
+          fields:
+            - name: Validation complexity
+              value: complex
+```
+
+The `detent-agent` block supports model and effort independently for code, rework,
+plan, merge, routine, and validator. Rework falls back to code for
+each omitted role-specific field. The model precedence for normal/validator
+execution is role-specific issue body, issue-wide body, explicit stage model
+(`gate.validator.model` for validators), selected route fixed model, route model
+field, connector issue model, applicable default-route model, then automatic
+selection. Within routing, existing role/default precedence is preserved.
+Effort precedence is role-specific issue body, issue-wide body, project
+`agent.effort`, backend effort, automatic stage effort, then automatic level effort.
+The independent security auditor retains its trusted gate model and does not
+consume issue-body model or effort overrides; its unpinned defaults use the
+configured `security_audit` policy stage.
+A model-only override still receives an effort default; an effort-only override
+still receives an automatic model. Explicit values are never clamped by defaults.
+
+With the policy enabled on an eligible backend, invalid explicit model/effort
+values are reported and dispatch fails; they are never replaced by automatic
+fallback. Policy-disabled and excluded backends retain the existing explicit
+catalog rejection behavior. If an automatic model is missing or retired,
+`unavailable: fallback` tries `fallback_order` in order; the preset tries Sol.
+`unavailable: fail` refuses fallback. No available configured model or a failed
+catalog lookup stops dispatch with an actionable error. It never inherits an
+arbitrary provider default, including during capacity failures.
+
+`detent doctor` shows the effective policy and per-setting instance/project/preset
+sources, plus backend/route provenance without commands or environment values.
+Session runtime identity and session diagnostics record the policy, matched rule
+or default reason, requested automatic model, actual requested/runtime models,
+effort, source fields, and fallback reason. Runtime updates preserve the decision.
+Policy reload affects new dispatches; active snapshots and explicit resumed
+sessions retain their established identity. Missing resume backends require
+restoring that backend or starting fresh. Legacy sessions without stored full
+identity retain legacy recovery checks. Invalid reload retains the last valid
+agent configuration. Hub-approved execution continues to require its approved
+effective policy; inheritance does not authorize unapproved policy changes.
+
+### Pricing provenance
+
+Verified September 7, 2026 against the official [API pricing table](https://developers.openai.com/api/docs/pricing):
+
+| Embedded model | Input USD / 1M | Cached input USD / 1M | Output USD / 1M |
+| --- | ---: | ---: | ---: |
+| gpt-5.6-sol | 4.00 | 0.40 | 20.00 |
+| gpt-5.6 (Sol alias) | 4.00 | 0.40 | 20.00 |
+| gpt-6-astra | 10.00 | 1.00 | 50.00 |
+
+[Sol's model documentation](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
+confirms the alias and promotional pricing through at least November 21, 2026.
+These are standard short-context API estimates, not verified bills or
+subscription invoices. Astra is 2.5 times Sol's token rates for the same token
+mix; task cost also depends on consumption, caching, and retries. Fast mode,
+long-context rates, cache-write premiums, Batch/Flex, and account billing can
+change the estimate. Detent does not separately model cache-write premiums.
+The [subscription credit table](https://learn.chatgpt.com/docs/pricing) uses
+credits, not USD; its published standard Sol/Astra rates are 100/10/500 and
+250/25/1250 per million input/cached/output tokens. Fast-mode multipliers differ
+between billing surfaces; do not apply a universal API-to-credit multiplier.
+External pricing files retain their existing override behavior.

--- a/internal/agentidentity/identity.go
+++ b/internal/agentidentity/identity.go
@@ -56,6 +56,7 @@ func (v Value) Normalize() Value {
 }
 
 type Identity struct {
+	Selection       Selection  `json:"selection,omitzero"`
 	BackendID       string     `json:"backend_id,omitempty"`
 	BackendKind     string     `json:"backend_kind,omitempty"`
 	Route           string     `json:"route,omitempty"`
@@ -66,6 +67,19 @@ type Identity struct {
 	ReasoningEffort Value      `json:"reasoning_effort,omitzero"`
 	ServiceTier     Value      `json:"service_tier,omitzero"`
 	ObservedAt      *time.Time `json:"observed_at,omitempty"`
+}
+
+type Selection struct {
+	Policy         string `json:"policy,omitempty"`
+	PolicySource   string `json:"policy_source,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+	Level          string `json:"level,omitempty"`
+	RequestedModel string `json:"requested_model,omitempty"`
+	ModelSource    string `json:"model_source,omitempty"`
+	EffortSource   string `json:"effort_source,omitempty"`
+	FallbackReason string `json:"fallback_reason,omitempty"`
+	BackendSource  string `json:"backend_source,omitempty"`
+	RouteSource    string `json:"route_source,omitempty"`
 }
 
 func Configured(backendID string, backendKind string, route string, role string, requestedModel string, provider string, effort string, serviceTier string, observedAt time.Time) Identity {
@@ -102,7 +116,7 @@ func RuntimeUpdate(model string, provider string, effort string, serviceTier str
 
 func (i Identity) IsZero() bool {
 	i = i.Normalize()
-	return i.BackendID == "" &&
+	return i.Selection == (Selection{}) && i.BackendID == "" &&
 		i.BackendKind == "" &&
 		i.Route == "" &&
 		i.Role == "" &&
@@ -134,6 +148,9 @@ func (i Identity) Normalize() Identity {
 func (i Identity) Merge(update Identity) Identity {
 	out := i.Normalize()
 	update = update.Normalize()
+	if update.Selection != (Selection{}) {
+		out.Selection = update.Selection
+	}
 	if update.BackendID != "" {
 		out.BackendID = update.BackendID
 	}

--- a/internal/agentoverride/agentoverride.go
+++ b/internal/agentoverride/agentoverride.go
@@ -10,14 +10,19 @@ import (
 )
 
 type Override struct {
-	Model  string
-	Effort string
-	Code   RoleOverride
-	Rework RoleOverride
-	Merge  RoleOverride
+	Model         string
+	Effort        string
+	Code          RoleOverride
+	Rework        RoleOverride
+	Merge         RoleOverride
+	Plan          RoleOverride
+	Routine       RoleOverride
+	Validator     RoleOverride
+	SecurityAudit RoleOverride
 }
 
 type RoleOverride struct {
+	Model  string `yaml:"model"`
 	Effort string `yaml:"effort"`
 }
 
@@ -29,12 +34,16 @@ type RoleEffort struct {
 }
 
 type blockYAML struct {
-	Schema int          `yaml:"schema"`
-	Model  string       `yaml:"model"`
-	Effort string       `yaml:"effort"`
-	Code   RoleOverride `yaml:"code"`
-	Rework RoleOverride `yaml:"rework"`
-	Merge  RoleOverride `yaml:"merge"`
+	Schema        int          `yaml:"schema"`
+	Model         string       `yaml:"model"`
+	Effort        string       `yaml:"effort"`
+	Code          RoleOverride `yaml:"code"`
+	Rework        RoleOverride `yaml:"rework"`
+	Merge         RoleOverride `yaml:"merge"`
+	Plan          RoleOverride `yaml:"plan"`
+	Routine       RoleOverride `yaml:"routine"`
+	Validator     RoleOverride `yaml:"validator"`
+	SecurityAudit RoleOverride `yaml:"security_audit"`
 }
 
 func FromIssueBody(body string) (Override, bool, error) {
@@ -60,15 +69,20 @@ func FromIssueBody(body string) (Override, bool, error) {
 	}
 
 	return Override{
-		Model:  strings.TrimSpace(raw.Model),
-		Effort: strings.TrimSpace(raw.Effort),
-		Code:   normalizeRoleOverride(raw.Code),
-		Rework: normalizeRoleOverride(raw.Rework),
-		Merge:  normalizeRoleOverride(raw.Merge),
+		Model:         strings.TrimSpace(raw.Model),
+		Effort:        strings.TrimSpace(raw.Effort),
+		Code:          normalizeRoleOverride(raw.Code),
+		Rework:        normalizeRoleOverride(raw.Rework),
+		Merge:         normalizeRoleOverride(raw.Merge),
+		Plan:          normalizeRoleOverride(raw.Plan),
+		Routine:       normalizeRoleOverride(raw.Routine),
+		Validator:     normalizeRoleOverride(raw.Validator),
+		SecurityAudit: normalizeRoleOverride(raw.SecurityAudit),
 	}, true, nil
 }
 
 func normalizeRoleOverride(override RoleOverride) RoleOverride {
+	override.Model = strings.TrimSpace(override.Model)
 	override.Effort = strings.TrimSpace(override.Effort)
 	return override
 }
@@ -84,9 +98,53 @@ func (o Override) EffortForRole(role string) (string, string) {
 		return o.Code.Effort, "code.effort"
 	case "merge":
 		return o.Merge.Effort, "merge.effort"
+	case "plan":
+		if o.Plan.Effort != "" {
+			return o.Plan.Effort, "plan.effort"
+		}
+	case "routine":
+		if o.Routine.Effort != "" {
+			return o.Routine.Effort, "routine.effort"
+		}
+	case "validator":
+		if o.Validator.Effort != "" {
+			return o.Validator.Effort, "validator.effort"
+		}
+	case "security_audit":
+		if o.SecurityAudit.Effort != "" {
+			return o.SecurityAudit.Effort, "security_audit.effort"
+		}
 	default:
 		return "", ""
 	}
+	return "", ""
+}
+
+func (o Override) ModelForRole(role string) (string, string) {
+	var model string
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "code":
+		model = o.Code.Model
+	case "rework":
+		model = o.Rework.Model
+		if model == "" && o.Code.Model != "" {
+			return o.Code.Model, "code.model"
+		}
+	case "merge":
+		model = o.Merge.Model
+	case "plan":
+		model = o.Plan.Model
+	case "routine":
+		model = o.Routine.Model
+	case "validator":
+		model = o.Validator.Model
+	case "security_audit":
+		model = o.SecurityAudit.Model
+	}
+	if model != "" {
+		return model, role + ".model"
+	}
+	return o.Model, "model"
 }
 
 func (o Override) RoleEfforts() []RoleEffort {

--- a/internal/budget/pricing.go
+++ b/internal/budget/pricing.go
@@ -30,6 +30,16 @@ type PricingTable map[string]ModelPricing
 // when models are added or updated. Under subscription auth, computed USD is
 // notional but still used for budget pacing.
 func DefaultPricingTable() PricingTable {
+	sol := ModelPricing{
+		USDPerInputToken:       0.000004,
+		USDPerCachedInputToken: 0.0000004,
+		USDPerOutputToken:      0.000020,
+	}
+	astra := ModelPricing{
+		USDPerInputToken:       0.000010,
+		USDPerCachedInputToken: 0.000001,
+		USDPerOutputToken:      0.000050,
+	}
 	gpt55 := ModelPricing{
 		USDPerInputToken:       0.000005,
 		USDPerCachedInputToken: 0.0000005,
@@ -57,6 +67,9 @@ func DefaultPricingTable() PricingTable {
 	}
 
 	return PricingTable{
+		"gpt-5.6-sol":               sol,
+		"gpt-5.6":                   sol,
+		"gpt-6-astra":               astra,
 		defaultPricingFallbackModel: gpt55,
 		"gpt-5.5":                   gpt55,
 		"gpt-5.4": {

--- a/internal/budget/pricing_test.go
+++ b/internal/budget/pricing_test.go
@@ -3,6 +3,7 @@ package budget
 import (
 	"bytes"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,9 @@ func TestDefaultPricingTable(t *testing.T) {
 		wantCached float64
 		wantOutput float64
 	}{
+		{model: "gpt-5.6-sol", wantInput: 0.000004, wantCached: 0.0000004, wantOutput: 0.000020},
+		{model: "gpt-5.6", wantInput: 0.000004, wantCached: 0.0000004, wantOutput: 0.000020},
+		{model: "gpt-6-astra", wantInput: 0.000010, wantCached: 0.000001, wantOutput: 0.000050},
 		{
 			model:      " GPT-5.5 ",
 			wantInput:  0.000005,
@@ -111,6 +115,26 @@ func TestDefaultPricingTable(t *testing.T) {
 			assertInDelta(t, row.USDPerInputToken, tt.wantInput)
 			assertInDelta(t, row.USDPerCachedInputToken, tt.wantCached)
 			assertInDelta(t, row.USDPerOutputToken, tt.wantOutput)
+		})
+	}
+}
+
+func TestSolAstraExternalPricingOverride(t *testing.T) {
+	for _, model := range []string{"gpt-5.6-sol", "gpt-5.6", "gpt-6-astra"} {
+		t.Run(model, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "prices.yaml")
+			raw := "models:\n  " + model + ":\n    input_usd_per_1m_tokens: 2\n    cached_input_usd_per_1m_tokens: 0.2\n    output_usd_per_1m_tokens: 6\n"
+			if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			pricing, err := PricingForConfig(Config{PricingPath: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			cost, ok := UsageCostUSD(pricing, model, 1_000_000, 500_000, 1_000_000)
+			if !ok || math.Abs(cost-7.1) > 1e-9 {
+				t.Fatalf("override cost = %v, %v; want 7.1", cost, ok)
+			}
 		})
 	}
 }

--- a/internal/cli/doctor_model_selection.go
+++ b/internal/cli/doctor_model_selection.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+)
+
+func checkDoctorModelSelection(id string, cfg workflowconfig.Config) doctorCheck {
+	policy := cfg.EffectiveModelSelection()
+	check := doctorCheck{Name: "Project " + id + " agent selection", Status: doctorOK}
+	if problems := policy.Validate(); len(problems) > 0 {
+		check.Status = doctorFail
+		check.Detail = strings.Join(problems, "; ")
+		return check
+	}
+	state := "disabled"
+	if policy.Active() {
+		state = "enabled"
+	}
+	details := []string{"automatic model selection: " + state}
+	for _, backend := range cfg.AgentBackendConfigs() {
+		source := cfg.Agents.Sources["backends."+backend.ID]
+		if source == "" {
+			source = "project"
+		}
+		details = append(details, fmt.Sprintf("backend %s (%s): %s", backend.ID, backend.Kind, source))
+	}
+	for _, route := range cfg.AgentRouteConfigs() {
+		source := cfg.Agents.Sources["routes."+route.Name]
+		if source == "" {
+			source = "project"
+		}
+		details = append(details, fmt.Sprintf("route %s: %s, backend=%s, model=%s", route.Name, source, route.Backend, route.Model))
+	}
+	keys := make([]string, 0, len(policy.Sources))
+	for key := range policy.Sources {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		details = append(details, key+"="+policy.Sources[key])
+	}
+	if policy.Configured() {
+		encoded, err := json.Marshal(policy)
+		if err != nil {
+			check.Status = doctorFail
+			check.Detail = "encode effective model policy: " + err.Error()
+			return check
+		}
+		details = append(details, "effective policy: "+string(encoded))
+	}
+	details = append(details, "pricing: standard API USD estimates; subscription charges, credits, Fast mode, long context, and cache-write premiums can differ")
+	check.Detail = strings.Join(details, "; ")
+	return check
+}

--- a/internal/cli/doctor_model_selection_test.go
+++ b/internal/cli/doctor_model_selection_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+)
+
+func TestDoctorModelSelectionProvenance(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		t.Run(map[bool]string{true: "enabled", false: "disabled"}[enabled], func(t *testing.T) {
+			cfg := workflowconfig.Default()
+			cfg.Agents.ModelSelection.ComplexModel = new("project-complex")
+			cfg.Agents.ModelSelection.Enabled = &enabled
+			host := workflowconfig.Agents{
+				Backends:       []workflowconfig.AgentBackend{{ID: "design", Kind: workflowconfig.AgentBackendClaudeCode, Command: "SECRET_ENV=value /private/secret-wrapper"}},
+				Routes:         []workflowconfig.AgentRoute{{Name: "design", Backend: "design", Model: "sonnet"}},
+				ModelSelection: workflowconfig.ModelSelection{Preset: new("sol_first"), NormalModel: new("host-normal")},
+			}
+			got := checkDoctorModelSelection("alpha", cfg.WithAgentDefaults(host, workflowconfig.AgentBudgetDefaults{}))
+			if got.Status != doctorOK {
+				t.Fatalf("check = %+v", got)
+			}
+			for _, want := range []string{"normal_model=instance", "complex_model=project", "levels.normal.effort=preset", "backend design (claude_code): instance", "route design: instance", "subscription charges"} {
+				if !strings.Contains(got.Detail, want) {
+					t.Errorf("detail missing %q", want)
+				}
+			}
+			for _, secret := range []string{"SECRET_ENV", "secret-wrapper", "/private"} {
+				if strings.Contains(got.Detail, secret) {
+					t.Errorf("detail leaks %q", secret)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -42,6 +42,8 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	}
 	for _, project := range cfg.Projects {
 		project.GlobalActiveHours = cfg.Global.ActiveHours
+		project.GlobalAgents = cfg.Global.Agents
+		project.GlobalBudget = cfg.Global.Budget
 		project.Identity = cfg.Global.Identity
 		checks = append(checks, checkDoctorProjectWithStore(ctx, project, doctorRuntimeStorePath(cfg.Path), deps, githubToken, allowWriteProbes)...)
 		if cfg.Client.Configured() {
@@ -212,6 +214,8 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 	jobs := make([]doctorCheckJob, 0, len(cfg.Projects))
 	for _, project := range cfg.Projects {
 		project.GlobalActiveHours = cfg.Global.ActiveHours
+		project.GlobalAgents = cfg.Global.Agents
+		project.GlobalBudget = cfg.Global.Budget
 		project.Identity = cfg.Global.Identity
 		id := doctorProjectID(project)
 		progress := newDoctorCheckProgress()
@@ -417,6 +421,9 @@ func checkDoctorProjectWithProgress(
 	checks = append(checks, checkDoctorFollowupGuidance(id, workflow.Config.Agent.Followups, workflow.Prompt))
 	setDoctorCurrentCheck("Project " + id + " pinned route models")
 	checks = append(checks, checkDoctorRouteModels(ctx, id, project, workflow.Config, deps))
+	if workflow.Config.Agents.ModelSelection.Configured() || len(workflow.Config.Agents.Sources) > 0 {
+		checks = append(checks, checkDoctorModelSelection(id, workflow.Config))
+	}
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		setDoctorCurrentCheck("Project " + id + " issue agent models")
 		checks = append(checks, checkDoctorIssueAgentModels(ctx, id, project, workflow.Config, deps))
@@ -1802,7 +1809,11 @@ func loadDoctorProjectWorkflow(ctx context.Context, project globalconfig.Project
 
 func loadDoctorProjectWorkflowUncached(ctx context.Context, project globalconfig.Project, deps doctorDeps) (workflowconfig.Workflow, error) {
 	if strings.TrimSpace(project.WorkflowRef) == "" {
-		return deps.loadWorkflow(project.Workflow)
+		workflow, err := deps.loadWorkflow(project.Workflow)
+		if err == nil {
+			workflow.Config = workflow.Config.WithAgentDefaults(project.GlobalAgents, project.GlobalBudget)
+		}
+		return workflow, err
 	}
 	return projectpkg.LoadWorkflowContext(ctx, project)
 }

--- a/internal/config/agent_inheritance.go
+++ b/internal/config/agent_inheritance.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"slices"
+	"strings"
+)
+
+type AgentBudgetDefaults struct {
+	PricingPath *string `yaml:"pricing_path,omitempty"`
+}
+
+func (c Config) WithAgentDefaults(instance Agents, budget AgentBudgetDefaults) Config {
+	if len(instance.Backends) == 0 && len(instance.Routes) == 0 && !instance.ModelSelection.Configured() && budget.PricingPath == nil && c.Agents.local == nil {
+		return c
+	}
+	local := c.Agents
+	if local.local != nil {
+		local = *local.local
+	} else {
+		local.pricingPath = c.Budget.PricingPath
+	}
+	c.Budget.PricingPath = local.pricingPath
+	sources := map[string]string{}
+	backends := []AgentBackend{}
+	if local.Backends == nil || len(local.Backends) > 0 {
+		for _, backend := range instance.Backends {
+			backends = append(backends, backend)
+			sources["backends."+backend.ID] = "instance"
+		}
+	}
+	projectBackends := local.Backends
+	if len(projectBackends) == 0 && (!slices.ContainsFunc(backends, func(value AgentBackend) bool { return value.ID == DefaultAgentBackendID }) || len(c.ConfiguredSubsettings("codex")) > 0) {
+		projectBackends = []AgentBackend{CodexAgentBackend(c.Codex)}
+	}
+	for _, backend := range projectBackends {
+		index := slices.IndexFunc(backends, func(value AgentBackend) bool { return value.ID == backend.ID })
+		if index < 0 {
+			backends = append(backends, backend)
+		} else {
+			backends[index] = backend
+		}
+		sources["backends."+backend.ID] = "project"
+	}
+	backends = slices.DeleteFunc(backends, func(value AgentBackend) bool { return value.Disabled })
+	routes := slices.Clone(local.Routes)
+	projectDefaults := map[string]bool{}
+	for _, route := range local.Routes {
+		sources["routes."+route.Name] = "project"
+		if route.Default && !route.Disabled {
+			projectDefaults[normalizeAgentRouteRole(route.Role)] = true
+		}
+	}
+	if local.Routes == nil || len(local.Routes) > 0 {
+		for _, route := range instance.Routes {
+			if slices.ContainsFunc(local.Routes, func(value AgentRoute) bool { return value.Name == route.Name }) {
+				continue
+			}
+			if route.Default && projectDefaults[normalizeAgentRouteRole(route.Role)] {
+				continue
+			}
+			routes = append(routes, route)
+			sources["routes."+route.Name] = "instance"
+		}
+	}
+	routes = slices.DeleteFunc(routes, func(value AgentRoute) bool { return value.Disabled })
+	if !slices.ContainsFunc(local.Routes, func(value AgentRoute) bool { return value.Name == "default" && value.Disabled }) && !slices.ContainsFunc(routes, func(value AgentRoute) bool { return value.Default && normalizeAgentRouteRole(value.Role) == "code" }) {
+		backendID := DefaultAgentBackendID
+		if len(projectBackends) > 0 {
+			backendID = projectBackends[0].ID
+		}
+		routes = append(routes, AgentRoute{Name: "default", Backend: backendID, Default: true})
+		sources["routes.default"] = "project"
+	}
+	c.Agents = Agents{
+		Backends: backends, Routes: routes,
+		ModelSelection: ResolveModelSelection(instance.ModelSelection, local.ModelSelection),
+		Sources:        sources, local: &local,
+	}
+	c.Agents.normalize()
+	_, pricingConfigured := c.configuredFields["budget.pricing_path"]
+	pricingConfigured = pricingConfigured || (local.pricingPath != "" && local.pricingPath != Default().Budget.PricingPath)
+	if !pricingConfigured && budget.PricingPath != nil {
+		c.Budget.PricingPath = strings.TrimSpace(*budget.PricingPath)
+		sources["budget.pricing_path"] = "instance"
+	} else {
+		sources["budget.pricing_path"] = "preset"
+		if pricingConfigured {
+			sources["budget.pricing_path"] = "project"
+		}
+	}
+	if c.Budget.PricingPath == "" {
+		c.Budget.PricingPath = Default().Budget.PricingPath
+	}
+	return c
+}
+
+func (c Config) EffectiveModelSelection() ModelSelection {
+	if c.Agents.ModelSelection.Sources != nil {
+		return c.Agents.ModelSelection
+	}
+	return ResolveModelSelection(ModelSelection{}, c.Agents.ModelSelection)
+}

--- a/internal/config/agent_inheritance_test.go
+++ b/internal/config/agent_inheritance_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAgentDefaultsInheritance(t *testing.T) {
+	var host Agents
+	if err := yaml.Unmarshal([]byte(`backends:
+  - id: design
+    kind: claude_code
+    command: /opt/detent/claude-wrapper
+routes:
+  - name: design
+    backend: design
+    model: sonnet
+    selector:
+      labels:
+        include: [design]
+model_selection:
+  preset: sol_first
+`), &host); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name, local, complex, normal, modelSource string
+		design, active                            bool
+	}{
+		{name: "existing project", complex: "gpt-6-astra", normal: "gpt-5.6-sol", modelSource: "preset", design: true, active: true},
+		{name: "future registration", complex: "gpt-6-astra", normal: "gpt-5.6-sol", modelSource: "preset", design: true, active: true},
+		{name: "partial model", local: "model_selection:\n  complex_model: custom-complex", complex: "custom-complex", normal: "gpt-5.6-sol", modelSource: "project", design: true, active: true},
+		{name: "partial effort", local: "model_selection:\n  levels:\n    complex:\n      effort: high", complex: "gpt-6-astra", normal: "gpt-5.6-sol", modelSource: "preset", design: true, active: true},
+		{name: "disable", local: "model_selection:\n  enabled: false", complex: "gpt-6-astra", normal: "gpt-5.6-sol", modelSource: "preset", design: true},
+		{name: "disable route", local: "routes:\n  - name: design\n    disabled: true", complex: "gpt-6-astra", normal: "gpt-5.6-sol", modelSource: "preset", active: true},
+		{name: "clear routes", local: "routes: []", complex: "gpt-6-astra", normal: "gpt-5.6-sol", modelSource: "preset", active: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			if err := yaml.Unmarshal([]byte(tt.local), &cfg.Agents); err != nil {
+				t.Fatal(err)
+			}
+			got := cfg.WithAgentDefaults(host, AgentBudgetDefaults{})
+			p := got.EffectiveModelSelection()
+			if p.Active() != tt.active || p.Model("complex") != tt.complex || p.Model("normal") != tt.normal || p.Sources["complex_model"] != tt.modelSource {
+				t.Fatalf("policy = %+v", p)
+			}
+			design := slices.ContainsFunc(got.AgentRouteConfigs(), func(r AgentRoute) bool { return r.Name == "design" })
+			if design != tt.design {
+				t.Fatalf("routes = %+v", got.Agents.Routes)
+			}
+			if !slices.ContainsFunc(got.Agents.Routes, func(r AgentRoute) bool { return r.Default && r.Backend == DefaultAgentBackendID }) {
+				t.Fatalf("missing project default: %+v", got.Agents.Routes)
+			}
+			if got.Agents.Sources["backends.design"] != "instance" {
+				t.Fatalf("sources = %+v", got.Agents.Sources)
+			}
+			if err := got.Agents.ValidateDefaults(); err != nil {
+				t.Fatal(err)
+			}
+			if again := got.WithAgentDefaults(host, AgentBudgetDefaults{}); !reflect.DeepEqual(got, again) {
+				t.Fatal("inheritance is not idempotent")
+			}
+		})
+	}
+}
+
+func TestModelSelectionPartialOverrides(t *testing.T) {
+	for _, tt := range []struct {
+		name, raw string
+		check     func(ModelSelection) bool
+	}{
+		{"only complex model", "complex_model: special", func(p ModelSelection) bool {
+			return p.Model("complex") == "special" && p.Model("normal") == "host-normal"
+		}},
+		{"only effort", "levels: {complex: {effort: high}}", func(p ModelSelection) bool {
+			return *p.Levels["complex"].Effort == "high" && *p.Levels["complex"].Model == "complex"
+		}},
+		{"clear backends", "backend_kinds: []", func(p ModelSelection) bool { return p.BackendKinds != nil && len(*p.BackendKinds) == 0 }},
+		{"clear fallback", "fallback_order: []", func(p ModelSelection) bool { return len(*p.FallbackOrder) == 0 }},
+		{"clear rules", "rules: []", func(p ModelSelection) bool { return len(*p.Rules) == 0 }},
+		{"disable rule", "rules: [{name: complex, disabled: true}]", func(p ModelSelection) bool { return len(*p.Rules) == 3 && (*p.Rules)[2].Disabled }},
+		{"clear stages", "stages: {}", func(p ModelSelection) bool { return p.Stages != nil && len(p.Stages) == 0 }},
+		{"one stage field", "stages: {merge: {model: complex}}", func(p ModelSelection) bool {
+			return *p.Stages["merge"].Model == "complex" && !*p.Stages["merge"].IssueComplexity
+		}},
+		{"fail", "unavailable: fail", func(p ModelSelection) bool { return *p.Unavailable == "fail" && len(*p.FallbackOrder) == 1 }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var project ModelSelection
+			if err := yaml.Unmarshal([]byte(tt.raw), &project); err != nil {
+				t.Fatal(err)
+			}
+			host := ModelSelection{Preset: new("sol_first"), NormalModel: new("host-normal")}
+			got := ResolveModelSelection(host, project)
+			if !tt.check(got) {
+				t.Fatalf("policy = %+v", got)
+			}
+			other := ResolveModelSelection(ModelSelection{Preset: new("sol_first"), NormalModel: new("other-instance")}, ModelSelection{})
+			if other.Model("normal") != "other-instance" || got.Model("normal") != "host-normal" {
+				t.Fatal("instance defaults leaked")
+			}
+		})
+	}
+}
+
+func TestAgentDefaultsPreserveProjectRoutes(t *testing.T) {
+	for _, id := range []string{"codex-alpha", "codex-beta"} {
+		t.Run(id, func(t *testing.T) {
+			cfg := Default()
+			cfg.Agents.Backends = []AgentBackend{{ID: id, Kind: AgentBackendCodex, Command: "codex"}}
+			cfg.Agents.Routes = []AgentRoute{{Name: "local", Backend: id, Default: true, Model: id + "-model"}}
+			host := Agents{Backends: []AgentBackend{{ID: "design", Kind: AgentBackendClaudeCode}}, Routes: []AgentRoute{{Name: "default", Backend: "design", Default: true}, {Name: "design", Backend: "design", Model: "sonnet"}}}
+			got := cfg.WithAgentDefaults(host, AgentBudgetDefaults{})
+			if got.Agents.Routes[0].Model != id+"-model" || len(got.Agents.Routes) != 2 {
+				t.Fatalf("routes = %+v", got.Agents.Routes)
+			}
+			host.Backends = nil
+			invalid := cfg.WithAgentDefaults(host, AgentBudgetDefaults{})
+			if err := invalid.Agents.ValidateDefaults(); err == nil || !strings.Contains(err.Error(), "reference") {
+				t.Fatalf("invalid reference error = %v", err)
+			}
+		})
+	}
+}
+
+func TestInheritedPricingAndClearing(t *testing.T) {
+	for _, tt := range []struct{ name, path, want string }{
+		{"omitted", "", "/instance/prices.yaml"},
+		{"project override", "pricing_path: /project/prices.yaml", "/project/prices.yaml"},
+		{"explicit embedded", "pricing_path: ''", Default().Budget.PricingPath},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := "---\ntracker:\n  kind: memory\nbudget:\n  " + tt.path + "\n---\n"
+			if tt.path == "" {
+				raw = "---\ntracker:\n  kind: memory\n---\n"
+			}
+			workflow, err := ParseWorkflow([]byte(raw))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := workflow.Config.WithAgentDefaults(Agents{}, AgentBudgetDefaults{PricingPath: new("/instance/prices.yaml")})
+			if got.Budget.PricingPath != tt.want {
+				t.Fatalf("pricing = %q, want %q", got.Budget.PricingPath, tt.want)
+			}
+			cleared := got.WithAgentDefaults(Agents{}, AgentBudgetDefaults{})
+			wantCleared := Default().Budget.PricingPath
+			if tt.name == "project override" {
+				wantCleared = tt.want
+			}
+			if cleared.Budget.PricingPath != wantCleared {
+				t.Fatalf("removed host pricing = %q", cleared.Budget.PricingPath)
+			}
+		})
+	}
+}
+
+func TestPolicyMarshalPreservesClearing(t *testing.T) {
+	for _, raw := range []string{"stages: {}", "levels: {}", "rules: []", "backend_kinds: []", "enabled: false", "preset: ''"} {
+		t.Run(raw, func(t *testing.T) {
+			var before, after ModelSelection
+			if err := yaml.Unmarshal([]byte(raw), &before); err != nil {
+				t.Fatal(err)
+			}
+			encoded, err := yaml.Marshal(before)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := yaml.Unmarshal(encoded, &after); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(before, after) {
+				t.Fatalf("clearing lost: %s", encoded)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -401,11 +401,16 @@ type MergeFastPath struct {
 }
 
 type Agents struct {
-	Backends []AgentBackend `yaml:"backends"`
-	Routes   []AgentRoute   `yaml:"routes"`
+	Backends       []AgentBackend    `yaml:"backends"`
+	Routes         []AgentRoute      `yaml:"routes"`
+	ModelSelection ModelSelection    `yaml:"model_selection"`
+	Sources        map[string]string `yaml:"-"`
+	local          *Agents
+	pricingPath    string
 }
 
 type AgentBackend struct {
+	Disabled bool           `yaml:"disabled,omitempty"`
 	ID       string         `yaml:"id"`
 	Kind     string         `yaml:"kind"`
 	Protocol string         `yaml:"protocol"`
@@ -417,7 +422,7 @@ type AgentBackend struct {
 	codexOptionsSet      bool
 	claudeCodeOptions    ClaudeCodeOptions
 	claudeCodeOptionsSet bool
-	optionsErr           error
+	optionsProblem       string
 }
 
 type BackendOptions struct {
@@ -450,6 +455,7 @@ type ClaudeCodeOptions struct {
 }
 
 type AgentRoute struct {
+	Disabled   bool              `yaml:"disabled,omitempty"`
 	Name       string            `yaml:"name"`
 	Role       string            `yaml:"role"`
 	Backend    string            `yaml:"backend"`
@@ -721,8 +727,8 @@ func (b AgentBackend) CodexOptions() CodexOptions {
 }
 
 func (b AgentBackend) decodedCodexOptions() (CodexOptions, error) {
-	if b.optionsErr != nil {
-		return CodexOptions{}, b.optionsErr
+	if b.optionsProblem != "" {
+		return CodexOptions{}, errors.New(b.optionsProblem)
 	}
 	if b.codexOptionsSet {
 		return b.codexOptions, nil
@@ -745,8 +751,8 @@ func (b AgentBackend) ClaudeCodeOptions() ClaudeCodeOptions {
 }
 
 func (b AgentBackend) decodedClaudeCodeOptions() (ClaudeCodeOptions, error) {
-	if b.optionsErr != nil {
-		return ClaudeCodeOptions{}, b.optionsErr
+	if b.optionsProblem != "" {
+		return ClaudeCodeOptions{}, errors.New(b.optionsProblem)
 	}
 	if b.claudeCodeOptionsSet {
 		return b.claudeCodeOptions, nil
@@ -765,13 +771,13 @@ func (b *AgentBackend) decodeOptions() {
 	b.codexOptionsSet = false
 	b.claudeCodeOptions = ClaudeCodeOptions{}
 	b.claudeCodeOptionsSet = false
-	b.optionsErr = nil
+	b.optionsProblem = ""
 
 	switch b.Kind {
 	case AgentBackendCodex:
 		options, err := b.decodedCodexOptions()
 		if err != nil {
-			b.optionsErr = err
+			b.optionsProblem = err.Error()
 			return
 		}
 		b.codexOptions = options
@@ -779,7 +785,7 @@ func (b *AgentBackend) decodeOptions() {
 	case AgentBackendClaudeCode:
 		options, err := b.decodedClaudeCodeOptions()
 		if err != nil {
-			b.optionsErr = err
+			b.optionsProblem = err.Error()
 			return
 		}
 		b.claudeCodeOptions = options
@@ -2351,11 +2357,19 @@ func normalizeAgentProtocol(protocol string) string {
 }
 
 func (a *Agents) validate(problems *[]string) {
+	policy := a.ModelSelection
+	if policy.Sources == nil {
+		policy = ResolveModelSelection(ModelSelection{}, policy)
+	}
+	*problems = append(*problems, policy.Validate()...)
 	backendIDs := make(map[string]struct{}, len(a.Backends))
 	if len(a.Backends) == 0 {
 		backendIDs[DefaultAgentBackendID] = struct{}{}
 	}
 	for _, backend := range a.Backends {
+		if backend.Disabled {
+			continue
+		}
 		if strings.TrimSpace(backend.ID) == "" {
 			*problems = append(*problems, "agents.backends.id is required")
 			continue
@@ -2391,6 +2405,9 @@ func (a *Agents) validate(problems *[]string) {
 
 	defaultRoutes := map[string]int{}
 	for _, route := range a.Routes {
+		if route.Disabled {
+			continue
+		}
 		if strings.TrimSpace(route.Backend) == "" {
 			*problems = append(*problems, "agents.routes.backend is required")
 		} else if _, ok := backendIDs[route.Backend]; !ok {

--- a/internal/config/configdoc/configdoc.go
+++ b/internal/config/configdoc/configdoc.go
@@ -201,6 +201,13 @@ func structNodes(
 			node.children = []*schemaNode{{key: "<name>", path: profilePath, typ: reflect.TypeFor[policy.Requirements](), synthetic: true, conditional: true, children: children}}
 		case valueType == reflect.TypeFor[config.BackendOptions]():
 			node.children = backendOptionNodes(path)
+		case valueType.Kind() == reflect.Map && valueType.Key().Kind() == reflect.String && valueType.Elem().Kind() == reflect.Struct && expandable(valueType.Elem()) && stack[valueType.Elem()] == 0:
+			entryPath := path + ".<name>"
+			children := structNodes(valueType.Elem(), entryPath, nil, true, stack)
+			for _, child := range flatten(children) {
+				child.synthetic = true
+			}
+			node.children = []*schemaNode{{key: "<name>", path: entryPath, typ: valueType.Elem(), synthetic: true, conditional: true, children: children}}
 		case valueType.Kind() == reflect.Struct && expandable(valueType) && stack[valueType] == 0:
 			node.children = structNodes(valueType, path, nodeSteps, node.conditional, stack)
 		case valueType.Kind() == reflect.Slice:

--- a/internal/config/global/agent_defaults_test.go
+++ b/internal/config/global/agent_defaults_test.go
@@ -1,0 +1,52 @@
+package global
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+)
+
+func TestParseGlobalAgentDefaults(t *testing.T) {
+	for _, tt := range []struct {
+		name, extra string
+		invalid     bool
+	}{
+		{name: "preset", extra: "model_selection: {preset: sol_first}"},
+		{name: "disabled", extra: "model_selection: {preset: sol_first, enabled: false}"},
+		{name: "invalid reference", extra: "routes: [{name: design, backend: missing}]", invalid: true},
+		{name: "invalid preset", extra: "model_selection: {preset: unknown}", invalid: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := yaml.Marshal(map[string]any{"apiVersion": "detent/v1", "kind": "GlobalConfig", "global": map[string]any{"max_concurrent_agents": 2, "scheduling": "weighted", "agents": map[string]any{}}, "projects": []any{}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var attrs map[string]any
+			if err := yaml.Unmarshal(raw, &attrs); err != nil {
+				t.Fatal(err)
+			}
+			var agents map[string]any
+			if err := yaml.Unmarshal([]byte(tt.extra), &agents); err != nil {
+				t.Fatal(err)
+			}
+			attrs["global"].(map[string]any)["agents"] = agents
+			raw, err = yaml.Marshal(attrs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := Parse(raw, "", WithHome(t.TempDir()))
+			if (err != nil) != tt.invalid {
+				t.Fatalf("Parse error=%v", err)
+			}
+			if tt.invalid {
+				return
+			}
+			policy := workflowconfig.ResolveModelSelection(got.Global.Agents.ModelSelection, workflowconfig.ModelSelection{})
+			if policy.Active() != (tt.name == "preset") || policy.Model("normal") != "gpt-5.6-sol" {
+				t.Fatalf("policy=%+v", policy)
+			}
+		})
+	}
+}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -136,18 +136,20 @@ func (u Update) NormalizedMaxDeferralHours() int {
 }
 
 type Settings struct {
-	MaxConcurrentAgents int                             `yaml:"max_concurrent_agents"`
-	RateWindowPacing    workflowconfig.RateWindowPacing `yaml:"rate_window_pacing"`
-	Scheduling          string                          `yaml:"scheduling"`
-	AgentPools          []AgentPool                     `yaml:"agent_pools,omitempty"`
-	ActiveHours         *activehours.Config             `yaml:"active_hours,omitempty"`
-	Identity            Identity                        `yaml:"identity,omitempty"`
-	Knowledge           Knowledge                       `yaml:"knowledge,omitempty"`
-	FairShare           map[string]any                  `yaml:"fair_share,omitempty"`
-	Startup             map[string]any                  `yaml:"startup,omitempty"`
-	Memory              Memory                          `yaml:"memory,omitempty"`
-	IO                  IO                              `yaml:"io,omitempty"`
-	CPU                 CPU                             `yaml:"cpu,omitempty"`
+	Agents              workflowconfig.Agents              `yaml:"agents,omitempty"`
+	Budget              workflowconfig.AgentBudgetDefaults `yaml:"budget,omitempty"`
+	MaxConcurrentAgents int                                `yaml:"max_concurrent_agents"`
+	RateWindowPacing    workflowconfig.RateWindowPacing    `yaml:"rate_window_pacing"`
+	Scheduling          string                             `yaml:"scheduling"`
+	AgentPools          []AgentPool                        `yaml:"agent_pools,omitempty"`
+	ActiveHours         *activehours.Config                `yaml:"active_hours,omitempty"`
+	Identity            Identity                           `yaml:"identity,omitempty"`
+	Knowledge           Knowledge                          `yaml:"knowledge,omitempty"`
+	FairShare           map[string]any                     `yaml:"fair_share,omitempty"`
+	Startup             map[string]any                     `yaml:"startup,omitempty"`
+	Memory              Memory                             `yaml:"memory,omitempty"`
+	IO                  IO                                 `yaml:"io,omitempty"`
+	CPU                 CPU                                `yaml:"cpu,omitempty"`
 }
 
 type Memory struct {
@@ -213,34 +215,36 @@ type AgentPool struct {
 }
 
 type Project struct {
-	ID                       string                          `yaml:"id"`
-	Pool                     string                          `yaml:"pool,omitempty"`
-	Workflow                 string                          `yaml:"workflow"`
-	WorkflowRef              string                          `yaml:"workflow_ref,omitempty"`
-	Workdir                  string                          `yaml:"workdir"`
-	Color                    string                          `yaml:"color,omitempty"`
-	Knowledge                Knowledge                       `yaml:"knowledge,omitempty"`
-	Weight                   int                             `yaml:"weight"`
-	Priority                 int                             `yaml:"priority"`
-	Paused                   bool                            `yaml:"paused,omitempty"`
-	PausedReason             string                          `yaml:"paused_reason,omitempty"`
-	PausedAt                 string                          `yaml:"paused_at,omitempty"`
-	PausedUntilIssue         string                          `yaml:"paused_until_issue,omitempty"`
-	PausedUntil              string                          `yaml:"paused_until,omitempty"`
-	ActiveHours              *activehours.Config             `yaml:"active_hours,omitempty"`
-	ActiveHoursOverrideUntil string                          `yaml:"active_hours_override_until,omitempty"`
-	CredentialRef            string                          `yaml:"credential_ref,omitempty"`
-	Authorization            selector.Selector               `yaml:"authorization,omitempty"`
-	Intake                   intakeconfig.Config             `yaml:"intake,omitempty"`
-	Memory                   ProjectMemory                   `yaml:"memory,omitempty"`
-	Identity                 Identity                        `yaml:"-"`
-	GlobalKnowledge          Knowledge                       `yaml:"-"`
-	GlobalActiveHours        *activehours.Config             `yaml:"-"`
-	GlobalRateWindowPacing   workflowconfig.RateWindowPacing `yaml:"-"`
-	GlobalMemory             Memory                          `yaml:"-"`
-	GlobalIO                 IO                              `yaml:"-"`
-	GlobalCPU                CPU                             `yaml:"-"`
-	IntakeConfigured         bool                            `yaml:"-"`
+	GlobalAgents             workflowconfig.Agents              `yaml:"-"`
+	GlobalBudget             workflowconfig.AgentBudgetDefaults `yaml:"-"`
+	ID                       string                             `yaml:"id"`
+	Pool                     string                             `yaml:"pool,omitempty"`
+	Workflow                 string                             `yaml:"workflow"`
+	WorkflowRef              string                             `yaml:"workflow_ref,omitempty"`
+	Workdir                  string                             `yaml:"workdir"`
+	Color                    string                             `yaml:"color,omitempty"`
+	Knowledge                Knowledge                          `yaml:"knowledge,omitempty"`
+	Weight                   int                                `yaml:"weight"`
+	Priority                 int                                `yaml:"priority"`
+	Paused                   bool                               `yaml:"paused,omitempty"`
+	PausedReason             string                             `yaml:"paused_reason,omitempty"`
+	PausedAt                 string                             `yaml:"paused_at,omitempty"`
+	PausedUntilIssue         string                             `yaml:"paused_until_issue,omitempty"`
+	PausedUntil              string                             `yaml:"paused_until,omitempty"`
+	ActiveHours              *activehours.Config                `yaml:"active_hours,omitempty"`
+	ActiveHoursOverrideUntil string                             `yaml:"active_hours_override_until,omitempty"`
+	CredentialRef            string                             `yaml:"credential_ref,omitempty"`
+	Authorization            selector.Selector                  `yaml:"authorization,omitempty"`
+	Intake                   intakeconfig.Config                `yaml:"intake,omitempty"`
+	Memory                   ProjectMemory                      `yaml:"memory,omitempty"`
+	Identity                 Identity                           `yaml:"-"`
+	GlobalKnowledge          Knowledge                          `yaml:"-"`
+	GlobalActiveHours        *activehours.Config                `yaml:"-"`
+	GlobalRateWindowPacing   workflowconfig.RateWindowPacing    `yaml:"-"`
+	GlobalMemory             Memory                             `yaml:"-"`
+	GlobalIO                 IO                                 `yaml:"-"`
+	GlobalCPU                CPU                                `yaml:"-"`
+	IntakeConfigured         bool                               `yaml:"-"`
 }
 
 func (p Project) EffectiveMemory() Memory {
@@ -757,6 +761,9 @@ func (c Config) Validate(opts ...Option) error {
 		problems = append(problems, "global.max_concurrent_agents: must be a positive integer")
 	}
 	problems = append(problems, c.Global.RateWindowPacing.Validate("global.rate_window_pacing")...)
+	if err := c.Global.Agents.ValidateDefaults(); err != nil {
+		problems = append(problems, err.Error())
+	}
 	if !validSchedulingMode(c.Global.Scheduling) {
 		problems = append(problems, "global.scheduling: must be one of "+strings.Join(schedulingModes, ", "))
 	}
@@ -2016,6 +2023,10 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 		return Config{}, buildValidationError(path, err)
 	}
 
+	for index := range builtProjects {
+		builtProjects[index].GlobalAgents = settings.Agents
+		builtProjects[index].GlobalBudget = settings.Budget
+	}
 	return Config{
 		Path:                  path,
 		APIVersion:            apiVersion,
@@ -2143,6 +2154,19 @@ func buildUpdate(value any) (Update, error) {
 
 func buildSettings(attrs map[string]any, opts options) (Settings, error) {
 	settings := defaultSettings()
+	if attrs["agents"] != nil {
+		if err := decodeYAMLValue(attrs["agents"], &settings.Agents); err != nil {
+			return Settings{}, fmt.Errorf("global.agents: %w", err)
+		}
+		if err := settings.Agents.ValidateDefaults(); err != nil {
+			return Settings{}, err
+		}
+	}
+	if attrs["budget"] != nil {
+		if err := decodeYAMLValue(attrs["budget"], &settings.Budget); err != nil {
+			return Settings{}, fmt.Errorf("global.budget: %w", err)
+		}
+	}
 	maxConcurrentAgents, err := intValue(attrs["max_concurrent_agents"], "global.max_concurrent_agents")
 	if err != nil {
 		return Settings{}, err

--- a/internal/config/model_selection.go
+++ b/internal/config/model_selection.go
@@ -1,0 +1,289 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+type ModelSelection struct {
+	Enabled       *bool                             `yaml:"enabled,omitempty"`
+	Preset        *string                           `yaml:"preset,omitempty"`
+	NormalModel   *string                           `yaml:"normal_model,omitempty"`
+	ComplexModel  *string                           `yaml:"complex_model,omitempty"`
+	BackendKinds  *[]string                         `yaml:"backend_kinds,omitempty"`
+	DefaultLevel  *string                           `yaml:"default_level,omitempty"`
+	Levels        map[string]ModelSelectionDefaults `yaml:"levels,omitempty"`
+	Stages        map[string]ModelSelectionStage    `yaml:"stages,omitempty"`
+	Rules         *[]ModelSelectionRule             `yaml:"rules,omitempty"`
+	Unavailable   *string                           `yaml:"unavailable,omitempty"`
+	FallbackOrder *[]string                         `yaml:"fallback_order,omitempty"`
+	Sources       map[string]string                 `yaml:"-"`
+}
+
+type ModelSelectionDefaults struct {
+	Model  *string `yaml:"model,omitempty"`
+	Effort *string `yaml:"effort,omitempty"`
+}
+
+type ModelSelectionStage struct {
+	Model           *string `yaml:"model,omitempty"`
+	Effort          *string `yaml:"effort,omitempty"`
+	Level           *string `yaml:"level,omitempty"`
+	IssueComplexity *bool   `yaml:"issue_complexity,omitempty"`
+}
+
+type ModelSelectionRule struct {
+	Name     string            `yaml:"name"`
+	Disabled bool              `yaml:"disabled,omitempty"`
+	Level    string            `yaml:"level"`
+	Roles    []string          `yaml:"roles,omitempty"`
+	Selector selector.Selector `yaml:"selector,omitempty"`
+	Efforts  []string          `yaml:"efforts,omitempty"`
+}
+
+func (p ModelSelection) MarshalYAML() (any, error) {
+	type plain ModelSelection
+	var node yaml.Node
+	if err := node.Encode(plain(p)); err != nil {
+		return nil, err
+	}
+	for _, field := range []struct {
+		name  string
+		empty bool
+	}{{"levels", p.Levels != nil && len(p.Levels) == 0}, {"stages", p.Stages != nil && len(p.Stages) == 0}} {
+		if field.empty {
+			node.Content = append(node.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: field.name}, &yaml.Node{Kind: yaml.MappingNode})
+		}
+	}
+	return &node, nil
+}
+
+func SolFirstModelSelection() ModelSelection {
+	return ModelSelection{
+		Enabled: new(true), Preset: new("sol_first"),
+		NormalModel: new("gpt-5.6-sol"), ComplexModel: new("gpt-6-astra"),
+		BackendKinds: &[]string{AgentBackendCodex}, DefaultLevel: new("normal"),
+		Levels: map[string]ModelSelectionDefaults{
+			"normal":       {Model: new("normal"), Effort: new("medium")},
+			"complex":      {Model: new("complex"), Effort: new("medium")},
+			"very_complex": {Model: new("complex"), Effort: new("high")},
+		},
+		Stages: map[string]ModelSelectionStage{
+			"code":           {IssueComplexity: new(true)},
+			"plan":           {IssueComplexity: new(true)},
+			"rework":         {IssueComplexity: new(true)},
+			"merge":          {IssueComplexity: new(false)},
+			"routine":        {IssueComplexity: new(false)},
+			"validator":      {IssueComplexity: new(false)},
+			"security_audit": {IssueComplexity: new(false)},
+		},
+		Rules: &[]ModelSelectionRule{
+			{Name: "very_complex", Level: "very_complex", Selector: selector.Selector{Labels: selector.Labels{Include: []string{"complexity:very-complex"}}}},
+			{Name: "explicit_effort", Level: "complex", Efforts: []string{"xhigh", "max"}},
+			{Name: "complex", Level: "complex", Selector: selector.Selector{Labels: selector.Labels{Include: []string{"complexity:complex"}}}},
+		},
+		Unavailable: new("fallback"), FallbackOrder: &[]string{"normal"},
+	}
+}
+
+func (p ModelSelection) Active() bool {
+	return p.Enabled != nil && *p.Enabled
+}
+
+func (p ModelSelection) Configured() bool {
+	return p.Enabled != nil || p.Preset != nil || p.NormalModel != nil || p.ComplexModel != nil || p.BackendKinds != nil || p.DefaultLevel != nil || p.Levels != nil || p.Stages != nil || p.Rules != nil || p.Unavailable != nil || p.FallbackOrder != nil
+}
+
+func (p ModelSelection) Model(value string) string {
+	switch value {
+	case "normal":
+		return selectionString(p.NormalModel)
+	case "complex":
+		return selectionString(p.ComplexModel)
+	default:
+		return strings.TrimSpace(value)
+	}
+}
+
+func selectionString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func ResolveModelSelection(instance, project ModelSelection) ModelSelection {
+	preset := instance.Preset
+	if project.Preset != nil {
+		preset = project.Preset
+	}
+	result := ModelSelection{Sources: map[string]string{}}
+	if selectionString(preset) == "sol_first" {
+		result.overlay(SolFirstModelSelection(), "preset")
+	}
+	result.overlay(instance, "instance")
+	result.overlay(project, "project")
+	return result
+}
+
+func selectionOverride[T any](target **T, value *T, sources map[string]string, key, source string) {
+	if value != nil {
+		*target = value
+		sources[key] = source
+	}
+}
+
+func (p *ModelSelection) overlay(v ModelSelection, source string) {
+	selectionOverride(&p.Enabled, v.Enabled, p.Sources, "enabled", source)
+	selectionOverride(&p.Preset, v.Preset, p.Sources, "preset", source)
+	selectionOverride(&p.NormalModel, v.NormalModel, p.Sources, "normal_model", source)
+	selectionOverride(&p.ComplexModel, v.ComplexModel, p.Sources, "complex_model", source)
+	selectionOverride(&p.BackendKinds, v.BackendKinds, p.Sources, "backend_kinds", source)
+	selectionOverride(&p.DefaultLevel, v.DefaultLevel, p.Sources, "default_level", source)
+	selectionOverride(&p.Unavailable, v.Unavailable, p.Sources, "unavailable", source)
+	selectionOverride(&p.FallbackOrder, v.FallbackOrder, p.Sources, "fallback_order", source)
+	if v.Levels != nil {
+		p.Levels = maps.Clone(p.Levels)
+		if len(v.Levels) == 0 || p.Levels == nil {
+			p.Levels = map[string]ModelSelectionDefaults{}
+			maps.DeleteFunc(p.Sources, func(key, _ string) bool { return strings.HasPrefix(key, "levels.") })
+		}
+		p.Sources["levels"] = source
+		for name, value := range v.Levels {
+			level := p.Levels[name]
+			selectionOverride(&level.Model, value.Model, p.Sources, "levels."+name+".model", source)
+			selectionOverride(&level.Effort, value.Effort, p.Sources, "levels."+name+".effort", source)
+			p.Levels[name] = level
+		}
+	}
+	if v.Stages != nil {
+		p.Stages = maps.Clone(p.Stages)
+		if len(v.Stages) == 0 || p.Stages == nil {
+			p.Stages = map[string]ModelSelectionStage{}
+			maps.DeleteFunc(p.Sources, func(key, _ string) bool { return strings.HasPrefix(key, "stages.") })
+		}
+		p.Sources["stages"] = source
+		for name, value := range v.Stages {
+			stage := p.Stages[name]
+			selectionOverride(&stage.Model, value.Model, p.Sources, "stages."+name+".model", source)
+			selectionOverride(&stage.Effort, value.Effort, p.Sources, "stages."+name+".effort", source)
+			selectionOverride(&stage.Level, value.Level, p.Sources, "stages."+name+".level", source)
+			selectionOverride(&stage.IssueComplexity, value.IssueComplexity, p.Sources, "stages."+name+".issue_complexity", source)
+			p.Stages[name] = stage
+		}
+	}
+	if v.Rules != nil {
+		if len(*v.Rules) == 0 {
+			maps.DeleteFunc(p.Sources, func(key, _ string) bool { return strings.HasPrefix(key, "rules.") })
+		}
+		rules := []ModelSelectionRule{}
+		if p.Rules != nil && len(*v.Rules) > 0 {
+			rules = slices.Clone(*p.Rules)
+		}
+		for _, rule := range *v.Rules {
+			index := slices.IndexFunc(rules, func(existing ModelSelectionRule) bool { return existing.Name == rule.Name })
+			if index < 0 {
+				rules = append(rules, rule)
+			} else {
+				rules[index] = rule
+			}
+			p.Sources["rules."+rule.Name] = source
+		}
+		p.Rules = &rules
+		p.Sources["rules"] = source
+	}
+}
+
+func (p ModelSelection) Validate() []string {
+	var problems []string
+	add := func(field, reason string) { problems = append(problems, "agents.model_selection."+field+" "+reason) }
+	if preset := selectionString(p.Preset); preset != "" && preset != "sol_first" {
+		add("preset", "must be sol_first or empty")
+	}
+	if !p.Active() {
+		return problems
+	}
+	for _, field := range []struct {
+		name  string
+		value *string
+	}{
+		{"normal_model", p.NormalModel}, {"complex_model", p.ComplexModel}, {"default_level", p.DefaultLevel},
+	} {
+		if selectionString(field.value) == "" {
+			add(field.name, "is required when enabled")
+		}
+	}
+	if p.Unavailable == nil || (*p.Unavailable != "fallback" && *p.Unavailable != "fail") {
+		add("unavailable", "must be fallback or fail")
+	}
+	if _, ok := p.Levels[selectionString(p.DefaultLevel)]; !ok {
+		add("default_level", "must reference a configured level")
+	}
+	for name, level := range p.Levels {
+		if p.Model(selectionString(level.Model)) == "" {
+			add("levels."+name+".model", "is required")
+		}
+		if selectionString(level.Effort) == "" {
+			add("levels."+name+".effort", "is required")
+		}
+		if selectionString(level.Effort) == "max" {
+			add("levels."+name+".effort", "must not automatically assign max")
+		}
+	}
+	for name, stage := range p.Stages {
+		if stage.Level != nil && *stage.Level != "" {
+			if _, ok := p.Levels[*stage.Level]; !ok {
+				add("stages."+name+".level", "must reference a configured level")
+			}
+		}
+		if selectionString(stage.Effort) == "max" {
+			add("stages."+name+".effort", "must not automatically assign max")
+		}
+	}
+	if p.Rules != nil {
+		seen := map[string]bool{}
+		for _, rule := range *p.Rules {
+			if len(rule.Name) > 80 || !validAgentIdentityLabel(rule.Name) {
+				add("rules", "names must be sanitized labels of at most 80 characters")
+			}
+			if rule.Name == "" || seen[rule.Name] {
+				add("rules", "must have unique nonempty names")
+			}
+			seen[rule.Name] = true
+			if rule.Disabled {
+				continue
+			}
+			if _, ok := p.Levels[rule.Level]; !ok {
+				add("rules."+rule.Name+".level", "must reference a configured level")
+			}
+			problems = append(problems, rule.Selector.Validate("agents.model_selection.rules."+rule.Name+".selector")...)
+			if !rule.Selector.Configured() && len(rule.Efforts) == 0 {
+				add("rules."+rule.Name, "requires a selector or explicit efforts")
+			}
+		}
+	}
+	return problems
+}
+
+func (a Agents) ValidateDefaults() error {
+	a.Backends = slices.Clone(a.Backends)
+	a.Routes = slices.Clone(a.Routes)
+	a.normalize()
+	var problems []string
+	for _, route := range a.Routes {
+		if route.Name == "" {
+			problems = append(problems, "inherited agent routes require a name")
+		}
+	}
+	a.validate(&problems)
+	if len(problems) > 0 {
+		return fmt.Errorf("invalid agent defaults: %s", strings.Join(problems, "; "))
+	}
+	return nil
+}

--- a/internal/project/agent_inheritance_reload_test.go
+++ b/internal/project/agent_inheritance_reload_test.go
@@ -1,0 +1,86 @@
+package project_test
+
+import (
+	"context"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+func TestManagerReloadsInheritedAgentSelection(t *testing.T) {
+	ctx := context.Background()
+	global := globalconfig.Config{
+		Global:   globalconfig.Settings{Agents: workflowconfig.Agents{ModelSelection: workflowconfig.ModelSelection{Preset: new("sol_first")}}},
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}, {ID: "beta", Weight: 1}},
+	}
+	created := 0
+	manager, err := project.NewManager(project.ManagerConfigFromGlobal(global), project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			created++
+			workflow := workflowConfig("memory")
+			if cfg.ID == "beta" {
+				workflow.Agents.ModelSelection.ComplexModel = new("beta-complex")
+			}
+			return project.New(project.Config{Project: cfg, Workflow: workflowconfig.Workflow{Config: workflow}}, project.Dependencies{Runner: blockingRunner{}})
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for _, item := range manager.Registry().List() {
+			if err := item.Close(); err != nil {
+				t.Error(err)
+			}
+		}
+	})
+	before, _ := manager.Registry().Get("alpha")
+	for _, tt := range []struct {
+		name    string
+		invalid bool
+	}{{name: "valid reload"}, {name: "invalid reference", invalid: true}, {name: "future registration"}} {
+		t.Run(tt.name, func(t *testing.T) {
+			next := global
+			next.Global.Agents.ModelSelection.NormalModel = new("host-normal")
+			if tt.invalid {
+				next.Global.Agents.Routes = []workflowconfig.AgentRoute{{Name: "broken", Backend: "missing"}}
+			}
+			if tt.name == "future registration" {
+				next.Projects = append(append([]globalconfig.Project(nil), global.Projects...), globalconfig.Project{ID: "future", Weight: 1})
+			}
+			_, err := manager.Reconcile(ctx, project.ManagerConfigFromGlobal(next))
+			if tt.invalid {
+				if err == nil {
+					t.Fatal("invalid reload accepted")
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			after, _ := manager.Registry().Get("alpha")
+			if before != after {
+				t.Fatal("host policy reload restarted project")
+			}
+			if model := after.Workflow().Config.EffectiveModelSelection().Model("normal"); model != "host-normal" {
+				t.Fatalf("normal = %s", model)
+			}
+			beta, _ := manager.Registry().Get("beta")
+			if model := beta.Workflow().Config.EffectiveModelSelection().Model("complex"); model != "beta-complex" {
+				t.Fatalf("complex = %s", model)
+			}
+			if tt.name == "future registration" {
+				future, ok := manager.Registry().Get("future")
+				if !ok || future.Workflow().Config.EffectiveModelSelection().Model("normal") != "host-normal" {
+					t.Fatal("future project did not inherit")
+				}
+			}
+		})
+	}
+	if created != 3 {
+		t.Fatalf("created = %d, want 3", created)
+	}
+}

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -131,6 +131,8 @@ type Manager struct {
 func ManagerConfigFromGlobal(cfg globalconfig.Config) ManagerConfig {
 	projects := append([]globalconfig.Project(nil), cfg.Projects...)
 	for index := range projects {
+		projects[index].GlobalAgents = cfg.Global.Agents
+		projects[index].GlobalBudget = cfg.Global.Budget
 		projects[index].GlobalKnowledge = cfg.Global.Knowledge
 		projects[index].GlobalRateWindowPacing = cfg.Global.RateWindowPacing
 		projects[index].GlobalMemory = cfg.Global.Memory
@@ -1460,6 +1462,8 @@ func sameProjectConfigExceptLiveFields(left globalconfig.Project, right globalco
 	left.GlobalMemory.PollIntervalMS = right.GlobalMemory.PollIntervalMS
 	left.GlobalIO = right.GlobalIO
 	left.GlobalCPU = right.GlobalCPU
+	left.GlobalAgents = right.GlobalAgents
+	left.GlobalBudget = right.GlobalBudget
 	return reflect.DeepEqual(left, right)
 }
 

--- a/internal/project/policy.go
+++ b/internal/project/policy.go
@@ -15,6 +15,7 @@ type policyChecker interface {
 }
 
 func ResolvePolicy(cfg globalconfig.Project, workflow workflowconfig.Workflow) (policy.Descriptor, error) {
+	workflow.Config = workflow.Config.WithAgentDefaults(cfg.GlobalAgents, cfg.GlobalBudget)
 	workflow.Config = workflowConfigWithProjectIdentity(cfg, workflow.Config)
 	return workflowconfig.ResolvePolicy(workflow)
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -255,6 +255,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	}
 
 	workflow := normalizeWorkflow(cfg.Workflow)
+	workflow.Config = workflow.Config.WithAgentDefaults(cfg.Project.GlobalAgents, cfg.Project.GlobalBudget)
 	if err := configureProjectPolicy(context.Background(), cfg.Project, &workflow, deps.Scheduling); err != nil {
 		return nil, projectDefinitionError{err: err}
 	}
@@ -461,7 +462,6 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 
 	watcherProject := cfg.Project
 	watcherProject.ID = string(id)
-	watcherFactory := resolveWorkflowWatcherFactory(deps, watcherProject, deps.GitHubToken, logger)
 	workflowPath := workflowSourceDisplayPath(cfg.Project)
 	workflowModifiedAt := workflowFileModifiedAt(cfg.Project)
 
@@ -494,7 +494,6 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		retroProduct:              retroProductConnector,
 		events:                    projectEvents,
 		logger:                    logger,
-		watcher:                   watcherFactory,
 		workflowReconcileInterval: deps.WorkflowReconcileInterval,
 		workflowSource: WorkflowSourceStatus{
 			Path:       workflowPath,
@@ -505,6 +504,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 			LoadedAt:   time.Now().UTC(),
 		},
 	}
+	project.watcher = resolveWorkflowWatcherFactory(deps, watcherProject, deps.GitHubToken, logger, project.Config)
 	retainScheduleOwner = true
 	return project, nil
 }
@@ -558,9 +558,14 @@ func (p *Project) updateLiveConfig(ctx context.Context, cfg globalconfig.Project
 
 	p.mu.Lock()
 	workflow := p.workflow
+	workflow.Config = workflow.Config.WithAgentDefaults(cfg.GlobalAgents, cfg.GlobalBudget)
+	if err := workflow.Config.Validate(); err != nil {
+		p.mu.Unlock()
+		return fmt.Errorf("validate inherited agent configuration: %w", err)
+	}
 	workflow.Config.ActiveHours = EffectiveActiveHours(cfg, p.workflowActiveHours)
 	workflow.Config.Agent.RateWindowPacing = effectiveRateWindowPacing(cfg, workflow.Config)
-	if workflow.Config.Policy.ID != "" && (!reflect.DeepEqual(workflow.Config.ActiveHours, p.workflow.Config.ActiveHours) || workflow.Config.Agent.RateWindowPacing != p.workflow.Config.Agent.RateWindowPacing) {
+	if workflow.Config.Policy.ID != "" && (!reflect.DeepEqual(workflow.Config.ActiveHours, p.workflow.Config.ActiveHours) || workflow.Config.Agent.RateWindowPacing != p.workflow.Config.Agent.RateWindowPacing || !reflect.DeepEqual(workflow.Config.Agents, p.workflow.Config.Agents) || workflow.Config.Budget.PricingPath != p.workflow.Config.Budget.PricingPath) {
 		p.mu.Unlock()
 		return errors.New("policy_mismatch: host execution overrides changed; approve the effective descriptor and restart Detent before applying them")
 	}
@@ -568,8 +573,13 @@ func (p *Project) updateLiveConfig(ctx context.Context, cfg globalconfig.Project
 	projectOrchestrator := p.orchestrator
 	running := p.done != nil
 	projectAdmission := p.admission
+	projectRunner := p.runner
 	p.mu.Unlock()
 
+	applyRunner, err := prepareRunnerWorkflow(projectRunner, workflow)
+	if err != nil {
+		return fmt.Errorf("prepare inherited agent configuration: %w", err)
+	}
 	if projectOrchestrator != nil && running {
 		if err := projectOrchestrator.UpdateConfig(ctx, runtimeConfig); err != nil {
 			return fmt.Errorf("update project live config: %w", err)
@@ -578,6 +588,7 @@ func (p *Project) updateLiveConfig(ctx context.Context, cfg globalconfig.Project
 	if projectAdmission != nil {
 		projectAdmission.UpdateProjectCandidate(runtimeConfig.Project)
 	}
+	applyRunner()
 
 	p.mu.Lock()
 	p.cfg = cfg
@@ -1454,6 +1465,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	previousPolicy := p.workflow.Config.Policy
 	p.mu.Unlock()
 	workflow := normalizeWorkflow(update.Workflow)
+	workflow.Config = workflow.Config.WithAgentDefaults(projectConfig.GlobalAgents, projectConfig.GlobalBudget)
 	if err := configureProjectPolicy(ctx, projectConfig, &workflow, scheduling); err != nil {
 		return p.workflowReloadError("repository policy reload rejected", update.Path, err)
 	}
@@ -1533,6 +1545,10 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		}
 	}
 
+	applyRunner, err := prepareRunnerWorkflow(runner, workflow)
+	if err != nil {
+		return p.workflowReloadError("prepare agent configuration rejected", update.Path, err)
+	}
 	runtimeConfig := projectOrchestratorConfig(projectConfig, workflow.Config)
 	if projectOrchestrator != nil && projectRunning {
 		if err := projectOrchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
@@ -1547,9 +1563,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 			return p.workflowReloadError("apply workflow reload failed", update.Path, err)
 		}
 	}
-	if updater, ok := runner.(workflowUpdater); ok {
-		updater.UpdateWorkflow(workflow)
-	}
+	applyRunner()
 	if projectIntake != nil {
 		projectIntake.Apply(preparedIntake)
 	}
@@ -2132,6 +2146,19 @@ type workflowUpdater interface {
 	UpdateWorkflow(workflowconfig.Workflow)
 }
 
+func prepareRunnerWorkflow(value orchestrator.Runner, workflow workflowconfig.Workflow) (func(), error) {
+	if updater, ok := value.(interface {
+		PrepareWorkflowUpdate(workflowconfig.Workflow) (func(), error)
+	}); ok {
+		return updater.PrepareWorkflowUpdate(workflow)
+	}
+	return func() {
+		if updater, ok := value.(workflowUpdater); ok {
+			updater.UpdateWorkflow(workflow)
+		}
+	}, nil
+}
+
 type schedulerFactory func(workflowconfig.Config) (scheduler.Scheduler, error)
 
 func resolveConnectorFactory(deps Dependencies) ConnectorFactory {
@@ -2303,23 +2330,31 @@ func resolveWorkflowWatcherFactory(
 	project globalconfig.Project,
 	githubToken string,
 	logger *slog.Logger,
+	currentProject func() globalconfig.Project,
 ) WorkflowWatcherFactory {
 	if deps.WorkflowWatcherFactory != nil {
 		return deps.WorkflowWatcherFactory
 	}
 	if strings.TrimSpace(project.WorkflowRef) != "" {
 		return func(string) (WorkflowWatcher, error) {
-			return newGitRefWorkflowWatcher(project, 0, logger)
+			watcher, err := newGitRefWorkflowWatcher(project, 0, logger)
+			if err != nil {
+				return nil, err
+			}
+			watcher.currentProject = currentProject
+			return watcher, nil
 		}
 	}
 	return func(path string) (WorkflowWatcher, error) {
 		return configwatcher.New(path,
 			configwatcher.WithLoader(func(path string) (workflowconfig.Workflow, error) {
+				project := currentProject()
 				workflow, err := workflowconfig.LoadWorkflow(path)
 				if err != nil {
 					return workflow, err
 				}
 				workflow = normalizeWorkflow(workflow)
+				workflow.Config = workflow.Config.WithAgentDefaults(project.GlobalAgents, project.GlobalBudget)
 				workflow.Config = workflowConfigWithProjectIdentity(project, workflow.Config)
 				workflow.Config = workflowConfigWithGitHubToken(workflow.Config, githubToken)
 				return workflow, nil

--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -32,16 +32,24 @@ type workflowGitRefSource struct {
 }
 
 type gitRefWorkflowWatcher struct {
-	source   workflowGitRefSource
-	interval time.Duration
-	logger   *slog.Logger
+	currentProject func() globalconfig.Project
+	agents         workflowconfig.Agents
+	budget         workflowconfig.AgentBudgetDefaults
+	source         workflowGitRefSource
+	interval       time.Duration
+	logger         *slog.Logger
 }
 
 func LoadWorkflow(cfg globalconfig.Project) (workflowconfig.Workflow, error) {
 	return LoadWorkflowContext(context.Background(), cfg)
 }
 
-func LoadWorkflowContext(ctx context.Context, cfg globalconfig.Project) (workflowconfig.Workflow, error) {
+func LoadWorkflowContext(ctx context.Context, cfg globalconfig.Project) (workflow workflowconfig.Workflow, err error) {
+	defer func() {
+		if err == nil {
+			workflow.Config = workflow.Config.WithAgentDefaults(cfg.GlobalAgents, cfg.GlobalBudget)
+		}
+	}()
 	if strings.TrimSpace(cfg.WorkflowRef) == "" {
 		workflowPath, err := plainWorkflowPath(cfg.Workflow)
 		if err != nil {
@@ -57,7 +65,7 @@ func LoadWorkflowContext(ctx context.Context, cfg globalconfig.Project) (workflo
 	if err != nil {
 		return workflowconfig.Workflow{}, err
 	}
-	workflow, _, err := source.load(ctx)
+	workflow, _, err = source.load(ctx)
 	return workflow, err
 }
 
@@ -299,6 +307,8 @@ func newGitRefWorkflowWatcher(cfg globalconfig.Project, interval time.Duration, 
 		logger = slog.Default()
 	}
 	return &gitRefWorkflowWatcher{
+		agents:   cfg.GlobalAgents,
+		budget:   cfg.GlobalBudget,
 		source:   source,
 		interval: interval,
 		logger:   logger,
@@ -313,6 +323,12 @@ func (w *gitRefWorkflowWatcher) Watch(ctx context.Context) (<-chan configwatcher
 	localWatcher, err := configwatcher.NewFile(w.source.localPath(), func(string) (workflowconfig.Workflow, error) {
 		workflow, _, err := w.source.load(ctx)
 		if err == nil {
+			agents, budget := w.agents, w.budget
+			if w.currentProject != nil {
+				project := w.currentProject()
+				agents, budget = project.GlobalAgents, project.GlobalBudget
+			}
+			workflow.Config = workflow.Config.WithAgentDefaults(agents, budget)
 			err = workflow.Config.Validate()
 		}
 		return workflow, err

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -440,6 +440,53 @@ func TestGitRefWorkflowWatcherReloadsWhenRefAdvances(t *testing.T) {
 	}
 }
 
+func TestWorkflowWatchersUseReloadedHostBackends(t *testing.T) {
+	for _, ref := range []string{"", "origin/main"} {
+		t.Run("ref="+ref, func(t *testing.T) {
+			repo := initWorkflowSourceRepo(t)
+			path := filepath.Join(repo, "WORKFLOW.md")
+			writeWorkflowSourceFile(t, path, "initial")
+			commitWorkflowSourceRepo(t, repo, "initial")
+			updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+			project := &Project{cfg: globalconfig.Project{Workflow: path, WorkflowRef: ref, Workdir: repo}}
+			factory := resolveWorkflowWatcherFactory(Dependencies{}, project.Config(), "", slog.New(slog.DiscardHandler), project.Config)
+			watcher, err := factory(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			updates, err := watcher.Watch(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			project.mu.Lock()
+			project.cfg.GlobalAgents = workflowconfig.Agents{Backends: []workflowconfig.AgentBackend{{ID: "new-backend", Kind: workflowconfig.AgentBackendCodex, Command: "codex"}}}
+			project.mu.Unlock()
+			if ref != "" {
+				path = workflowconfig.LocalWorkflowPath(path)
+			}
+			raw := "---\ntracker:\n  kind: memory\nagents:\n  routes:\n    - name: new-default\n      backend: new-backend\n      default: true\n---\nupdated\n"
+			if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			update := readWorkflowSourceUpdate(t, updates)
+			if update.Err != nil {
+				t.Fatal(update.Err)
+			}
+			found := false
+			for _, backend := range update.Workflow.Config.AgentBackendConfigs() {
+				if backend.ID == "new-backend" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatal("watcher used obsolete host backends")
+			}
+		})
+	}
+}
+
 func TestGitRefWorkflowWatcherReloadsLocalOverlayLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -269,6 +269,21 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 }
 
 func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
+	if err := r.UpdateWorkflowChecked(workflow); err != nil {
+		r.logger.Warn("reload agent configuration rejected; retaining last known good workflow", "error", err)
+	}
+}
+
+func (r *Runner) UpdateWorkflowChecked(workflow config.Workflow) error {
+	apply, err := r.PrepareWorkflowUpdate(workflow)
+	if err != nil {
+		return err
+	}
+	apply()
+	return nil
+}
+
+func (r *Runner) PrepareWorkflowUpdate(workflow config.Workflow) (func(), error) {
 	r.mu.RLock()
 	currentBackends := cloneAgentBackends(r.agentRuntime.backends)
 	factory := r.agentBackendFactory
@@ -278,6 +293,9 @@ func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
 	r.mu.RUnlock()
 
 	runtime, err := newAgentRuntime(workflow, currentBackends, factory)
+	if err != nil {
+		return nil, err
+	}
 	budgetChecker := currentBudgetChecker
 	dispatchEstimator := currentDispatchEstimator
 	var budgetErr error
@@ -285,13 +303,14 @@ func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
 		budgetChecker, dispatchEstimator, budgetErr = budgetGuardBuilder(workflow.Config.Budget)
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.workflow = workflow
 	if budgetErr != nil {
-		r.logger.Warn("reload budget dispatch guards failed", "error", budgetErr)
-	} else {
+		return nil, fmt.Errorf("reload budget dispatch guards: %w", budgetErr)
+	}
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+
+		r.workflow = workflow
 		r.budgetChecker = budgetChecker
 		r.dispatchEstimator = dispatchEstimator
 		r.enforcedBudget, r.enforcedBudgetKnown = enforcedBudgetConfig(workflow.Config.Budget, budgetChecker)
@@ -307,12 +326,8 @@ func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
 				r.logger.Warn("budget dispatch guards reloaded without enforced config reporting")
 			}
 		}
-	}
-	if err != nil {
-		r.logger.Warn("reload agent runtime failed", "error", err)
-		return
-	}
-	r.agentRuntime = runtime
+		r.agentRuntime = runtime
+	}, nil
 }
 
 func (r *Runner) EnforcedBudget() (config.Budget, bool) {
@@ -407,6 +422,9 @@ func newAgentRuntime(
 	staticBackends map[string]AgentBackend,
 	factory AgentBackendFactory,
 ) (agentRuntime, error) {
+	if problems := workflow.Config.EffectiveModelSelection().Validate(); len(problems) > 0 {
+		return agentRuntime{}, errors.New(strings.Join(problems, "; "))
+	}
 	backendConfigs := workflow.Config.AgentBackendConfigs()
 	backends := make(map[string]AgentBackend, len(backendConfigs))
 	configsByID := make(map[string]config.AgentBackend, len(backendConfigs))
@@ -1532,7 +1550,7 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	prompt += recoveryPrompt
 	routeRole := agentRuntime.effectiveRunRole(role)
-	selection, backend, backendConfig, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), routeRole)
+	selection, backend, backendConfig, err := agentRuntime.selectRequestBackend(req, selectorContext(req.SelectorContext, workflow), routeRole)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -1543,11 +1561,8 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	runStartedAt := r.now()
 	modelProvider, serviceTier, configuredEffort := agentTurnIdentityOptions(backendConfig)
-	projectEffort, projectEffortField := workflow.Config.Agent.Effort.Resolve(role)
-	resolvedOverride := resolveAgentOverride(ctx, req.Issue, info.Path, selection.Model, role, agentEffortCandidate{
-		Field:  projectEffortField,
-		Effort: projectEffort,
-	}, backend)
+	baseModel := effectiveModel("", selection.Model, agentRuntime.defaultModelForRole(role))
+	resolvedOverride := resolveRequestAgentSelection(ctx, req, info.Path, baseModel, role, workflow.Config, backendConfig, backend)
 	selectedModel := resolvedOverride.Model
 	effort := configuredEffort
 	if resolvedOverride.Effort != "" {
@@ -1558,14 +1573,26 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 			r.logger.Warn("report detent-agent override rejection failed", "issue_id", req.Issue.ID, "identifier", req.Issue.Identifier, "error", err)
 		}
 	}
+	if resolvedOverride.Err != nil {
+		return RunResult{}, resolvedOverride.Err
+	}
 	sessionModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(role))
 	executionIdentity := tracker.NativeExecutionIdentity{Role: role, Backend: selection.BackendID, Model: sessionModel}
 	if executionIdentity.Model == "" {
 		executionIdentity.Model = "provider_default"
 	}
 	runtimeIdentity := configuredRuntimeIdentity(selection, backendConfig, role, sessionModel, startedAt)
+	runtimeIdentity.Selection = resolvedOverride.Selection
+	runtimeIdentity.Selection.BackendSource = workflow.Config.Agents.Sources["backends."+selection.BackendID]
+	runtimeIdentity.Selection.RouteSource = workflow.Config.Agents.Sources["routes."+selection.RouteName]
 	if effort != "" {
 		runtimeIdentity.ReasoningEffort = agentidentity.NewValue(effort, agentidentity.ProvenanceConfigured)
+	}
+	if hasResumeIdentity(req) {
+		runtimeIdentity = req.ResumeState.RuntimeIdentity.ObserveAt(startedAt)
+		effort = runtimeIdentity.ReasoningEffort.Value
+		modelProvider = runtimeIdentity.Provider.Value
+		serviceTier = runtimeIdentity.ServiceTier.Value
 	}
 	var budgetProjection *dispatchBudgetProjection
 	if workflow.Config.Budget.EffectiveBillingMode() != config.BillingModeSubscription {
@@ -2809,6 +2836,12 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	if override := strings.TrimSpace(validator.Model); override != "" {
 		selectedModel = override
 	}
+	baseModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(RoleValidator))
+	resolvedSelection := resolveAgentSelection(ctx, req.Issue, info.Path, baseModel, RoleValidator, workflow.Config, backendConfig, backend)
+	if resolvedSelection.Err != nil {
+		return gate.ValidatorResult{}, resolvedSelection.Err
+	}
+	selectedModel = resolvedSelection.Model
 	sessionModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(RoleValidator))
 
 	startedAt := req.StartedAt
@@ -2817,6 +2850,12 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	}
 	runStartedAt := r.now()
 	runtimeIdentity := configuredRuntimeIdentity(selection, backendConfig, RoleValidator, sessionModel, startedAt)
+	runtimeIdentity.Selection = resolvedSelection.Selection
+	runtimeIdentity.Selection.BackendSource = workflow.Config.Agents.Sources["backends."+selection.BackendID]
+	runtimeIdentity.Selection.RouteSource = workflow.Config.Agents.Sources["routes."+selection.RouteName]
+	if resolvedSelection.Effort != "" {
+		runtimeIdentity.ReasoningEffort = agentidentity.NewValue(resolvedSelection.Effort, agentidentity.ProvenanceConfigured)
+	}
 	runReq := RunRequest{
 		Issue:            req.Issue,
 		StartedAt:        req.StartedAt,
@@ -2873,6 +2912,9 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	usage := newSessionTokenUsage(false)
 	workerProcessObserved := false
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
+	if resolvedSelection.Effort != "" {
+		effort = resolvedSelection.Effort
+	}
 	turnResult, cleanupScratch, turnErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(sessionCtx, backend, AgentTurnRequest{
 		Workspace:          info.Path,
 		Prompt:             prompt,
@@ -5257,6 +5299,15 @@ func runtimeIdentityProviderSessionID(backendKind string, threadID string, turnI
 func runtimeIdentityLogAttrs(identity agentidentity.Identity) []any {
 	identity = identity.Normalize()
 	attrs := []any{
+		"model_selection_policy", identity.Selection.Policy,
+		"model_selection_policy_source", identity.Selection.PolicySource,
+		"model_selection_reason", identity.Selection.Reason,
+		"model_selection_requested", identity.Selection.RequestedModel,
+		"model_selection_fallback_reason", identity.Selection.FallbackReason,
+		"model_selection_model_source", identity.Selection.ModelSource,
+		"model_selection_effort_source", identity.Selection.EffortSource,
+		"backend_source", identity.Selection.BackendSource,
+		"route_source", identity.Selection.RouteSource,
 		"backend_id", identity.BackendID,
 		"backend_kind", identity.BackendKind,
 		"route", identity.Route,

--- a/internal/runner/agent_override.go
+++ b/internal/runner/agent_override.go
@@ -40,6 +40,7 @@ func resolveAgentOverride(
 		})
 		override = agentoverride.Override{}
 	}
+	override.Model, _ = override.ModelForRole(role)
 	efforts := agentEffortCandidates(override, role, projectEffort)
 	if override.Model == "" && len(efforts) == 0 {
 		return result

--- a/internal/runner/model_selection.go
+++ b/internal/runner/model_selection.go
@@ -1,0 +1,208 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/agentoverride"
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+type agentSelection struct {
+	resolvedAgentOverride
+	Selection agentidentity.Selection
+	Err       error
+}
+
+func hasResumeIdentity(req RunRequest) bool {
+	return req.RetryMode == RetryModeResume && !agentResumeStateEmpty(req.ResumeState) && !req.ResumeState.RuntimeIdentity.IsZero()
+}
+
+func (r agentRuntime) selectRequestBackend(req RunRequest, ctx selector.Context, role string) (RouteSelection, AgentBackend, config.AgentBackend, error) {
+	if !hasResumeIdentity(req) {
+		return r.selectBackendForRole(req.Issue, ctx, r.effectiveRunRole(role))
+	}
+	identity := req.ResumeState.RuntimeIdentity
+	backend, ok := r.backends[identity.BackendID]
+	backendConfig := r.backendConfigs[identity.BackendID]
+	if !ok || backendConfig.Kind != identity.BackendKind {
+		return RouteSelection{}, nil, config.AgentBackend{}, errors.New("resumed agent backend is no longer configured; restore the established backend or start a fresh attempt")
+	}
+	model := effectiveModel("", identity.RequestedModel.Value, identity.ResolvedModel.Value)
+	return RouteSelection{BackendID: identity.BackendID, Model: model, RouteName: identity.Route}, backend, backendConfig, nil
+}
+
+func resolveRequestAgentSelection(ctx context.Context, req RunRequest, workspace, baseModel, role string, cfg config.Config, backendConfig config.AgentBackend, backend AgentBackend) agentSelection {
+	if hasResumeIdentity(req) {
+		identity := req.ResumeState.RuntimeIdentity
+		model := effectiveModel("", identity.RequestedModel.Value, identity.ResolvedModel.Value)
+		return agentSelection{resolvedAgentOverride: resolvedAgentOverride{Model: model, Effort: identity.ReasoningEffort.Value}, Selection: identity.Selection}
+	}
+	return resolveAgentSelection(ctx, req.Issue, workspace, baseModel, role, cfg, backendConfig, backend)
+}
+
+func resolveAgentSelection(ctx context.Context, issue connector.Issue, workspace, baseModel, role string, cfg config.Config, backendConfig config.AgentBackend, backend AgentBackend) agentSelection {
+	policy := cfg.EffectiveModelSelection()
+	projectEffort, field := cfg.Agent.Effort.Resolve(role)
+	if !policy.Active() || policy.BackendKinds == nil || !slices.Contains(*policy.BackendKinds, backendConfig.Kind) {
+		return agentSelection{resolvedAgentOverride: resolveAgentOverride(ctx, issue, workspace, baseModel, role, agentEffortCandidate{Field: field, Effort: projectEffort}, backend)}
+	}
+	result := agentSelection{Selection: agentidentity.Selection{Policy: "automatic", PolicySource: policy.Sources["enabled"]}}
+	if policy.Preset != nil && *policy.Preset != "" {
+		result.Selection.Policy = *policy.Preset
+	}
+	override, _, err := agentoverride.FromIssueBody(issue.Description)
+	if err != nil {
+		return result.reject("block", "", err.Error())
+	}
+	explicitModel, modelField := override.ModelForRole(role)
+	explicitEffort, effortField := override.EffortForRole(role)
+	roleEffort := explicitEffort != ""
+	if explicitEffort == "" {
+		explicitEffort, effortField = override.Effort, "effort"
+	}
+	level, reason := selectionComplexity(policy, issue, role, explicitEffort, roleEffort, explicitModel == "")
+	defaults := policy.Levels[level]
+	stage := policy.Stages[role]
+	result.Model = strings.TrimSpace(baseModel)
+	result.Selection.Reason = reason
+	result.Selection.Level = level
+	result.Selection.ModelSource = "route"
+	if explicitModel != "" {
+		result.Model = explicitModel
+		result.Selection.ModelSource = "issue." + modelField
+	}
+	automaticModel := result.Model == ""
+	if automaticModel {
+		model := defaults.Model
+		result.Selection.ModelSource = "levels." + level + ".model"
+		if stage.Model != nil && *stage.Model != "" {
+			model = stage.Model
+			result.Selection.ModelSource = "stages." + role + ".model"
+		}
+		result.Model = policy.Model(selectionValue(model))
+		result.Selection.ModelSource = selectionSource(policy, result.Selection.ModelSource, selectionValue(model))
+	}
+	result.Effort = explicitEffort
+	result.Selection.EffortSource = "issue." + effortField
+	if result.Effort == "" {
+		result.Effort = projectEffort
+		result.Selection.EffortSource = field
+	}
+	if result.Effort == "" {
+		_, _, result.Effort = agentTurnIdentityOptions(backendConfig)
+		result.Selection.EffortSource = "backend"
+	}
+	if result.Effort == "" {
+		result.Effort = selectionValue(defaults.Effort)
+		result.Selection.EffortSource = selectionSource(policy, "levels."+level+".effort", "")
+		if stage.Effort != nil && *stage.Effort != "" {
+			result.Effort = *stage.Effort
+			result.Selection.EffortSource = selectionSource(policy, "stages."+role+".effort", "")
+		}
+	}
+	result.Selection.RequestedModel = result.Model
+	provider, ok := backend.(AgentModelCatalogProvider)
+	if !ok {
+		result.Err = errors.New("automatic model selection requires a backend model catalog; configure an eligible backend or disable the policy")
+		return result
+	}
+	models, err := provider.ListModels(ctx)
+	if err != nil {
+		result.Err = errors.New("automatic model selection: model catalog unavailable; retry catalog discovery before dispatch")
+		return result
+	}
+	model, available := availableSelectionModel(models, result.Model)
+	if !available && !automaticModel {
+		return result.reject(modelField, result.Model, "explicit model is unavailable or retired in the selected backend catalog")
+	}
+	if !available && policy.Unavailable != nil && *policy.Unavailable == "fallback" && policy.FallbackOrder != nil {
+		for _, candidate := range *policy.FallbackOrder {
+			if fallback, ok := availableSelectionModel(models, policy.Model(candidate)); ok {
+				model, available = fallback, true
+				result.Selection.FallbackReason = "automatic model unavailable or retired"
+				break
+			}
+		}
+	}
+	if !available {
+		result.Err = errors.New("automatic model selection: no configured model is available; update agents.model_selection models or fallback_order after checking the backend catalog")
+		return result
+	}
+	result.Model = canonicalAgentModel(model, result.Model)
+	if effort, ok := supportedAgentEffort(model, result.Effort); ok {
+		result.Effort = effort
+	} else {
+		if explicitEffort != "" {
+			return result.reject(effortField, explicitEffort, "explicit effort is unsupported by the selected model")
+		}
+		result.Err = fmt.Errorf("automatic model selection: effort default %q is unsupported by model %q; configure a supported effort", result.Effort, result.Model)
+	}
+	return result
+}
+
+func (s agentSelection) reject(field, value, reason string) agentSelection {
+	s.Rejections = append(s.Rejections, AgentOverrideRejection{Field: field, Value: value, Reason: reason})
+	s.Err = fmt.Errorf("agent override rejected: %s: %s", field, reason)
+	return s
+}
+
+func selectionValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func availableSelectionModel(models []AgentModel, name string) (AgentModel, bool) {
+	if strings.TrimSpace(name) == "" {
+		return AgentModel{}, false
+	}
+	model, found := findAgentModel(models, name)
+	return model, found && strings.TrimSpace(model.Upgrade) == ""
+}
+
+func selectionSource(policy config.ModelSelection, field, model string) string {
+	if model == "normal" || model == "complex" {
+		field = model + "_model"
+	}
+	return policy.Sources[field] + ":" + field
+}
+
+func selectionComplexity(policy config.ModelSelection, issue connector.Issue, role, effort string, roleEffort, modelOmitted bool) (string, string) {
+	level := selectionValue(policy.DefaultLevel)
+	stage := policy.Stages[role]
+	if stage.Level != nil && *stage.Level != "" {
+		return *stage.Level, "stage_complexity"
+	}
+	if policy.Rules != nil {
+		for _, rule := range *policy.Rules {
+			if rule.Disabled {
+				continue
+			}
+			if len(rule.Roles) > 0 {
+				if !slices.Contains(rule.Roles, role) {
+					continue
+				}
+			} else if stage.IssueComplexity == nil || !*stage.IssueComplexity {
+				if !roleEffort || len(rule.Efforts) == 0 {
+					continue
+				}
+			}
+			if len(rule.Efforts) > 0 && (!modelOmitted || !slices.Contains(rule.Efforts, strings.ToLower(effort))) {
+				continue
+			}
+			if !selector.Match(issue, rule.Selector, selector.Context{}) {
+				continue
+			}
+			return rule.Level, "rule:" + rule.Name
+		}
+	}
+	return level, "default_complexity"
+}

--- a/internal/runner/model_selection_test.go
+++ b/internal/runner/model_selection_test.go
@@ -1,0 +1,219 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func selectionCatalog() []AgentModel {
+	return []AgentModel{
+		{ID: "gpt-5.6-sol", Model: "gpt-5.6-sol", SupportedReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max"}},
+		{ID: "gpt-6-astra", Model: "gpt-6-astra", Default: true, SupportedReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max"}},
+	}
+}
+
+func TestSelectionReloadAndResume(t *testing.T) {
+	backend := &catalogAgentBackend{models: selectionCatalog()}
+	cfg := config.Default()
+	cfg.Agents.ModelSelection = config.ModelSelection{Preset: new("sol_first")}
+	runner, err := NewRunner(Dependencies{Workflow: config.Workflow{Config: cfg}, Workspace: &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir()}}, AgentBackend: backend})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, oldRuntime, _, _ := runner.runtimeSnapshot()
+	identity := agentidentity.Configured("codex", "codex", "default", RoleCode, "gpt-5.6-sol", "", "medium", "", time.Now())
+	identity.Selection = agentidentity.Selection{Policy: "sol_first", Reason: "default_complexity"}
+	resume := RunRequest{RetryMode: RetryModeResume, ResumeState: store.AgentResumeState{ProviderThreadID: "thread-1", RuntimeIdentity: identity}}
+	cfg.Agents.ModelSelection.NormalModel = new("gpt-6-astra")
+	if err := runner.UpdateWorkflowChecked(config.Workflow{Config: cfg}); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name string
+		req  RunRequest
+		want string
+	}{
+		{name: "new dispatch", want: "gpt-6-astra"},
+		{name: "resumed dispatch", req: resume, want: "gpt-5.6-sol"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			capacity, err := runner.DispatchCapacity(context.Background(), tt.req)
+			if err != nil || capacity.Model != tt.want {
+				t.Fatalf("capacity=%+v error=%v", capacity, err)
+			}
+		})
+	}
+	if initial.Config.EffectiveModelSelection().Model("normal") != "gpt-5.6-sol" || oldRuntime.backends["codex"] != backend {
+		t.Fatal("active snapshot changed")
+	}
+	backend.err = errors.New("catalog unavailable")
+	got := resolveRequestAgentSelection(context.Background(), resume, "", "gpt-6-astra", RoleCode, cfg, config.AgentBackend{Kind: config.AgentBackendCodex}, backend)
+	if got.Err != nil || got.Model != "gpt-5.6-sol" || got.Effort != "medium" {
+		t.Fatalf("resume = %+v", got)
+	}
+	_, _, _, err = (agentRuntime{}).selectRequestBackend(resume, selector.Context{}, RoleCode)
+	if err == nil {
+		t.Fatal("missing resume backend accepted")
+	}
+	bad := cfg
+	bad.Agents.ModelSelection.DefaultLevel = new("missing")
+	if err := runner.UpdateWorkflowChecked(config.Workflow{Config: bad}); err == nil {
+		t.Fatal("invalid reload accepted")
+	}
+	lastGood, _, _, _ := runner.runtimeSnapshot()
+	if *lastGood.Config.EffectiveModelSelection().DefaultLevel != "normal" {
+		t.Fatal("invalid reload replaced last known good config")
+	}
+}
+
+func TestCustomSelectionSettings(t *testing.T) {
+	for _, tt := range []struct {
+		name                      string
+		mutate                    func(*config.ModelSelection)
+		kind, role, model, effort string
+	}{
+		{name: "disabled", mutate: func(p *config.ModelSelection) { p.Enabled = new(false) }, model: "", effort: ""},
+		{name: "cleared eligible backends", mutate: func(p *config.ModelSelection) { p.BackendKinds = &[]string{} }, model: "", effort: ""},
+		{name: "custom backend excluded", kind: config.AgentBackendClaudeCode, model: "", effort: ""},
+		{name: "cleared fallback", mutate: func(p *config.ModelSelection) { p.FallbackOrder = &[]string{} }, model: "gpt-5.6-sol", effort: "medium"},
+		{name: "stage defaults", mutate: func(p *config.ModelSelection) {
+			p.Stages = map[string]config.ModelSelectionStage{RoleMerge: {Model: new("complex"), Effort: new("high")}}
+		}, role: RoleMerge, model: "gpt-6-astra", effort: "high"},
+		{name: "role rule", mutate: func(p *config.ModelSelection) {
+			p.Rules = &[]config.ModelSelectionRule{{Name: "merge-complex", Roles: []string{RoleMerge}, Level: "complex", Selector: selector.Selector{Fields: []selector.FieldEquals{{Name: "Complex", Value: "yes"}}}}}
+		}, role: RoleMerge, model: "gpt-6-astra", effort: "medium"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Agents.ModelSelection.Preset = new("sol_first")
+			if tt.mutate != nil {
+				tt.mutate(&cfg.Agents.ModelSelection)
+			}
+			kind, role := tt.kind, tt.role
+			if kind == "" {
+				kind = config.AgentBackendCodex
+			}
+			if role == "" {
+				role = RoleCode
+			}
+			backend := &catalogAgentBackend{models: selectionCatalog()}
+			got := resolveAgentSelection(context.Background(), connector.Issue{Fields: map[string]string{"Complex": "yes"}}, "", "", role, cfg, config.AgentBackend{Kind: kind}, backend)
+			if got.Err != nil || got.Model != tt.model || got.Effort != tt.effort {
+				t.Fatalf("selection=%+v", got)
+			}
+		})
+	}
+}
+
+func TestAutomaticModelSelection(t *testing.T) {
+	for _, tt := range []struct {
+		name, body, role, label, base, projectEffort, model, effort string
+	}{
+		{name: "missing metadata", model: "gpt-5.6-sol", effort: "medium"},
+		{name: "generic enhancement", label: "enhancement", model: "gpt-5.6-sol", effort: "medium"},
+		{name: "high effort", body: "effort: high", model: "gpt-5.6-sol", effort: "high"},
+		{name: "complex metadata", label: "complexity:complex", model: "gpt-6-astra", effort: "medium"},
+		{name: "very complex", label: "complexity:very-complex", model: "gpt-6-astra", effort: "high"},
+		{name: "model only", body: "model: gpt-6-astra", model: "gpt-6-astra", effort: "medium"},
+		{name: "explicit low", body: "effort: low", label: "complexity:very-complex", model: "gpt-6-astra", effort: "low"},
+		{name: "xhigh signal", body: "effort: xhigh", model: "gpt-6-astra", effort: "xhigh"},
+		{name: "max signal", body: "effort: max", model: "gpt-6-astra", effort: "max"},
+		{name: "both explicit", body: "model: gpt-5.6-sol\neffort: max", label: "complexity:very-complex", model: "gpt-5.6-sol", effort: "max"},
+		{name: "role fields", body: "model: gpt-6-astra\neffort: high\ncode:\n  model: gpt-5.6-sol\n  effort: low", model: "gpt-5.6-sol", effort: "low"},
+		{name: "role model issue effort", body: "effort: xhigh\ncode:\n  model: gpt-5.6-sol", model: "gpt-5.6-sol", effort: "xhigh"},
+		{name: "role effort issue model", body: "model: gpt-5.6-sol\ncode:\n  effort: xhigh", model: "gpt-5.6-sol", effort: "xhigh"},
+		{name: "code inherited in rework", role: RoleRework, body: "code:\n  model: gpt-6-astra\n  effort: low", model: "gpt-6-astra", effort: "low"},
+		{name: "entering rework", role: RoleRework, model: "gpt-5.6-sol", effort: "medium"},
+		{name: "routine stays normal", role: RoleRoutine, label: "complexity:very-complex", body: "effort: xhigh", model: "gpt-5.6-sol", effort: "xhigh"},
+		{name: "merge stays normal", role: RoleMerge, label: "complexity:very-complex", model: "gpt-5.6-sol", effort: "medium"},
+		{name: "validator stays normal", role: RoleValidator, label: "complexity:complex", model: "gpt-5.6-sol", effort: "medium"},
+		{name: "role specific merge signal", role: RoleMerge, body: "merge:\n  effort: xhigh", model: "gpt-6-astra", effort: "xhigh"},
+		{name: "route pin", base: "gpt-5.6-sol", label: "complexity:very-complex", model: "gpt-5.6-sol", effort: "high"},
+		{name: "issue wins route", base: "gpt-6-astra", body: "model: gpt-5.6-sol", model: "gpt-5.6-sol", effort: "medium"},
+		{name: "project effort not complexity", projectEffort: "xhigh", model: "gpt-5.6-sol", effort: "xhigh"},
+		{name: "issue effort wins project", projectEffort: "high", body: "effort: low", model: "gpt-5.6-sol", effort: "low"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Agents.ModelSelection = config.ModelSelection{Preset: new("sol_first")}
+			cfg.Agent.Effort.Code = tt.projectEffort
+			issue := connector.Issue{Priority: new(1), State: "Rework"}
+			if tt.body != "" {
+				issue.Description = "```detent-agent\nschema: 1\n" + tt.body + "\n```"
+			}
+			if tt.label != "" {
+				issue.Labels = []string{tt.label}
+			}
+			backend := &catalogAgentBackend{models: selectionCatalog(), defaultModel: "gpt-6-astra"}
+			role := tt.role
+			if role == "" {
+				role = RoleCode
+			}
+			got := resolveAgentSelection(context.Background(), issue, t.TempDir(), tt.base, role, cfg, config.AgentBackend{Kind: config.AgentBackendCodex}, backend)
+			if got.Err != nil || got.Model != tt.model || got.Effort != tt.effort {
+				t.Fatalf("selection = %+v, want %s %s", got, tt.model, tt.effort)
+			}
+			if backend.defaultCalls != 0 || backend.calls != 1 {
+				t.Fatalf("catalog/default calls = %d/%d", backend.calls, backend.defaultCalls)
+			}
+			if got.Selection.Reason == "" || got.Selection.ModelSource == "" || got.Selection.EffortSource == "" {
+				t.Fatalf("missing provenance: %+v", got.Selection)
+			}
+		})
+	}
+}
+
+func TestAutomaticModelSelectionFailures(t *testing.T) {
+	for _, tt := range []struct {
+		name, body, unavailable     string
+		catalog                     []AgentModel
+		catalogErr                  error
+		fallback, failure, rejected bool
+	}{
+		{name: "Astra unavailable", catalog: selectionCatalog()[:1], fallback: true},
+		{name: "Astra retired", catalog: []AgentModel{selectionCatalog()[0], {ID: "gpt-6-astra", Upgrade: "replacement"}}, fallback: true},
+		{name: "neither available", failure: true},
+		{name: "catalog unavailable", catalogErr: errors.New("secret catalog transport details"), failure: true},
+		{name: "fail configured", catalog: selectionCatalog()[:1], unavailable: "fail", failure: true},
+		{name: "invalid explicit model", catalog: selectionCatalog(), body: "model: absent", failure: true, rejected: true},
+		{name: "invalid explicit effort", catalog: selectionCatalog(), body: "effort: absent", failure: true, rejected: true},
+		{name: "invalid role does not downgrade", catalog: selectionCatalog(), body: "effort: low\ncode:\n  effort: absent", failure: true, rejected: true},
+		{name: "malformed override", catalog: selectionCatalog(), body: "unknown: value", failure: true, rejected: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Agents.ModelSelection = config.ModelSelection{Preset: new("sol_first")}
+			if tt.unavailable != "" {
+				cfg.Agents.ModelSelection.Unavailable = &tt.unavailable
+			}
+			issue := connector.Issue{Labels: []string{"complexity:complex"}}
+			if tt.body != "" {
+				issue.Description = "```detent-agent\nschema: 1\n" + tt.body + "\n```"
+			}
+			backend := &catalogAgentBackend{models: tt.catalog, err: tt.catalogErr}
+			got := resolveAgentSelection(context.Background(), issue, "", "", RoleCode, cfg, config.AgentBackend{Kind: config.AgentBackendCodex}, backend)
+			if (got.Err != nil) != tt.failure || (len(got.Rejections) > 0) != tt.rejected {
+				t.Fatalf("selection = %+v", got)
+			}
+			if (got.Selection.FallbackReason != "") != tt.fallback {
+				t.Fatalf("fallback = %+v", got.Selection)
+			}
+			if tt.fallback && (got.Model != "gpt-5.6-sol" || got.Selection.RequestedModel != "gpt-6-astra") {
+				t.Fatalf("fallback identity = %+v", got)
+			}
+			if got.Err != nil && strings.Contains(got.Err.Error(), "secret") {
+				t.Fatal("catalog details leaked")
+			}
+		})
+	}
+}

--- a/internal/runner/provider_capacity.go
+++ b/internal/runner/provider_capacity.go
@@ -13,12 +13,15 @@ type ProviderCapacityResolver interface {
 func (r *Runner) DispatchCapacity(ctx context.Context, req RunRequest) (providercapacity.Requirement, error) {
 	workflow, runtime, _, _ := r.runtimeSnapshot()
 	role := runRole(req.Mode, req.Issue)
-	selection, backend, _, err := runtime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), runtime.effectiveRunRole(role))
+	selection, backend, backendConfig, err := runtime.selectRequestBackend(req, selectorContext(req.SelectorContext, workflow), role)
 	if err != nil {
 		return providercapacity.Requirement{}, err
 	}
-	effort, field := workflow.Config.Agent.Effort.Resolve(role)
-	override := resolveAgentOverride(ctx, req.Issue, "", selection.Model, role, agentEffortCandidate{Field: field, Effort: effort}, backend)
+	baseModel := effectiveModel("", selection.Model, runtime.defaultModelForRole(role))
+	override := resolveRequestAgentSelection(ctx, req, "", baseModel, role, workflow.Config, backendConfig, backend)
+	if override.Err != nil {
+		return providercapacity.Requirement{}, override.Err
+	}
 	model := effectiveModel("", override.Model, runtime.defaultModelForRole(role))
 	if model == "" {
 		model = "provider_default"

--- a/internal/runner/security_audit.go
+++ b/internal/runner/security_audit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/procgroup"
@@ -63,8 +64,20 @@ func (r *Runner) Audit(ctx context.Context, req SecurityAuditRequest) (execution
 	if configuredModel := strings.TrimSpace(auditConfig.Model); configuredModel != "" {
 		selectedModel = configuredModel
 	}
+	baseModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(RoleSecurityAudit))
+	selectionIssue := req.Issue
+	selectionIssue.Description = ""
+	resolvedSelection := resolveAgentSelection(ctx, selectionIssue, auditWorkspace, baseModel, RoleSecurityAudit, workflow.Config, backendConfig, backend)
+	if resolvedSelection.Err != nil {
+		return execution, resolvedSelection.Err
+	}
+	selectedModel = resolvedSelection.Model
 	sessionModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(RoleSecurityAudit))
 	runtimeIdentity := configuredRuntimeIdentity(selection, backendConfig, RoleSecurityAudit, sessionModel, startedAt)
+	runtimeIdentity.Selection = resolvedSelection.Selection
+	if resolvedSelection.Effort != "" {
+		runtimeIdentity.ReasoningEffort = agentidentity.NewValue(resolvedSelection.Effort, agentidentity.ProvenanceConfigured)
+	}
 	runReq := RunRequest{Issue: req.Issue, StartedAt: startedAt, SelectorContext: req.SelectorContext}
 	sessionID, sessionStarted, err := r.startSession(ctx, runReq, startedAt, runtimeIdentity, store.AgentResumeState{}, "", "")
 	if err != nil {
@@ -74,6 +87,9 @@ func (r *Runner) Audit(ctx context.Context, req SecurityAuditRequest) (execution
 	runResult := RunResult{FinalState: FinalStateCompleted, RuntimeIdentity: runtimeIdentity}
 	var output strings.Builder
 	modelProvider, serviceTier, effort := agentTurnIdentityOptions(backendConfig)
+	if resolvedSelection.Effort != "" {
+		effort = resolvedSelection.Effort
+	}
 	removeAuditWorkspace = false
 	turnResult, cleanupScratch, turnErr := runAgentBackendTurnWithToolsUsingLimitPreservingScratch(ctx, backend, AgentTurnRequest{
 		Workspace:               auditWorkspace,

--- a/internal/store/ai_debug.go
+++ b/internal/store/ai_debug.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/store/sqlc"
 )
 
@@ -19,23 +20,24 @@ type AIDebugAttemptReader interface {
 }
 
 type AIDebugSession struct {
-	ID                    int64      `json:"id"`
-	WorkAttemptID         int64      `json:"work_attempt_id,omitempty"`
-	StartedAt             *time.Time `json:"started_at,omitempty"`
-	CompletedAt           *time.Time `json:"completed_at,omitempty"`
-	InputTokens           int64      `json:"input_tokens"`
-	CachedInputTokens     int64      `json:"cached_input_tokens"`
-	OutputTokens          int64      `json:"output_tokens"`
-	ReasoningOutputTokens int64      `json:"reasoning_output_tokens"`
-	TotalTokens           int64      `json:"total_tokens"`
-	Turns                 int64      `json:"turns"`
-	Model                 string     `json:"model,omitempty"`
-	RequestedModel        string     `json:"requested_model,omitempty"`
-	Effort                string     `json:"effort,omitempty"`
-	RuntimeSeconds        int64      `json:"runtime_seconds"`
-	FinalState            string     `json:"final_state,omitempty"`
-	ResumedFromSessionID  int64      `json:"resumed_from_session_id,omitempty"`
-	ProviderSessionID     string     `json:"provider_session_id,omitempty"`
+	RuntimeIdentity       agentidentity.Identity `json:"runtime_identity,omitzero"`
+	ID                    int64                  `json:"id"`
+	WorkAttemptID         int64                  `json:"work_attempt_id,omitempty"`
+	StartedAt             *time.Time             `json:"started_at,omitempty"`
+	CompletedAt           *time.Time             `json:"completed_at,omitempty"`
+	InputTokens           int64                  `json:"input_tokens"`
+	CachedInputTokens     int64                  `json:"cached_input_tokens"`
+	OutputTokens          int64                  `json:"output_tokens"`
+	ReasoningOutputTokens int64                  `json:"reasoning_output_tokens"`
+	TotalTokens           int64                  `json:"total_tokens"`
+	Turns                 int64                  `json:"turns"`
+	Model                 string                 `json:"model,omitempty"`
+	RequestedModel        string                 `json:"requested_model,omitempty"`
+	Effort                string                 `json:"effort,omitempty"`
+	RuntimeSeconds        int64                  `json:"runtime_seconds"`
+	FinalState            string                 `json:"final_state,omitempty"`
+	ResumedFromSessionID  int64                  `json:"resumed_from_session_id,omitempty"`
+	ProviderSessionID     string                 `json:"provider_session_id,omitempty"`
 }
 
 func (s *sqliteStore) ListIssueAIDebugWorkAttempts(ctx context.Context, identity IssueIdentity) ([]WorkAttempt, error) {
@@ -87,7 +89,12 @@ func (s *sqliteStore) ListIssueAIDebugSessions(ctx context.Context, identity Iss
 		}
 		startedAt := aiDebugTimePointer(startedAtValue)
 		completedAt := aiDebugTimePointer(completedAtValue)
+		runtimeIdentity, err := unmarshalRuntimeIdentity(row.RuntimeIdentityJson.String)
+		if err != nil {
+			return nil, err
+		}
 		sessions = append(sessions, AIDebugSession{
+			RuntimeIdentity:       runtimeIdentity,
 			ID:                    row.ID,
 			WorkAttemptID:         row.WorkAttemptID.Int64,
 			StartedAt:             startedAt,

--- a/internal/store/migrations/00054_add_session_runtime_identity.sql
+++ b/internal/store/migrations/00054_add_session_runtime_identity.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE codex_sessions ADD COLUMN runtime_identity_json TEXT;
+
+-- +goose Down
+ALTER TABLE codex_sessions DROP COLUMN runtime_identity_json;

--- a/internal/store/model_selection_test.go
+++ b/internal/store/model_selection_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/agentidentity"
+)
+
+func TestSessionModelSelectionRoundTrip(t *testing.T) {
+	for _, fallback := range []bool{false, true} {
+		t.Run(map[bool]string{false: "normal", true: "fallback"}[fallback], func(t *testing.T) {
+			ctx := context.Background()
+			backend := openTestStore(t, ctx)
+			now := time.Now().UTC()
+			identity := agentidentity.Configured("codex", "codex", "default", "code", "gpt-5.6-sol", "", "medium", "", now)
+			identity.Selection = agentidentity.Selection{Policy: "sol_first", Reason: "default_complexity", RequestedModel: "gpt-5.6-sol", ModelSource: "preset:normal_model", EffortSource: "preset:levels.normal.effort"}
+			if fallback {
+				identity.Selection.RequestedModel = "gpt-6-astra"
+				identity.Selection.FallbackReason = "automatic model unavailable or retired"
+			}
+			id, err := backend.StartSession(ctx, SessionStart{ProjectID: "alpha", IssueID: "123", Identifier: "example/repo#123", StartedAt: now, RuntimeIdentity: identity})
+			if err != nil {
+				t.Fatal(err)
+			}
+			identity = identity.Merge(agentidentity.RuntimeUpdate("gpt-5.6-sol", "openai", "medium", "default", now))
+			if err := backend.FinishSession(ctx, id, SessionFinish{CompletedAt: now.Add(time.Second), FinalState: "completed", ProviderThreadID: "thread-1", RuntimeIdentity: identity}); err != nil {
+				t.Fatal(err)
+			}
+			resume, err := backend.LatestIssueAgentResumeState(ctx, IssueIdentity{ProjectID: "alpha", IssueID: "123"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !resume.RuntimeIdentity.MateriallyEqual(identity) {
+				t.Fatalf("resume identity = %+v, want %+v", resume.RuntimeIdentity, identity)
+			}
+			sessions, err := backend.(AIDebugSessionReader).ListIssueAIDebugSessions(ctx, IssueIdentity{ProjectID: "alpha", IssueID: "123"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(sessions) != 1 || sessions[0].RuntimeIdentity.Selection != identity.Selection {
+				t.Fatalf("session provenance = %+v", sessions)
+			}
+		})
+	}
+}

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -202,6 +202,7 @@ type CodexSession struct {
 	WorkerReapReason             sql.NullString `json:"worker_reap_reason"`
 	WorkerCleanupRoot            sql.NullString `json:"worker_cleanup_root"`
 	WorkerCleanupPath            sql.NullString `json:"worker_cleanup_path"`
+	RuntimeIdentityJson          sql.NullString `json:"runtime_identity_json"`
 }
 
 type DetentRun struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -501,9 +501,10 @@ INSERT INTO codex_sessions (
   provider_session_id,
   resumed_from_session_id,
   orphan_recovery_outcome,
-  orphan_recovery_fallback_reason
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path
+  orphan_recovery_fallback_reason,
+  runtime_identity_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path, runtime_identity_json
 `
 
 type CreateCodexSessionParams struct {
@@ -544,6 +545,7 @@ type CreateCodexSessionParams struct {
 	ResumedFromSessionID         sql.NullInt64  `json:"resumed_from_session_id"`
 	OrphanRecoveryOutcome        sql.NullString `json:"orphan_recovery_outcome"`
 	OrphanRecoveryFallbackReason sql.NullString `json:"orphan_recovery_fallback_reason"`
+	RuntimeIdentityJson          sql.NullString `json:"runtime_identity_json"`
 }
 
 func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSessionParams) (CodexSession, error) {
@@ -585,6 +587,7 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		arg.ResumedFromSessionID,
 		arg.OrphanRecoveryOutcome,
 		arg.OrphanRecoveryFallbackReason,
+		arg.RuntimeIdentityJson,
 	)
 	var i CodexSession
 	err := row.Scan(
@@ -635,6 +638,7 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.WorkerReapReason,
 		&i.WorkerCleanupRoot,
 		&i.WorkerCleanupPath,
+		&i.RuntimeIdentityJson,
 	)
 	return i, err
 }
@@ -1843,7 +1847,7 @@ func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash string) (ApiKey, 
 }
 
 const getCodexSession = `-- name: GetCodexSession :one
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path, runtime_identity_json
 FROM codex_sessions
 WHERE id = ?
 `
@@ -1899,6 +1903,7 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.WorkerReapReason,
 		&i.WorkerCleanupRoot,
 		&i.WorkerCleanupPath,
+		&i.RuntimeIdentityJson,
 	)
 	return i, err
 }
@@ -1937,6 +1942,7 @@ SELECT
   CAST(COALESCE(s.agent_backend_id, '') AS TEXT) AS agent_backend_id,
   CAST(COALESCE(s.agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(COALESCE(s.agent_role, '') AS TEXT) AS agent_role,
+  CAST(COALESCE(s.runtime_identity_json, '') AS TEXT) AS runtime_identity_json,
   CAST(s.completed_at AS TEXT) AS completed_at
 FROM codex_sessions AS s
 JOIN work_attempts AS w ON w.id = s.work_attempt_id
@@ -1989,15 +1995,16 @@ type GetLatestCompletedAgentResumeStateParams struct {
 }
 
 type GetLatestCompletedAgentResumeStateRow struct {
-	ID                int64  `json:"id"`
-	ProviderThreadID  string `json:"provider_thread_id"`
-	ProviderSessionID string `json:"provider_session_id"`
-	RequestedModel    string `json:"requested_model"`
-	Model             string `json:"model"`
-	AgentBackendID    string `json:"agent_backend_id"`
-	AgentBackendKind  string `json:"agent_backend_kind"`
-	AgentRole         string `json:"agent_role"`
-	CompletedAt       string `json:"completed_at"`
+	ID                  int64  `json:"id"`
+	ProviderThreadID    string `json:"provider_thread_id"`
+	ProviderSessionID   string `json:"provider_session_id"`
+	RequestedModel      string `json:"requested_model"`
+	Model               string `json:"model"`
+	AgentBackendID      string `json:"agent_backend_id"`
+	AgentBackendKind    string `json:"agent_backend_kind"`
+	AgentRole           string `json:"agent_role"`
+	RuntimeIdentityJson string `json:"runtime_identity_json"`
+	CompletedAt         string `json:"completed_at"`
 }
 
 func (q *Queries) GetLatestCompletedAgentResumeState(ctx context.Context, arg GetLatestCompletedAgentResumeStateParams) (GetLatestCompletedAgentResumeStateRow, error) {
@@ -2024,6 +2031,7 @@ func (q *Queries) GetLatestCompletedAgentResumeState(ctx context.Context, arg Ge
 		&i.AgentBackendID,
 		&i.AgentBackendKind,
 		&i.AgentRole,
+		&i.RuntimeIdentityJson,
 		&i.CompletedAt,
 	)
 	return i, err
@@ -2040,6 +2048,7 @@ SELECT
   CAST(COALESCE(agent_backend_id, '') AS TEXT) AS agent_backend_id,
   CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(COALESCE(agent_role, '') AS TEXT) AS agent_role,
+  CAST(COALESCE(runtime_identity_json, '') AS TEXT) AS runtime_identity_json,
   CAST(completed_at AS TEXT) AS completed_at
 FROM codex_sessions
 WHERE completed_at IS NOT NULL
@@ -2063,16 +2072,17 @@ type GetLatestIssueAgentResumeStateParams struct {
 }
 
 type GetLatestIssueAgentResumeStateRow struct {
-	ID                int64  `json:"id"`
-	ProjectID         string `json:"project_id"`
-	ProviderThreadID  string `json:"provider_thread_id"`
-	ProviderSessionID string `json:"provider_session_id"`
-	RequestedModel    string `json:"requested_model"`
-	Model             string `json:"model"`
-	AgentBackendID    string `json:"agent_backend_id"`
-	AgentBackendKind  string `json:"agent_backend_kind"`
-	AgentRole         string `json:"agent_role"`
-	CompletedAt       string `json:"completed_at"`
+	ID                  int64  `json:"id"`
+	ProjectID           string `json:"project_id"`
+	ProviderThreadID    string `json:"provider_thread_id"`
+	ProviderSessionID   string `json:"provider_session_id"`
+	RequestedModel      string `json:"requested_model"`
+	Model               string `json:"model"`
+	AgentBackendID      string `json:"agent_backend_id"`
+	AgentBackendKind    string `json:"agent_backend_kind"`
+	AgentRole           string `json:"agent_role"`
+	RuntimeIdentityJson string `json:"runtime_identity_json"`
+	CompletedAt         string `json:"completed_at"`
 }
 
 func (q *Queries) GetLatestIssueAgentResumeState(ctx context.Context, arg GetLatestIssueAgentResumeStateParams) (GetLatestIssueAgentResumeStateRow, error) {
@@ -2093,6 +2103,7 @@ func (q *Queries) GetLatestIssueAgentResumeState(ctx context.Context, arg GetLat
 		&i.AgentBackendID,
 		&i.AgentBackendKind,
 		&i.AgentRole,
+		&i.RuntimeIdentityJson,
 		&i.CompletedAt,
 	)
 	return i, err
@@ -3344,7 +3355,7 @@ func (q *Queries) ListIssueActivityEvents(ctx context.Context, arg ListIssueActi
 }
 
 const listIssueCodexSessions = `-- name: ListIssueCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path, runtime_identity_json
 FROM codex_sessions
 WHERE project_id = ?1
   AND (
@@ -3424,6 +3435,7 @@ func (q *Queries) ListIssueCodexSessions(ctx context.Context, arg ListIssueCodex
 			&i.WorkerReapReason,
 			&i.WorkerCleanupRoot,
 			&i.WorkerCleanupPath,
+			&i.RuntimeIdentityJson,
 		); err != nil {
 			return nil, err
 		}
@@ -3607,6 +3619,7 @@ SELECT
   CAST(COALESCE(s.agent_backend_id, '') AS TEXT) AS agent_backend_id,
   CAST(COALESCE(s.agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
   CAST(COALESCE(s.agent_role, '') AS TEXT) AS agent_role,
+  CAST(COALESCE(s.runtime_identity_json, '') AS TEXT) AS runtime_identity_json,
   CAST(COALESCE(w.worker_type, '') AS TEXT) AS worker_type,
   CAST(COALESCE(w.worker_host, '') AS TEXT) AS worker_host,
   CAST(COALESCE(w.lane, '') AS TEXT) AS lane,
@@ -3623,24 +3636,25 @@ ORDER BY s.started_at DESC, s.id DESC
 `
 
 type ListOrphanedAgentSessionsRow struct {
-	ID                int64         `json:"id"`
-	WorkAttemptID     sql.NullInt64 `json:"work_attempt_id"`
-	ProjectID         string        `json:"project_id"`
-	IssueID           string        `json:"issue_id"`
-	Identifier        string        `json:"identifier"`
-	IssueURL          string        `json:"issue_url"`
-	ProviderThreadID  string        `json:"provider_thread_id"`
-	ProviderSessionID string        `json:"provider_session_id"`
-	RequestedModel    string        `json:"requested_model"`
-	Model             string        `json:"model"`
-	AgentBackendID    string        `json:"agent_backend_id"`
-	AgentBackendKind  string        `json:"agent_backend_kind"`
-	AgentRole         string        `json:"agent_role"`
-	WorkerType        string        `json:"worker_type"`
-	WorkerHost        string        `json:"worker_host"`
-	Lane              string        `json:"lane"`
-	AttemptNumber     int64         `json:"attempt_number"`
-	StartedAt         string        `json:"started_at"`
+	ID                  int64         `json:"id"`
+	WorkAttemptID       sql.NullInt64 `json:"work_attempt_id"`
+	ProjectID           string        `json:"project_id"`
+	IssueID             string        `json:"issue_id"`
+	Identifier          string        `json:"identifier"`
+	IssueURL            string        `json:"issue_url"`
+	ProviderThreadID    string        `json:"provider_thread_id"`
+	ProviderSessionID   string        `json:"provider_session_id"`
+	RequestedModel      string        `json:"requested_model"`
+	Model               string        `json:"model"`
+	AgentBackendID      string        `json:"agent_backend_id"`
+	AgentBackendKind    string        `json:"agent_backend_kind"`
+	AgentRole           string        `json:"agent_role"`
+	RuntimeIdentityJson string        `json:"runtime_identity_json"`
+	WorkerType          string        `json:"worker_type"`
+	WorkerHost          string        `json:"worker_host"`
+	Lane                string        `json:"lane"`
+	AttemptNumber       int64         `json:"attempt_number"`
+	StartedAt           string        `json:"started_at"`
 }
 
 func (q *Queries) ListOrphanedAgentSessions(ctx context.Context, projectID string) ([]ListOrphanedAgentSessionsRow, error) {
@@ -3666,6 +3680,7 @@ func (q *Queries) ListOrphanedAgentSessions(ctx context.Context, projectID strin
 			&i.AgentBackendID,
 			&i.AgentBackendKind,
 			&i.AgentRole,
+			&i.RuntimeIdentityJson,
 			&i.WorkerType,
 			&i.WorkerHost,
 			&i.Lane,
@@ -3823,7 +3838,7 @@ func (q *Queries) ListPendingWorkAttemptCapacityReleases(ctx context.Context, pr
 }
 
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed, orphan_recovery_fallback_reason, worker_pid, worker_pgid, worker_started_at, worker_reaped_at, worker_reap_outcome, project_id, worker_reap_reason, worker_cleanup_root, worker_cleanup_path, runtime_identity_json
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?
@@ -3886,6 +3901,7 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.WorkerReapReason,
 			&i.WorkerCleanupRoot,
 			&i.WorkerCleanupPath,
+			&i.RuntimeIdentityJson,
 		); err != nil {
 			return nil, err
 		}
@@ -4752,8 +4768,9 @@ SET agent_backend_id = COALESCE(?1, agent_backend_id),
     reasoning_effort_provenance = ?12,
     service_tier = ?13,
     service_tier_provenance = ?14,
-    identity_observed_at = ?15
-WHERE id = ?16
+    identity_observed_at = ?15,
+    runtime_identity_json = ?16
+WHERE id = ?17
 `
 
 type UpdateCodexSessionIdentityParams struct {
@@ -4772,6 +4789,7 @@ type UpdateCodexSessionIdentityParams struct {
 	ServiceTier               sql.NullString `json:"service_tier"`
 	ServiceTierProvenance     sql.NullString `json:"service_tier_provenance"`
 	IdentityObservedAt        sql.NullString `json:"identity_observed_at"`
+	RuntimeIdentityJson       sql.NullString `json:"runtime_identity_json"`
 	ID                        int64          `json:"id"`
 }
 
@@ -4792,6 +4810,7 @@ func (q *Queries) UpdateCodexSessionIdentity(ctx context.Context, arg UpdateCode
 		arg.ServiceTier,
 		arg.ServiceTierProvenance,
 		arg.IdentityObservedAt,
+		arg.RuntimeIdentityJson,
 		arg.ID,
 	)
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -215,7 +215,12 @@ func (s *sqliteStore) StartSession(ctx context.Context, attrs SessionStart) (int
 		RequestedModel: agentidentity.NewValue(requestedModel, agentidentity.ProvenanceConfigured),
 	})
 
+	identityJSON, err := marshalRuntimeIdentity(identity)
+	if err != nil {
+		return 0, err
+	}
 	session, err := s.queries.CreateCodexSession(ctx, sqlc.CreateCodexSessionParams{
+		RuntimeIdentityJson:          nullString(identityJSON),
 		RunID:                        nullPositiveInt64(attrs.RunID),
 		ProjectID:                    nullString(attrs.ProjectID),
 		WorkAttemptID:                nullPositiveInt64(attrs.WorkAttemptID),
@@ -368,7 +373,12 @@ func (s *sqliteStore) UpdateSessionIdentity(ctx context.Context, sessionID int64
 		return ErrNotFound
 	}
 	identity = identity.Normalize()
+	identityJSON, err := marshalRuntimeIdentity(identity)
+	if err != nil {
+		return err
+	}
 	rows, err := s.queries.UpdateCodexSessionIdentity(ctx, sqlc.UpdateCodexSessionIdentityParams{
+		RuntimeIdentityJson:       nullString(identityJSON),
 		AgentBackendID:            nullString(identity.BackendID),
 		AgentBackendKind:          nullString(identity.BackendKind),
 		AgentRole:                 nullString(identity.Role),
@@ -462,7 +472,12 @@ func (s *sqliteStore) LatestCompletedAgentResumeState(ctx context.Context, attrs
 	if err != nil {
 		return AgentResumeState{}, err
 	}
+	runtimeIdentity, err := unmarshalRuntimeIdentity(row.RuntimeIdentityJson)
+	if err != nil {
+		return AgentResumeState{}, err
+	}
 	return AgentResumeState{
+		RuntimeIdentity:   runtimeIdentity,
 		DetentSessionID:   row.ID,
 		ProviderThreadID:  strings.TrimSpace(row.ProviderThreadID),
 		ProviderSessionID: strings.TrimSpace(row.ProviderSessionID),
@@ -500,7 +515,12 @@ func (s *sqliteStore) LatestIssueAgentResumeState(ctx context.Context, identity 
 	if err != nil {
 		return AgentResumeState{}, err
 	}
+	runtimeIdentity, err := unmarshalRuntimeIdentity(row.RuntimeIdentityJson)
+	if err != nil {
+		return AgentResumeState{}, err
+	}
 	return AgentResumeState{
+		RuntimeIdentity:   runtimeIdentity,
 		DetentSessionID:   row.ID,
 		ProviderThreadID:  strings.TrimSpace(row.ProviderThreadID),
 		ProviderSessionID: strings.TrimSpace(row.ProviderSessionID),
@@ -528,8 +548,13 @@ func (s *sqliteStore) ListOrphanedAgentSessions(ctx context.Context, projectID s
 		if err != nil {
 			return nil, err
 		}
+		runtimeIdentity, err := unmarshalRuntimeIdentity(row.RuntimeIdentityJson)
+		if err != nil {
+			return nil, err
+		}
 		orphans = append(orphans, OrphanedAgentSession{
 			ResumeState: AgentResumeState{
+				RuntimeIdentity:   runtimeIdentity,
 				DetentSessionID:   row.ID,
 				ProviderThreadID:  strings.TrimSpace(row.ProviderThreadID),
 				ProviderSessionID: strings.TrimSpace(row.ProviderSessionID),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -511,6 +511,7 @@ type AgentResumeLookup struct {
 }
 
 type AgentResumeState struct {
+	RuntimeIdentity   agentidentity.Identity
 	DetentSessionID   int64
 	ProviderThreadID  string
 	ProviderSessionID string


### PR DESCRIPTION
## Summary

- Add opt-in instance-wide Sol-first selection and inherited backend, route, and pricing defaults. Projects can override individual policy settings, replace named routes/backends, or explicitly disable and clear inherited settings.
- Resolve model and effort independently from issue overrides, existing routes, and deterministic complexity metadata. Validate against backend catalogs, explain configured fallback or failure, and retain established identity for resumed sessions and last-known-good configuration on rejected reloads.
- Expose effective sources and selection reasons in doctor and session diagnostics. Add verified Sol, its alias, and Astra pricing with documentation distinguishing API estimates from subscription charges and credits.

Fixes #2175

## UI Surface Contract

- [x] N/A: no operator screen layout, density, or responsive visibility changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: changes are configuration, CLI diagnostics, and existing session/API data; no visual operator screen changes.

## Test Plan

- [x] Focused table-driven tests cover independent issue model/effort precedence, complexity/stage defaults, unavailable models and catalog failures, explicit rejection, and custom backend exclusions.
- [x] Multi-project tests cover partial overrides, explicit false/empty settings, route disable, future registration, host reload and watcher updates, invalid reload retention, pricing overrides, and redaction.
- [x] Session persistence and resume tests retain runtime selection identity across changed defaults.
- [x] `make generate`
- [x] `make check` — race tests, lint, vet, NilAway, and coverage gates passed; total coverage 80.1%.
- [x] Designated safety-critical dispatch-control files are unchanged; their additional boundary fuzz gate is not triggered.
