### PR TITLE
fix(diagnostics): record dependency refusals

### DIFF
--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3147,10 +3147,11 @@ func TestFilterImplementDependencyDeferralsUsesDurableAttemptHistory(t *testing.
 		blockerState  string
 		historyErr    error
 		wantCandidate bool
+		wantDetail    string
 	}{
-		{name: "unresolved blocker suppresses worker after restart", blockerState: "Todo"},
+		{name: "unresolved blocker suppresses worker after restart", blockerState: "Todo", wantDetail: "waiting on dependency digitaldrywood/detent#134"},
 		{name: "terminal blocker releases worker after restart", blockerState: "Done", wantCandidate: true},
-		{name: "history lookup failure suppresses worker", blockerState: "Todo", historyErr: errors.New("attempt store unavailable")},
+		{name: "history lookup failure suppresses worker", blockerState: "Todo", historyErr: errors.New("attempt store unavailable"), wantDetail: "dependency deferral history unavailable: attempt store unavailable"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3175,6 +3176,14 @@ func TestFilterImplementDependencyDeferralsUsesDurableAttemptHistory(t *testing.
 			filtered := orch.filterImplementDependencyDeferrals(t.Context(), []connector.Issue{issue})
 			if got := len(filtered) == 1; got != tt.wantCandidate {
 				t.Fatalf("candidate retained = %v, want %v", got, tt.wantCandidate)
+			}
+			decisions := orch.workAttempts.(*recordingWorkAttemptStore).decisions
+			if tt.wantCandidate {
+				if len(decisions) != 0 {
+					t.Fatalf("released candidate has refusals: %+v", decisions)
+				}
+			} else if len(decisions) != 1 || decisions[0].Reason != dispatchSkipBlockedByDependency || decisions[0].WaitReason != tt.wantDetail {
+				t.Fatalf("dependency refusal = %+v, want detail %q", decisions, tt.wantDetail)
 			}
 		})
 	}

