### PR TITLE
fix(shell): preserve quoted Windows arguments

### DIFF
--- a/.detent/skills/windows-shell-command-boundary.md
+++ b/.detent/skills/windows-shell-command-boundary.md
@@ -1,0 +1,14 @@
+---
+name: windows-shell-command-boundary
+description: Diagnose literal quotes or corrupted arguments at Go's Windows shell boundary.
+when_to_use: A configured Windows command works interactively but a Go-launched child receives literal quotes, split paths, expanded percent expressions, or corrupted backslashes.
+---
+
+- Trace both parsers: Go normally serializes argv for CommandLineToArgvW, while cmd.exe interprets a script. Inspect the actual child argv rather than only exec.Cmd.Args.
+- Reproduce with a real child process. A test helper that emits its argv as JSON exposes empty arguments, quotes, spaces, percent signs, and trailing backslashes. Use Git with a quoted existing directory when the reported symptom involves git -C.
+- Keep a legacy-launch control when Windows execution is available only in CI: require the recorded failure from the original boundary and success from the corrected boundary in the same Windows test.
+- For cmd.exe, use Windows-specific SysProcAttr.CmdLine with an outer quote pair and /S /C. Preserve the operator's configured script verbatim; do not escape intentional operators or environment expansion.
+- Treat appended literal arguments separately. Encode backslashes before quotes and at the end for the child parser, then escape cmd metacharacters. Batch-file escaping rules are not interchangeable with direct /C execution.
+- Test configured shell syntax and literal appended arguments independently, including percent expressions that name real environment variables. Test a quoted executable path as well as quoted directory arguments.
+- Keep non-cmd shells on their established launch path. Windows PowerShell's legacy native argument parsing differs from modern PowerShell; do not silently redefine that contract while repairing cmd.
+- Cross-compilation proves build compatibility only. Require current-head Windows execution evidence before declaring the repair validated.

