### PR TITLE
fix(procgroup): confirm exit after cleanup EPERM

### DIFF
--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -331,9 +331,13 @@ func stopStallTimer(timer *time.Timer) {
 }
 
 func waitAndCleanup(cmd *exec.Cmd, processGroupID int) error {
+	return waitAndCleanupWith(cmd, processGroupID, procgroup.Cleanup)
+}
+
+func waitAndCleanupWith(cmd *exec.Cmd, processGroupID int, cleanup func(int) error) error {
 	err := cmd.Wait()
-	if cleanupErr := procgroup.Cleanup(processGroupID); cleanupErr != nil {
-		err = errors.Join(err, cleanupErr)
+	if cleanupErr := cleanup(processGroupID); cleanupErr != nil {
+		err = errors.Join(err, fmt.Errorf("clean up claude process group %d after %s: %w", processGroupID, cmd.ProcessState, cleanupErr))
 	}
 	return err
 }

--- a/internal/claudecode/process_unix_test.go
+++ b/internal/claudecode/process_unix_test.go
@@ -171,6 +171,67 @@ func waitForProcessExit(t *testing.T, pid int) {
 	}
 }
 
+func TestWaitAndCleanupPreservesFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		exitCode   int
+		cleanupErr error
+	}{
+		{name: "successful exit and cleanup"},
+		{name: "successful exit with cleanup failure", cleanupErr: syscall.EPERM},
+		{name: "failed exit", exitCode: 9},
+		{name: "failed exit and cleanup", exitCode: 9, cleanupErr: syscall.EPERM},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := exec.CommandContext(t.Context(), "sh", "-c", "exit "+strconv.Itoa(tt.exitCode))
+			if err := cmd.Start(); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			cleanupCalls := 0
+			waitErr := waitAndCleanupWith(cmd, cmd.Process.Pid, func(groupID int) error {
+				cleanupCalls++
+				if groupID != cmd.Process.Pid {
+					t.Errorf("cleanup group = %d, want %d", groupID, cmd.Process.Pid)
+				}
+				if cmd.ProcessState == nil || cmd.ProcessState.ExitCode() != tt.exitCode {
+					t.Errorf("process state at cleanup = %v, want exit status %d", cmd.ProcessState, tt.exitCode)
+				}
+				return tt.cleanupErr
+			})
+			if cleanupCalls != 1 {
+				t.Fatalf("cleanup calls = %d, want 1", cleanupCalls)
+			}
+			var exitErr *exec.ExitError
+			if errors.As(waitErr, &exitErr) != (tt.exitCode != 0) {
+				t.Errorf("wait error = %v, want exit error = %t", waitErr, tt.exitCode != 0)
+			}
+			if tt.cleanupErr != nil {
+				if !errors.Is(waitErr, tt.cleanupErr) {
+					t.Errorf("wait error = %v, want cleanup error %v", waitErr, tt.cleanupErr)
+				}
+				want := fmt.Sprintf("clean up claude process group %d after exit status %d", cmd.Process.Pid, tt.exitCode)
+				if waitErr == nil || !strings.Contains(waitErr.Error(), want) {
+					t.Errorf("wait error = %v, want diagnostic %q", waitErr, want)
+				}
+			}
+			state := turnState{sawResult: true, resultSubtype: "success"}
+			err := finalTurnError(t.Context(), state, waitErr, "")
+			wantFailure := tt.exitCode != 0 || tt.cleanupErr != nil
+			if errors.Is(err, ErrTurnFailed) != wantFailure {
+				t.Errorf("finalTurnError() = %v, want turn failure = %t", err, wantFailure)
+			}
+			if !wantFailure && err != nil {
+				t.Errorf("finalTurnError() = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func processAlive(pid int) bool {
 	err := syscall.Kill(pid, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)

--- a/internal/procgroup/process_group_unix.go
+++ b/internal/procgroup/process_group_unix.go
@@ -80,13 +80,8 @@ func terminateTree(
 		if err == nil || errors.Is(err, syscall.ESRCH) {
 			return nil
 		}
-		if errors.Is(err, syscall.EPERM) {
-			members, inspectErr := inspect(processGroupID)
-			if inspectErr == nil && processGroupExited(members) {
-				if len(members) > 0 || errors.Is(signal(-processGroupID, 0), syscall.ESRCH) {
-					return nil
-				}
-			}
+		if errors.Is(err, syscall.EPERM) && confirmSignaledGroupExit(processGroupID, signal, inspect) {
+			return nil
 		}
 		return err
 	}
@@ -96,21 +91,44 @@ func terminateTree(
 	return cmd.Process.Kill()
 }
 
+func confirmSignaledGroupExit(
+	processGroupID int,
+	signal func(int, syscall.Signal) error,
+	inspect func(int) ([]processGroupMember, error),
+) bool {
+	members, err := inspect(processGroupID)
+	if err != nil || !processGroupExited(members) {
+		return false
+	}
+	return len(members) > 0 || errors.Is(signal(-processGroupID, 0), syscall.ESRCH)
+}
+
 func Cleanup(processGroupID int) error {
+	return cleanup(processGroupID, syscall.Kill, inspectProcessGroup)
+}
+
+func cleanup(
+	processGroupID int,
+	signal func(int, syscall.Signal) error,
+	inspect func(int) ([]processGroupMember, error),
+) error {
 	if processGroupID <= 0 {
 		return nil
 	}
-	err := syscall.Kill(-processGroupID, syscall.SIGKILL)
+	err := signal(-processGroupID, syscall.SIGKILL)
 	if errors.Is(err, syscall.ESRCH) {
 		return nil
 	}
+	if errors.Is(err, syscall.EPERM) && confirmSignaledGroupExit(processGroupID, signal, inspect) {
+		return nil
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("signal process group %d with SIGKILL: %w", processGroupID, err)
 	}
 	if waitForProcessGroupExit(processGroupID, DefaultTerminationGrace) {
 		return nil
 	}
-	members, inspectErr := inspectProcessGroup(processGroupID)
+	members, inspectErr := inspect(processGroupID)
 	if inspectErr == nil && processGroupExited(members) {
 		return nil
 	}
@@ -118,7 +136,7 @@ func Cleanup(processGroupID int) error {
 		return nil
 	}
 	if inspectErr == nil {
-		members, inspectErr = inspectProcessGroup(processGroupID)
+		members, inspectErr = inspect(processGroupID)
 		if inspectErr == nil && processGroupExited(members) {
 			return nil
 		}

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -306,6 +306,80 @@ func TestTerminateTreeDisambiguatesEPERM(t *testing.T) {
 	}
 }
 
+func TestCleanupDisambiguatesEPERM(t *testing.T) {
+	inspectErr := errors.New("inspect failed")
+	tests := []struct {
+		name       string
+		members    []processGroupMember
+		inspectErr error
+		probeErr   error
+		wantProbe  bool
+		wantErr    error
+	}{
+		{name: "exited process group", probeErr: syscall.ESRCH, wantProbe: true},
+		{name: "zombie-only process group", members: []processGroupMember{{state: "Z"}}},
+		{name: "mixed live and zombie group", members: []processGroupMember{{state: "Z"}, {state: "S"}}, wantErr: syscall.EPERM},
+		{name: "live unauthorized process group", members: []processGroupMember{{state: "S"}}, wantErr: syscall.EPERM},
+		{name: "hidden live unauthorized process group", probeErr: syscall.EPERM, wantProbe: true, wantErr: syscall.EPERM},
+		{name: "empty snapshot with existing process group", wantProbe: true, wantErr: syscall.EPERM},
+		{name: "failed process group inspection", inspectErr: inspectErr, probeErr: syscall.ESRCH, wantErr: syscall.EPERM},
+		{name: "failed existence probe", probeErr: syscall.EIO, wantProbe: true, wantErr: syscall.EPERM},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var signals []syscall.Signal
+			inspectCalls := 0
+			signal := func(pid int, signal syscall.Signal) error {
+				if pid != -123 {
+					t.Fatalf("signal target = %d, want -123", pid)
+				}
+				signals = append(signals, signal)
+				switch signal {
+				case syscall.SIGKILL:
+					return syscall.EPERM
+				case 0:
+					if inspectCalls != 1 {
+						t.Fatalf("probe before group inspection")
+					}
+					return tt.probeErr
+				default:
+					t.Fatalf("signal = %v, want %v or 0", signal, syscall.SIGKILL)
+					return nil
+				}
+			}
+			inspect := func(processGroupID int) ([]processGroupMember, error) {
+				inspectCalls++
+				if len(signals) != 1 || signals[0] != syscall.SIGKILL {
+					t.Fatalf("inspection signals = %v, want initial SIGKILL", signals)
+				}
+				if processGroupID != 123 {
+					t.Fatalf("inspect process group = %d, want 123", processGroupID)
+				}
+				return tt.members, tt.inspectErr
+			}
+
+			err := cleanup(123, signal, inspect)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("cleanup() error = %v, want %v", err, tt.wantErr)
+			}
+			if inspectCalls != 1 {
+				t.Fatalf("inspection calls = %d, want 1", inspectCalls)
+			}
+			wantSignals := 1
+			if tt.wantProbe {
+				wantSignals++
+			}
+			if len(signals) != wantSignals {
+				t.Fatalf("signal calls = %v, want %d calls", signals, wantSignals)
+			}
+			if tt.wantProbe && signals[1] != 0 {
+				t.Fatalf("second signal = %v, want 0", signals[1])
+			}
+		})
+	}
+}
+
 func TestCleanup(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

A successful Claude turn could fail afterward because process-group cleanup returned EPERM during the child exit/reap race. Instrumented CLI race repetitions reproduced the exact reported error twice: the child exited with status 0, cleanup SIGKILL returned EPERM, and subsequent inspection plus signal-0 confirmed that the group had exited.

Cleanup now shares cancellation's strict exit confirmation: accept visible zombie-only groups, or an empty inspection followed by ESRCH, while retaining permission failures for live or uninspectable groups. Errors identify the cleanup operation, process group, and child exit state. Backend routing assertions remain unchanged.

Fixes #2271

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff. No UI changes.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A.

## Test Plan

- [x] `make check` (80.0% coverage; all configured package/file floors passed)
- [x] `go test -race ./internal/procgroup ./internal/claudecode -count=10`
- [x] Claude CLI routing race test, 5 repetitions.
- [x] Deterministic cleanup and cancellation EPERM tables, 100 race repetitions, covering the captured sequence and preservation of live-group, inspection, and probe errors. Cleanup regression failed before the fix.
- [x] Claude wait/cleanup table verifies ordering, diagnostics, and preservation of child exit and cleanup failures after a successful result.
- [x] Actual cleanup probe: 8 concurrent workers, 5000 successful child exits each; 34 failures before the fix, zero in the same 40000-exit probe afterward.

The initial 100-repetition CLI diagnostic command captured two exact failures, then exceeded Go's default ten-minute timeout during repeated workspace operations. The bounded final five-repetition run passed. Detailed evidence is recorded in the issue Workpad.
