### PR TITLE
test(workspace): relax shell fixture deadline

### DIFF
--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1064,7 +1064,7 @@ func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
 		AutoBranch: true,
 		Hooks: Hooks{
 			AfterCreate: "printf 'ok\n' > " + shellQuote(tracePath),
-			Timeout:     5 * time.Second,
+			Timeout:     time.Minute,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Give the functional non-login shell fixture a one-minute bounded deadlock guard instead of a five-second hook deadline, avoiding intermittent deadline failures during full validation. Preserve shell invocation and hook output assertions, production timeouts, and dedicated timeout tests.

Fixes #2279

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes requiring browser verification.

## Test Plan

- [x] `go test -race ./internal/workspace -run '^TestLocalGitHooksUseNonLoginShell$' -count=20` (9.206s).
- [x] `make check CHECK_LOCK_WAIT=30m` passed, including the full race suite and workspace coverage (70.1%). Overall coverage: 80.0%; all configured package and file floors passed.
