### PR TITLE
fix(merge): hand off resolved fallbacks before CI waits

### DIFF
--- a/.detent/skills/portable-git-fixture-commands.md
+++ b/.detent/skills/portable-git-fixture-commands.md
@@ -1,0 +1,13 @@
+---
+name: portable-git-fixture-commands
+description: Diagnose Windows-only Git fixture failures caused by quotes reaching child commands literally.
+when_to_use: Use when a shell-driven Git fixture passes on POSIX but Windows reports a quoted directory argument as invalid.
+---
+
+# Portable Git fixture commands
+
+- Check the child command's actual error. Literal surrounding quotes in a rejected `git -C` directory can indicate command-line construction at the `cmd /C` boundary, before the behavior under test executes. A unit test of the constructed argument slice does not prove Windows execution works.
+- For large GitHub Actions logs containing Go test JSON, identify events with `Action: fail`, then collect output for their package/test pairs. Searching for words such as `timeout` also matches passing test names and can hide the relevant failure.
+- When the test only needs to mutate a generated sibling repository, derive its path with `filepath.Rel` from the command's working directory and normalize separators with `filepath.ToSlash`. An unquoted relative path is appropriate only when its remaining components are controlled fixture names without whitespace or shell metacharacters; a shared temporary-root prefix containing spaces then disappears.
+- Keep quoted user-path coverage at the shared command boundary. Do not treat a fixture-relative path as a production quoting fix, strip user quotes, or skip Windows coverage. Track a discovered shared-shell defect separately when it is outside the current task.
+- Verify the fixture still performs its intended mutation and that the protected operation rejects or accepts it for the intended reason. Confirm the corrected command through native Windows CI as well as focused local tests.

--- a/internal/orchestrator/merge_fallback_test.go
+++ b/internal/orchestrator/merge_fallback_test.go
@@ -119,3 +119,70 @@ func TestMergeFallbackRoutesBoundedOutcomesToRework(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeFallbackResolvedHeadHandoff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		head       string
+		ci         string
+		wantRework bool
+	}{
+		{name: "resolved pushed head waits past resolution deadline", head: "validated-head", ci: "pending"},
+		{name: "validation failure", head: "validated-head", ci: "failure", wantRework: true},
+		{name: "replaced head with green CI", head: "replacement-head", ci: "success", wantRework: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 7, 22, 2, 24, 0, time.UTC)
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents: 1, MergeFastPathEnabled: true,
+				ActiveStates: []string{"Rework", "Merging"}, ObservedStates: []string{"Merging"}, TerminalStates: []string{"Done"},
+			})
+			issue := connector.Issue{
+				ID: "issue-2273", Identifier: "digitaldrywood/detent#2273", State: "Merging", PRRepository: "digitaldrywood/detent",
+				PullRequest: &connector.PullRequest{
+					Number: 2274, State: "OPEN", MergeableState: "clean", HeadSHA: tt.head, CIStatus: tt.ci,
+				},
+			}
+			tracker := &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}}
+			orch := &Orchestrator{cfg: cfg, connector: tracker, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{Issue: issue, Attempt: 1, Mode: runpkg.RunModeMerge, StartedAt: now.Add(-21 * time.Minute)}
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-21 * time.Minute)}
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{
+				IssueID: issue.ID, CompletedAt: now, Request: runpkg.RunRequest{Mode: runpkg.RunModeMerge},
+				Result: runpkg.RunResult{
+					FinalState: runpkg.FinalStateCompleted, Output: runpkg.RunOutputMergeFallbackResolved,
+					MergePrecheck: &runpkg.MergePrecheck{Status: "clean", HeadSHA: "validated-head"},
+				},
+			})
+			if len(tracker.merges) != 0 || len(state.Running) != 0 || len(state.Claimed) != 0 {
+				t.Fatalf("handoff retained execution or merged: merges=%v running=%v claimed=%v", tracker.merges, state.Running, state.Claimed)
+			}
+			if tt.wantRework {
+				if len(tracker.updates) != 1 || tracker.updates[0].state != "Rework" {
+					t.Fatalf("updates = %#v, want Rework", tracker.updates)
+				}
+				return
+			}
+			if len(tracker.updates) != 0 {
+				t.Fatalf("updates = %#v, want passive CI wait", tracker.updates)
+			}
+			retry := state.Retry[issue.ID]
+			if retry.Wait.Kind != retryWaitCurrentHeadCI || retry.Attempt != 1 {
+				t.Fatalf("retry = %#v, want current-head CI wait without another implementation", retry)
+			}
+			reservation := state.mergeReservations[issue.PRRepository]
+			if reservation.ExpiresAt.IsZero() || !reservation.ExpiresAt.After(now) {
+				t.Fatalf("reservation = %#v, want bounded merge ownership", reservation)
+			}
+			_, handled, _ := orch.pollMergeWorkerCurrentHeadCI(t.Context(), &state, issue, retry, now.Add(time.Minute))
+			if !handled || len(state.Running) != 0 || len(tracker.updates) != 0 {
+				t.Fatal("pending CI redispatched resolution or transitioned the issue after the fallback deadline")
+			}
+		})
+	}
+}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -1539,6 +1539,12 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		o.finishMergeRevocation(ctx, state, event, running, revocation)
 		return true
 	}
