### PR TITLE
feat(hub): package portable self-hosting and recovery

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,9 @@ archives:
     files:
       - README.md
       - LICENSE
+      - docs/*.md
+      - docs/**/*
+      - scripts/hub-smoke.py
 
 brews:
   - name: detent
@@ -80,6 +83,11 @@ nfpms:
       - deb
       - rpm
     contents:
+      - src: docs/
+        dst: /usr/share/doc/detent/docs
+        type: tree
+      - src: scripts/hub-smoke.py
+        dst: /usr/share/doc/detent/scripts/hub-smoke.py
       - src: LICENSE
         dst: /usr/share/doc/detent/copyright
         file_info:

--- a/docs/examples/hub/Caddyfile
+++ b/docs/examples/hub/Caddyfile
@@ -1,0 +1,6 @@
+hub.example.com {
+ request_body {
+  max_size 1MB
+ }
+ reverse_proxy 127.0.0.1:7777
+}

--- a/docs/examples/hub/detent-hub.service
+++ b/docs/examples/hub/detent-hub.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Detent customer-operated Hub
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=detent-hub
+Group=detent-hub
+StateDirectory=detent-hub
+StateDirectoryMode=0700
+UMask=0077
+EnvironmentFile=/etc/detent-hub/credentials.env
+ExecStart=/usr/bin/detent hub serve --database /var/lib/detent-hub/hub.db --listen 127.0.0.1:7777 --github-disabled
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+TimeoutStopSec=45
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/hub-api.md
+++ b/docs/hub-api.md
@@ -2,7 +2,7 @@
 
 Detent Hub owns its SQLite database and exposes fleet coordination through an authenticated HTTP API. Clients must never open or copy the live database files.
 
-This page documents implemented behavior, including native collaboration and scoped runner enrollment through `/api/v2`. The [native Hub and Cloud RFC](cloud-hub-rfc.md) defines the broader architecture; native Changes, hosted human identity, artifact custody, and deployment contracts remain separate deliverables.
+This page documents implemented behavior, including native collaboration, Changes and scoped runner enrollment through `/api/v2`. See [self-hosted operations](hub-self-hosting.md) for deployment, export/import and recovery, and [artifact deployment](artifacts-deployment.md) for independent durable storage. The [native Hub and Cloud RFC](cloud-hub-rfc.md) defines the broader architecture.
 
 ## Approved repository policy
 
@@ -729,11 +729,12 @@ than trusting a stale worker checkpoint to identify the current version.
 Collaboration content, content versions, typed events, idempotency responses and
 owner backups all contain retained data. This release has no automatic native
 content expiry or issue-deletion endpoint. Append-only triggers deliberately
-reject ordinary history deletion. Retention durations, backup expiry and a
-privileged maintenance command remain deployment decisions and implementation
-work for #2197; append-only storage is not a promise of permanent retention.
+reject ordinary history deletion. [Self-hosted operations](hub-self-hosting.md)
+defines full-instance export/import, credential fencing on restore, whole-instance
+retirement and operator-managed backup expiry. Scoped purge remains unimplemented;
+append-only storage is not a promise of permanent retention.
 
-The privileged deletion procedure must use the following contract:
+A future scoped deletion procedure must use the following contract:
 
 1. Authorize the organization and record the deletion scope outside the affected
    content. Fence writers and active leases, then take an owner backup when
@@ -760,9 +761,11 @@ The privileged deletion procedure must use the following contract:
 
 The implemented tests prove ordinary append-only enforcement, immutable identity,
 scoped revision retrieval, backup-compatible migration and restart persistence.
-They do not claim that the future privileged purge/restore maintenance command is
-implemented. Until it is, operators must retain backups deliberately and must not
-disable triggers on a running Hub as a substitute for supported deletion.
+They do not claim that a privileged scoped purge command is implemented.
+The supported full-instance restore revokes copied credentials and releases leases;
+it does not implement scoped erasure or automatically replay a customer deletion
+ledger. Operators must retain backups deliberately and must not disable triggers
+on a running Hub as a substitute for supported deletion.
 
 ## Provider capacity reports
 