--- a/internal/shell/command_integration_test.go
+++ b/internal/shell/command_integration_test.go
@@ -1,0 +1,97 @@
+package shell
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"slices"
+	"testing"
+)
+
+func TestShellArgumentProcess(t *testing.T) {
+	if os.Getenv("DETENT_SHELL_ARGUMENT_PROCESS") != "1" {
+		return
+	}
+	index := slices.Index(os.Args, "--")
+	if index < 0 {
+		t.Fatal("missing argument separator")
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(os.Args[index+1:]); err != nil {
+		t.Fatal(err)
+	}
+	os.Exit(0)
+}
+
+func TestCommandWithArgsExecution(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helper := filepath.Join(t.TempDir(), "argument helper"+filepath.Ext(executable))
+	if err := os.WriteFile(helper, data, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	shells := []string{"sh"}
+	if runtime.GOOS == "windows" {
+		shells = []string{"cmd", "powershell", "pwsh", "bash"}
+	}
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "none"},
+		{name: "spaces", args: []string{"path with spaces", "quoted'value"}},
+		{name: "paths", args: []string{`C:/directory with spaces/file`, `C:\directory with spaces\`, ""}},
+		{name: "quotes", args: []string{`say "hello"`, `quoted'value`, `a\"b`, `"&echo injected&"`}},
+		{name: "percent", args: []string{"percent%value", "%PATH%", "100%%", "%DETENT_SHELL_VALUE%"}},
+		{name: "operators", args: []string{"Bash(git *)", "a&b|c<d>e(f)^!", "--model", "fable"}},
+	}
+	for _, shellName := range shells {
+		t.Run(shellName, func(t *testing.T) {
+			t.Parallel()
+			if _, err := exec.LookPath(shellName); err != nil {
+				t.Skipf("shell unavailable: %v", err)
+			}
+			quote := argQuoterForOS(shellName, runtime.GOOS)
+			command := quote(helper) + " -test.run=TestShellArgumentProcess -- configured"
+			if runtime.GOOS == "windows" {
+				if shellBase(shellName) == "cmd" {
+					command = `"` + helper + `" -test.run=TestShellArgumentProcess -- configured`
+				} else if isPowerShell(shellBase(shellName)) {
+					command = "& " + command
+				}
+			}
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
+					if shellName == "powershell" && (tt.name == "quotes" || tt.name == "paths") {
+						t.Skip("Windows PowerShell uses legacy native argument parsing")
+					}
+					cmd := CommandWithArgs(t.Context(), command, shellName, tt.args)
+					cmd.Env = append(cmd.Environ(), "DETENT_SHELL_ARGUMENT_PROCESS=1", "DETENT_SHELL_VALUE=expanded", "MSYS2_ARG_CONV_EXCL=*")
+					output, err := cmd.CombinedOutput()
+					if err != nil {
+						t.Fatalf("command failed: %v\n%s", err, output)
+					}
+					var got []string
+					if err := json.Unmarshal(output, &got); err != nil {
+						t.Fatalf("decode output %q: %v", output, err)
+					}
+					want := append([]string{"configured"}, tt.args...)
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("child arguments = %#v, want %#v", got, want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/shell/command_integration_test.go
+++ b/internal/shell/command_integration_test.go
@@ -62,7 +62,7 @@ func TestCommandWithArgsExecution(t *testing.T) {
 				t.Skipf("shell unavailable: %v", err)
 			}
 			quote := argQuoterForOS(shellName, runtime.GOOS)
-			command := quote(helper) + " -test.run=TestShellArgumentProcess -- configured"
+			command := quote(helper) + " " + quote("-test.run=TestShellArgumentProcess") + " -- configured"
 			if runtime.GOOS == "windows" {
 				if shellBase(shellName) == "cmd" {
 					command = `"` + helper + `" -test.run=TestShellArgumentProcess -- configured`

--- a/internal/shell/command_other.go
+++ b/internal/shell/command_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package shell
+
+import "os/exec"
+
+func configureCommand(_ *exec.Cmd, _ string) {}

--- a/internal/shell/command_windows.go
+++ b/internal/shell/command_windows.go
@@ -1,0 +1,15 @@
+package shell
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureCommand(cmd *exec.Cmd, goos string) {
+	if goos != "windows" || shellBase(cmd.Args[0]) != "cmd" {
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine: syscall.EscapeArg(cmd.Args[0]) + ` /S /C "` + cmd.Args[len(cmd.Args)-1] + `"`,
+	}
+}

--- a/internal/shell/command_windows_test.go
+++ b/internal/shell/command_windows_test.go
@@ -1,0 +1,116 @@
+package shell
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCommandWindowsConfiguredArguments(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		args string
+		want []string
+	}{
+		{name: "spaces", args: `"C:/path with spaces"`, want: []string{"C:/path with spaces"}},
+		{name: "quotes", args: `"say \"hello\""`, want: []string{`say "hello"`}},
+		{name: "percent", args: `"percent%value" "%DETENT_SHELL_VALUE%"`, want: []string{"percent%value", "expanded"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := Command(t.Context(), `"`+executable+`" -test.run=TestShellArgumentProcess -- `+tt.args, "cmd")
+			cmd.Env = append(cmd.Environ(), "DETENT_SHELL_ARGUMENT_PROCESS=1", "DETENT_SHELL_VALUE=expanded")
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("command failed: %v\n%s", err, output)
+			}
+			var got []string
+			if err := json.Unmarshal(output, &got); err != nil {
+				t.Fatalf("decode output %q: %v", output, err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("child arguments = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandWindowsQuotedGitDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"plain", "directory with spaces", "percent%value"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := filepath.Join(t.TempDir(), name)
+			if err := os.Mkdir(dir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			script := `git -C "` + filepath.ToSlash(dir) + `" --version`
+			legacy := exec.CommandContext(t.Context(), "cmd", "/C", script)
+			output, err := legacy.CombinedOutput()
+			if err == nil || !strings.Contains(string(output), "cannot change to '\"") {
+				t.Fatalf("legacy launch = %v, %s; want literal-quote directory failure", err, output)
+			}
+			for _, shellName := range []string{"", "cmd.exe", filepath.Join(os.Getenv("SystemRoot"), "System32", "cmd.exe")} {
+				cmd := Command(t.Context(), script, shellName)
+				output, err := cmd.CombinedOutput()
+				if err != nil || !strings.HasPrefix(string(output), "git version ") {
+					t.Fatalf("shell %q: %v, %s", shellName, err, output)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandWindowsPreservesShellSyntax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{name: "expansion", script: `echo %DETENT_SHELL_VALUE%`, want: "expanded"},
+		{name: "sequence", script: `echo first&&echo second`, want: "first\r\nsecond"},
+		{name: "pipeline", script: `echo piped|findstr piped`, want: "piped"},
+		{name: "redirection", script: `echo redirected>result.txt&&type result.txt`, want: "redirected"},
+		{name: "escaped operator", script: `echo first^&second`, want: "first&second"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := Command(t.Context(), tt.script, "cmd")
+			cmd.Dir = t.TempDir()
+			cmd.Env = append(cmd.Environ(), "DETENT_SHELL_VALUE=expanded")
+			output, err := cmd.CombinedOutput()
+			if err != nil || strings.TrimSpace(string(output)) != tt.want {
+				t.Fatalf("command = %v, %q; want %q", err, output, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandWindowsLeavesOtherShellsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	for _, shellName := range []string{"powershell.exe", "pwsh.exe", "bash.exe", "custom.exe"} {
+		t.Run(shellName, func(t *testing.T) {
+			t.Parallel()
+			cmd := Command(t.Context(), `echo "quoted"`, shellName)
+			if cmd.SysProcAttr != nil {
+				t.Fatalf("SysProcAttr = %+v, want default serialization", cmd.SysProcAttr)
+			}
+		})
+	}
+}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -42,7 +42,9 @@ func Command(ctx context.Context, command string, shellName string) *exec.Cmd {
 
 func CommandForOS(ctx context.Context, command string, shellName string, goos string) *exec.Cmd {
 	spec := CommandSpecForOS(command, shellName, goos)
-	return exec.CommandContext(ctx, spec.Name, spec.Args...) // #nosec G204 -- workflow shell and command are operator-supplied.
+	cmd := exec.CommandContext(ctx, spec.Name, spec.Args...) // #nosec G204 -- workflow shell and command are operator-supplied.
+	configureCommand(cmd, goos)
+	return cmd
 }
 
 func CommandWithArgs(ctx context.Context, command string, shellName string, args []string) *exec.Cmd {
@@ -50,8 +52,7 @@ func CommandWithArgs(ctx context.Context, command string, shellName string, args
 }
 
 func CommandWithArgsForOS(ctx context.Context, command string, shellName string, args []string, goos string) *exec.Cmd {
-	spec := CommandSpecWithArgsForOS(command, shellName, args, goos)
-	return exec.CommandContext(ctx, spec.Name, spec.Args...) // #nosec G204 -- workflow shell and command are operator-supplied.
+	return CommandForOS(ctx, commandWithArgsForOS(command, shellName, args, goos), shellName, goos)
 }
 
 func CommandSpecForOS(command string, shellName string, goos string) CommandSpec {
@@ -116,9 +117,28 @@ func quotePowerShellArg(arg string) string {
 }
 
 func quoteCmdArg(arg string) string {
-	arg = strings.ReplaceAll(arg, "%", "%%")
-	arg = strings.ReplaceAll(arg, `"`, `\"`)
-	return `"` + arg + `"`
+	var quoted strings.Builder
+	quoted.WriteString(`^"`)
+	backslashes := 0
+	for _, char := range arg {
+		if char == '\\' {
+			backslashes++
+			continue
+		}
+		if char == '"' {
+			quoted.WriteString(strings.Repeat(`\`, 2*backslashes+1))
+		} else {
+			quoted.WriteString(strings.Repeat(`\`, backslashes))
+		}
+		backslashes = 0
+		if strings.ContainsRune("()[]%!^\"`<>&|;, *?\t", char) {
+			quoted.WriteByte('^')
+		}
+		quoted.WriteRune(char)
+	}
+	quoted.WriteString(strings.Repeat(`\`, 2*backslashes))
+	quoted.WriteString(`^"`)
+	return quoted.String()
 }
 
 func shellBase(name string) string {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -137,7 +137,7 @@ func TestCommandSpecWithArgsQuotesForConfiguredShell(t *testing.T) {
 			name:     "windows cmd",
 			goos:     "windows",
 			wantName: "cmd",
-			wantArgs: []string{"/C", `claude "-p" "--model" "fable" "Bash(git *)" "quoted'value" "percent%%value"`},
+			wantArgs: []string{"/C", `claude ^"-p^" ^"--model^" ^"fable^" ^"Bash^(git^ ^*^)^" ^"quoted'value^" ^"percent^%value^"`},
 		},
 		{
 			name:     "windows powershell",
@@ -176,5 +176,31 @@ func TestCommandBuildsExecCommand(t *testing.T) {
 	cmd := CommandForOS(context.Background(), "echo ok", "bash", "linux")
 	if !reflect.DeepEqual(cmd.Args, []string{"bash", "-c", "echo ok"}) {
 		t.Fatalf("Args = %#v, want bash -c command", cmd.Args)
+	}
+}
+
+func TestQuoteCmdArg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "empty", want: `^"^"`},
+		{name: "spaces", arg: `path with spaces`, want: `^"path^ with^ spaces^"`},
+		{name: "embedded quote", arg: `say "hello"`, want: `^"say^ \^"hello\^"^"`},
+		{name: "percent", arg: `%PATH%`, want: `^"^%PATH^%^"`},
+		{name: "trailing backslash", arg: `C:\path with spaces\`, want: `^"C:\path^ with^ spaces\\^"`},
+		{name: "backslash before quote", arg: `a\"b`, want: `^"a\\\^"b^"`},
+		{name: "shell syntax", arg: `a&b|c<d>e(f)^!`, want: `^"a^&b^|c^<d^>e^(f^)^^^!^"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := quoteCmdArg(tt.arg); got != tt.want {
+				t.Fatalf("quoteCmdArg(%q) = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve quoted configured command arguments on Windows by passing cmd.exe its script verbatim through the Windows command-line boundary. Quoted Git directories and executable paths with spaces reach the child correctly.
- Encode appended literal arguments for both cmd and the child parser, covering embedded quotes, trailing backslashes, percent signs, and shell metacharacters while retaining intentional configured shell syntax. Preserve POSIX and PowerShell launch behavior.
- Add executable regressions, including a legacy-launch control reproducing Git receiving literal directory quotes, and a reusable Windows shell debugging skill draft.

Fixes #2277

## UI Surface Contract

- [x] N/A: this change has no UI surface or layout impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Focused shell race tests pass on macOS.
- [x] Windows shell test binary cross-compiles.
- [x] `make check` on head `9f617c22`: 80.1% overall coverage, 94.3% shell coverage; all package/file floors pass.
- [x] [Current-head CI](https://github.com/digitaldrywood/detent/actions/runs/34179813902): all 11 jobs pass, including Windows subprocess regressions for cmd, Bash, pwsh, and applicable Windows PowerShell cases. Downloaded Windows evidence confirms the legacy Git failure control and every applicable shell regression passed.

Dependency #2282 is resolved and its migration repair is included in the branch base.
