### PR TITLE
fix(telemetry): keep fleet snapshots publishing after startup

### DIFF
--- a/internal/boardsnapshot/store.go
+++ b/internal/boardsnapshot/store.go
@@ -97,6 +97,7 @@ func prepareStartupSnapshot(snapshot *telemetry.Snapshot, now time.Time) {
 		Complete:   true,
 	}
 	snapshot.Runtime = telemetry.SnapshotSection{Source: telemetry.SnapshotSourceUnknown}
+	snapshot.Shutdown = telemetry.Shutdown{Status: "running"}
 	snapshot.Refresh = startupRefresh(snapshot.Refresh, now)
 	snapshot.Counts.Running = 0
 	snapshot.Running = nil

--- a/internal/boardsnapshot/store_test.go
+++ b/internal/boardsnapshot/store_test.go
@@ -43,6 +43,7 @@ func TestFileStoreLoad(t *testing.T) {
 				if err := writer.Save(context.Background(), telemetry.Snapshot{
 					GeneratedAt: tt.savedAt.Add(-time.Second),
 					Counts:      telemetry.Counts{Running: 2},
+					Shutdown:    telemetry.Shutdown{Status: "draining", Draining: true},
 				}); err != nil {
 					t.Fatalf("Save() error = %v", err)
 				}
@@ -63,6 +64,9 @@ func TestFileStoreLoad(t *testing.T) {
 			}
 			if found && got.Refresh.ReadinessStatus() != telemetry.RefreshStatusInitializing {
 				t.Fatalf("Load() refresh = %#v, want initializing", got.Refresh)
+			}
+			if found && got.Shutdown != (telemetry.Shutdown{Status: "running"}) {
+				t.Fatalf("Load() shutdown = %#v, want the new process running", got.Shutdown)
 			}
 		})
 	}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	defaultSnapshotInterval      = time.Second
+	defaultTelemetryReadTimeout  = 500 * time.Millisecond
 	defaultBoardSnapshotInterval = 30 * time.Second
 	defaultTokenTrendWindowSize  = 60
 	defaultTokenThroughputWindow = time.Minute
