### PR TITLE
fix(orchestrator): keep startup progress observable

### DIFF
--- a/.detent/skills/synctest-mutex-join-testing.md
+++ b/.detent/skills/synctest-mutex-join-testing.md
@@ -1,0 +1,11 @@
+---
+name: synctest-mutex-join-testing
+description: Test cancellation and retirement of a writer without deadlocking the virtual-time harness on mutex contention.
+when_to_use: Use when a testing/synctest test waits for quiescence while a shutdown or retirement goroutine is blocked acquiring a mutex held by a deliberately stalled operation.
+---
+
+- Inspect the isolated test's goroutine dump. A test in `synctest.Wait`, a fake operation blocked on a channel, and a retirement goroutine in `sync.Mutex.Lock` identify a harness cycle: mutex contention is not a durable block that lets synctest declare quiescence.
+- Keep channel barriers at the actual external operation. Wait for its entry, inspect the observable state, then release it or cancel its context before joining retirement.
+- Do not call `synctest.Wait` while intentionally retaining that mutex cycle. Do not replace it with sleeps or change production locking solely to accommodate virtual time.
+- For a negative join assertion, check that retirement has not completed while the external operation is held; then release or cancel the operation and await both its result and retirement's completion.
+- Verify successful completion and cancellation as separate cases, and run the focused cases under the race detector.

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -654,7 +654,10 @@ func publishSnapshotOnce(
 		}
 		snapshot := state.Snapshot(now)
 		snapshot.Project = projectMetadata
-		snapshot.Tracker = liveSnapshotSection(now)
+		snapshot.Tracker = unknownSnapshotSection()
+		if !state.LastRefreshAt.IsZero() {
+			snapshot.Tracker = liveSnapshotSection(state.LastRefreshAt)
+		}
 		snapshot.Runtime = liveSnapshotSection(now)
 		snapshot.DashboardURL = cleanDashboardURL(dashboardURL)
 		merged = mergeSnapshot(merged, snapshot)

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -616,7 +616,9 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	t.Parallel()
 
 	registry := projectpkg.NewRegistry()
-	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+	healthy := startRefreshProject(t, "alpha")
+	waitForProjectDataSeq(t, healthy, 1)
+	mustSetProject(t, registry, healthy)
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
@@ -1349,7 +1351,9 @@ func TestPublishSnapshotOncePausedProjectSuppressesStartupError(t *testing.T) {
 	}
 
 	registry := projectpkg.NewRegistry()
-	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+	healthy := startRefreshProject(t, "alpha")
+	waitForProjectDataSeq(t, healthy, 1)
+	mustSetProject(t, registry, healthy)
 	mustSetProject(t, registry, failedProject)
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 23, 14, 30, 0, 0, time.UTC)
@@ -1520,6 +1524,7 @@ func TestPublishSnapshotOncePreservesPipeline(t *testing.T) {
 			t.Fatalf("Project.Stop() error = %v", err)
 		}
 	})