+	if event.Result.Output == runpkg.RunOutputMergeFallbackResolved &&
+		event.Result.MergePrecheck != nil && event.Result.MergePrecheck.HeadSHA != "" &&
+		(issue.PullRequest == nil || issue.PullRequest.HeadSHA != event.Result.MergePrecheck.HeadSHA) {
+		o.reworkMergeWorkerResult(ctx, state, event, running, issue, mergeFallbackRequiresReworkReason, nil, "Pull request head changed after deterministic merge-fallback validation.")
+		return true
+	}
 	missingChecks := mergeWorkerMissingRequiredChecks(issue)
 	streaks := o.evaluateMergeRequiredCheckStreaks(ctx, issue, missingChecks, event.CompletedAt)
 	if persistent := persistentMissingRequiredCheckStreaks(streaks); len(persistent) > 0 {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -699,6 +699,7 @@ func mergePrecheckFromWorkspace(precheck workspace.MergePrepareResult) MergePrec
 		Message:     precheck.Message,
 		DiffStats:   diffStatsFromWorkspace(precheck.DiffStat),
 		HeadChanged: precheck.HeadChanged,
+		HeadSHA:     precheck.HeadSHA,
 	}
 }
 
@@ -714,12 +715,14 @@ func mergeFallbackResult(output string) string {
 	return RunOutputMergeFallbackRework
 }
 