--- a/docs/hub-self-hosting.md
+++ b/docs/hub-self-hosting.md
@@ -1,0 +1,326 @@
+# Self-hosted Hub operations
+
+One customer-controlled Linux host or ordinary VM, one Hub process, and local
+durable storage are the supported deployment described here. Use the released
+Detent binary and systemd, with a TLS reverse proxy. This is single-host operation
+with explicit downtime for maintenance; there is no active-active replication,
+automatic failover, or high availability guarantee. Never share a live SQLite
+file over NFS/SMB, mount it into runners, or run a second owner against it.
+
+No WorkOS, Stripe, Detent Cloud account, `cloud.detent.build` callback, or paid
+infrastructure is required. The native-only example disables GitHub transport.
+Ordinary local Detent remains supported separately: omit `client.hub_url` and
+run `detent` using local configuration and the selected local/tracker backend.
+Durable artifacts are optional in both modes; local-only artifact availability
+depends on retaining the runner and its workspace.
+
+## Install one host
+
+Select a reviewed release version and architecture from the existing
+[release distribution](release.md). Verify the archive/package checksum before
+installation and keep that version's binary, checksum and deployment files for
+recovery. Linux packages install `/usr/bin/detent`; archive installations must
+install the executable at that path or adjust the example unit. Do not use an
+unversioned download URL for an upgrade. The release includes this runbook and
+the [Hub unit](examples/hub/detent-hub.service) and
+[Caddy example](examples/hub/Caddyfile); equivalent files are in the same tagged
+source checkout. Native package documentation lives under `/usr/share/doc/detent/docs`.
+
+On a clean Linux host with systemd, install the selected Detent package and a
+separately pinned Caddy package through your normal OS package process. Then:
+
+```sh
+sudo useradd --system --home-dir /var/lib/detent-hub --shell /usr/sbin/nologin detent-hub
+sudo install -d -m 0700 -o detent-hub -g detent-hub /var/lib/detent-hub
+sudo install -d -m 0700 -o root -g root /etc/detent-hub
+sudo install -m 0644 docs/examples/hub/detent-hub.service /etc/systemd/system/detent-hub.service
+sudo install -m 0600 /dev/null /etc/detent-hub/credentials.env
+sudoedit /etc/detent-hub/credentials.env
+```
+
+Use the corresponding `/usr/share/doc/detent/docs/examples/hub` source path when installing
+from a native package without a source checkout. In `credentials.env`, set
+`DETENT_HUB_ADMIN_TOKEN=<fresh-high-entropy-token-from-your-secret-manager>`.
+Generate at least 32 random bytes; the bracketed value is a placeholder, not a
+credential. Keep the real value out of shell arguments/history, repositories,
+screenshots, logs and issue reports. systemd reads the root-only file before
+dropping privileges. Configure your real DNS name in Caddy, install its reviewed
+configuration, allow inbound HTTPS, and restrict port 7777 to loopback.
+
+```sh
+sudo systemd-analyze verify /etc/systemd/system/detent-hub.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now detent-hub
+sudo systemctl status detent-hub
+```
+
+These commands operate on the example installation only. The ordinary
+`detent service install` command supervises the local orchestrator; use this
+separate Hub unit for `hub serve`. The Hub has no source checkouts, agent login
+sessions or execution workspaces on this host. Do not expose the backend port
+by relying on `--trusted-proxy` alone: that flag declares trust, it does not
+create TLS or configure a firewall. Alternatively use `--tls-cert` and
+`--tls-key` with an explicit public listen address. Do not log Authorization
+headers or request/response bodies at the proxy. Keep private keys readable
+only by the TLS owner. The API continues to enforce scoped bearer auth behind
+the proxy; arbitrary identity headers are not an authentication integration.
+
+## Durable paths and outbound access
+
+| Location | Owner and recovery treatment |
+| --- | --- |
+| `/var/lib/detent-hub/hub.db` and SQLite sidecars | Hub-only local disk; back up through the owner or stopped-owner command |
+| `/var/lib/detent-hub/hub.db.lock` | Ownership coordination; not a backup or a lock to manually remove while running |
+| `/etc/detent-hub/credentials.env` | Secret manager/root; back up separately with restricted access and revocation records |
+| systemd unit, TLS configuration/certificates | Versioned operator configuration; preserve with the selected binary/checksum |
+| `/var/lib/detent-hub/backups/` | Private example staging path; copy finished snapshots to encrypted off-host backup storage |
+| runner identity, config and workspace roots | Private runner-local state; reenroll credentials on migration |
+| artifact catalog and object bucket | Separate durable service; Hub snapshots contain references, not artifact bytes |
+
+Native metadata service operation requires no outbound Internet connection.
+TLS certificate automation may require DNS/ACME access; private PKI can avoid
+that dependency. Operators installing packages need access to their package
+source. Runners need HTTPS to this Hub and, when configured, the independent
+artifact service; their chosen Git host, model providers and build tools need
+their own outbound access. These are customer-selected endpoints, not Detent
+Cloud dependencies. Artifact service outbound access is limited to the selected
+Hub and object store (plus any explicitly selected credential provider).
+
+For GitHub compatibility, remove `--github-disabled` only after configuring
+GitHub credentials for the dedicated service user and, if used, a webhook HMAC
+secret through the existing CLI environment options. Allow GitHub API traffic
+and the separately selected Git transport. Follow [GitHub profiles](github-profiles.md)
+for import, mirror cutover and projection; native-only mode does not project
+changes to GitHub. The example service's `ProtectHome` means interactive login
+files in a human home directory are deliberately unavailable.
+
+## Authentication, projects and runners
+
+The bootstrap administrator is inserted once. Changing its environment value on
+restart does not rotate it or resurrect a revoked token. Use the existing
+`POST /api/v1/tokens`, `POST /api/v1/tokens/{id}/rotate`, and
+`DELETE /api/v1/tokens/{id}` operations. Plaintext creation/rotation responses
+are returned once with `Cache-Control: no-store`; persist them directly to
+private secret storage. Generic worker/operator tokens do not automatically
+expire; explicitly rotate/revoke them and track their owners. Issue project
+grants through `/api/v2/tokens/{id}/grants`. Use individual operator credentials
+so author IDs remain attributable. Generic scoped bearer authentication works
+without hosted identity; do not assume an OIDC proxy can mint Hub credentials.
+
+Follow [Hub API enrollment](hub-api.md#scoped-runner-onboarding) for exact
+JSON requests and [repository policy](config.md#repository-policy-with-hub-execution)
+for approval. The supported sequence is:
+
+1. Create the organization/project and its workflow states as administrator.
+2. On each runner run `detent hub runner init --hub-url https://hub.example.com --identity-file /private/runner/identity.json`.
+   Give the generated binding IDs to the administrator. Never copy one runner's
+   identity file to another machine.
+3. Create a one-use enrollment for those exact IDs, project grants and required
+   operations. Deliver it privately and run `detent hub runner enroll` with the
+   corresponding identity file, Hub URL and enrollment environment variable.
+4. Configure `client.hub_url`, `identity_file`, `organization_id` and
+   `native_projects` on each runner. Keep backend/provider login on that runner.
+5. Approve the trusted repository/workflow descriptor with `detent hub policy`.
+   Configure required tags or exact runner/machine IDs in repository policy;
+   set administrator-owned runner tags, project access and capacity through
+   `detent hub runner`. A runner cannot grant itself tags or repository access.
+6. Check two distinct runners against their selectors before enabling real work.
+   An exact offline host stays queued; tags are routing constraints and do not
+   grant authority. Logical runners sharing a host share its capacity.
+
+Enrollment grants last at most 900 seconds. Enrolled credentials last 24 hours
+from enrollment/renewal; renew before expiry through the supported runner CLI.
+Revocation is permanent for that identity. After expiry/revocation or migration,
+initialize a fresh binding and have an administrator enroll it, then update exact
+ID selectors and approve the resulting policy. Preserve old principal rows for
+history; never reactivate them by editing SQLite. See `detent hub runner --help`
+for renewal, rotation, revocation, routing and fleet inspection commands.
+
+## Optional durable artifacts
+
+Use the existing [artifact deployment](artifacts-deployment.md) and its systemd,
+Caddy and S3-compatible configuration examples. It is an independently available
+authorization/download process with a durable catalog/outbox and a private object
+store. Execution runners may be disposable; the artifact process, catalog and
+bucket are not. Keep them outside runner workspaces. No AWS compute, hosted
+account or particular storage vendor is mandatory.
+
+Run `detent artifacts --artifact-config /private/service.json verify-storage`
+against the selected endpoint before enabling it. Only a passing live probe
+establishes that provider's required conditional-write, integrity and optional
+versioning behavior; local fixtures are not live provider certification.
+Configure a dedicated scoped publisher credential, project service binding and
+finite retention/capacity policy. Runners receive no bucket credentials. Omitting
+durable configuration remains truthful local-only operation.
+
+## Backup and export
+
+`detent hub backup` is also the supported full-instance collaboration export.
+It includes organizations, projects, stable issue/comment/change IDs, versions,
+events, provenance, external references, identity rows, grants, approved policies,
+outbox and artifact references. It is a SQLite snapshot, not a per-project JSON
+merge format. Importing into an existing Hub or selectively merging tenants is
+unsupported. Raw artifacts, TLS files, runner workspaces and provider credentials
+are separate backups. Treat snapshots as sensitive customer data even though
+Hub bearer credentials are stored as hashes.
+
+Drain runners and stop the Hub before CLI maintenance. `backup` and `verify`
+acquire its ownership lock and fail if another owner is running. They check
+identity, integrity, foreign keys and supported schema without upgrading the
+source. The existing service-owned `Service.Backup` API remains available for
+embedded online snapshots; no unauthenticated backup-download endpoint is added.
+
+```sh
+sudo systemctl stop detent-hub
+sudo -u detent-hub install -d -m 0700 /var/lib/detent-hub/backups
+sudo -u detent-hub /usr/bin/detent hub backup --database /var/lib/detent-hub/hub.db --output '/var/lib/detent-hub/backups/<unique-snapshot>.db'
+sudo -u detent-hub /usr/bin/detent hub verify --database '/var/lib/detent-hub/backups/<unique-snapshot>.db'
+sudo systemctl start detent-hub
+```
+
+Replace angle-bracket placeholders before execution. Backup output must not
+exist and must differ from the source. Copy only the completed snapshot to the
+backup system. Never copy live DB/WAL/SHM files. Record checksum, capture time,
+binary version, returned schema version, retention deadline, custody policy and
+configuration revision outside the snapshot. Test an isolated restore regularly.
+
+## Restore/import and move between Hubs
+
+Use a trusted, unexpired snapshot and a **new** local destination. Fence the old
+Hub and stop its runners before moving production traffic. Restoring does not
+stop processes or revoke credentials on the source machine. A restored clone
+must never run concurrently against the same external projection/workspace.
+
+Load a fresh high-entropy `DETENT_HUB_ADMIN_TOKEN` from private secret storage in
+the maintenance process environment, then run as the database owner:
+
+```sh
+detent hub verify --database '/private/backup/<snapshot>.db'
+detent hub restore --database '/private/backup/<snapshot>.db' --output /private/restored/hub.db
+detent hub serve --database /private/restored/hub.db --listen 127.0.0.1:7777 --github-disabled
+```
+
+Restore validates the source, copies through SQLite backup, migrates a private
+staging copy, checks integrity, and publishes the new path without overwriting
+anything. Before publication it revokes every copied generic/runner credential
+and enrollment, releases every active lease, rotates cursor authority and creates
+a fresh administrator principal. The supplied token must differ from every
+source credential. JSON output gives the new administrator ID and schema, never
+the token. Existing identities, grants, event ordering, policy provenance and
+external references remain intact for attribution. Old pagination cursors must
+be discarded. Attempts with released leases are presented as interrupted by the
+existing run-history logic; they do not authorize resumed side effects.
+
+Verify authenticated `/health`, content/history and references while isolated.
+Create fresh human/operator and integration credentials, restore only currently
+approved project grants, reenroll runners using new bindings, and reapprove
+policies with exact ID selectors. Reconfigure review-policy principal IDs where
+credentials changed. Set the service environment to the fresh administrator
+credential; ordinary startup will not replace the copied revoked bootstrap row.
+
+For artifacts, preserve catalog/service/artifact IDs and object versions, update
+the trusted Hub origin, replace publisher credentials, and update the project
+binding before reopening downloads. Existing grants depend on revoked principals
+and must be reacquired. Keep current deletion markers independently of catalog
+rollback and follow the artifact restore procedure. Hub backup alone cannot
+restore object access. Keep GitHub transport disabled until an operator checks
+pending outbox work against current GitHub state and resolves any already-applied
+external effects; restoring a snapshot does not roll back a GitHub mutation.
+
+## Upgrade, interruption and compatibility
+
+Pin a release and retain the old binary plus a verified pre-upgrade snapshot.
+Drain runners, stop the unit, create/verify a backup, install the selected binary,
+then start the Hub. Startup applies embedded forward goose migrations before
+health becomes ready. Each migration is transactional; a crash rolls back the
+unfinished migration. Earlier completed migrations remain applied and the same
+binary retries the remainder on restart. Fix disk/permission problems first.
+Never manually advance the schema table or run the unrelated local orchestrator
+`make db-migrate` against a Hub database.
+
+If restore is interrupted before publication, the requested destination is absent.
+A private `.hub-restore-*` directory may remain beside it; retain it for diagnosis
+or remove it only after confirming no maintenance process owns it. Retry from the
+original backup to a new destination. Never serve a staging database. Once a
+destination is published, it has already been migrated and old authority fenced.
+
+A binary rejects a schema newer than it supports with `ErrUnsupportedSchema`
+(`database=N supported=M`); there is no automatic downgrade. Keep the failed
+database for diagnosis. Use the newer compatible binary, or restore the
+pre-upgrade snapshot into a new path with a binary supporting that snapshot.
+Switch the unit's database path only after validation. Never point an older binary
+at the upgraded live file. Pre-upgrade backups retain the old schema because
+offline backup does not migrate it. Recovery commands are available beginning
+with the release that packages this runbook; keep that recovery binary too.
+
+Prefer identical release versions across Hub and runners. Rolling overlap is
+supported only where `/api/v2/capabilities` and the runner agree on protocol major
+2, schema 1 and all required features. Version strings alone do not confer
+compatibility. Unsupported majors/missing required features fail closed before
+claim/start; older clients cannot bypass approved policy or provider reservations.
+The v1 compatibility API remains for legacy configured clients and requires
+GitHub compatibility configuration; it is not a fallback for a failed native
+negotiation. Fixtures cover old/new feature sets, not every historical binary.
+
+## Retention, deletion and expiration
+
+Native collaboration currently has no automatic expiry and no supported
+per-issue/organization purge command. Current content, revisions, comments,
+Changes, events, idempotency responses and identity attribution remain until
+whole-instance retirement. Do not promise scoped erasure or disable append-only
+triggers. Choose a separate Hub per retention boundary if whole-instance deletion
+is required. A finite per-record retention requirement requires further product
+work before adopting this deployment for that requirement.
+
+Operators must define a finite backup lifetime, log rotation and export expiry
+in their own backup system. For example, a reviewed policy can expire snapshots
+after 30 days; Detent does not schedule that expiration. Record the deadline and
+refuse expired snapshots during manual restore. Do not keep indefinite copies in
+download folders. Revocation records and the retirement/deletion ledger belong
+outside rollbackable backups. Restore always invalidates old Hub authority, but
+it does not erase previously exported content or apply a customer deletion ledger.
+
+Whole-instance retirement means stopping/fencing Hub and runners, disabling
+ingress and artifact authorization, recording the retired scope/IDs in the
+external ledger, and deleting the database, sidecars, private staging directories,
+exports, backups, service logs and relevant encryption keys through the storage
+owner's approved erasure process. Verify expiry/deletion in every backup replica
+and disallow restoring a retired snapshot. Do not reuse retired IDs. GitHub
+projections and artifact objects/catalogs need their own authorized deletion and
+verification; database deletion does not erase them.
+
+Webhook raw payloads have the existing configurable retention (default 7 days);
+typed collaboration/projection records are separate retained data. Artifact
+policy enforces live/abandoned-upload/deletion-marker lifetimes; its backup system
+owns object/catalog backup expiration. Deletion-marker retention must outlive
+artifact backups plus abandoned uploads. See [artifact retention](artifacts-deployment.md#retention-and-accounting).
+
+## Diagnostics
+
+Use authenticated `/health`, `detent doctor`, the existing fleet/queue surfaces,
+and private service logs. Supply credentials through environment/private files;
+do not paste bearer headers or content into diagnostic reports.
+
+| Symptom | Evidence and next action |
+| --- | --- |
+| No matching runner | Fleet/queue exclusion reason, heartbeat, tags, exact IDs, project access, drain state and host capacity; fix the intended binding or bring that host online; never widen selectors automatically |
+| Expired/revoked identity | Unauthorized response and local identity expiry; renew before expiry, otherwise initialize/enroll a new binding and approve changed ID selectors |
+| Policy mismatch | Hub policy descriptor/approval and locally resolved policy ID; inspect trusted repository/workflow changes and obtain explicit administrator approval |
+| Storage outage | Artifact error (`storage_unreachable`, integrity/missing/expiry reason), service maintenance logs and `verify-storage`; restore configured storage access, preserve pending catalog/outbox, never advertise unverified bytes |
+| GitHub compatibility/projection failure | `/api/v1/outbox/health`, `/api/v1/repositories/freshness`, `/health` and GitHub profile; distinguish disabled transport, missing permissions, rate budget, stale projection, conflict and dead-letter/operator action before retrying |
+| Startup/schema failure | systemd exit status and private journal, `hub verify` while stopped; check local disk, permissions, ownership and binary/schema versions; do not remove an active lock |
+
+## Reproduce the validation fixture
+
+Build `tmp/detent` with `make build` and run
+`python3 scripts/hub-smoke.py tmp/detent`. The fixture installs a binary into an
+empty private directory, uses ephemeral loopback ports, verifies bootstrap,
+restart, export/verify/import and revoked-source authentication, and cleans up
+only its own child processes/files. No real credentials are used.
+
+For Linux/container validation, cross-build the binary and Hub test executable
+for the container architecture, copy them and the smoke script into a fixture
+directory, then run a Python-capable Linux image with `--network none`, a read-only
+fixture mount and private writable temp storage. Run the smoke script plus the
+Hub recovery/routing/protocol tests there. No production deployment or paid
+resources are needed. The required repository gate remains `make check`.

--- a/internal/cli/hub.go
+++ b/internal/cli/hub.go
@@ -57,6 +57,7 @@ func newHubCommandWithRun(version string, lookupEnv func(string) string, run hub
 	cmd.AddCommand(newHubRunnerCommand(version, lookupEnv))
 	cmd.AddCommand(newHubPolicyCommand(lookupEnv))
 	cmd.AddCommand(newHubIssueCommand(lookupEnv))
+	cmd.AddCommand(newHubRecoveryCommands(lookupEnv)...)
 	return cmd
 }
 

--- a/internal/cli/hub_recovery.go
+++ b/internal/cli/hub_recovery.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/digitaldrywood/detent/internal/hubserver"
+)
+
+func newHubRecoveryCommands(lookupEnv func(string) string) []*cobra.Command {
+	var commands []*cobra.Command
+	for _, operation := range []string{"backup", "verify", "restore"} {
+		var source, destination, tokenEnv string
+		cmd := &cobra.Command{
+			Use: operation,
+			Short: map[string]string{
+				"backup":  "Export a stopped Hub to a new private SQLite snapshot",
+				"verify":  "Verify a stopped Hub or snapshot without migrating it",
+				"restore": "Import a Hub snapshot with fresh credentials and fenced leases",
+			}[operation],
+			Example:      "detent hub " + operation + " --database /private/hub.db",
+			Args:         NoArgs,
+			SilenceUsage: true,
+			RunE: func(cmd *cobra.Command, _ []string) error {
+				if _, err := OutputForCommand(cmd); err != nil {
+					return err
+				}
+				if strings.TrimSpace(source) == "" {
+					return fmt.Errorf("hub %s requires --database", operation)
+				}
+				if operation != "verify" && strings.TrimSpace(destination) == "" {
+					return fmt.Errorf("hub %s requires --output", operation)
+				}
+				switch operation {
+				case "backup":
+					return hubserver.BackupDatabase(cmd.Context(), source, destination)
+				case "restore":
+					if !validEnvName(tokenEnv) {
+						return errors.New("invalid administrator token environment variable name")
+					}
+					result, err := hubserver.RestoreDatabase(cmd.Context(), source, destination, []byte(lookupEnv(tokenEnv)))
+					if err != nil {
+						return err
+					}
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+				default:
+					result, err := hubserver.VerifyDatabase(cmd.Context(), source)
+					if err != nil {
+						return err
+					}
+					return json.NewEncoder(cmd.OutOrStdout()).Encode(result)
+				}
+			},
+		}
+		cmd.Flags().StringVar(&source, "database", "", "existing stopped Hub database or snapshot")
+		if operation != "verify" {
+			cmd.Flags().StringVar(&destination, "output", "", "new destination database; existing paths are never replaced")
+		}
+		if operation == "restore" {
+			cmd.Flags().StringVar(&tokenEnv, "admin-token-env", "DETENT_HUB_ADMIN_TOKEN", "environment variable containing a fresh administrator token")
+		}
+		commands = append(commands, cmd)
+	}
+	return commands
+}

--- a/internal/cli/hub_recovery_test.go
+++ b/internal/cli/hub_recovery_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/hubserver"
+)
+
+func TestHubRecoveryCommands(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "hub.db")
+	service, err := hubserver.Open(t.Context(), hubserver.Config{DatabasePath: path, GitHubDisabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
+	backup := filepath.Join(t.TempDir(), "backup.db")
+	restored := filepath.Join(t.TempDir(), "restored.db")
+	const token = "example-fresh-administrator-token-for-recovery"
+	for _, test := range []struct {
+		name string
+		args []string
+		fail bool
+	}{
+		{"missing source", []string{"verify"}, true},
+		{"missing output", []string{"backup", "--database", path}, true},
+		{"verify", []string{"verify", "--database", path}, false},
+		{"backup", []string{"backup", "--database", path, "--output", backup}, false},
+		{"existing backup", []string{"backup", "--database", path, "--output", backup}, true},
+		{"invalid environment", []string{"restore", "--database", backup, "--output", restored, "--admin-token-env", "BAD=ENV"}, true},
+		{"restore", []string{"restore", "--database", backup, "--output", restored}, false},
+		{"verify restore", []string{"verify", "--database", restored}, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := newHubCommandWithRun("test", func(string) string { return token }, nil)
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			cmd.SetArgs(test.args)
+			err := cmd.ExecuteContext(t.Context())
+			if (err != nil) != test.fail {
+				t.Fatalf("error = %v, output = %s", err, &output)
+			}
+			if strings.Contains(output.String(), token) {
+				t.Fatal("command exposed administrator token")
+			}
+			if !test.fail && test.args[0] != "backup" {
+				var result hubserver.RecoveryResult
+				if err := json.Unmarshal(output.Bytes(), &result); err != nil || result.SchemaVersion == 0 {
+					t.Fatalf("invalid recovery output: %s, %v", &output, err)
+				}
+			}
+		})
+	}
+	service, err = hubserver.Open(t.Context(), hubserver.Config{DatabasePath: restored, GitHubDisabled: true, InitialAdminToken: []byte(token)})
+	if err != nil {
+		t.Fatalf("start restored Hub without an original bootstrap principal: %v", err)
+	}
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/hubserver/recovery.go
+++ b/internal/hubserver/recovery.go
@@ -1,0 +1,204 @@
+package hubserver
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/digitaldrywood/detent/internal/apikey"
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+type RecoveryResult struct {
+	DatabasePath    string `json:"database_path"`
+	SchemaVersion   int64  `json:"schema_version"`
+	AdministratorID string `json:"administrator_id,omitempty"`
+}
+
+func BackupDatabase(ctx context.Context, source, destination string) (resultErr error) {
+	db, err := openRecoverySource(ctx, source)
+	if err != nil {
+		return err
+	}
+	defer func() { resultErr = errors.Join(resultErr, db.Close()) }()
+	return db.backup(ctx, destination)
+}
+
+func VerifyDatabase(ctx context.Context, source string) (result RecoveryResult, resultErr error) {
+	db, err := openRecoverySource(ctx, source)
+	if err != nil {
+		return result, err
+	}
+	defer func() { resultErr = errors.Join(resultErr, db.Close()) }()
+	return RecoveryResult{DatabasePath: db.path, SchemaVersion: db.schemaVersion}, nil
+}
+
+func openRecoverySource(ctx context.Context, source string) (*database, error) {
+	cfg := (Config{DatabasePath: source}).normalized()
+	path, err := canonicalDatabasePath(source)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect hub recovery source: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("hub recovery source must be an existing regular database file")
+	}
+	if err := cfg.validateDatabaseFilesystem(filepath.Dir(path)); err != nil {
+		return nil, err
+	}
+	lock, err := instancelock.Acquire(path + ".lock")
+	if err != nil {
+		return nil, fmt.Errorf("stop the owning Hub before offline maintenance: %w", err)
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(path, cfg.BusyTimeout)+"&mode=rw")
+	if err != nil {
+		return nil, errors.Join(err, lock.Close())
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	owner := &database{db: db, lock: lock, path: path}
+	if err := owner.configure(ctx, cfg.BusyTimeout); err != nil {
+		return nil, errors.Join(err, owner.Close())
+	}
+	if err := verifyRecoveryDatabase(ctx, db); err != nil {
+		return nil, errors.Join(err, owner.Close())
+	}
+	version, err := currentSchemaVersion(ctx, db)
+	if err != nil {
+		return nil, errors.Join(err, owner.Close())
+	}
+	if version < 1 || version > supportedSchemaVersion {
+		return nil, errors.Join(fmt.Errorf("%w: database=%d supported=%d", ErrUnsupportedSchema, version, supportedSchemaVersion), owner.Close())
+	}
+	owner.schemaVersion = version
+	return owner, nil
+}
+
+func verifyRecoveryDatabase(ctx context.Context, db *sql.DB) error {
+	var identity int64
+	if err := db.QueryRowContext(ctx, "PRAGMA application_id").Scan(&identity); err != nil {
+		return err
+	}
+	if identity != hubApplicationID {
+		return ErrDatabaseIdentity
+	}
+	var integrity string
+	if err := db.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&integrity); err != nil {
+		return err
+	}
+	if integrity != "ok" {
+		return errors.New("hub database integrity check failed")
+	}
+	var violations int
+	if err := db.QueryRowContext(ctx, "SELECT count(*) FROM pragma_foreign_key_check").Scan(&violations); err != nil {
+		return err
+	}
+	if violations != 0 {
+		return errors.New("hub database foreign key check failed")
+	}
+	return nil
+}
+
+func RestoreDatabase(ctx context.Context, source, destination string, adminToken []byte) (result RecoveryResult, resultErr error) {
+	value := strings.TrimSpace(string(adminToken))
+	if len(value) < 32 || len(value) > maxBearerTokenBytes || strings.ContainsAny(value, " \t\r\n") {
+		return result, errors.New("restore requires a fresh administrator token of 32 to 4096 non-whitespace bytes")
+	}
+	path, err := canonicalDatabasePath(destination)
+	if err != nil {
+		return result, err
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		return result, errors.New("restore destination must not exist")
+	}
+	if err := validateLocalDatabaseFilesystem(filepath.Dir(path)); err != nil {
+		return result, err
+	}
+	lock, err := instancelock.Acquire(path + ".lock")
+	if err != nil {
+		return result, err
+	}
+	defer func() { resultErr = errors.Join(resultErr, lock.Close()) }()
+	staging, err := os.MkdirTemp(filepath.Dir(path), ".hub-restore-")
+	if err != nil {
+		return result, err
+	}
+	defer func() { resultErr = errors.Join(resultErr, os.RemoveAll(staging)) }()
+	stagedPath := filepath.Join(staging, "hub.db")
+	if err := BackupDatabase(ctx, source, stagedPath); err != nil {
+		return result, err
+	}
+	db, err := openDatabase(ctx, (Config{DatabasePath: stagedPath}).normalized())
+	if err != nil {
+		return result, err
+	}
+	administratorID, prepareErr := db.prepareRestore(ctx, value)
+	if err := errors.Join(prepareErr, db.Close()); err != nil {
+		return result, err
+	}
+	if err := os.Link(stagedPath, path); err != nil {
+		return result, fmt.Errorf("publish restored hub without replacing existing data: %w", err)
+	}
+	return RecoveryResult{DatabasePath: path, SchemaVersion: db.schemaVersion, AdministratorID: administratorID}, nil
+}
+
+func (d *database) prepareRestore(ctx context.Context, adminToken string) (string, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback()
+	now, err := d.currentTime()
+	if err != nil {
+		return "", err
+	}
+	timestamp := formatHubTime(now)
+	for _, statement := range []string{
+		"UPDATE api_tokens SET revoked_at = coalesce(revoked_at, ?), updated_at = ?",
+		"UPDATE runner_enrollments SET revoked_at = coalesce(revoked_at, ?)",
+		"UPDATE leases SET released_at = ?, updated_at = ? WHERE released_at IS NULL",
+		"UPDATE hub_identity SET cursor_key = randomblob(32)",
+	} {
+		args := make([]any, strings.Count(statement, "?"))
+		for i := range args {
+			args[i] = timestamp
+		}
+		if _, err := tx.ExecContext(ctx, statement, args...); err != nil {
+			return "", err
+		}
+	}
+	id := "restore-admin-" + uuid.NewString()
+	var bootstrapExists bool
+	if err := tx.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM api_tokens WHERE id = ?)", bootstrapTokenID).Scan(&bootstrapExists); err != nil {
+		return "", err
+	}
+	if !bootstrapExists {
+		id = bootstrapTokenID
+	}
+	hash := apikey.HashToken(adminToken)
+	var tokenExists bool
+	if err := tx.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM api_tokens WHERE token_hash = ?)", hash).Scan(&tokenExists); err != nil {
+		return "", err
+	}
+	if tokenExists {
+		return "", errors.New("recovery administrator token must not match any source credential")
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO api_tokens
+		(id, name, token_hash, token_fingerprint, scope, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'admin', ?, ?)`, id, id, hash, tokenFingerprint(hash), timestamp, timestamp); err != nil {
+		return "", fmt.Errorf("create recovery administrator: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return "", err
+	}
+	return id, verifyRecoveryDatabase(ctx, d.db)
+}

--- a/internal/hubserver/recovery_migration_test.go
+++ b/internal/hubserver/recovery_migration_test.go
@@ -1,0 +1,114 @@
+package hubserver
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/pressly/goose/v3"
+)
+
+func TestRecoveryInterruptedMigration(t *testing.T) {
+	t.Parallel()
+	for _, stage := range []string{"schema", "version"} {
+		t.Run(stage, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "older.db")
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			files, err := migrationFiles.ReadDir("migrations")
+			if err != nil {
+				t.Fatal(err)
+			}
+			migrations := fstest.MapFS{}
+			for _, file := range files {
+				if file.Name() >= "00016_" {
+					continue
+				}
+				data, err := migrationFiles.ReadFile("migrations/" + file.Name())
+				if err != nil {
+					t.Fatal(err)
+				}
+				migrations[file.Name()] = &fstest.MapFile{Data: data}
+			}
+			provider, err := goose.NewProvider(goose.DialectSQLite3, db, migrations, goose.WithDisableGlobalRegistry(true), goose.WithTableName(hubSchemaTable), goose.WithSlog(discardLogger()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := provider.Up(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.ExecContext(t.Context(), fmt.Sprintf("PRAGMA application_id = %d", hubApplicationID)); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			command := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestRecoveryMigrationProcess$")
+			command.Env = append(os.Environ(), "DETENT_TEST_MIGRATION_PATH="+path, "DETENT_TEST_MIGRATION_STAGE="+stage)
+			output, err := command.CombinedOutput()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 23 {
+				t.Fatalf("interruption helper: %v: %s", err, output)
+			}
+			verified, err := VerifyDatabase(t.Context(), path)
+			if err != nil || verified.SchemaVersion != 15 {
+				t.Fatalf("interrupted migration did not roll back: %+v, %v", verified, err)
+			}
+			backup := filepath.Join(t.TempDir(), "pre-upgrade.db")
+			if err := BackupDatabase(t.Context(), path, backup); err != nil {
+				t.Fatal(err)
+			}
+			verified, err = VerifyDatabase(t.Context(), backup)
+			if err != nil || verified.SchemaVersion != 15 {
+				t.Fatalf("backup migrated the source: %+v, %v", verified, err)
+			}
+			restored := filepath.Join(t.TempDir(), "restored.db")
+			if _, err := RestoreDatabase(t.Context(), backup, restored, []byte(recoveryTestToken)); err != nil {
+				t.Fatal(err)
+			}
+			verified, err = VerifyDatabase(t.Context(), restored)
+			if err != nil || verified.SchemaVersion != supportedSchemaVersion {
+				t.Fatalf("migration retry: %+v, %v", verified, err)
+			}
+		})
+	}
+}
+
+func TestRecoveryMigrationProcess(t *testing.T) {
+	path := os.Getenv("DETENT_TEST_MIGRATION_PATH")
+	if path == "" {
+		return
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(t.Context(), "PRAGMA journal_mode = WAL"); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.BeginTx(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := migrationFiles.ReadFile("migrations/00016_artifacts.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ExecContext(t.Context(), string(data)); err != nil {
+		t.Fatal(err)
+	}
+	if os.Getenv("DETENT_TEST_MIGRATION_STAGE") == "version" {
+		if _, err := tx.ExecContext(t.Context(), "INSERT INTO hub_schema_version(version_id,is_applied) VALUES(16,1)"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	os.Exit(23)
+}

--- a/internal/hubserver/recovery_test.go
+++ b/internal/hubserver/recovery_test.go
@@ -1,0 +1,217 @@
+package hubserver
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/runnerauth"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+const recoveryTestToken = "fresh-recovery-administrator-token-example"
+
+func TestRecoveryPreservesCollaborationAndFencesAuthority(t *testing.T) {
+	t.Parallel()
+	f := newNativeFixture(t, nil, "", "portable")
+	issue := f.create(t, "retained content")
+	issuePath := f.base + "/work-items/" + string(issue.WorkItemID)
+	requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, issuePath+"/comments", f.token,
+		tracker.CreateComment{Mutation: tracker.Mutation{IdempotencyKey: "comment"}, Body: "retained discussion"}), http.StatusOK)
+	approveHubTestPolicy(t, f.service, f.base+"/policy", hubTestPolicy())
+	worker := f.worker(t, "recovery-worker")
+	lease := claimNativeAttempt(t, f, worker, "recovery-machine", "recovery-session", issue.WorkItemID)
+	requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, issuePath+"/events", worker, nativeStartedEvent(lease)), http.StatusOK)
+	runner := prepareRunner(t, f, runnerauth.Read, runnerauth.Claim)
+	runner.enroll(t)
+	pending := prepareRunner(t, f, runnerauth.Read)
+	change := newChangeFixture(t, f.service)
+	change.publish(t, "portable-version", "")
+	changeBefore := change.detail(t)
+	_, projectionID := seedProjection(t, f.service.database.db)
+	var cursorKey []byte
+	if err := f.service.database.db.QueryRowContext(t.Context(), "SELECT cursor_key FROM hub_identity").Scan(&cursorKey); err != nil {
+		t.Fatal(err)
+	}
+	preserved := map[string][]byte{}
+	for _, suffix := range []string{"", "/comments", "/history"} {
+		response := performHubAPIRequest(t, f.service, http.MethodGet, issuePath+suffix, f.token, nil)
+		requireNativeStatus(t, response, http.StatusOK)
+		preserved[suffix] = bytes.Clone(response.Body.Bytes())
+	}
+	sourcePath := f.service.database.path
+	if err := f.service.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sourceBefore, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backup := filepath.Join(t.TempDir(), "export.db")
+	if err := BackupDatabase(t.Context(), sourcePath, backup); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(t.TempDir(), "import.db")
+	result, err := RestoreDatabase(t.Context(), backup, destination, []byte(recoveryTestToken))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SchemaVersion != supportedSchemaVersion || result.AdministratorID == "" {
+		t.Fatalf("restore result = %+v", result)
+	}
+	restored := openTestService(t, Config{DatabasePath: destination})
+	change.service, change.token = restored, recoveryTestToken
+	if got := change.detail(t); !reflect.DeepEqual(got, changeBefore) {
+		t.Fatalf("restored Change or artifact references changed: got %+v, want %+v", got, changeBefore)
+	}
+	for _, test := range []struct{ name, token string }{
+		{"administrator", testHubAdminToken}, {"operator", f.token}, {"worker", worker}, {"runner", runner.redemption.Credential},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requireNativeStatus(t, performHubAPIRequest(t, restored, http.MethodGet, "/health", test.token, nil), http.StatusUnauthorized)
+		})
+	}
+	requireNativeStatus(t, performHubAPIRequest(t, restored, http.MethodGet, "/health", recoveryTestToken, nil), http.StatusOK)
+	requireNativeStatus(t, performHubAPIRequest(t, restored, http.MethodPost, pending.base+"/runner-enrollments/redeem", pending.enrollment.Token, pending.redemption), http.StatusUnauthorized)
+	for suffix, want := range preserved {
+		response := performHubAPIRequest(t, restored, http.MethodGet, issuePath+suffix, recoveryTestToken, nil)
+		requireNativeStatus(t, response, http.StatusOK)
+		if !bytes.Equal(response.Body.Bytes(), want) {
+			t.Fatalf("restored %s changed: %s", suffix, response.Body)
+		}
+	}
+	for _, test := range []struct{ name, query, want string }{
+		{"released leases", "SELECT count(*) FROM leases WHERE released_at IS NULL", "0"},
+		{"preserved runner identities", "SELECT count(*) FROM runner_identities", "1"},
+		{"preserved principal", "SELECT count(*) FROM api_tokens WHERE id = 'bootstrap-admin' AND revoked_at IS NOT NULL", "1"},
+		{"external identity", fmt.Sprintf("SELECT github_node_id FROM issues WHERE id = %d", projectionID), "I_issue"},
+		{"foreign keys", "SELECT count(*) FROM pragma_foreign_key_check", "0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var got string
+			if err := restored.database.db.QueryRowContext(t.Context(), test.query).Scan(&got); err != nil || got != test.want {
+				t.Fatalf("got %q, want %q: %v", got, test.want, err)
+			}
+		})
+	}
+	var restoredKey []byte
+	if err := restored.database.db.QueryRowContext(t.Context(), "SELECT cursor_key FROM hub_identity").Scan(&restoredKey); err != nil || bytes.Equal(cursorKey, restoredKey) {
+		t.Fatalf("cursor authority was not rotated: %v", err)
+	}
+	if err := restored.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyDatabase(t.Context(), destination); err != nil {
+		t.Fatal(err)
+	}
+	sourceAfter, err := os.ReadFile(sourcePath)
+	if err != nil || !bytes.Equal(sourceBefore, sourceAfter) {
+		t.Fatalf("backup changed source database: %v", err)
+	}
+}
+
+func TestRecoveryRejectsUnsafeSourcesAndDestinations(t *testing.T) {
+	t.Parallel()
+	for _, test := range []string{"missing", "empty", "future", "foreign database", "active owner", "existing destination", "same path", "reused credential", "short credential", "cancelled"} {
+		t.Run(test, func(t *testing.T) {
+			t.Parallel()
+			source := filepath.Join(t.TempDir(), "source.db")
+			s := openTestService(t, Config{DatabasePath: source})
+			if test != "active owner" {
+				if err := s.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			destination := filepath.Join(t.TempDir(), "restored.db")
+			token := recoveryTestToken
+			ctx := t.Context()
+			switch test {
+			case "missing":
+				source += ".missing"
+			case "empty":
+				source += ".empty"
+				if err := os.WriteFile(source, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			case "future", "foreign database":
+				db, err := sql.Open("sqlite", source)
+				if err != nil {
+					t.Fatal(err)
+				}
+				statement := fmt.Sprintf("INSERT INTO hub_schema_version(version_id,is_applied) VALUES (%d,1)", supportedSchemaVersion+1)
+				if test == "foreign database" {
+					statement = "PRAGMA application_id = 123"
+				}
+				if _, err := db.ExecContext(ctx, statement); err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Close(); err != nil {
+					t.Fatal(err)
+				}
+			case "existing destination":
+				if err := os.WriteFile(destination, []byte("preserve"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			case "same path":
+				destination = source
+			case "reused credential":
+				token = testHubAdminToken
+			case "short credential":
+				token = "short"
+			case "cancelled":
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			before, beforeErr := os.ReadFile(destination)
+			if _, err := RestoreDatabase(ctx, source, destination, []byte(token)); err == nil {
+				t.Fatal("unsafe restore succeeded")
+			}
+			after, afterErr := os.ReadFile(destination)
+			if !reflect.DeepEqual(before, after) || (beforeErr == nil) != (afterErr == nil) {
+				t.Fatal("failed restore published or changed destination")
+			}
+			staging, err := filepath.Glob(filepath.Join(filepath.Dir(destination), ".hub-restore-*"))
+			if err != nil || len(staging) != 0 {
+				t.Fatalf("failed restore left staging files: %v, %v", staging, err)
+			}
+		})
+	}
+}
+
+func TestSelfHostedRunnerVersionCompatibility(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name         string
+		version      string
+		major        int
+		capabilities []string
+		want         int
+	}{
+		{"older feature set", "older-release", 2, []string{"native_issues", "scoped_collaboration"}, http.StatusOK},
+		{"current feature set", "current-release", 2, []string{"native_issues", "scoped_collaboration", tracker.NativeExecutionCapability}, http.StatusOK},
+		{"unknown required feature", "future-release", 2, []string{"native_issues", "scoped_collaboration", "future_required"}, http.StatusUnprocessableEntity},
+		{"unsupported major", "future-release", 99, []string{"native_issues", "scoped_collaboration"}, http.StatusUnprocessableEntity},
+		{"missing required feature", "older-release", 2, []string{"native_issues"}, http.StatusUnprocessableEntity},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			f := newNativeFixture(t, nil, "", "compatibility")
+			issue := f.create(t, "work")
+			approveHubTestPolicy(t, f.service, f.base+"/policy", hubTestPolicy())
+			r := prepareRunner(t, f, runnerauth.Read, runnerauth.Claim)
+			r.redemption.Version = test.version
+			r.enroll(t)
+			claim := tracker.NativeClaim{PolicyID: hubTestPolicy().ID, WorkItemID: issue.WorkItemID,
+				MachineID: r.binding.MachineID, SessionID: "version-session", TTLSeconds: 90,
+				ProtocolMajor: test.major, Capabilities: test.capabilities}
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, f.base+"/claims", r.redemption.Credential, claim), test.want)
+		})
+	}
+}

--- a/scripts/hub-smoke.py
+++ b/scripts/hub-smoke.py
@@ -1,0 +1,106 @@
+import http.client
+import json
+import os
+import pathlib
+import queue
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+
+
+def run(binary):
+    with tempfile.TemporaryDirectory(prefix="detent-hub-smoke-") as directory:
+        root = pathlib.Path(directory)
+        installed = root / "bin" / "detent"
+        installed.parent.mkdir()
+        shutil.copy2(binary, installed)
+        token = secrets.token_hex(32)
+        environment = {
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": str(root),
+            "TMPDIR": str(root),
+            "DETENT_HUB_ADMIN_TOKEN": token,
+        }
+        database = root / "data" / "hub.db"
+        snapshot = root / "backup.db"
+        restored = root / "restored.db"
+
+        def command(*args):
+            result = subprocess.run(
+                [str(installed), "hub", *args],
+                env=environment,
+                capture_output=True,
+                timeout=30,
+                check=True,
+            )
+            for credential in (token, environment["DETENT_HUB_ADMIN_TOKEN"]):
+                assert credential.encode() not in result.stdout + result.stderr
+            return result.stdout
+
+        def request(port, credential):
+            connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+            try:
+                connection.request("GET", "/health", headers={"Authorization": "Bearer " + credential})
+                response = connection.getresponse()
+                body = json.loads(response.read())
+                return response.status, body
+            finally:
+                connection.close()
+
+        def serve(path, rejected=None):
+            addresses = queue.Queue()
+            startup = []
+            process = subprocess.Popen(
+                [str(installed), "hub", "serve", "--database", str(path),
+                 "--listen", "127.0.0.1:0", "--github-disabled"],
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            def read_address():
+                for line in process.stdout:
+                    startup.append(line)
+                    match = re.search(r"127\.0\.0\.1:(\d+)", line)
+                    if match:
+                        addresses.put(int(match.group(1)))
+
+            reader = threading.Thread(target=read_address, daemon=True)
+            reader.start()
+            try:
+                try:
+                    port = addresses.get(timeout=30)
+                except queue.Empty:
+                    raise RuntimeError("Hub did not report its listener: " + "".join(startup)) from None
+                status, body = request(port, environment["DETENT_HUB_ADMIN_TOKEN"])
+                assert status == 200 and body["status"] == "ok", (status, body)
+                assert body["schema_version"] > 0
+                if rejected:
+                    assert request(port, rejected)[0] == 401
+            finally:
+                process.terminate()
+                process.wait(timeout=15)
+                reader.join(timeout=5)
+                process.stdout.close()
+            assert process.returncode == 0, process.returncode
+
+        serve(database)
+        serve(database)
+        command("backup", "--database", str(database), "--output", str(snapshot))
+        verified = json.loads(command("verify", "--database", str(snapshot)))
+        assert verified["schema_version"] > 0
+        environment["DETENT_HUB_ADMIN_TOKEN"] = secrets.token_hex(32)
+        result = json.loads(command("restore", "--database", str(snapshot), "--output", str(restored)))
+        assert result["administrator_id"].startswith("restore-admin-")
+        serve(restored, rejected=token)
+        command("verify", "--database", str(restored))
+        print("Hub isolated installation, restart, backup, restore and credential fencing passed")
+
+
+if __name__ == "__main__":
+    run(pathlib.Path(sys.argv[1]).resolve())


### PR DESCRIPTION
## Summary

- Package a supported single-host Hub deployment with systemd/TLS examples and an operator runbook covering authentication, runners, repository policy, optional durable artifacts, connectivity, diagnostics and retention.
- Add stopped-owner backup/export and verification without source migration, plus full-instance restore/import to a new destination. Restore preserves collaboration, identities and external references while revoking copied credentials/enrollments, releasing leases, rotating cursor authority and creating a fresh administrator.
- Document forward migration, interrupted recovery and protocol compatibility. Selective import, scoped purge and automatic high availability remain unsupported; backup expiration and whole-instance retirement are explicit operator responsibilities.

Fixes #2197

## UI Surface Contract

- [x] N/A; this change uses existing health, doctor and onboarding surfaces.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A for browser verification; no primary operator screen changes.

## Test Plan

- [x] `make check`: build, lint, vet, NilAway, race tests, 80.0% total coverage and all configured package/file floors.
- [x] Standard-library recovery tests verify preserved content/Changes/artifact references, source immutability, fresh authority, unsafe-path rejection, missing-bootstrap recovery and interrupted transactional migration before/after schema-version recording.
- [x] Linux container with networking disabled: isolated installation/restart/backup/restore smoke, two-runner routing, shared-host capacity and mixed protocol-feature compatibility.
- [x] Focused artifact tests cover runner-independent access, provider contracts, storage outage, backup and deletion recovery.
- [x] GoReleaser snapshot builds six archives and Linux amd64/arm64 DEB/RPM packages; archive contents verified and the arm64 DEB installed and passed its bundled smoke test without networking.
- [x] Example unit passes `systemd-analyze verify` in a disposable Linux container; no production deployment or paid provisioning.