+	waitForProjectDataSeq(t, project, 1)
 	mustSetProject(t, registry, project)
 
 	snapshotHub := hub.New[telemetry.Snapshot]()

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1030,7 +1030,9 @@ func TestPublishSnapshotOnceDoesNotLetPausedProjectsHoldFleetReadiness(t *testin
 	t.Parallel()
 
 	registry := projectpkg.NewRegistry()
-	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+	healthy := startRefreshProject(t, "alpha")
+	waitForProjectDataSeq(t, healthy, 1)
+	mustSetProject(t, registry, healthy)
 
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -1017,8 +1017,8 @@ func TestRunWithShutdownPublishesDrainStatusDuringBlockedConnectorRefresh(t *tes
 	for {
 		snapshot, ok := snapshotHub.Latest()
 		if ok && snapshot.Shutdown.Draining {
-			if snapshot.Shutdown.SessionsRemaining != 1 {
-				t.Fatalf("SessionsRemaining = %d, want 1", snapshot.Shutdown.SessionsRemaining)
+			if snapshot.Shutdown.SessionsRemaining != 0 {
+				t.Fatalf("SessionsRemaining = %d, want 0 from live initializing runtime", snapshot.Shutdown.SessionsRemaining)
 			}
 			break
 		}

--- a/internal/cli/telemetry_liveness_test.go
+++ b/internal/cli/telemetry_liveness_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -82,7 +83,7 @@ func TestTelemetryPublicationSurvivesStalledSourceAfterRestart(t *testing.T) {
 						t.Fatalf("startup retained prior shutdown state: %#v", initial.Shutdown)
 					}
 					server := newTelemetryWebServer(t, snapshots, registry)
-					events := httptest.NewRecorder()
+					events := &telemetryEventRecorder{ResponseRecorder: httptest.NewRecorder()}
 					eventsDone := make(chan struct{})
 					go func() {
 						defer close(eventsDone)
@@ -93,9 +94,9 @@ func TestTelemetryPublicationSurvivesStalledSourceAfterRestart(t *testing.T) {
 						<-eventsDone
 					}()
 					synctest.Wait()
-					frames := strings.Count(events.Body.String(), "event: snapshot\n")
-					if events.Code != http.StatusOK || frames != 1 {
-						t.Fatalf("startup SSE status = %d, snapshot frames = %d", events.Code, frames)
+					frames := strings.Count(events.body(), "event: snapshot\n")
+					if events.status() != http.StatusOK || frames != 1 {
+						t.Fatalf("startup SSE status = %d, snapshot frames = %d", events.status(), frames)
 					}
 					model, err := tui.NewModel(ctx, snapshots)
 					if err != nil {
@@ -145,12 +146,12 @@ func TestTelemetryPublicationSurvivesStalledSourceAfterRestart(t *testing.T) {
 						if !health.GeneratedAt.Equal(current.GeneratedAt) || health.AgeSeconds > 1 {
 							t.Fatalf("health freshness = %#v, snapshot generated at %v", health, current.GeneratedAt)
 						}
-						if got := strings.Count(events.Body.String(), "event: snapshot\n"); got <= frames {
+						if got := strings.Count(events.body(), "event: snapshot\n"); got <= frames {
 							t.Fatalf("SSE froze at %d snapshot frames", got)
 						} else {
 							frames = got
 						}
-						if !strings.Contains(events.Body.String(), "beta active worker") || !strings.Contains(events.Body.String(), "gamma active worker") {
+						if !strings.Contains(events.body(), "beta active worker") || !strings.Contains(events.body(), "gamma active worker") {
 							t.Fatal("SSE did not include current running workers")
 						}
 						if source == "lifetime_totals" && (current.LifetimeTotals.Available || !strings.Contains(current.LifetimeTotals.DegradedReason, "deadline")) {
@@ -158,8 +159,11 @@ func TestTelemetryPublicationSurvivesStalledSourceAfterRestart(t *testing.T) {
 						}
 						if source == "project_state" {
 							alpha := current.Projects[0]
-							if alpha.Runtime.Source != telemetry.SnapshotSourceUnknown || !strings.Contains(alpha.Refresh.LastError, "deadline") {
-								t.Fatalf("stalled project = %#v, want unknown with deadline diagnostic", alpha)
+							if alpha.Runtime.Source != telemetry.SnapshotSourceLive || !alpha.Refresh.Initializing() || alpha.Refresh.LastRefreshAt != nil || alpha.Refresh.InFlight == nil || alpha.Refresh.InFlight.Stage != "tracker_fetch" {
+								t.Fatalf("stalled project = %#v, want live runtime and initializing tracker with stage diagnostic", alpha)
+							}
+							if !cached && alpha.Tracker.Source != telemetry.SnapshotSourceUnknown {
+								t.Fatal("uninitialized tracker presented as fresh")
 							}
 							if cached && alpha.Tracker.Source != telemetry.SnapshotSourceCached {
 								t.Fatal("stalled project lost cached tracker provenance")
@@ -324,4 +328,43 @@ func (stalledTelemetryConnector) FetchCandidateIssues(ctx context.Context) ([]co
 func (stalledTelemetryConnector) FetchIssuesByStates(ctx context.Context, _ []string) ([]connector.Issue, error) {
 	<-ctx.Done()
 	return nil, ctx.Err()
+}
+
+type telemetryEventRecorder struct {
+	*httptest.ResponseRecorder
+	mu sync.Mutex
+}
+
+func (r *telemetryEventRecorder) Write(data []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ResponseRecorder.Write(data)
+}
+
+func (r *telemetryEventRecorder) WriteString(data string) (int, error) {
+	return r.Write([]byte(data))
+}
+
+func (r *telemetryEventRecorder) WriteHeader(status int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ResponseRecorder.WriteHeader(status)
+}
+
+func (r *telemetryEventRecorder) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ResponseRecorder.Flush()
+}
+
+func (r *telemetryEventRecorder) body() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.Body.String()
+}
+
+func (r *telemetryEventRecorder) status() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.Code
 }

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -768,6 +768,11 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	delete(state.ReapedWorkspaces, issue.ID)
 	delete(state.Completed, issue.ID)
 
+	runningProgress := state.Running[issue.ID]
+	progress := newWorkerProgress(runningProgress, o.runningWorkAttemptHeartbeat(state, runningProgress, now), o.workAttempts, o.cfg.OutputTruncationMaxBytes)
+	runningProgress.progress = progress
+	state.Running[issue.ID] = runningProgress
+
 	reservation := reserveMergeCandidate(state, issue, now)
 	request := RunRequest{
 		Policy:              o.cfg.Policy,
@@ -783,7 +788,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		StartedAt:           now,
 		WorkerHost:          workerHost,
 		SelectorContext:     o.selectorContext(),
-		OnUsageUpdate:       o.usageUpdateHandler(runCtx, issue.ID, startupTimer),
+		OnUsageUpdate:       o.usageUpdateHandler(runCtx, issue.ID, startupTimer, progress),
 		OnActivityUpdate:    o.activityUpdateHandler(runCtx, issue),
 		OnOverrideRejected:  o.agentOverrideRejectionHandler(runCtx, issue),
 		ProgressProbe:       o.sessionProgressProbe(issue),
@@ -1057,7 +1062,12 @@ func (o *Orchestrator) usageUpdateHandler(
 	ctx context.Context,
 	issueID string,
 	startupTimer mergeWorkerStartupTimer,
+	progresses ...*workerProgress,
 ) runpkg.UsageUpdateHandler {
+	var progress *workerProgress
+	if len(progresses) > 0 {
+		progress = progresses[0]
+	}
 	return func(update runpkg.UsageUpdate) error {
 		select {
 		case <-ctx.Done():
@@ -1067,7 +1077,12 @@ func (o *Orchestrator) usageUpdateHandler(
 		if startupTimer != nil {
 			startupTimer.Stop()
 		}
-		if update.DispatchLoopStart != nil {
+		if progress != nil {
+			if err := progress.observe(ctx, update); err != nil {
+				return err
+			}
+		}
+		if update.DispatchLoopStart != nil && progress == nil {
 			applied := make(chan struct{})
 			select {
 			case <-ctx.Done():
@@ -1081,17 +1096,17 @@ func (o *Orchestrator) usageUpdateHandler(
 				return nil
 			}
 		}
-		if strings.TrimSpace(update.WorkerGitHubActor.Login) != "" {
+		if strings.TrimSpace(update.WorkerGitHubActor.Login) != "" && progress == nil {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case o.runUpdates <- runUpdate{issueID: issueID, usage: update}:
+			case o.runUpdates <- runUpdate{issueID: issueID, usage: update, progress: progress}:
 				return nil
 			}
 		}
 
 		select {
-		case o.runUpdates <- runUpdate{issueID: issueID, usage: update}:
+		case o.runUpdates <- runUpdate{issueID: issueID, usage: update, progress: progress}:
 			return nil
 		default:
 			return nil

--- a/internal/orchestrator/heartbeat.go
+++ b/internal/orchestrator/heartbeat.go
@@ -43,6 +43,7 @@ type heartbeatSettings struct {
 }
 
 type heartbeatTarget struct {
+	progress             *workerProgress
 	issueID              string
 	claimOwner           string
 	workAttemptHeartbeat store.WorkAttemptHeartbeat
@@ -160,7 +161,7 @@ func (m *heartbeatManager) upsert(target heartbeatTarget) {
 	}
 	m.mu.Lock()
 	current, ok := m.targets[target.issueID]
-	if ok && current.workAttemptHeartbeat.AttemptID == target.workAttemptHeartbeat.AttemptID {
+	if ok && current.workAttemptHeartbeat.AttemptID == target.workAttemptHeartbeat.AttemptID && current.progress == target.progress {
 		target.sequence = current.sequence
 		target.nextDue = current.nextDue
 		target.inFlight = current.inFlight
@@ -189,6 +190,7 @@ func (m *heartbeatManager) remove(issueID string) {
 	delete(m.targets, strings.TrimSpace(issueID))
 	m.mu.Unlock()
 	m.notify()
+	target.progress.close()
 	if target.flightDone != nil {
 		<-target.flightDone
 	}
@@ -295,6 +297,11 @@ func (m *heartbeatManager) execute(ctx context.Context, target heartbeatTarget) 
 	defer cancel()
 	settings := m.settingsSnapshot()
 	result := heartbeatResult{issueID: target.issueID, sequence: target.sequence}
+	if target.progress != nil {
+		running := target.progress.latest.Load()
+		target.workerProcess = running.WorkerProcess
+		target.workspacePath = running.WorkspacePath
+	}
 	result.workerAlive, result.workerChecked, result.livenessError = heartbeatWorkerLiveness(target.workerProcess)
 	result.workspaceModifiedAt, result.workspaceAdvanced = heartbeatWorkspaceActivity(target.workspacePath, target.workspaceModifiedAt)
 	if result.workerChecked && !result.workerAlive && result.livenessError == nil {
@@ -302,14 +309,8 @@ func (m *heartbeatManager) execute(ctx context.Context, target heartbeatTarget) 
 		return
 	}
 	now := m.now().UTC()
-	heartbeat := target.workAttemptHeartbeat
-	heartbeat.HeartbeatAt = now
-	heartbeat.LeaseExpiresAt = now.Add(settings.leaseTTL)
-	result.heartbeat = heartbeat
-	if settings.workAttempts != nil && heartbeat.AttemptID > 0 {
-		result.workAttemptError = settings.workAttempts.RecordWorkAttemptHeartbeat(operationCtx, heartbeat)
-		result.workAttemptRenewed = result.workAttemptError == nil
-	}
+	result.heartbeat, result.workAttemptError = m.persistHeartbeat(operationCtx, target, settings, now)
+	result.workAttemptRenewed = result.workAttemptError == nil && settings.workAttempts != nil && result.heartbeat.AttemptID > 0
 	if settings.scheduling != nil {
 		result.claim, result.claimError = settings.scheduling.RenewClaim(operationCtx, target.issueID, now)
 		result.claimOwnerLost = errors.Is(result.claimError, ErrSchedulingClaimLost)
@@ -323,6 +324,31 @@ func (m *heartbeatManager) execute(ctx context.Context, target heartbeatTarget) 
 		result.claimRenewed = result.claimError == nil && !result.claimOwnerLost
 	}
 	m.finish(target, result)
+}
+
+func (m *heartbeatManager) persistHeartbeat(ctx context.Context, target heartbeatTarget, settings heartbeatSettings, now time.Time) (store.WorkAttemptHeartbeat, error) {
+	heartbeat := target.workAttemptHeartbeat
+	heartbeat.HeartbeatAt = now
+	heartbeat.LeaseExpiresAt = now.Add(settings.leaseTTL)
+	if target.progress != nil {
+		target.progress.mu.Lock()
+		defer target.progress.mu.Unlock()
+		if target.progress.closed {
+			return heartbeat, context.Canceled
+		}
+		now = m.now().UTC()
+		heartbeat.LeaseExpiresAt = now.Add(settings.leaseTTL)
+		heartbeat = target.progress.heartbeat(heartbeat, now)
+	}
+	if settings.workAttempts != nil && heartbeat.AttemptID > 0 {
+		if err := settings.workAttempts.RecordWorkAttemptHeartbeat(ctx, heartbeat); err != nil {
+			return heartbeat, err
+		}
+		if target.progress != nil {
+			target.progress.persisted.Store(&heartbeat)
+		}
+	}
+	return heartbeat, nil
 }
 
 func (m *heartbeatManager) settingsSnapshot() heartbeatSettings {
@@ -521,11 +547,13 @@ func (o *Orchestrator) trackRunningHeartbeat(state *State, running Running, clai
 	if o == nil || o.heartbeats == nil || strings.TrimSpace(running.Issue.ID) == "" {
 		return
 	}
+	running = running.withProgress()
 	owner := strings.TrimSpace(claimed.Owner)
 	if owner == "" {
 		owner = o.claimOwner()
 	}
 	o.heartbeats.upsert(heartbeatTarget{
+		progress:             running.progress,
 		issueID:              running.Issue.ID,
 		claimOwner:           owner,
 		workAttemptHeartbeat: o.runningWorkAttemptHeartbeat(state, running, now),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -332,6 +332,10 @@ type Orchestrator struct {
 	ciTriggerLabelMu        sync.Mutex
 	ciTriggerLabelHeads     map[string]ciTriggerLabelHead
 	stateRequests           chan stateRequest
+	refreshSignalMu         sync.Mutex
+	refreshStarted          chan struct{}
+	initialStateReady       chan struct{}
+	initialStatePublished   sync.Once
 	drainRequests           chan drainRequest
 	forceRequests           chan forceRequest
 	recoveryRequests        chan workAttemptRecoveryRequest
@@ -360,12 +364,14 @@ type Orchestrator struct {
 	latestState             atomic.Pointer[State]
 	latestRuntimeState      atomic.Pointer[runtimeState]
 	refreshInProgress       atomic.Bool
+	refreshProgress         atomic.Pointer[telemetry.RefreshProgress]
 	tickWatchdog            *tickWatchdog
 }
 
 type runtimeState struct {
-	Running map[string]Running
-	Claimed map[string]Claimed
+	WorkAttempts []telemetry.WorkAttempt
+	Running      map[string]Running
+	Claimed      map[string]Claimed
 }
 
 type validatorStageResult struct {
@@ -405,9 +411,10 @@ type configUpdateRequest struct {
 }
 
 type runUpdate struct {
-	issueID string
-	usage   runpkg.UsageUpdate
-	applied chan struct{}
+	progress *workerProgress
+	issueID  string
+	usage    runpkg.UsageUpdate
+	applied  chan struct{}
 }
 
 type capacityClearRequest struct {
@@ -696,6 +703,8 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		dispatchGateSamples:     map[dispatchGateSampleKey]time.Time{},
 		ciTriggerLabelHeads:     map[string]ciTriggerLabelHead{},
 		stateRequests:           make(chan stateRequest),
+		refreshStarted:          make(chan struct{}),
+		initialStateReady:       make(chan struct{}),
 		drainRequests:           make(chan drainRequest),
 		forceRequests:           make(chan forceRequest),
 		recoveryRequests:        make(chan workAttemptRecoveryRequest),
@@ -772,9 +781,17 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	defer o.validatorWG.Wait()
 	defer o.securityAuditWG.Wait()
 	defer o.releaseRunningSlots(&state)
+	o.startTick(&state, time.Now())
+	o.publishState(&state)
+	recoveryTiming := newRefreshTiming(o.logger, o.cfg.Project.ID, false)
+	recoveryTiming.message = "project startup recovery timing"
+	recoveryTiming.progress = &o.refreshProgress
+	recoveryTiming.next("recovery")
 	o.recoverDurableWorkAttempts(ctx, &state, time.Now())
-	if len(state.Running) > 0 {
-		o.publishState(&state)
+	recoveryTiming.log(ctx, ctx.Err() == nil, &state)
+	o.publishState(&state)
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	initialTickAt := time.Now()
 	o.startTick(&state, initialTickAt)
@@ -788,26 +805,31 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case now := <-ticker.C:
+			state.syncWorkerProgress()
 			o.startTick(&state, now)
 			o.tick(ctx, &state, now)
 			o.finishTick(&state)
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.refreshes:
+			state.syncWorkerProgress()
 			o.startTick(&state, time.Now())
 			o.tickManual(ctx, &state, request)
 			o.finishTick(&state)
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.reconciles:
+			state.syncWorkerProgress()
 			o.startTick(&state, time.Now())
 			o.reconcileTarget(ctx, &state, request)
 			o.finishTick(&state)
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.capacityClearRequests:
+			state.syncWorkerProgress()
 			cleared := o.clearBackendCapacity(&state, request.scope, request.at)
 			if request.reply != nil {
 				request.reply <- capacityClearReply{cleared: cleared}
 			}
 		case request := <-o.credentialChanges:
+			state.syncWorkerProgress()
 			scheduled := o.scheduleBackendCredentialProbe(&state, request.scope, request.at)
 			request.reply <- scheduled
 			if scheduled {
@@ -817,10 +839,13 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 				resetTicker(ticker, state.PollInterval)
 			}
 		case request := <-o.trackerClearRequests:
+			state.syncWorkerProgress()
 			request.reply <- trackerClearReply{cleared: o.clearTrackerAvailability(&state, request.at)}
 		case request := <-o.forgeClearRequests:
+			state.syncWorkerProgress()
 			request.reply <- forgeClearReply{cleared: o.clearForgeAvailability(&state, request.host, request.at)}
 		case request := <-o.failureCanaryRequests:
+			state.syncWorkerProgress()
 			result := o.requestProjectFailureBreakerCanary(&state, request.at)
 			request.reply <- result
 			if result.Requested {
@@ -830,35 +855,47 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 				resetTicker(ticker, state.PollInterval)
 			}
 		case request := <-o.stopRequests:
+			state.syncWorkerProgress()
 			o.handleStopRunRequest(ctx, &state, request)
 		case request := <-o.modelPermitRequests:
+			state.syncWorkerProgress()
 			request.reply <- o.handleModelPermitRequest(&state, request.issueID)
 		case result := <-o.runResults:
+			state.syncWorkerProgress()
 			o.handleRunResult(ctx, &state, result)
 		case update := <-o.runUpdates:
+			state.syncWorkerProgress()
 			o.handleRunUpdate(&state, update)
 			if update.applied != nil {
 				close(update.applied)
 			}
 		case result := <-heartbeatResults:
+			state.syncWorkerProgress()
 			o.handleHeartbeatResult(&state, result)
 		case event := <-o.validatorCapacityEvents:
+			state.syncWorkerProgress()
 			o.handleValidatorCapacityEvent(&state, event)
 		case request := <-o.drainRequests:
+			state.syncWorkerProgress()
 			o.startDrain(&state, request.at)
 			request.reply <- struct{}{}
 		case request := <-o.forceRequests:
+			state.syncWorkerProgress()
 			request.reply <- o.forceQuit(request.ctx, &state, request.at)
 		case request := <-o.recoveryRequests:
+			state.syncWorkerProgress()
 			response, err := o.handleWorkAttemptRecovery(ctx, &state, request.request, request.at)
 			request.reply <- workAttemptRecoveryReply{response: response, err: err}
 		case request := <-o.operatorMoves:
+			state.syncWorkerProgress()
 			request.reply <- o.handleOperatorMove(&state, request.request, request.at)
 		case update := <-o.configUpdates:
+			state.syncWorkerProgress()
 			o.applyRuntimeUpdate(&state, update.update, ticker)
 			o.finishTick(&state)
 			update.reply <- struct{}{}
 		case request := <-o.stateRequests:
+			state.syncWorkerProgress()
 			request.reply <- state.clone()
 		}
 		o.publishState(&state)
@@ -876,7 +913,14 @@ func (o *Orchestrator) startTick(state *State, at time.Time) {
 	if o == nil {
 		return
 	}
+	state.syncWorkerProgress()
 	o.refreshInProgress.Store(true)
+	o.refreshSignalMu.Lock()
+	if o.refreshStarted != nil {
+		close(o.refreshStarted)
+	}
+	o.refreshStarted = make(chan struct{})
+	o.refreshSignalMu.Unlock()
 	if o.tickWatchdog == nil || state == nil {
 		return
 	}
@@ -891,6 +935,8 @@ func (o *Orchestrator) finishTick(state *State) {
 	if o == nil {
 		return
 	}
+	o.publishState(state)
+	o.refreshProgress.Store(nil)
 	o.refreshInProgress.Store(false)
 	if o.tickWatchdog == nil || state == nil {
 		return
@@ -1052,42 +1098,70 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 		return State{}, ErrStopped
 	default:
 	}
-	if latest := o.latestState.Load(); latest != nil && o.refreshInProgress.Load() {
-		state := latest.clone()
-		if runtime := o.latestRuntimeState.Load(); runtime != nil {
-			state.Running = cloneRunning(runtime.Running)
-			state.Claimed = cloneClaimed(runtime.Claimed)
+	if o.latestState.Load() == nil {
+		select {
+		case <-ctx.Done():
+			return State{}, ctx.Err()
+		case <-o.done:
+			return State{}, ErrStopped
+		case <-o.initialStateReady:
 		}
-		pool := o.dispatchPoolSnapshot()
-		state.PoolName = pool.Name
-		state.PoolCapacity = pool.Capacity
-		state.PoolAvailable = pool.Available
-		state.PoolDraining = pool.Draining
-		return state, nil
 	}
-
+	o.refreshSignalMu.Lock()
+	refreshStarted := o.refreshStarted
+	o.refreshSignalMu.Unlock()
+	if o.refreshInProgress.Load() {
+		return o.publishedState(), nil
+	}
 	request := stateRequest{reply: make(chan State, 1)}
 	select {
 	case <-ctx.Done():
 		return State{}, ctx.Err()
 	case <-o.done:
 		return State{}, ErrStopped
+	case <-refreshStarted:
+		return o.publishedState(), nil
 	case o.stateRequests <- request:
 	}
-
 	select {
 	case <-ctx.Done():
 		return State{}, ctx.Err()
 	case <-o.done:
 		return State{}, ErrStopped
+	case <-refreshStarted:
+		return o.publishedState(), nil
 	case state := <-request.reply:
-		pool := o.dispatchPoolSnapshot()
-		state.PoolName = pool.Name
-		state.PoolCapacity = pool.Capacity
-		state.PoolAvailable = pool.Available
-		state.PoolDraining = pool.Draining
-		return state, nil
+		return o.observableState(state), nil
 	}
+}
+
+func (o *Orchestrator) publishedState() State {
+	state := o.latestState.Load().clone()
+	if runtime := o.latestRuntimeState.Load(); runtime != nil {
+		state.Running = cloneRunning(runtime.Running)
+		state.Claimed = cloneClaimed(runtime.Claimed)
+		state.WorkAttempts = cloneTelemetryWorkAttempts(runtime.WorkAttempts)
+	}
+	return o.observableState(state)
+}
+
+func (o *Orchestrator) observableState(state State) State {
+	pool := o.dispatchPoolSnapshot()
+	state.PoolName = pool.Name
+	state.PoolCapacity = pool.Capacity
+	state.PoolAvailable = pool.Available
+	state.PoolDraining = pool.Draining
+	if progress := o.refreshProgress.Load(); progress != nil {
+		state.RefreshProgress = *progress
+	}
+	for _, running := range state.Running {
+		if running.progress != nil {
+			if heartbeat := running.progress.persisted.Load(); heartbeat != nil {
+				o.applyWorkAttemptHeartbeatSnapshot(&state, running.WorkAttemptID, *heartbeat, running.LastMessageTruncation)
+			}
+		}
+	}
+	return state
 }
 
 func (o *Orchestrator) publishState(state *State) {
@@ -1096,9 +1170,13 @@ func (o *Orchestrator) publishState(state *State) {
 	}
 	cloned := state.clone()
 	o.latestState.Store(&cloned)
+	if o.initialStateReady != nil {
+		o.initialStatePublished.Do(func() { close(o.initialStateReady) })
+	}
 	o.latestRuntimeState.Store(&runtimeState{
-		Running: cloned.Running,
-		Claimed: cloned.Claimed,
+		WorkAttempts: cloned.WorkAttempts,
+		Running:      cloned.Running,
+		Claimed:      cloned.Claimed,
 	})
 }
 
@@ -1107,8 +1185,9 @@ func (o *Orchestrator) publishRuntimeState(state *State) {
 		return
 	}
 	o.latestRuntimeState.Store(&runtimeState{
-		Running: cloneRunning(state.Running),
-		Claimed: cloneClaimed(state.Claimed),
+		WorkAttempts: cloneTelemetryWorkAttempts(state.WorkAttempts),
+		Running:      cloneRunning(state.Running),
+		Claimed:      cloneClaimed(state.Claimed),
 	})
 }
 

--- a/internal/orchestrator/refresh_timing.go
+++ b/internal/orchestrator/refresh_timing.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type refreshTiming struct {
+	progress     *atomic.Pointer[telemetry.RefreshProgress]
 	logger       *slog.Logger
 	projectID    string
+	message      string
 	manual       bool
 	startedAt    time.Time
 	phaseStarted time.Time
@@ -21,6 +26,7 @@ func newRefreshTiming(logger *slog.Logger, projectID string, manual bool) *refre
 	now := time.Now()
 	return &refreshTiming{
 		logger:       logger,
+		message:      "project refresh timing",
 		projectID:    strings.TrimSpace(projectID),
 		manual:       manual,
 		startedAt:    now,
@@ -34,9 +40,17 @@ func (t *refreshTiming) next(phase string) {
 		return
 	}
 	now := time.Now()
-	t.finishPhase(now)
+	if t.phase != strings.TrimSpace(phase) {
+		t.finishPhase(now)
+	}
 	t.phase = strings.TrimSpace(phase)
 	t.phaseStarted = now
+	if t.progress != nil {
+		t.progress.Store(&telemetry.RefreshProgress{Stage: t.phase, StartedAt: t.startedAt, StageStartedAt: now})
+	}
+	if t.logger != nil {
+		t.logger.Info("project refresh stage", "project_id", t.projectID, "stage", t.phase, "elapsed", now.Sub(t.startedAt))
+	}
 }
 
 func (t *refreshTiming) log(ctx context.Context, completed bool, state *State) time.Duration {
@@ -62,7 +76,7 @@ func (t *refreshTiming) log(ctx context.Context, completed bool, state *State) t
 		)
 	}
 	attrs = append(attrs, t.phases...)
-	t.logger.InfoContext(ctx, "project refresh timing", attrs...)
+	t.logger.InfoContext(ctx, t.message, attrs...)
 	return duration
 }
 

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -36,59 +36,10 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	if !ok {
 		return
 	}
-	if event.usage.DispatchLoopStart != nil {
-		running.DispatchLoopStart = dispatchLoopStartRecordFromSnapshot(running, *event.usage.DispatchLoopStart)
+	if event.progress != nil && event.progress != running.progress {
+		return
 	}
-
-	if event.usage.SessionID != "" {
-		running.SessionID = event.usage.SessionID
-	}
-	if event.usage.DetentSessionID > 0 {
-		running.DetentSessionID = event.usage.DetentSessionID
-	}
-	if !event.usage.RuntimeIdentity.IsZero() {
-		running.RuntimeIdentity = running.RuntimeIdentity.Merge(event.usage.RuntimeIdentity)
-	}
-	if strings.TrimSpace(event.usage.WorkerGitHubActor.Login) != "" {
-		running.WorkerGitHubActor = event.usage.WorkerGitHubActor
-	}
-	if event.usage.TurnCount > 0 {
-		running.TurnCount = event.usage.TurnCount
-	}
-	if !event.usage.LastEventAt.IsZero() {
-		running.LastEventAt = event.usage.LastEventAt
-	}
-	if event.usage.LastEvent != "" {
-		running.LastEvent = event.usage.LastEvent
-	}
-	if event.usage.LastMessage != "" {
-		running.LastMessage = event.usage.LastMessage
-		running.LastMessageTruncation = runtimeoutput.CloneTruncation(event.usage.LastMessageTruncation)
-	}
-	if len(event.usage.RecentEvents) > 0 {
-		running.RecentEvents = cloneActivityEvents(event.usage.RecentEvents)
-	}
-	if event.usage.ProcessIdentity != "" {
-		running.ProcessIdentity = event.usage.ProcessIdentity
-	}
-	if event.usage.WorkerProcess.PID > 0 && !event.usage.WorkerProcess.StartedAt.IsZero() {
-		running.WorkerProcess = event.usage.WorkerProcess
-	}
-	if event.usage.WorkspacePath != "" {
-		running.WorkspacePath = event.usage.WorkspacePath
-	}
-	if event.usage.WorkProductPushed {
-		running.WorkProductPushed = true
-	}
-	if diffStatsPresent(event.usage.DiffStats) {
-		running.DiffStats = event.usage.DiffStats
-	}
-	if !event.usage.RSSObservedAt.IsZero() {
-		running.RSSBytes = event.usage.RSSBytes
-		running.RSSCeilingBytes = event.usage.RSSCeilingBytes
-		running.RSSObservedAt = event.usage.RSSObservedAt
-	}
-	running.Tokens = event.usage.Tokens
+	running = applyRunningUsage(running, event.usage).withProgress()
 	state.Running[event.issueID] = running
 	o.trackRunningHeartbeat(state, running, state.Claimed[event.issueID], o.clockNow())
 	if event.usage.RateLimits != nil {
@@ -104,7 +55,7 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 		o.recordProjectFailureBreakerProgress(state, event.issueID, progressedAt)
 		o.advanceDispatchRecovery(state, event.issueID, progressedAt)
 	}
-	if o.workAttempts != nil && running.WorkAttemptID > 0 {
+	if event.progress == nil && o.workAttempts != nil && running.WorkAttemptID > 0 {
 		now := event.usage.LastEventAt
 		if now.IsZero() {
 			now = time.Now()
@@ -132,6 +83,8 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		}
 		return
 	}
+	running = running.withProgress()
+	state.Running[event.IssueID] = running
 	if !completionMatchesRunning(event, running) {
 		o.rejectWorkerCompletion(ctx, state, event, running, "worker generation or work-attempt lease no longer owns the item", nil)
 		return
@@ -2974,6 +2927,7 @@ func cancelRunning(state *State, issueID string) {
 
 func (o *Orchestrator) releaseRunningSlots(state *State) {
 	for issueID, running := range state.Running {
+		running.progress.close()
 		o.releaseGlobalDispatchSlot(running.globalSlot)
 		running.globalSlot = scheduler.Slot{}
 		state.Running[issueID] = running

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -53,6 +53,12 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		NextRefreshAt:       timePointer(s.NextRefreshAt),
 		Sources:             sources,
 	}
+	if s.RefreshProgress.Stage != "" {
+		progress := s.RefreshProgress
+		progress.ElapsedSeconds = max(0, int64(now.Sub(progress.StartedAt)/time.Second))
+		progress.StageElapsedSeconds = max(0, int64(now.Sub(progress.StageStartedAt)/time.Second))
+		refresh.InFlight = &progress
+	}
 	if !s.ManualRefresh.IsZero() {
 		manual := cloneRefreshAttempt(s.ManualRefresh)
 		refresh.Manual = &manual

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
@@ -17,6 +18,65 @@ import (
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
+
+func TestStateReadersCrossStartupAndRefreshBoundaries(t *testing.T) {
+	for _, starting := range []bool{false, true} {
+		name := "refresh starts with reader waiting"
+		if starting {
+			name = "reader precedes initial publication"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				state := newState(normalizeConfig(Config{}))
+				orch := &Orchestrator{done: make(chan struct{}), initialStateReady: make(chan struct{}), refreshStarted: make(chan struct{}), stateRequests: make(chan stateRequest)}
+				if !starting {
+					orch.publishState(&state)
+				}
+				done := make(chan error, 1)
+				go func() {
+					_, err := orch.State(t.Context())
+					done <- err
+				}()
+				synctest.Wait()
+				orch.startTick(&state, time.Now())
+				orch.publishState(&state)
+				if err := <-done; err != nil {
+					t.Fatal(err)
+				}
+			})
+		})
+	}
+}
+
+func TestRefreshProgressPreservesTrackerFreshness(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		age  time.Duration
+		want telemetry.RefreshStatus
+	}{
+		{name: "initializing", want: telemetry.RefreshStatusInitializing},
+		{name: "recent tracker data", age: time.Second, want: telemetry.RefreshStatusReady},
+		{name: "stale tracker data", age: time.Hour, want: telemetry.RefreshStatusDegraded},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			state := newState(normalizeConfig(Config{PollInterval: time.Minute}))
+			if tt.age > 0 {
+				state.LastRefreshAt = now.Add(-tt.age)
+			}
+			state.RefreshProgress = telemetry.RefreshProgress{Stage: "tracker_fetch", StartedAt: now.Add(-10 * time.Second), StageStartedAt: now.Add(-5 * time.Second)}
+			refresh := state.Snapshot(now).Refresh.WithFreshness(now)
+			if refresh.ReadinessStatus() != tt.want || refresh.InFlight == nil || refresh.InFlight.ElapsedSeconds != 10 || refresh.InFlight.StageElapsedSeconds != 5 {
+				t.Fatalf("refresh = %#v, want %s with progress", refresh, tt.want)
+			}
+			later := refresh.WithFreshness(now.Add(time.Second))
+			if later.InFlight.ElapsedSeconds != 11 || refresh.InFlight.ElapsedSeconds != 10 {
+				t.Fatal("freshness update failed to advance duration on an independent copy")
+			}
+		})
+	}
+}
 
 func TestStatePreservesPublishedRunningAttemptsDuringRefresh(t *testing.T) {
 	t.Parallel()

--- a/internal/orchestrator/startup_observability_test.go
+++ b/internal/orchestrator/startup_observability_test.go
@@ -1,0 +1,114 @@
+package orchestrator_test
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestStartupRefreshKeepsStateAndWorkerProgressObservable(t *testing.T) {
+	for _, cancelRefresh := range []bool{false, true} {
+		name := "complete refresh"
+		if cancelRefresh {
+			name = "cancel refresh"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				issue := testIssue("startup-worker", "digitaldrywood/detent#2270", "Todo")
+				tracker := &pendingDispatchConnector{fakeConnector: newFakeConnector(issue, testIssue("startup-worker-2", "digitaldrywood/detent#2271", "Todo")), started: make(chan struct{}), release: make(chan struct{})}
+				reaper := &startupStalledReaper{started: make(chan struct{}), release: make(chan struct{})}
+				runner := newBlockingRunner()
+				orch, err := orchestrator.New(orchestrator.Config{
+					PollInterval: time.Hour, MaxConcurrentAgents: 2,
+					ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"},
+				}, orchestrator.Dependencies{Connector: tracker, Runner: runner, WorkspaceReaper: reaper})
+				if err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := context.WithCancel(t.Context())
+				done := make(chan error, 1)
+				go func() { done <- orch.Run(ctx) }()
+				defer func() { cancel(); <-done }()
+				<-tracker.started
+				state := startupState(t, orch)
+				if got := state.Snapshot(time.Now()).Refresh; !got.Initializing() || got.LastRefreshAt != nil {
+					t.Fatalf("initial refresh = %#v", got)
+				}
+				initialProgress := state.Snapshot(time.Now().Add(2 * time.Minute)).Refresh.InFlight
+				if initialProgress == nil || initialProgress.Stage != "tracker_fetch" || initialProgress.ElapsedSeconds != 120 || initialProgress.StageElapsedSeconds != 120 {
+					t.Fatalf("initial progress = %#v", initialProgress)
+				}
+				close(tracker.release)
+				requests := []orchestrator.RunRequest{<-runner.started, <-runner.started}
+				<-reaper.started
+				for _, request := range requests {
+					for _, message := range []string{"workspace created", "tests running"} {
+						err := request.OnUsageUpdate(runpkg.UsageUpdate{
+							SessionID: request.Issue.ID + "-session", TurnCount: 1, LastEventAt: time.Now(), LastMessage: message,
+							DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{WorkspaceDiffAvailable: true},
+						})
+						if err != nil {
+							t.Fatal(err)
+						}
+						state = startupState(t, orch)
+						progress := state.Snapshot(time.Now().Add(time.Minute)).Refresh.InFlight
+						if progress == nil || progress.Stage != "workspace_cleanup" || progress.StageElapsedSeconds != 60 {
+							t.Fatalf("cleanup progress = %#v", progress)
+						}
+						if got := state.Running[request.Issue.ID]; got.LastMessage != message || got.SessionID != request.Issue.ID+"-session" {
+							t.Fatalf("running worker = %#v, want progress %q during stalled cleanup", got, message)
+						}
+						if got := state.Snapshot(time.Now()).Refresh; got.ReadinessStatus() != telemetry.RefreshStatusInitializing || got.LastRefreshAt != nil {
+							t.Fatalf("in-flight refresh = %#v, want initializing", got)
+						}
+					}
+				}
+				if cancelRefresh {
+					cancel()
+				} else {
+					close(reaper.release)
+					synctest.Wait()
+					if got := startupState(t, orch).Snapshot(time.Now()).Refresh; !got.Ready() || got.InFlight != nil {
+						t.Fatalf("completed refresh = %#v", got)
+					}
+				}
+			})
+		})
+	}
+}
+
+func startupState(t *testing.T, orch *orchestrator.Orchestrator) orchestrator.State {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	state, err := orch.State(ctx)
+	if err != nil {
+		t.Fatalf("State() during stalled startup: %v", err)
+	}
+	return state
+}
+
+type startupStalledReaper struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (r *startupStalledReaper) ReapWorkspace(context.Context, connector.Issue) (orchestrator.WorkspaceReapResult, error) {
+	return orchestrator.WorkspaceReapResult{}, nil
+}
+
+func (r *startupStalledReaper) ReconcileWorkspaces(ctx context.Context, _ []connector.Issue) (orchestrator.WorkspaceReconcileResult, error) {
+	close(r.started)
+	select {
+	case <-ctx.Done():
+		return orchestrator.WorkspaceReconcileResult{}, ctx.Err()
+	case <-r.release:
+		return orchestrator.WorkspaceReconcileResult{}, nil
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -56,6 +56,7 @@ type State struct {
 	DataSeq                  uint64
 	LastRefreshAt            time.Time
 	LastRefreshDuration      time.Duration
+	RefreshProgress          telemetry.RefreshProgress
 	NextRefreshAt            time.Time
 	LastRefreshError         string
 	LastRefreshErrorAt       time.Time
@@ -135,6 +136,7 @@ type StalenessWarning struct {
 }
 
 type Running struct {
+	progress                    *workerProgress
 	Policy                      policy.Descriptor
 	Issue                       connector.Issue
 	Attempt                     int
@@ -461,6 +463,7 @@ func (s State) clone() State {
 		DataSeq:                  s.DataSeq,
 		LastRefreshAt:            s.LastRefreshAt,
 		LastRefreshDuration:      s.LastRefreshDuration,
+		RefreshProgress:          s.RefreshProgress,
 		NextRefreshAt:            s.NextRefreshAt,
 		LastRefreshError:         s.LastRefreshError,
 		LastRefreshErrorAt:       s.LastRefreshErrorAt,
@@ -528,6 +531,7 @@ func (s State) clone() State {
 	}
 
 	for id, running := range s.Running {
+		running = running.withProgress()
 		running.Issue = cloneIssue(running.Issue)
 		running.LastMessageTruncation = runtimeoutput.CloneTruncation(running.LastMessageTruncation)
 		running.RecentEvents = cloneActivityEvents(running.RecentEvents)

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -57,6 +57,8 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	defer o.endGlobalProjectCycle()
 	completed := false
 	timing := newRefreshTiming(o.logger, o.cfg.Project.ID, manual != nil)
+	timing.progress = &o.refreshProgress
+	timing.next("preflight")
 	defer func() {
 		state.LastRefreshDuration = timing.log(ctx, completed, state)
 	}()
@@ -277,6 +279,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	}
 	state.Pipeline = overlayIssueStateSnapshots(state.Pipeline, state.tickTransitions.pipeline)
 	if refreshOK {
+		timing.next("workspace_cleanup")
 		o.reapDueWorkspacesAfterRefresh(ctx, state, now)
 	}
 	completed = true

--- a/internal/orchestrator/worker_progress.go
+++ b/internal/orchestrator/worker_progress.go
@@ -1,0 +1,200 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+type workerProgress struct {
+	mu          sync.Mutex
+	latest      atomic.Pointer[Running]
+	persisted   atomic.Pointer[store.WorkAttemptHeartbeat]
+	closed      bool
+	base        store.WorkAttemptHeartbeat
+	attempts    store.WorkAttemptStore
+	leaseTTL    time.Duration
+	outputLimit int
+}
+
+func newWorkerProgress(running Running, heartbeat store.WorkAttemptHeartbeat, attempts store.WorkAttemptStore, outputLimit int) *workerProgress {
+	running.Issue = cloneIssue(running.Issue)
+	running.progress = nil
+	progress := &workerProgress{
+		base:        heartbeat,
+		attempts:    attempts,
+		leaseTTL:    heartbeat.LeaseExpiresAt.Sub(heartbeat.HeartbeatAt),
+		outputLimit: outputLimit,
+	}
+	progress.latest.Store(&running)
+	return progress
+}
+
+func applyRunningUsage(running Running, update runpkg.UsageUpdate) Running {
+	if update.DispatchLoopStart != nil {
+		running.DispatchLoopStart = dispatchLoopStartRecordFromSnapshot(running, *update.DispatchLoopStart)
+	}
+
+	if update.SessionID != "" {
+		running.SessionID = update.SessionID
+	}
+	if update.DetentSessionID > 0 {
+		running.DetentSessionID = update.DetentSessionID
+	}
+	if !update.RuntimeIdentity.IsZero() {
+		running.RuntimeIdentity = running.RuntimeIdentity.Merge(update.RuntimeIdentity)
+	}
+	if strings.TrimSpace(update.WorkerGitHubActor.Login) != "" {
+		running.WorkerGitHubActor = update.WorkerGitHubActor
+	}
+	if update.TurnCount > 0 {
+		running.TurnCount = update.TurnCount
+	}
+	if !update.LastEventAt.IsZero() {
+		running.LastEventAt = update.LastEventAt
+	}
+	if update.LastEvent != "" {
+		running.LastEvent = update.LastEvent
+	}
+	if update.LastMessage != "" {
+		running.LastMessage = update.LastMessage
+		running.LastMessageTruncation = runtimeoutput.CloneTruncation(update.LastMessageTruncation)
+	}
+	if len(update.RecentEvents) > 0 {
+		running.RecentEvents = cloneActivityEvents(update.RecentEvents)
+	}
+	if update.ProcessIdentity != "" {
+		running.ProcessIdentity = update.ProcessIdentity
+	}
+	if update.WorkerProcess.PID > 0 && !update.WorkerProcess.StartedAt.IsZero() {
+		running.WorkerProcess = update.WorkerProcess
+	}
+	if update.WorkspacePath != "" {
+		running.WorkspacePath = update.WorkspacePath
+	}
+	if update.WorkProductPushed {
+		running.WorkProductPushed = true
+	}
+	if diffStatsPresent(update.DiffStats) {
+		running.DiffStats = update.DiffStats
+	}
+	if !update.RSSObservedAt.IsZero() {
+		running.RSSBytes = update.RSSBytes
+		running.RSSCeilingBytes = update.RSSCeilingBytes
+		running.RSSObservedAt = update.RSSObservedAt
+	}
+	running.Tokens = update.Tokens
+	return running
+}
+
+func (r Running) withProgress() Running {
+	if r.progress == nil {
+		return r
+	}
+	p := r.progress.latest.Load()
+	if p == nil {
+		return r
+	}
+	r = applyRunningUsage(r, runpkg.UsageUpdate{
+		SessionID:             p.SessionID,
+		DetentSessionID:       p.DetentSessionID,
+		RuntimeIdentity:       p.RuntimeIdentity,
+		WorkerGitHubActor:     p.WorkerGitHubActor,
+		TurnCount:             p.TurnCount,
+		LastEventAt:           p.LastEventAt,
+		LastEvent:             p.LastEvent,
+		LastMessage:           p.LastMessage,
+		LastMessageTruncation: p.LastMessageTruncation,
+		RecentEvents:          p.RecentEvents,
+		ProcessIdentity:       p.ProcessIdentity,
+		WorkerProcess:         p.WorkerProcess,
+		WorkspacePath:         p.WorkspacePath,
+		WorkProductPushed:     p.WorkProductPushed,
+		DiffStats:             p.DiffStats,
+		RSSObservedAt:         p.RSSObservedAt,
+		RSSBytes:              p.RSSBytes,
+		RSSCeilingBytes:       p.RSSCeilingBytes,
+		Tokens:                p.Tokens,
+	})
+	r.DispatchLoopStart = p.DispatchLoopStart
+	return r
+}
+
+func (p *workerProgress) observe(ctx context.Context, update runpkg.UsageUpdate) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p.closed {
+		return context.Canceled
+	}
+	running := applyRunningUsage(*p.latest.Load(), update)
+	persistCheckpoint := update.DispatchLoopStart != nil && p.attempts != nil && running.WorkAttemptID > 0
+	visible := running
+	if persistCheckpoint {
+		visible.DispatchLoopStart.Persisted = false
+	}
+	p.latest.Store(&visible)
+	if !persistCheckpoint {
+		return nil
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, heartbeatOperationTimeout)
+	defer cancel()
+	now := time.Now()
+	base := p.base
+	base.LeaseExpiresAt = now.Add(p.leaseTTL)
+	heartbeat := p.heartbeat(base, now)
+	heartbeat.WorkerMetadataJSON = runningWorkAttemptMetadataJSON(running, nil)
+	if err := p.attempts.RecordWorkAttemptHeartbeat(operationCtx, heartbeat); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			p.closed = true
+		}
+		return err
+	}
+	p.latest.Store(&running)
+	p.persisted.Store(&heartbeat)
+	return nil
+}
+
+func (p *workerProgress) heartbeat(base store.WorkAttemptHeartbeat, now time.Time) store.WorkAttemptHeartbeat {
+	running := p.latest.Load()
+	base.HeartbeatAt = now
+	if base.Phase != "backoff" {
+		base.Phase = runningWorkAttemptPhase(*running, nil)
+	}
+	message := firstNonBlank(running.LastMessage, running.LastEvent, "worker running")
+	base.StatusMessage = runtimeoutput.Truncate(strings.TrimSpace(message), p.outputLimit).Value
+	base.WorkerMetadataJSON = runningWorkAttemptMetadataJSON(*running, nil)
+	base.MetricsJSON = runningWorkAttemptMetricsJSON(*running)
+	base.NextAction = runningWorkAttemptNextAction(*running, base.Phase)
+	base.DetentSessionID = running.DetentSessionID
+	base.ProviderSessionID = running.SessionID
+	base.RuntimeIdentity = running.RuntimeIdentity
+	return base
+}
+
+func (p *workerProgress) close() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.closed = true
+	p.mu.Unlock()
+}
+
+func (s *State) syncWorkerProgress() {
+	if s == nil {
+		return
+	}
+	for issueID, running := range s.Running {
+		s.Running[issueID] = running.withProgress()
+	}
+}

--- a/internal/orchestrator/worker_progress_test.go
+++ b/internal/orchestrator/worker_progress_test.go
@@ -1,0 +1,188 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestWorkerProgressCheckpointPersistence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{name: "persisted"},
+		{name: "storage unavailable", err: errors.New("storage unavailable")},
+		{name: "retired attempt", err: store.ErrNotFound},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			attempts := &progressAttemptStore{err: tt.err}
+			running := Running{Issue: connector.Issue{ID: "worker", State: "In Progress"}, WorkAttemptID: 2270, Generation: 1, Mode: runpkg.RunModeImplement}
+			base := store.WorkAttemptHeartbeat{AttemptID: running.WorkAttemptID, HeartbeatAt: now, LeaseExpiresAt: now.Add(time.Minute)}
+			progress := newWorkerProgress(running, base, attempts, 4096)
+			running.progress = progress
+			update := runpkg.UsageUpdate{SessionID: "session", LastMessage: "tests running", DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{WorkspaceDiffAvailable: true}}
+			if err := progress.observe(t.Context(), update); !errors.Is(err, tt.err) {
+				t.Fatalf("observe() = %v, want %v", err, tt.err)
+			}
+			if got := running.withProgress(); got.DispatchLoopStart.Persisted != (tt.err == nil) || got.LastMessage != update.LastMessage {
+				t.Fatalf("progress = %#v", got)
+			}
+			if got := progress.persisted.Load(); (got != nil) != (tt.err == nil) {
+				t.Fatalf("persisted heartbeat = %#v", got)
+			}
+			if len(attempts.heartbeats) != 1 || !strings.Contains(attempts.heartbeats[0].WorkerMetadataJSON, "dispatch_loop_start") {
+				t.Fatalf("checkpoint heartbeats = %#v", attempts.heartbeats)
+			}
+			progress.close()
+			if err := progress.observe(t.Context(), runpkg.UsageUpdate{LastMessage: "late callback"}); !errors.Is(err, context.Canceled) {
+				t.Fatalf("retired callback = %v", err)
+			}
+			if got := running.withProgress().LastMessage; got != update.LastMessage {
+				t.Fatalf("retired worker changed to %q", got)
+			}
+		})
+	}
+}
+
+func TestWorkerProgressHeartbeatUsesLatestObservation(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	attempts := &progressAttemptStore{}
+	running := Running{Issue: connector.Issue{ID: "worker"}, WorkAttemptID: 2270, Generation: 1, Mode: runpkg.RunModeImplement}
+	base := store.WorkAttemptHeartbeat{AttemptID: running.WorkAttemptID, HeartbeatAt: now, LeaseExpiresAt: now.Add(time.Minute)}
+	progress := newWorkerProgress(running, base, attempts, 4096)
+	running.progress = progress
+	manager := newHeartbeatManager(normalizeConfig(Config{}), nil, attempts, time.Now, nil)
+	target := heartbeatTarget{issueID: running.Issue.ID, progress: progress, workAttemptHeartbeat: base}
+	manager.upsert(target)
+	for _, message := range []string{"workspace created", "tests running"} {
+		update := runpkg.UsageUpdate{SessionID: "session", LastMessage: message, RecentEvents: []telemetry.ActivityEvent{{Message: message}}}
+		if err := progress.observe(t.Context(), update); err != nil {
+			t.Fatal(err)
+		}
+		update.RecentEvents[0].Message = "caller changed its copy"
+	}
+	if len(attempts.heartbeats) != 0 {
+		t.Fatal("ordinary observations performed synchronous persistence")
+	}
+	cfg := normalizeConfig(Config{Claiming: ClaimingConfig{LeaseTTL: 2 * time.Minute}})
+	manager.configure(cfg, nil, attempts)
+	manager.execute(t.Context(), target)
+	if len(attempts.heartbeats) != 1 || attempts.heartbeats[0].StatusMessage != "tests running" || attempts.heartbeats[0].Phase != "testing" {
+		t.Fatalf("dedicated heartbeat = %#v", attempts.heartbeats)
+	}
+	if got := attempts.heartbeats[0]; got.LeaseExpiresAt.Sub(got.HeartbeatAt) != 2*time.Minute {
+		t.Fatalf("heartbeat ignored updated lease duration: %#v", got)
+	}
+	if got := running.withProgress(); got.SessionID != "session" || got.RecentEvents[0].Message != "tests running" {
+		t.Fatalf("progress snapshot = %#v", got)
+	}
+	state := newState(Config{})
+	state.Running[running.Issue.ID] = running
+	state.WorkAttempts = []telemetry.WorkAttempt{{AttemptID: running.WorkAttemptID}}
+	orch := &Orchestrator{}
+	observed := orch.observableState(state.clone())
+	if got := observed.WorkAttempts[0]; got.StatusMessage != "tests running" || got.HeartbeatAt == nil {
+		t.Fatalf("observable attempt = %#v", got)
+	}
+	previous := attempts.heartbeats[0].HeartbeatAt
+	heartbeat, err := manager.persistHeartbeat(t.Context(), target, manager.settingsSnapshot(), now.Add(-time.Hour))
+	if err != nil || heartbeat.HeartbeatAt.Before(previous) {
+		t.Fatalf("delayed heartbeat regressed timestamp: %v, %v", heartbeat.HeartbeatAt, err)
+	}
+	manager.remove(running.Issue.ID)
+	if err := progress.observe(t.Context(), runpkg.UsageUpdate{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("removed heartbeat target accepted callback: %v", err)
+	}
+}
+
+func TestWorkerProgressCheckpointCancellationAndRetirement(t *testing.T) {
+	for _, cancelCheckpoint := range []bool{false, true} {
+		name := "retirement joins persistence"
+		if cancelCheckpoint {
+			name = "checkpoint honors cancellation"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				now := time.Now()
+				attempts := &progressAttemptStore{started: make(chan struct{}), release: make(chan struct{})}
+				running := Running{Issue: connector.Issue{ID: "worker"}, WorkAttemptID: 2270}
+				progress := newWorkerProgress(running, store.WorkAttemptHeartbeat{AttemptID: 2270, HeartbeatAt: now, LeaseExpiresAt: now.Add(time.Minute)}, attempts, 4096)
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				done := make(chan error, 1)
+				go func() {
+					done <- progress.observe(ctx, runpkg.UsageUpdate{LastMessage: "checkpoint", DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{}})
+				}()
+				<-attempts.started
+				inFlight := progress.latest.Load()
+				if inFlight.LastMessage != "checkpoint" || inFlight.DispatchLoopStart.Persisted {
+					t.Fatalf("in-flight checkpoint = %#v", inFlight)
+				}
+				retired := make(chan struct{})
+				go func() { progress.close(); close(retired) }()
+				select {
+				case <-retired:
+					t.Fatal("retirement returned with checkpoint persistence in flight")
+				default:
+				}
+				if cancelCheckpoint {
+					cancel()
+				} else {
+					close(attempts.release)
+				}
+				err := <-done
+				if cancelCheckpoint && !errors.Is(err, context.Canceled) || !cancelCheckpoint && err != nil {
+					t.Fatalf("checkpoint = %v", err)
+				}
+				<-retired
+				if inFlight.DispatchLoopStart.Persisted || progress.latest.Load().DispatchLoopStart.Persisted == cancelCheckpoint {
+					t.Fatal("checkpoint persistence mutated an earlier snapshot or published the wrong outcome")
+				}
+			})
+		})
+	}
+}
+
+func TestRunUpdateRejectsRetiredWorkerProgress(t *testing.T) {
+	t.Parallel()
+	state := newState(Config{})
+	current := &workerProgress{}
+	state.Running["worker"] = Running{Issue: connector.Issue{ID: "worker"}, progress: current, LastMessage: "current"}
+	orch := &Orchestrator{}
+	orch.handleRunUpdate(&state, runUpdate{issueID: "worker", progress: &workerProgress{}, usage: runpkg.UsageUpdate{LastMessage: "retired"}})
+	if got := state.Running["worker"].LastMessage; got != "current" {
+		t.Fatalf("replacement worker progress = %q", got)
+	}
+}
+
+type progressAttemptStore struct {
+	recordingWorkAttemptStore
+	err     error
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *progressAttemptStore) RecordWorkAttemptHeartbeat(ctx context.Context, heartbeat store.WorkAttemptHeartbeat) error {
+	if s.started != nil {
+		close(s.started)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.release:
+		}
+	}
+	s.heartbeats = append(s.heartbeats, heartbeat)
+	return s.err
+}

--- a/internal/store/pool_contention_e2e_test.go
+++ b/internal/store/pool_contention_e2e_test.go
@@ -94,8 +94,21 @@ func TestPoolContentionTelemetryEndToEnd(t *testing.T) {
 
 	stateCtx, cancelState := context.WithTimeout(ctx, synchronizationWatchdog)
 	defer cancelState()
-	if _, err := orch.State(stateCtx); err != nil {
-		t.Fatalf("orchestrator State() error = %v", err)
+	stateTicker := time.NewTicker(time.Millisecond)
+	defer stateTicker.Stop()
+	for {
+		state, err := orch.State(stateCtx)
+		if err != nil {
+			t.Fatalf("orchestrator State() error = %v", err)
+		}
+		if state.DataSeq > 0 {
+			break
+		}
+		select {
+		case <-stateCtx.Done():
+			t.Fatal("initial scheduler decision did not complete")
+		case <-stateTicker.C:
+		}
 	}
 	decisions, err := runtimeStore.ListRecentSchedulerDecisions(
 		ctx,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -693,23 +693,32 @@ const (
 	RefreshSourceProject    RefreshSourceName = "project"
 )
 
+type RefreshProgress struct {
+	Stage               string    `json:"stage"`
+	StartedAt           time.Time `json:"started_at"`
+	StageStartedAt      time.Time `json:"stage_started_at"`
+	ElapsedSeconds      int64     `json:"elapsed_seconds"`
+	StageElapsedSeconds int64     `json:"stage_elapsed_seconds"`
+}
+
 type Refresh struct {
-	PollIntervalSeconds     int64           `json:"poll_interval_seconds,omitempty"`
-	StaleAfterSeconds       int64           `json:"stale_after_seconds,omitempty"`
-	LastDurationSeconds     int64           `json:"last_duration_seconds,omitempty"`
-	ObservedSweepSeconds    int64           `json:"observed_sweep_seconds,omitempty"`
-	BehindBySeconds         int64           `json:"behind_by_seconds,omitempty"`
-	FailureThreshold        int             `json:"failure_threshold,omitempty"`
-	DataSeq                 uint64          `json:"data_seq,omitempty"`
-	Status                  RefreshStatus   `json:"status,omitempty"`
-	LastRefreshAt           *time.Time      `json:"last_refresh_at,omitempty"`
-	NextRefreshAt           *time.Time      `json:"next_refresh_at,omitempty"`
-	NextRefreshOverdue      bool            `json:"next_refresh_overdue"`
-	StalenessWindowExceeded bool            `json:"staleness_window_exceeded,omitempty"`
-	LastError               string          `json:"last_error,omitempty"`
-	LastErrorAt             *time.Time      `json:"last_error_at,omitempty"`
-	Sources                 []RefreshSource `json:"sources,omitempty"`
-	Manual                  *RefreshAttempt `json:"manual,omitempty"`
+	InFlight                *RefreshProgress `json:"in_flight,omitempty"`
+	PollIntervalSeconds     int64            `json:"poll_interval_seconds,omitempty"`
+	StaleAfterSeconds       int64            `json:"stale_after_seconds,omitempty"`
+	LastDurationSeconds     int64            `json:"last_duration_seconds,omitempty"`
+	ObservedSweepSeconds    int64            `json:"observed_sweep_seconds,omitempty"`
+	BehindBySeconds         int64            `json:"behind_by_seconds,omitempty"`
+	FailureThreshold        int              `json:"failure_threshold,omitempty"`
+	DataSeq                 uint64           `json:"data_seq,omitempty"`
+	Status                  RefreshStatus    `json:"status,omitempty"`
+	LastRefreshAt           *time.Time       `json:"last_refresh_at,omitempty"`
+	NextRefreshAt           *time.Time       `json:"next_refresh_at,omitempty"`
+	NextRefreshOverdue      bool             `json:"next_refresh_overdue"`
+	StalenessWindowExceeded bool             `json:"staleness_window_exceeded,omitempty"`
+	LastError               string           `json:"last_error,omitempty"`
+	LastErrorAt             *time.Time       `json:"last_error_at,omitempty"`
+	Sources                 []RefreshSource  `json:"sources,omitempty"`
+	Manual                  *RefreshAttempt  `json:"manual,omitempty"`
 }
 
 type RefreshFailureReason string
@@ -800,6 +809,12 @@ func (r Refresh) ReadinessStatus() RefreshStatus {
 }
 
 func (r Refresh) WithFreshness(now time.Time) Refresh {
+	if r.InFlight != nil {
+		progress := *r.InFlight
+		progress.ElapsedSeconds = max(0, int64(now.Sub(progress.StartedAt)/time.Second))
+		progress.StageElapsedSeconds = max(0, int64(now.Sub(progress.StageStartedAt)/time.Second))
+		r.InFlight = &progress
+	}
 	r.NextRefreshOverdue = r.NextRefreshAt != nil && !now.IsZero() && now.After(*r.NextRefreshAt)
 	r.BehindBySeconds = 0
 	if r.NextRefreshOverdue {


### PR DESCRIPTION
## Summary

A slow first refresh could hide project state and leave new workers waiting for a startup checkpoint acknowledgment. Publish initializing state before recovery and deliver worker observations and bounded, durable checkpoints independently of the scheduler loop. Preserve attempt ownership, cancellation, and serialized heartbeat writes.

Expose the current recovery/refresh stage and elapsed duration while work is in flight. Keep tracker freshness tied to its last successful refresh, retain cached tracker provenance during startup, and preserve bounded fleet reads and healthy-project updates.

Fixes #2270

## UI Surface Contract

- [x] N/A: this change does not introduce a high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Existing dashboard/SSE freshness and worker progress are covered by the fleet regression; visual layout is unchanged.

## Test Plan

- [x] Deterministic regression reproduces the original 500 ms state timeout, then verifies two new workers remain observable during held first-fetch and cleanup operations, including completion and cancellation.
- [x] Focused race tests cover startup boundaries, checkpoint durability, heartbeat progress, retirement, stale worker callbacks, freshness, operator stop, and fleet publication.
- [x] `make check` — full race suite and coverage gate passed; 80.0% overall coverage, all configured package/file floors met.
- [x] Current-head CI — all 11 checks passed on `18ef70e7`, including Ubuntu race tests, macOS/Windows portability, browser visual verification, security, and release builds.
- [x] Readiness fixture correction passed 100 consecutive focused race runs and the full local gate.

Historical production-stage attribution remains unproven. The regression demonstrates the blocking paths, and in-flight stage timestamps plus structured timing logs expose future slow operations without inspecting the live process.