--- a/internal/orchestrator/implement_dependency_deferral.go
+++ b/internal/orchestrator/implement_dependency_deferral.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/digitaldrywood/detent/internal/store"
-
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
@@ -18,6 +17,7 @@ type deferredCandidate struct {
 	record             implementProgressRecord
 	blocked            bool
 	historyUnavailable bool
+	detail             string
 }
 
 func (o *Orchestrator) evaluateImplementDependencyDeferral(
@@ -100,7 +100,7 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 			if o.logger != nil {
 				o.logger.Warn("implement dependency deferral history lookup failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 			}
-			candidates[issue.ID] = &deferredCandidate{issue: issue, blocked: true, historyUnavailable: true}
+			candidates[issue.ID] = &deferredCandidate{issue: issue, blocked: true, historyUnavailable: true, detail: "dependency deferral history unavailable: " + err.Error()}
 			continue
 		}
 		if len(attempts) == 0 {
@@ -110,7 +110,7 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 		if !ok || !record.DependencyDeferral || record.Reason != implementDependencyDeferralReason || len(record.DependencyBlockers) == 0 {
 			continue
 		}
-		candidate := &deferredCandidate{issue: issue, record: record, blocked: true}
+		candidate := &deferredCandidate{issue: issue, record: record, blocked: true, detail: "dependency resolution unavailable: no blocker identifiers"}
 		candidates[issue.ID] = candidate
 		for _, blocker := range record.DependencyBlockers {
 			identifier := strings.TrimSpace(blocker.Identifier)
@@ -129,17 +129,17 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 		return issues
 	}
 	if len(identifiers) == 0 {
-		return removeDeferredImplementCandidates(issues, candidates)
+		return o.removeDeferredImplementCandidates(ctx, issues, candidates)
 	}
 	resolver, ok := o.connector.(connector.IssueReferenceResolver)
 	if !ok {
-		o.warnImplementDependencyDeferralRefresh(candidates, errors.New("issue reference resolver unavailable"))
-		return removeDeferredImplementCandidates(issues, candidates)
+		o.markImplementDependencyDeferralRefreshUnavailable(candidates, errors.New("issue reference resolver unavailable"))
+		return o.removeDeferredImplementCandidates(ctx, issues, candidates)
 	}
 	resolved, err := resolver.FetchIssueStatesByIdentifiers(ctx, identifiers)
 	if err != nil {
-		o.warnImplementDependencyDeferralRefresh(candidates, err)
-		return removeDeferredImplementCandidates(issues, candidates)
+		o.markImplementDependencyDeferralRefreshUnavailable(candidates, err)
+		return o.removeDeferredImplementCandidates(ctx, issues, candidates)
 	}
 	byIdentifier := make(map[string]connector.Issue, len(resolved))
 	for _, issue := range resolved {
@@ -151,24 +151,28 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 		if candidate.historyUnavailable {
 			continue
 		}
-		candidate.blocked = false
+		var details []string
 		for _, blocker := range candidate.record.DependencyBlockers {
 			resolvedIssue, found := byIdentifier[normalizedIssueIdentifier(blocker.Identifier)]
-			if !found || !implementDependencyTerminal(resolvedIssue, o.cfg.TerminalStates) {
-				candidate.blocked = true
-				break
+			if !found {
+				label := strings.TrimSpace(blocker.Identifier)
+				if label == "" {
+					label = "unknown dependency"
+				}
+				details = append(details, "dependency resolution unavailable: missing blocker result for "+label)
+				continue
 			}
-		}
-		var humanRefs []connector.BlockedRef
-		for _, blocker := range candidate.record.DependencyBlockers {
-			resolvedIssue := byIdentifier[normalizedIssueIdentifier(blocker.Identifier)]
+			if implementDependencyTerminal(resolvedIssue, o.cfg.TerminalStates) {
+				continue
+			}
 			if connector.HumanOwned(resolvedIssue) {
-				humanRefs = append(humanRefs, connector.BlockedRef{Identifier: blocker.Identifier, HumanOwned: true, HumanCompletionReady: connector.HumanPrerequisiteReady(resolvedIssue)})
+				details = append(details, humanDependencyWaitReason([]connector.BlockedRef{{Identifier: blocker.Identifier, HumanOwned: true}}))
+			} else {
+				details = append(details, "waiting on dependency "+blocker.Identifier)
 			}
 		}
-		if reason := humanDependencyWaitReason(humanRefs); reason != "" {
-			o.recordSchedulerDecision(ctx, nil, time.Now(), dispatchPlanDecision{Issue: candidate.issue, SkipDetail: reason}, string(store.SchedulerDecisionResultSkipped), dispatchSkipBlockedByDependency)
-		}
+		candidate.blocked = len(details) > 0
+		candidate.detail = strings.Join(details, "; ")
 		if o.logger != nil {
 			o.logger.Debug(
 				"implement dependency deferral evaluated",
@@ -179,10 +183,11 @@ func (o *Orchestrator) filterImplementDependencyDeferrals(
 			)
 		}
 	}
-	return removeDeferredImplementCandidates(issues, candidates)
+	return o.removeDeferredImplementCandidates(ctx, issues, candidates)
 }
 
-func removeDeferredImplementCandidates(
+func (o *Orchestrator) removeDeferredImplementCandidates(
+	ctx context.Context,
 	issues []connector.Issue,
 	candidates map[string]*deferredCandidate,
 ) []connector.Issue {
@@ -190,6 +195,7 @@ func removeDeferredImplementCandidates(
 	for _, issue := range issues {
 		candidate, ok := candidates[issue.ID]
 		if ok && candidate.blocked {
+			o.recordSchedulerDecision(ctx, nil, time.Now(), dispatchPlanDecision{Issue: issue, SkipDetail: candidate.detail}, string(store.SchedulerDecisionResultSkipped), dispatchSkipBlockedByDependency)
 			continue
 		}
 		filtered = append(filtered, issue)
@@ -251,11 +257,15 @@ func (o *Orchestrator) warnRejectedImplementDependencyRefs(issue connector.Issue
 	o.logger.Warn("implement dependency deferral rejected", attrs...)
 }
 
-func (o *Orchestrator) warnImplementDependencyDeferralRefresh(candidates map[string]*deferredCandidate, err error) {
-	if o == nil || o.logger == nil {
-		return
-	}
+func (o *Orchestrator) markImplementDependencyDeferralRefreshUnavailable(candidates map[string]*deferredCandidate, err error) {
 	for _, candidate := range candidates {
+		if candidate.historyUnavailable {
+			continue
+		}
+		candidate.detail = "dependency resolution unavailable for " + implementDependencyBlockerLabels(candidate.record.DependencyBlockers) + ": " + err.Error()
+		if o.logger == nil {
+			continue
+		}
 		o.logger.Warn(
 			"implement dependency deferral refresh failed",
 			"issue_id", candidate.issue.ID,

--- a/internal/orchestrator/implement_dependency_deferral_test.go
+++ b/internal/orchestrator/implement_dependency_deferral_test.go
@@ -1,0 +1,139 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/explain"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestDependencyDeferralRefusalDetails(t *testing.T) {
+	t.Parallel()
+	const ref = "owner/repo#10"
+	human := humanDependencyIssue("", true)
+	readyHuman := humanDependencyIssue("Verified authentication", true)
+	for _, tt := range []struct {
+		name       string
+		tracker    connector.Connector
+		historyErr error
+		ref        string
+		want       []string
+	}{
+		{name: "ordinary blocker", tracker: hydratingDispatchConnector{blockers: []connector.Issue{{Identifier: ref, State: "Rework"}}}, ref: ref, want: []string{"waiting on dependency " + ref}},
+		{name: "missing resolver", tracker: struct{ connector.Connector }{memory.New(memory.Config{})}, ref: ref, want: []string{"dependency resolution unavailable", ref, "issue reference resolver unavailable"}},
+		{name: "failed lookup", tracker: dependencyFailureTracker{Connector: memory.New(memory.Config{}), resolveErr: errors.New("tracker unavailable")}, ref: ref, want: []string{"dependency resolution unavailable", ref, "tracker unavailable"}},
+		{name: "missing result", tracker: hydratingDispatchConnector{}, ref: ref, want: []string{"missing blocker result for " + ref}},
+		{name: "missing identifier", tracker: hydratingDispatchConnector{}, want: []string{"no blocker identifiers"}},
+		{name: "history unavailable", historyErr: errors.New("history offline"), want: []string{"dependency deferral history unavailable: history offline"}},
+		{name: "human pending", tracker: hydratingDispatchConnector{blockers: []connector.Issue{human}}, ref: ref, want: []string{"waiting on human prerequisite " + ref, "closure and completion evidence required"}},
+		{name: "human ready", tracker: hydratingDispatchConnector{blockers: []connector.Issue{readyHuman}}, ref: ref},
+		{name: "terminal", tracker: hydratingDispatchConnector{blockers: []connector.Issue{{Identifier: ref, State: "Done"}}}, ref: ref},
+		{name: "closed", tracker: hydratingDispatchConnector{blockers: []connector.Issue{{Identifier: ref, Closed: true}}}, ref: ref},
+		{name: "merged", tracker: hydratingDispatchConnector{blockers: []connector.Issue{{Identifier: ref, PullRequest: &connector.PullRequest{State: "merged"}}}}, ref: ref},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := implementProgressIssueWithoutPR()
+			attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{implementProgressDependencyDeferralHistoryAttempt(1, tt.ref, "Todo")}, historyErr: tt.historyErr}
+			o := &Orchestrator{cfg: normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, TerminalStates: []string{"Done"}}), connector: tt.tracker, workAttempts: attempts}
+			filtered := o.filterImplementDependencyDeferrals(t.Context(), []connector.Issue{issue})
+			if len(tt.want) == 0 {
+				if len(filtered) != 1 || len(attempts.decisions) != 0 {
+					t.Fatalf("ready dependency: candidates=%+v refusals=%+v", filtered, attempts.decisions)
+				}
+				return
+			}
+			if len(filtered) != 0 || len(attempts.decisions) != 1 {
+				t.Fatalf("suppression: candidates=%+v refusals=%+v", filtered, attempts.decisions)
+			}
+			decision := attempts.decisions[0]
+			if decision.Reason != dispatchSkipBlockedByDependency || decision.Result != store.SchedulerDecisionResultSkipped || decision.Selected || decision.IssueID != issue.ID {
+				t.Fatalf("refusal=%+v", decision)
+			}
+			for _, detail := range tt.want {
+				if !strings.Contains(decision.WaitReason, detail) {
+					t.Fatalf("detail=%q, want %q", decision.WaitReason, detail)
+				}
+			}
+		})
+	}
+}
+
+func TestDependencyDeferralEvidenceAndReleaseAcrossRestart(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	path := filepath.Join(t.TempDir(), "detent.db")
+	cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, TerminalStates: []string{"Done"}})
+	issue := implementProgressIssueWithoutPR()
+	history := implementProgressDependencyDeferralHistoryAttempt(1, "digitaldrywood/detent#134", "Todo")
+	backend, err := store.Open(ctx, store.Config{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempts := backend.(store.WorkAttemptStore)
+	id, err := attempts.StartWorkAttempt(ctx, store.WorkAttemptStart{ProjectID: "detent", IssueID: issue.ID, Identifier: issue.Identifier, WorkerType: "agent", Lane: issue.State, StartedAt: history.CompletedAt.Add(-time.Minute)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := attempts.CompleteWorkAttempt(ctx, store.WorkAttemptCompletion{AttemptID: id, CompletedAt: history.CompletedAt, Status: store.WorkAttemptStatusTerminal, TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: history.WorkerMetadataJSON}); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{cfg: cfg, workAttempts: attempts}
+	o.recordSchedulerDecision(ctx, nil, history.CompletedAt.Add(time.Minute), dispatchPlanDecision{Issue: issue, Selected: true}, string(store.SchedulerDecisionResultSelected), "selected")
+	if err := backend.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name, state   string
+		wantCandidate bool
+	}{
+		{name: "restart suppresses open dependency", state: "Todo"},
+		{name: "restart releases completed dependency", state: "Done", wantCandidate: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reopened, err := store.Open(ctx, store.Config{Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := reopened.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			o := &Orchestrator{cfg: cfg, workAttempts: reopened.(store.WorkAttemptStore), connector: hydratingDispatchConnector{blockers: []connector.Issue{{Identifier: "digitaldrywood/detent#134", State: tt.state}}}}
+			reader := reopened.(store.IssueSchedulerDecisionStore)
+			service := explain.New(explain.Dependencies{Scheduler: reader})
+			query := explain.Query{ProjectID: "detent", IssueID: issue.ID}
+			if tt.wantCandidate {
+				explanation, err := service.Explain(ctx, query)
+				if err != nil || explanation.Eligibility.State != explain.EligibilityRefused {
+					t.Fatalf("persisted refusal after restart=%+v, error=%v", explanation.Eligibility, err)
+				}
+			}
+			filtered := o.filterImplementDependencyDeferrals(ctx, []connector.Issue{issue})
+			if (len(filtered) == 1) != tt.wantCandidate {
+				t.Fatalf("candidates=%+v", filtered)
+			}
+			decisions, err := reader.ListIssueSchedulerDecisions(ctx, store.IssueSchedulerDecisionQuery{Identity: store.IssueIdentity{ProjectID: "detent", IssueID: issue.ID}})
+			if err != nil || len(decisions) != 2 {
+				t.Fatalf("decisions=%+v, error=%v", decisions, err)
+			}
+			explanation, err := service.Explain(ctx, query)
+			if err != nil || explanation.Eligibility.State != explain.EligibilityRefused || explanation.Eligibility.Latest == nil {
+				t.Fatalf("explanation=%+v, error=%v", explanation.Eligibility, err)
+			}
+			latest := explanation.Eligibility.Latest
+			if latest.EvidenceID != fmt.Sprintf("scheduler:%d", decisions[0].ID) || latest.Reason != "waiting on dependency digitaldrywood/detent#134" {
+				t.Fatalf("latest=%+v, decisions=%+v", latest, decisions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Record a durable `blocked_by_dependency` scheduler refusal whenever dependency-deferral filtering suppresses a candidate, so issue explanations replace stale selected decisions with the actual wait.
- Include blocker references and distinct details for unavailable attempt history, missing resolver, failed lookups, and missing results. Preserve fail-closed dispatch and release completed dependencies and verified human prerequisites.
- Cover refusal persistence and explanation selection across a database restart. Incident recovery using merged #2248 is already verified in [the issue](https://github.com/digitaldrywood/detent/issues/2253): #2063 records refusal decision 84863, and #2064 resumed with active attempt 7874. No recovery logic is duplicated.

Fixes #2253

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, or responsive visibility changes.
- [x] No persistent top-of-screen messaging added.
- [x] No visual changes to primary operator screens; diagnostics are verified by regression tests.

## Test Plan

- [x] Focused race regressions for dependency deferrals, human prerequisites, and existing invalid-Rework-wait recovery.
- [x] SQLite reopen regression verifies persisted refusal supersedes historical selection and completed dependencies release after restart.
- [x] `make check`: build, lint, vet, NilAway, race tests, 80.1% total coverage, and configured package/file coverage floors all passed.