@@ -634,13 +635,8 @@ func publishSnapshotOnce(
 		if orch == nil {
 			continue
 		}
-		state, err := orch.State(ctx)
+		state, err := readTelemetrySource(ctx, "project_state", string(trackedProject.ID()), orch.State)
 		if err != nil {
-			slog.Default().Warn(
-				"project telemetry snapshot skipped",
-				slog.String("project_id", string(trackedProject.ID())),
-				slog.String("error", err.Error()),
-			)
 			lastErrorAt := now
 			merged = mergeSnapshot(merged, telemetry.Snapshot{
 				Project:      projectMetadata,
@@ -931,7 +927,7 @@ func lifetimeTotals(ctx context.Context, source lifetimeTotalsSource) telemetry.
 	if source == nil {
 		return telemetry.LifetimeTotals{DegradedReason: "runtime store unavailable"}
 	}
-	totals, err := source.LifetimeTotals(ctx)
+	totals, err := readTelemetrySource(ctx, "lifetime_totals", "", source.LifetimeTotals)
 	if err != nil {
 		return telemetry.LifetimeTotals{DegradedReason: "read runtime store lifetime totals: " + err.Error()}
 	}
@@ -950,6 +946,26 @@ func lifetimeTotals(ctx context.Context, source lifetimeTotalsSource) telemetry.
 		ResumedInputTokens:    totals.ResumedInputTokens,
 		ResumedCachedTokens:   totals.ResumedCachedTokens,
 	}
+}
+
+func readTelemetrySource[T any](ctx context.Context, source, projectID string, read func(context.Context) (T, error)) (T, error) {
+	readCtx, cancel := context.WithTimeout(ctx, defaultTelemetryReadTimeout)
+	defer cancel()
+	started := time.Now()
+	value, err := read(readCtx)
+	if err != nil {
+		err = fmt.Errorf("telemetry source %s: %w", source, err)
+		if ctx.Err() == nil {
+			slog.Default().Warn("telemetry source read failed",
+				"source", source,
+				"project_id", projectID,
+				"elapsed", time.Since(started),
+				"timeout", defaultTelemetryReadTimeout,
+				"error", err,
+			)
+		}
+	}
+	return value, err
 }
 
 func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {

--- a/internal/cli/telemetry_liveness_test.go
+++ b/internal/cli/telemetry_liveness_test.go
@@ -1,0 +1,327 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/boardsnapshot"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/tui"
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+func TestTelemetryPublicationSurvivesStalledSourceAfterRestart(t *testing.T) {
+	for _, source := range []string{"project_state", "lifetime_totals"} {
+		for _, cached := range []bool{false, true} {
+			name := source + "/initializing"
+			if cached {
+				name = source + "/cached_draining"
+			}
+			t.Run(name, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(t.Context())
+					defer cancel()
+					snapshots := hub.New[telemetry.Snapshot]()
+					registry := project.NewRegistry()
+					var requests []orchestrator.RunRequest
+					for _, id := range []string{"beta", "gamma"} {
+						tracker := memory.New(memory.Config{Issues: []connector.Issue{{ID: id, Identifier: id + "#1", Title: id + " active worker", State: "In Progress", AssignedToWorker: true}}})
+						runner := newRestartRecoveryRunner()
+						tracked := newTelemetryProject(t, id, tracker, runner)
+						if err := tracked.Start(ctx); err != nil {
+							t.Fatal(err)
+						}
+						mustSetProject(t, registry, tracked)
+						select {
+						case request := <-runner.started:
+							requests = append(requests, request)
+						case <-time.After(10 * time.Second):
+							state, err := tracked.Orchestrator().State(ctx)
+							t.Fatalf("worker did not start: dispatch = %#v, error = %v", state.DispatchStatus, err)
+						}
+					}
+					var totals lifetimeTotalsSource
+					if source == "project_state" {
+						tracker := stalledTelemetryConnector{Connector: memory.New(memory.Config{})}
+						tracked := newTelemetryProject(t, "alpha", tracker, nil)
+						if err := tracked.Start(ctx); err != nil {
+							t.Fatal(err)
+						}
+						mustSetProject(t, registry, tracked)
+					} else {
+						totals = stalledTelemetryTotals{}
+					}
+					if err := publishStartupSnapshotOnce(ctx, globalconfig.Config{}, snapshots, nil, "", time.Now()); err != nil {
+						t.Fatal(err)
+					}
+					if cached {
+						seedRestartTelemetry(t, ctx, snapshots)
+					}
+					initial, _ := snapshots.Latest()
+					var previousSeq uint64
+					if initial.Shutdown.Draining || initial.Shutdown.Status != "running" {
+						t.Fatalf("startup retained prior shutdown state: %#v", initial.Shutdown)
+					}
+					server := newTelemetryWebServer(t, snapshots, registry)
+					events := httptest.NewRecorder()
+					eventsDone := make(chan struct{})
+					go func() {
+						defer close(eventsDone)
+						server.Handler().ServeHTTP(events, httptest.NewRequestWithContext(ctx, http.MethodGet, "/events?view=board", nil))
+					}()
+					defer func() {
+						cancel()
+						<-eventsDone
+					}()
+					synctest.Wait()
+					frames := strings.Count(events.Body.String(), "event: snapshot\n")
+					if events.Code != http.StatusOK || frames != 1 {
+						t.Fatalf("startup SSE status = %d, snapshot frames = %d", events.Code, frames)
+					}
+					model, err := tui.NewModel(ctx, snapshots)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer model.Close()
+					terminal, next := model.Update(model.Init()())
+					var seq atomic.Uint64
+					done := make(chan struct{})
+					go func() {
+						defer close(done)
+						publishSnapshots(ctx, registry, nil, snapshots, &seq, nil, totals, "", nil, time.Second, time.Now)
+					}()
+					defer func() {
+						cancel()
+						<-done
+					}()
+					for index := range 2 {
+						for _, request := range requests {
+							if err := request.OnUsageUpdate(orchestrator.UsageUpdate{LastEventAt: time.Now(), LastMessage: "worker progress", Tokens: orchestrator.TokenTotals{TotalTokens: int64(index+1) * 100}}); err != nil {
+								t.Fatal(err)
+							}
+						}
+						time.Sleep(2 * time.Second)
+						synctest.Wait()
+						current, _ := snapshots.Latest()
+						if !current.GeneratedAt.After(initial.GeneratedAt) || current.Seq <= previousSeq {
+							t.Fatalf("publication froze at %v (seq %d) while two workers run", current.GeneratedAt, current.Seq)
+						}
+						if len(current.Running) != 2 || current.Shutdown.Draining || current.Shutdown.Status != "running" {
+							t.Fatalf("running = %d, shutdown = %#v", len(current.Running), current.Shutdown)
+						}
+						for _, running := range current.Running {
+							if running.Tokens.Total != int64(index+1)*100 {
+								t.Fatalf("worker progress froze: %#v", running.Tokens)
+							}
+						}
+						healthResponse := httptest.NewRecorder()
+						server.Handler().ServeHTTP(healthResponse, httptest.NewRequestWithContext(ctx, http.MethodGet, "/health", nil))
+						var health struct {
+							GeneratedAt time.Time `json:"snapshot_generated_at"`
+							AgeSeconds  int64     `json:"snapshot_age_seconds"`
+						}
+						if err := json.Unmarshal(healthResponse.Body.Bytes(), &health); err != nil {
+							t.Fatal(err)
+						}
+						if !health.GeneratedAt.Equal(current.GeneratedAt) || health.AgeSeconds > 1 {
+							t.Fatalf("health freshness = %#v, snapshot generated at %v", health, current.GeneratedAt)
+						}
+						if got := strings.Count(events.Body.String(), "event: snapshot\n"); got <= frames {
+							t.Fatalf("SSE froze at %d snapshot frames", got)
+						} else {
+							frames = got
+						}
+						if !strings.Contains(events.Body.String(), "beta active worker") || !strings.Contains(events.Body.String(), "gamma active worker") {
+							t.Fatal("SSE did not include current running workers")
+						}
+						if source == "lifetime_totals" && (current.LifetimeTotals.Available || !strings.Contains(current.LifetimeTotals.DegradedReason, "deadline")) {
+							t.Fatalf("lifetime totals = %#v, want unavailable with deadline diagnostic", current.LifetimeTotals)
+						}
+						if source == "project_state" {
+							alpha := current.Projects[0]
+							if alpha.Runtime.Source != telemetry.SnapshotSourceUnknown || !strings.Contains(alpha.Refresh.LastError, "deadline") {
+								t.Fatalf("stalled project = %#v, want unknown with deadline diagnostic", alpha)
+							}
+							if cached && alpha.Tracker.Source != telemetry.SnapshotSourceCached {
+								t.Fatal("stalled project lost cached tracker provenance")
+							}
+						}
+						terminal, next = terminal.Update(next())
+						view := terminal.View().Content
+						if !strings.Contains(view, "beta#1") || !strings.Contains(view, "gamma#1") || strings.Contains(view, "draining sessions") {
+							t.Fatalf("terminal did not advance to live workers: %s", view)
+						}
+						initial = current
+						previousSeq = current.Seq
+					}
+				})
+			})
+		}
+	}
+}
+
+func TestReadTelemetrySource(t *testing.T) {
+	sourceErr := errors.New("source unavailable")
+	for _, tt := range []struct {
+		name         string
+		cancelParent bool
+		stall        bool
+		readErr      error
+		wantErr      error
+	}{
+		{name: "success"},
+		{name: "source error", readErr: sourceErr, wantErr: sourceErr},
+		{name: "deadline", stall: true, wantErr: context.DeadlineExceeded},
+		{name: "service cancellation", cancelParent: true, stall: true, wantErr: context.Canceled},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				parent, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				if tt.cancelParent {
+					cancel()
+				}
+				var sourceContextErr func() error
+				value, err := readTelemetrySource(parent, "example", "alpha", func(ctx context.Context) (int, error) {
+					sourceContextErr = ctx.Err
+					deadline, ok := ctx.Deadline()
+					if !ok || time.Until(deadline) != defaultTelemetryReadTimeout {
+						t.Fatalf("source deadline = %v, %v", deadline, ok)
+					}
+					if tt.stall {
+						<-ctx.Done()
+						return 0, ctx.Err()
+					}
+					return 42, tt.readErr
+				})
+				if !errors.Is(err, tt.wantErr) || (tt.wantErr == nil && value != 42) {
+					t.Fatalf("read = %d, %v; want error %v", value, err, tt.wantErr)
+				}
+				if sourceContextErr() == nil || (parent.Err() != nil && !tt.cancelParent) {
+					t.Fatal("source context was not released independently of service context")
+				}
+				if err != nil && !strings.Contains(err.Error(), "telemetry source example:") {
+					t.Fatalf("error lacks source identity: %v", err)
+				}
+			})
+		})
+	}
+}
+
+func newTelemetryProject(t *testing.T, id string, tracker connector.Connector, runner orchestrator.Runner) *project.Project {
+	t.Helper()
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	tracked, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: id, Workdir: t.TempDir(), Weight: 1},
+		Workflow: workflowconfig.Workflow{Config: cfg, Prompt: "Telemetry fixture"},
+	}, project.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OrchestratorFactory: func(cfg orchestrator.Config, deps orchestrator.Dependencies) (*orchestrator.Orchestrator, error) {
+			return orchestrator.New(orchestrator.Config{
+				Project: cfg.Project, PollInterval: time.Hour, MaxConcurrentAgents: 1,
+				ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"},
+			}, deps)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := tracked.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Error(err)
+		}
+	})
+	return tracked
+}
+
+func seedRestartTelemetry(t *testing.T, ctx context.Context, snapshots *hub.Hub[telemetry.Snapshot]) {
+	t.Helper()
+	cache, err := boardsnapshot.New(boardsnapshot.Config{Path: filepath.Join(t.TempDir(), "snapshot.json"), MaxAge: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Save(ctx, telemetry.Snapshot{
+		Seq:         900,
+		GeneratedAt: time.Now().Add(-time.Second),
+		Counts:      telemetry.Counts{Running: 1},
+		Running:     []telemetry.Running{{Issue: telemetry.Issue{ID: "previous-process-worker", ProjectID: "alpha"}}},
+		Shutdown:    telemetry.Shutdown{Status: "draining", Draining: true},
+		Project:     telemetry.Project{ID: "alpha"},
+		Projects:    []telemetry.ProjectSnapshot{{Project: telemetry.Project{ID: "alpha"}}},
+		BoardIssues: []telemetry.Issue{{ID: "cached", ProjectID: "alpha", Identifier: "alpha#1", State: "Todo"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, found, err := cache.Load(ctx)
+	if err != nil || !found {
+		t.Fatalf("Load() = %v, %v", found, err)
+	}
+	if loaded.Counts.Running != 0 || len(loaded.Running) != 0 || loaded.Runtime.Source != telemetry.SnapshotSourceUnknown {
+		t.Fatalf("cached runtime was not cleared: counts %#v, running %#v, runtime %#v", loaded.Counts, loaded.Running, loaded.Runtime)
+	}
+	if err := snapshots.Publish(loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type stalledTelemetryTotals struct{}
+
+func newTelemetryWebServer(t *testing.T, snapshots *hub.Hub[telemetry.Snapshot], registry *project.Registry) *web.Server {
+	t.Helper()
+	db, err := store.Open(t.Context(), store.Config{Path: filepath.Join(t.TempDir(), "runtime.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	server, err := web.NewServer(web.Config{
+		Logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LookupEnv:           func(string) string { return "" },
+		SSEFragmentInterval: time.Millisecond,
+	}, web.Dependencies{Hub: snapshots, Registry: registry, Store: db, Connector: memory.New(memory.Config{})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	return server
+}
+
+func (stalledTelemetryTotals) LifetimeTotals(ctx context.Context) (store.LifetimeTotals, error) {
+	<-ctx.Done()
+	return store.LifetimeTotals{}, ctx.Err()
+}
+
+type stalledTelemetryConnector struct {
+	connector.Connector
+}
+
+func (stalledTelemetryConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (stalledTelemetryConnector) FetchIssuesByStates(ctx context.Context, _ []string) ([]connector.Issue, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1020,6 +1020,7 @@ func TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation(t *testing.T)
 		t.Fatalf("WriteFile(%s) error = %v", workflowPath, err)
 	}
 	waitForProjectLog(t, &logs, "workflow reload failed")
+	waitForWorkflowReloadError(t, got)
 	select {
 	case extra := <-connectorConfigs:
 		t.Fatalf("connector rebuilt after invalid reload = %#v", extra)
@@ -1797,6 +1798,26 @@ func waitForProjectLog(t *testing.T, logs *lockedBuffer, want string) {
 		case <-ticker.C:
 		case <-deadline:
 			t.Fatalf("timed out waiting for project log %q; logs = %q", want, logs.String())
+		}
+	}
+}
+
+func waitForWorkflowReloadError(t *testing.T, got *project.Project) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(10 * time.Second)
+
+	for {
+		status := got.WorkflowSourceStatus()
+		if status.LastReloadError != "" && !status.ReloadFailedAt.IsZero() {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatalf("timed out waiting for workflow reload failure; status = %#v", got.WorkflowSourceStatus())
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Keep fleet snapshots publishing when a project-state or lifetime-total read stalls. Give each source an independent synchronous 500 ms deadline and report its source, project, elapsed time, timeout, and error while healthy projects and workers remain visible.
- Clear the previous process's shutdown state when loading the startup cache, preserving cached tracker data and unknown runtime provenance.
- Add deterministic multi-project restart regressions for initializing and cached draining snapshots, including prior-process sequence numbers and workers. Verify advancing timestamps, worker usage, board SSE, terminal output, health freshness, and cancellation cleanup.
- Synchronize the workflow reload regression on persisted error status before checking last-good workflow and degraded health. The warning is emitted before status is stored, so observing the log alone can race the assertion. Preserve the token, error, and recovery assertions with a bounded condition wait.

The telemetry fixtures reproduce two ways a sequential read can freeze publication. The production incident has no stack trace identifying which source stalled.

Fixes #2255

## UI Surface Contract

- [x] N/A: restores dashboard freshness without layout, density, or visibility changes.
- [x] No persistent top-of-screen messaging is added; cached shutdown status is reset on startup.
- [x] Earlier isolated Chrome verification confirmed cached-to-live board updates without a reload, 95 advancing SSE frames, both healthy workers, degraded-source reporting, advancing health timestamps with age 0s, fleet display, and no console warnings or errors. The live fleet was untouched.

## Test Plan

- [x] Workflow reload regression: `go test -race ./internal/project -run '^TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation$' -count=50`.
- [x] Telemetry restart/source and board-cache regressions: ten runs under the race detector, including SSE, TUI, and health freshness.
- [x] Full `make check CHECK_LOCK_WAIT=45m` passed: build, lint (zero issues), vet, NilAway, race suite, 80.1% aggregate coverage, and configured package/file floors. Only the shared-lock wait allowance was extended.
- [x] All 11 CI checks passed on `d320259b31c1960fbe85dee4be10166f46f6fbae`: https://github.com/digitaldrywood/detent/actions/runs/34158423990 (including Ubuntu normal/race tests, Browser Visual, and macOS/Windows portability).