+const mergeFallbackValidationTimeout = time.Hour
+
 func (r *Runner) verifyMergeFallback(
 	ctx context.Context,
 	backend workspace.Backend,
 	info workspace.Info,
 	issue workspace.Issue,
-	targetBranch string,
+	opts workspace.MergePrepareOptions,
 	result RunResult,
 ) (RunResult, error) {
 	result.MergeFallbackFindings = strings.TrimSpace(result.Output)
@@ -732,20 +735,29 @@ func (r *Runner) verifyMergeFallback(
 		result.Output = RunOutputMergeFallbackRework
 		return result, nil
 	}
-	precheck, err := preparer.PrepareMerge(ctx, info, issue, workspace.MergePrepareOptions{TargetBranch: strings.TrimSpace(targetBranch)})
+	validationCtx, cancel := context.WithTimeout(ctx, mergeFallbackValidationTimeout)
+	defer cancel()
+	precheck, err := preparer.PrepareMerge(validationCtx, info, issue, opts)
 	if err != nil {
-		if cause := context.Cause(ctx); errors.Is(cause, ErrMergeFallbackBudgetExceeded) {
-			err = errors.Join(cause, err)
+		if ctx.Err() != nil {
+			return result, fmt.Errorf("verify merge fallback: %w", errors.Join(ctx.Err(), err))
 		}
-		return result, fmt.Errorf("verify merge fallback: %w", err)
+		if !errors.Is(err, workspace.ErrMergeResolutionInvalid) && !errors.Is(validationCtx.Err(), context.DeadlineExceeded) {
+			return result, fmt.Errorf("verify merge fallback: %w", err)
+		}
+		result.Output = RunOutputMergeFallbackRework
+		result.MergeFallbackFindings += "\nDeterministic validation failed: " + err.Error()
+		return result, nil
 	}
 	converted := mergePrecheckFromWorkspace(precheck)
 	result.MergePrecheck = &converted
-	if precheck.Status != workspace.MergePrepareStatusClean {
+	if precheck.Status != workspace.MergePrepareStatusClean || strings.TrimSpace(precheck.HeadSHA) == "" {
+		result.MergeFallbackFindings += fmt.Sprintf("\nDeterministic verification returned status %q, head %q: %s", precheck.Status, precheck.HeadSHA, precheck.Message)
 		result.Output = RunOutputMergeFallbackRework
 		return result, nil
 	}
 	result.PullRequestHeadPushed = result.PullRequestHeadPushed || precheck.HeadChanged
+	result.ForgeWriteCompleted = true
 	return result, nil
 }
 
@@ -1898,7 +1910,17 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if req.Issue.PullRequest != nil {
 			targetBranch = req.Issue.PullRequest.BaseRef
 		}
-		result, turnErr = r.verifyMergeFallback(sessionCtx, runWorkspace, info, workspaceIssue, targetBranch, result)
+		cancelSession()
+		expectedRemoteHead := ""
+		if req.Issue.PullRequest != nil {
+			expectedRemoteHead = req.Issue.PullRequest.HeadSHA
+		}
+		result, turnErr = r.verifyMergeFallback(ctx, runWorkspace, info, workspaceIssue, workspace.MergePrepareOptions{
+			TargetBranch:       targetBranch,
+			VerifyResolution:   true,
+			ValidationCommand:  gate.Effective(workflow.Config.Gate).Run,
+			ExpectedRemoteHead: expectedRemoteHead,
+		}, result)
 		if turnErr != nil {
 			result.FinalState = finalStateForTurnError(turnErr)
 		}

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/config"
@@ -408,7 +409,7 @@ func TestRunnerMergeFallbackUsesDedicatedBudget(t *testing.T) {
 	}
 }
 
-func TestRunnerMergeFallbackBudgetExpiresDuringReverification(t *testing.T) {
+func TestRunnerMergeFallbackValidationOutlivesResolutionBudget(t *testing.T) {
 	t.Parallel()
 
 	durationLimit := &controlledDurationLimit{}
@@ -418,9 +419,15 @@ func TestRunnerMergeFallbackBudgetExpiresDuringReverification(t *testing.T) {
 			if call == 0 {
 				return workspace.MergePrepareResult{Status: workspace.MergePrepareStatusConflict}, nil
 			}
+			deadline, bounded := ctx.Deadline()
+			if !bounded || time.Until(deadline) > time.Hour {
+				t.Fatal("deterministic validation must have a separate bounded context")
+			}
 			durationLimit.Expire()
-			<-ctx.Done()
-			return workspace.MergePrepareResult{}, ctx.Err()
+			if err := ctx.Err(); err != nil {
+				return workspace.MergePrepareResult{}, err
+			}
+			return workspace.MergePrepareResult{Status: workspace.MergePrepareStatusClean, HeadSHA: "validated-head"}, nil
 		},
 	}
 	runner, err := NewRunner(Dependencies{
@@ -447,11 +454,11 @@ func TestRunnerMergeFallbackBudgetExpiresDuringReverification(t *testing.T) {
 		},
 		Mode: RunModeMerge,
 	})
-	if !errors.Is(err, ErrMergeFallbackBudgetExceeded) {
-		t.Fatalf("Run() error = %v, want ErrMergeFallbackBudgetExceeded", err)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want resolved handoff after validation outlives the resolution budget", err)
 	}
-	if result.FinalState != FinalStateMergeFallbackExceeded {
-		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateMergeFallbackExceeded)
+	if result.Output != RunOutputMergeFallbackResolved {
+		t.Fatalf("Output = %q, want resolved handoff", result.Output)
 	}
 	if result.MergeFallbackFindings == "" {
 		t.Fatal("MergeFallbackFindings is empty")
@@ -792,4 +799,52 @@ func (s *durationBlockingSessionStore) UpdateSessionWorkerProcess(ctx context.Co
 	s.expireSession()
 	<-ctx.Done()
 	return ctx.Err()
+}
+
+func TestMergeFallbackValidationBoundaries(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		cancel bool
+		fail   bool
+	}{
+		{name: "gate failure", fail: true},
+		{name: "validation deadline"},
+		{name: "lease or shutdown cancellation", cancel: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				backend := &fakeMergeWorkspaceBackend{prepareFunc: func(ctx context.Context, _ int) (workspace.MergePrepareResult, error) {
+					if tt.fail {
+						return workspace.MergePrepareResult{}, errors.Join(workspace.ErrMergeResolutionInvalid, errors.New("make check failed"))
+					}
+					if tt.cancel {
+						cancel()
+					}
+					<-ctx.Done()
+					return workspace.MergePrepareResult{}, ctx.Err()
+				}}
+				started := time.Now()
+				result, err := (&Runner{}).verifyMergeFallback(ctx, backend, workspace.Info{}, workspace.Issue{}, workspace.MergePrepareOptions{}, RunResult{
+					FinalState: FinalStateCompleted, Output: "DETENT_MERGE_FALLBACK: resolved",
+				})
+				if tt.cancel {
+					if !errors.Is(err, context.Canceled) {
+						t.Fatalf("error = %v, want parent cancellation", err)
+					}
+					return
+				}
+				if err != nil || result.Output != RunOutputMergeFallbackRework || !strings.Contains(result.MergeFallbackFindings, "Deterministic validation failed") {
+					t.Fatalf("verification = %#v, %v; want actionable Rework", result, err)
+				}
+				if !tt.fail && time.Since(started) != mergeFallbackValidationTimeout {
+					t.Fatalf("validation elapsed = %v, want bounded deadline %v", time.Since(started), mergeFallbackValidationTimeout)
+				}
+			})
+		})
+	}
 }

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -268,14 +268,14 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 	b.WriteString("- Resolve only merge conflicts or blockers required by the rebase.\n")
 	b.WriteString("- Do not perform general code review, investigate unrelated correctness findings, or make unrelated refactors.\n")
 	b.WriteString("- If you discover work beyond conflict resolution, record it in your final response and stop.\n\n")
-	b.WriteString("### Phase 2: re-verify the resolved head\n\n")
-	b.WriteString("- Start this phase only after the rebase is conflict-free and the workspace is source-clean.\n")
-	b.WriteString("- Run the focused merge gate when current validation remains valid; run the full configured gate if you edit code, resolve conflicts, or validation state is stale.\n")
-	b.WriteString("- Push with lease protection after the gate passes; never use an unguarded force-push.\n")
-	b.WriteString("- Do not merge the pull request or change the issue state. Detent re-checks the branch and performs the handoff.\n\n")
+	b.WriteString("### Phase 2: hand off the resolved head\n\n")
+	b.WriteString("- Finish the rebase and commit the conflict resolution; leave the workspace source-clean.\n")
+	b.WriteString("- Return immediately. Detent independently verifies branch ownership, cleanliness, and target ancestry, runs the full configured local gate with a separate bounded validation budget, and pushes with lease protection.\n")
+	b.WriteString("- Do not run or wait for local validation or CI in this agent session. Detent owns validation, publishing, and current-head CI waiting after your return.\n")
+	b.WriteString("- Do not merge the pull request or change the issue state.\n\n")
 	b.WriteString("End your final response with exactly one of these lines:\n")
-	b.WriteString("- `DETENT_MERGE_FALLBACK: resolved` only after both phases succeed.\n")
-	b.WriteString("- `DETENT_MERGE_FALLBACK: rework` when conflict resolution, verification, or an out-of-scope finding requires normal Rework.\n")
+	b.WriteString("- `DETENT_MERGE_FALLBACK: resolved` after the rebase and committed resolution are complete; this requests verification and is not proof of validation.\n")
+	b.WriteString("- `DETENT_MERGE_FALLBACK: rework` when conflict resolution or an out-of-scope finding requires normal Rework.\n")
 
 	prompt := prependWorkspaceIsolationBlock(b.String(), workflow.Config, opts.WorkspacePath, opts.Branch)
 	var err error
@@ -296,7 +296,7 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 	if promptDeliverableKind(workflow.Config.Deliverable) == config.DeliverablePullRequest {
 		prompt = appendClosingReferenceInstruction(prompt, issue)
 	}
-	prompt = strings.TrimRight(prompt, " \t\r\n") + "\n\n## Merge-fallback enforcement\n\nBroader workflow instructions above do not authorize general review or unrelated fixes in this session. Detent accepts resolution only when your final response ends with `DETENT_MERGE_FALLBACK: resolved` and its deterministic recheck finds a clean head. Otherwise end with `DETENT_MERGE_FALLBACK: rework`."
+	prompt = strings.TrimRight(prompt, " \t\r\n") + "\n\n## Merge-fallback enforcement\n\nBroader workflow instructions above do not authorize general review or unrelated fixes in this session. Return immediately after committing the resolution; do not run the local gate, push, watch CI, or wait for checks, even if broader workflow instructions request them. Detent performs bounded local validation and current-head CI waiting after you return. Detent accepts resolution only when your final response ends with `DETENT_MERGE_FALLBACK: resolved` and its deterministic recheck finds a clean head. Otherwise end with `DETENT_MERGE_FALLBACK: rework`."
 	return prompt, nil
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -3726,6 +3726,7 @@ func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
 		"Deterministic merge pre-check status: conflict",
 		"CONFLICT (content): Merge conflict in README.md",
 		"Do not perform general code review",
+		"do not run the local gate, push, watch CI, or wait for checks",
 		"DETENT_MERGE_FALLBACK: resolved",
 		"DETENT_MERGE_FALLBACK: rework",
 		"https://github.com/digitaldrywood/detent/pull/900",
@@ -3759,10 +3760,17 @@ func TestRunnerMergeFallbackOutcomes(t *testing.T) {
 		{
 			name:             "resolved conflict is deterministically reverified",
 			agentOutput:      "Resolved the README conflict and passed make check.\nDETENT_MERGE_FALLBACK: resolved",
-			verification:     workspace.MergePrepareResult{Status: workspace.MergePrepareStatusClean, HeadChanged: true},
+			verification:     workspace.MergePrepareResult{Status: workspace.MergePrepareStatusClean, HeadChanged: true, HeadSHA: "validated-head"},
 			wantOutput:       RunOutputMergeFallbackResolved,
 			wantPrepareCalls: 2,
 			wantHeadPushed:   true,
+		},
+		{
+			name:             "clean claim without verified head exits to rework",
+			agentOutput:      "DETENT_MERGE_FALLBACK: resolved",
+			verification:     workspace.MergePrepareResult{Status: workspace.MergePrepareStatusClean},
+			wantOutput:       RunOutputMergeFallbackRework,
+			wantPrepareCalls: 2,
 		},
 		{
 			name:             "review finding exits to rework without investigation",
@@ -3830,7 +3838,7 @@ func TestRunnerMergeFallbackOutcomes(t *testing.T) {
 			if result.Output != tt.wantOutput {
 				t.Fatalf("Run().Output = %q, want %q", result.Output, tt.wantOutput)
 			}
-			if result.MergeFallbackFindings != tt.agentOutput {
+			if !strings.HasPrefix(result.MergeFallbackFindings, tt.agentOutput) {
 				t.Fatalf("MergeFallbackFindings = %q, want agent output", result.MergeFallbackFindings)
 			}
 			if workspaceBackend.prepareCalls != tt.wantPrepareCalls {
@@ -3838,6 +3846,9 @@ func TestRunnerMergeFallbackOutcomes(t *testing.T) {
 			}
 			if result.PullRequestHeadPushed != tt.wantHeadPushed {
 				t.Fatalf("PullRequestHeadPushed = %t, want %t", result.PullRequestHeadPushed, tt.wantHeadPushed)
+			}
+			if tt.wantPrepareCalls == 2 && (!workspaceBackend.prepareOptions.VerifyResolution || workspaceBackend.prepareOptions.ValidationCommand != "make check") {
+				t.Fatalf("verification options = %#v, want trusted resolution validation", workspaceBackend.prepareOptions)
 			}
 			if workspaceBackend.prepareOptions.TargetBranch != "main" {
 				t.Fatalf("verification target branch = %q, want main", workspaceBackend.prepareOptions.TargetBranch)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -619,6 +619,7 @@ type SessionProgressProbe func(context.Context) (string, error)
 type ModelPermitAcquirer func(context.Context) error
 
 type MergePrecheck struct {
+	HeadSHA     string
 	Status      string
 	Message     string
 	DiffStats   DiffStats

--- a/internal/workspace/merge.go
+++ b/internal/workspace/merge.go
@@ -7,9 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
 )
 
 const defaultGitRemote = "origin"
+
+var ErrMergeResolutionInvalid = errors.New("merge resolution is invalid")
 
 func (l *LocalGit) PrepareMerge(
 	ctx context.Context,
@@ -20,6 +25,9 @@ func (l *LocalGit) PrepareMerge(
 	normalized, err := l.normalizeInfo(info, issue)
 	if err != nil {
 		return MergePrepareResult{}, err
+	}
+	if opts.VerifyResolution {
+		return l.prepareResolvedMerge(ctx, normalized, issue, opts)
 	}
 	release, err := l.acquireSourceOperation(ctx)
 	if err != nil {
@@ -203,4 +211,121 @@ func commandErrorOutput(err error) string {
 		return strings.TrimSpace(commandErr.Output)
 	}
 	return strings.TrimSpace(err.Error())
+}
+
+func (l *LocalGit) prepareResolvedMerge(ctx context.Context, info Info, issue Issue, opts MergePrepareOptions) (MergePrepareResult, error) {
+	remote := strings.TrimSpace(opts.Remote)
+	if remote == "" {
+		remote = defaultGitRemote
+	}
+	target := strings.TrimSpace(opts.TargetBranch)
+	if target == "" {
+		var err error
+		target, err = remoteDefaultBranch(ctx, info.Path, remote)
+		if err != nil {
+			return MergePrepareResult{}, err
+		}
+	}
+	head, base, remoteHead, err := l.resolvedMergeHeads(ctx, info, issue, remote, target)
+	if err != nil {
+		return MergePrepareResult{}, err
+	}
+	if remoteHead != strings.TrimSpace(opts.ExpectedRemoteHead) && remoteHead != head {
+		return MergePrepareResult{}, fmt.Errorf("%w: remote branch changed before merge-fallback validation", ErrMergeResolutionInvalid)
+	}
+	if err := l.validateMergeResolution(ctx, info, issue, opts.ValidationCommand); err != nil {
+		return MergePrepareResult{}, err
+	}
+	currentHead, currentBase, currentRemote, err := l.resolvedMergeHeads(ctx, info, issue, remote, target)
+	if err != nil {
+		return MergePrepareResult{}, err
+	}
+	if currentHead != head || currentBase != base || currentRemote != remoteHead {
+		return MergePrepareResult{}, fmt.Errorf("%w: local head, target base, or remote branch changed during merge-fallback validation", ErrMergeResolutionInvalid)
+	}
+	if _, err := runGitAt(ctx, info.Path, "push", "--force-with-lease=refs/heads/"+info.Branch+":"+remoteHead, remote, head+":refs/heads/"+info.Branch); err != nil {
+		return MergePrepareResult{}, fmt.Errorf("push validated merge resolution: %w", err)
+	}
+	return MergePrepareResult{Status: MergePrepareStatusClean, HeadSHA: head, HeadChanged: remoteHead != head}, nil
+}
+
+func (l *LocalGit) resolvedMergeHeads(ctx context.Context, info Info, issue Issue, remote, target string) (string, string, string, error) {
+	release, err := l.acquireSourceOperation(ctx)
+	if err != nil {
+		return "", "", "", err
+	}
+	defer release()
+	branch, err := runGitAt(ctx, info.Path, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		return "", "", "", err
+	}
+	if strings.TrimSpace(info.Branch) == "" || strings.TrimSpace(branch) != info.Branch {
+		return "", "", "", fmt.Errorf("%w: merge resolution is not on the owned workspace branch", ErrMergeResolutionInvalid)
+	}
+	inProgress, err := rebaseInProgress(ctx, info.Path)
+	if err != nil {
+		return "", "", "", err
+	}
+	if inProgress {
+		return "", "", "", fmt.Errorf("%w: merge resolution still has a rebase in progress", ErrMergeResolutionInvalid)
+	}
+	diff, err := l.DiffStat(ctx, info, issue)
+	if err != nil {
+		return "", "", "", err
+	}
+	if diff != (DiffStat{}) {
+		return "", "", "", fmt.Errorf("%w: merge resolution workspace is not source-clean", ErrMergeResolutionInvalid)
+	}
+	ref := "refs/remotes/" + remote + "/" + target
+	if _, err := runGitAt(ctx, info.Path, "fetch", remote, "+refs/heads/"+target+":"+ref); err != nil {
+		return "", "", "", err
+	}
+	base, err := runGitAt(ctx, info.Path, "rev-parse", ref)
+	if err != nil {
+		return "", "", "", err
+	}
+	head, err := runGitAt(ctx, info.Path, "rev-parse", "HEAD")
+	if err != nil {
+		return "", "", "", err
+	}
+	if _, err := runGitAt(ctx, info.Path, "merge-base", "--is-ancestor", strings.TrimSpace(base), strings.TrimSpace(head)); err != nil {
+		var commandErr *CommandError
+		if errors.As(err, &commandErr) && commandErr.ExitCode == 1 {
+			err = errors.Join(ErrMergeResolutionInvalid, err)
+		}
+		return "", "", "", fmt.Errorf("merge resolution does not contain the current target branch: %w", err)
+	}
+	remoteHead, exists, err := remoteBranchHead(ctx, info.Path, remote, info.Branch)
+	if err != nil {
+		return "", "", "", err
+	}
+	if !exists {
+		return "", "", "", fmt.Errorf("%w: merge resolution remote branch is missing", ErrMergeResolutionInvalid)
+	}
+	return strings.TrimSpace(head), strings.TrimSpace(base), remoteHead, nil
+}
+
+func (l *LocalGit) validateMergeResolution(ctx context.Context, info Info, issue Issue, command string) (err error) {
+	if strings.TrimSpace(command) == "" {
+		return nil
+	}
+	scratch, err := PrepareWorkerScratch(ctx, info.Path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, CleanupWorkerScratch(info.Path))
+	}()
+	cmd := commandshell.Command(ctx, command, l.hooks.Shell)
+	cmd.Dir = info.Path
+	cmd.Env = hookEnv(info, issue)
+	cmd.WaitDelay = workspaceCommandWaitDelay
+	procgroup.SetTempDir(cmd, scratch)
+	procgroup.Configure(ctx, cmd)
+	l.logger.Info("validating merge resolution", "workspace_path", info.Path, "command", command)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("merge resolution gate failed: %w: %s", errors.Join(ErrMergeResolutionInvalid, ctx.Err(), err), output)
+	}
+	return nil
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -143,11 +143,15 @@ type MergePreparer interface {
 }
 
 type MergePrepareOptions struct {
-	Remote       string
-	TargetBranch string
+	VerifyResolution   bool
+	ValidationCommand  string
+	ExpectedRemoteHead string
+	Remote             string
+	TargetBranch       string
 }
 
 type MergePrepareResult struct {
+	HeadSHA     string
 	Status      MergePrepareStatus
 	DiffStat    DiffStat
 	Message     string

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -2859,8 +2859,12 @@ func TestLocalGitPrepareMergeValidatesResolvedHead(t *testing.T) {
 				if tt.gate == "remote" {
 					branch = info.Branch
 				}
-				quotedSource := `"` + filepath.ToSlash(source) + `"`
-				command += " && git -C " + quotedSource + " commit --allow-empty -m external && git -C " + quotedSource + " push origin HEAD:" + branch
+				relativeSource, err := filepath.Rel(info.Path, source)
+				if err != nil {
+					t.Fatal(err)
+				}
+				relativeSource = filepath.ToSlash(relativeSource)
+				command += " && git -C " + relativeSource + " commit --allow-empty -m external && git -C " + relativeSource + " push origin HEAD:" + branch
 			default:
 				if tt.gate != "" {
 					command += " && " + tt.gate

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -2792,3 +2792,103 @@ func skipWindows(t *testing.T) {
 		t.Skip("requires a UNIX test environment")
 	}
 }
+
+func TestLocalGitPrepareMergeValidatesResolvedHead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		before     string
+		gate       string
+		wantError  string
+		wantPushed bool
+	}{
+		{name: "resolved committed head", wantPushed: true},
+		{name: "already pushed head", before: "push"},
+		{name: "gate failure", gate: "git detent-invalid-gate", wantError: "gate failed"},
+		{name: "dirty resolution", before: "dirty", wantError: "not source-clean"},
+		{name: "stale target", before: "base", wantError: "does not contain"},
+		{name: "replaced remote", before: "remote", wantError: "remote branch changed before"},
+		{name: "gate changes head", gate: "git commit --allow-empty -m changed", wantError: "changed during"},
+		{name: "gate dirties source", gate: "git rm README.md", wantError: "not source-clean"},
+		{name: "gate changes branch", gate: "git checkout -b other", wantError: "owned workspace branch"},
+		{name: "gate changes target", gate: "base", wantError: "does not contain"},
+		{name: "gate replaces remote", gate: "remote", wantError: "changed during"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			remote := initBareRemote(t)
+			runGit(t, source, "remote", "add", "origin", remote)
+			runGit(t, source, "push", "-u", "origin", "main")
+			backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+				Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := Issue{Identifier: "DD-RESOLVED"}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, info.Path, "push", "origin", "HEAD:"+info.Branch)
+			expectedRemote := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
+			runGit(t, info.Path, "commit", "--allow-empty", "-m", "resolved")
+			head := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
+			mutateRemote := func(branch string) {
+				runGit(t, source, "commit", "--allow-empty", "-m", "external")
+				runGit(t, source, "push", "origin", "HEAD:"+branch)
+			}
+			switch tt.before {
+			case "push":
+				runGit(t, info.Path, "push", "origin", "HEAD:"+info.Branch)
+			case "dirty":
+				runGit(t, info.Path, "rm", "README.md")
+			case "base":
+				mutateRemote("main")
+			case "remote":
+				mutateRemote(info.Branch)
+			}
+			remoteBefore := strings.TrimSpace(runGit(t, source, "ls-remote", "origin", "refs/heads/"+info.Branch))
+			command := "git config detent.validation passed"
+			switch tt.gate {
+			case "base", "remote":
+				branch := "main"
+				if tt.gate == "remote" {
+					branch = info.Branch
+				}
+				quotedSource := `"` + filepath.ToSlash(source) + `"`
+				command += " && git -C " + quotedSource + " commit --allow-empty -m external && git -C " + quotedSource + " push origin HEAD:" + branch
+			default:
+				if tt.gate != "" {
+					command += " && " + tt.gate
+				}
+			}
+			result, err := backend.(MergePreparer).PrepareMerge(t.Context(), info, issue, MergePrepareOptions{
+				TargetBranch: "main", VerifyResolution: true, ValidationCommand: command, ExpectedRemoteHead: expectedRemote,
+			})
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("PrepareMerge() = %#v, %v; want error containing %q", result, err, tt.wantError)
+				}
+				if tt.gate != "remote" {
+					if got := strings.TrimSpace(runGit(t, source, "ls-remote", "origin", "refs/heads/"+info.Branch)); got != remoteBefore {
+						t.Fatalf("remote changed on failed validation: %q, want %q", got, remoteBefore)
+					}
+				}
+				return
+			}
+			if err != nil || result.Status != MergePrepareStatusClean || result.HeadSHA != head || result.HeadChanged != tt.wantPushed {
+				t.Fatalf("PrepareMerge() = %#v, %v; want validated head %s, pushed %t", result, err, head, tt.wantPushed)
+			}
+			if got := strings.TrimSpace(runGit(t, info.Path, "config", "--get", "detent.validation")); got != "passed" {
+				t.Fatalf("local gate evidence = %q", got)
+			}
+			if got := strings.Fields(runGit(t, source, "ls-remote", "origin", "refs/heads/"+info.Branch))[0]; got != head {
+				t.Fatalf("remote head = %s, want %s", got, head)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Resolved merge fallbacks return from the agent after committing conflict resolution. Detent then runs the configured local gate under a separate one-hour limit; unresolved agent work retains the existing conflict-resolution budget.
- Native verification checks branch ownership, source cleanliness, current target ancestry, and stable local/base/remote heads before pushing the validated SHA with an explicit lease. Invalid resolution or validation expiry routes to Rework; parent cancellation and native transport errors retain their error paths.
- Pending current-head CI uses the existing bounded wait, releasing the worker/claim while retaining the merge reservation. A refreshed PR head must match the validated SHA before handoff. The base-refresh safeguards from #2282 remain intact.

Includes the existing portable Git fixture skill draft. Shared Windows shell quoting and an intermittent unrelated hook-test deadline are tracked separately in #2277 and #2279.

Fixes #2273

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual changes.

## Test Plan

- [x] Controlled deadline reproduction failed before the fix during post-resolution verification.
- [x] Focused runner, workspace, and orchestrator merge regressions passed after rebasing onto the #2282 repair at eff4f3f4.
- [x] Real Git tests cover committed/already-pushed resolution, failed gate, dirty source, stale base, replaced remote, and local/base/remote mutations during validation.
- [x] Lifecycle tests cover pending CI beyond the resolution deadline, failed CI, replaced green head, unresolved timeout, validation expiry, and parent cancellation.
- [x] Full `make check CHECK_LOCK_WAIT=30m` passed on b1f60405: build, lint, vet, NilAway, race suite, 80.1% total coverage, and all configured package/file floors. Only the bounded shared-lock queue allowance was extended; the initial default run exhausted its 15-minute lock wait before validation.
- [x] All 11 current-head CI jobs passed on b1f60405 in [run 34178495671](https://github.com/digitaldrywood/detent/actions/runs/34178495671), including Linux race tests and macOS/Windows portability.
