### PR TITLE
fix(cloud): authorize scoped Change review policies

### DIFF
--- a/docs/hub-api.md
+++ b/docs/hub-api.md
@@ -647,7 +647,13 @@ also supply their current `lease_id`, `fencing_token`, `run_id`, and `attempt_id
 | `POST /work-items/{item}/changes/{change}/versions/{version}/reviews` | Operator decision: `approved`, `changes_requested`, or `commented`, plus optional `body` |
 | `POST /work-items/{item}/changes/{change}/versions/{version}/checks` | Credential pinned in the immutable expected check set |
 | `GET /change-review-policy` | Inspect the approved native review/CI expectations |
-| `PUT /change-review-policy` | Instance administrator; compare `expected_review_policy_id` and approve `policy` |
+| `PUT /change-review-policy` | Self-hosted instance administrator, or hosted owner/admin with a target-project write grant; compare `expected_review_policy_id` and approve `policy` |
+
+Hosted approval requires an active organization owner/admin membership, a valid
+human session and CSRF token, and a write grant for the target project. Runner
+management grants are not required. Bearer tokens cannot replace human membership.
+The server rechecks the session, membership role and project grant inside the
+mutation transaction, including before returning a cached approval response.
 
 Before publishing, an administrator approves a review policy tied to the current
 repository `policy_id`. Its `require_review` setting cannot weaken a repository

--- a/internal/hubserver/changes.go
+++ b/internal/hubserver/changes.go
@@ -23,7 +23,7 @@ func (s *Service) registerChangeRoutes(e *echo.Echo) {
 	write := s.requireNativeScope(apiScopeWorker, apiScopeOperator)
 	operator := s.requireNativeScope(apiScopeOperator)
 	e.GET(nativeBase+"/change-review-policy", s.getChangeReviewPolicy, read)
-	e.PUT(nativeBase+"/change-review-policy", s.approveChangeReviewPolicy, s.requireInstanceAdmin(), s.requireNativeScope(apiScopeAdmin))
+	e.PUT(nativeBase+"/change-review-policy", s.approveChangeReviewPolicy, s.requireChangeReviewPolicyAdmin())
 	e.GET(changeBase, s.listChanges, read)
 	e.POST(changeBase, s.createChange, write)
 	e.GET(changeBase+"/:change", s.getChange, read)
@@ -33,6 +33,20 @@ func (s *Service) registerChangeRoutes(e *echo.Echo) {
 	e.GET(changeBase+"/:change/versions/:version/viewed-files", s.changeViewedFiles, operator)
 	e.POST(changeBase+"/:change/versions/:version/viewed-files", s.viewChangeFile, operator)
 	e.POST(changeBase+"/:change/versions/:version/checks", s.submitChangeCheck, write)
+}
+
+func (s *Service) requireChangeReviewPolicyAdmin() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		if s.config.Hosted == nil {
+			return s.requireInstanceAdmin()(s.requireNativeScope(apiScopeAdmin)(next))
+		}
+		return s.requireOnboardingAdmin()(func(c echo.Context) error {
+			scope := nativeRequestScope(c)
+			scope.requireHostedAdmin = true
+			c.Set("native_scope", scope)
+			return next(c)
+		})
+	}
 }
 
 func readChangePolicy(ctx context.Context, query nativeQueryer, scope nativeScope) (tracker.ChangeReviewPolicy, error) {

--- a/internal/hubserver/hosted_auth.go
+++ b/internal/hubserver/hosted_auth.go
@@ -190,6 +190,9 @@ func (s *Service) recheckHostedMutation(ctx context.Context, tx *sql.Tx, scope n
 	if err != nil || membership.Role.Slug == "viewer" {
 		return auth.ErrHostedIdentity
 	}
+	if scope.requireHostedAdmin && membership.Role.Slug != "owner" && membership.Role.Slug != "admin" {
+		return auth.ErrHostedIdentity
+	}
 	var count int
 	err = tx.QueryRowContext(ctx, `SELECT count(*) FROM hosted_sessions s, hosted_members m
 WHERE s.token_hash = ? AND s.revoked_at IS NULL AND julianday(s.expires_at) > julianday(?) AND m.user_id = ? AND m.membership_id = ? AND m.active = 1`, scope.credential.SessionHash, formatHubTime(s.config.now()), identity.Subject, membership.ID).Scan(&count)

--- a/internal/hubserver/hosted_changes_test.go
+++ b/internal/hubserver/hosted_changes_test.go
@@ -1,0 +1,332 @@
+package hubserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/changerequest"
+	"github.com/digitaldrywood/detent/internal/onboarding"
+	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func TestHostedChangePolicyAuthorization(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name, role, grant, email string
+		runner                   bool
+		want                     int
+	}{
+		{"owner", "owner", "write", "owner@example.test", true, http.StatusOK},
+		{"admin without runner grants", "admin", "write", "admin@example.test", false, http.StatusOK},
+		{"owner without runner grants", "owner", "write", "owner@example.test", false, http.StatusOK},
+		{"member", "member", "write", "member@example.test", true, http.StatusNotFound},
+		{"viewer", "viewer", "write", "viewer@example.test", true, http.StatusNotFound},
+		{"read only owner", "owner", "read", "owner@example.test", true, http.StatusNotFound},
+		{"ungranted owner", "owner", "", "owner@example.test", false, http.StatusNotFound},
+		{"staff owner", "owner", "write", "staff@example.test", true, http.StatusForbidden},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			f := newHostedSecurityFixture(t)
+			owner := f.user(t, "setup", "owner", "setup@example.test", "write", "")
+			requireNativeStatus(t, f.request(t, owner, http.MethodPut, f.base+"/onboarding/policy", policy.Change{Policy: hubTestPolicy()}), http.StatusOK)
+			user := f.user(t, "approver", test.role, test.email, test.grant, "")
+			if test.grant != "" {
+				f.grant(t, user, test.grant == "write", test.runner)
+			}
+			request := tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "approve"}, Policy: tracker.ChangeReviewPolicy{PolicyID: hubTestPolicy().ID, RequireReview: true}}
+			requireNativeStatus(t, f.request(t, user, http.MethodPut, f.base+"/change-review-policy", request), test.want)
+			var count int
+			if err := f.service.database.db.QueryRowContext(t.Context(), "SELECT count(*) FROM change_review_policies").Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if (count == 1) != (test.want == http.StatusOK) {
+				t.Fatalf("stored policies = %d, response status = %d", count, test.want)
+			}
+		})
+	}
+}
+
+func TestHostedChangePolicyJourney(t *testing.T) {
+	t.Parallel()
+	f := newBrowserHostedFixture(t, true)
+	seedHubAPIToken(t, f.service, "ungranted-ci", "ungranted-ci-token", apiScopeOperator)
+	for _, project := range []string{f.project, f.privateProject} {
+		t.Run(project, func(t *testing.T) {
+			base := "/api/v2/organizations/org_browser_preview/projects/" + project
+			requireNativeStatus(t, f.form(t, "owner", "/organization/grants", url.Values{"user": {"user_browser_owner"}, "project": {project}, "write": {"true"}, "runner": {"true"}}), http.StatusSeeOther)
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/onboarding", map[string]any{"idempotency_key": "setup", "progress": onboarding.Progress{Repository: "existing"}}), http.StatusOK)
+			descriptor := hubTestPolicy()
+			descriptor.ConfigDigest = policy.Digest([]byte(project))
+			descriptor.Gates.Kind, descriptor.Gates.RequiredChecks, descriptor.Gates.Validator = "human_review", 1, true
+			descriptor.Gates.AutomatedReview = ""
+			descriptor = descriptor.WithID()
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/onboarding/policy", policy.Change{Policy: descriptor}), http.StatusOK)
+			principal := "ci-" + project
+			seedHubAPIToken(t, f.service, principal, "credential-"+project, apiScopeOperator)
+			if _, err := f.service.database.db.ExecContext(t.Context(), "INSERT INTO token_grants(token_id,organization_id,project_id) VALUES (?,'org_browser_preview',?)", principal, project); err != nil {
+				t.Fatal(err)
+			}
+			rules := tracker.ChangeReviewPolicy{PolicyID: descriptor.ID, RequireReview: true, RequiredChecks: []tracker.ChangeCheckSpec{{Name: "test", PrincipalID: principal, WorkflowID: "ci.yml", WorkflowSHA256: policy.Digest([]byte("trusted CI")), Source: "independent", MaxAgeSeconds: 3600}}}
+			for _, test := range []struct {
+				name string
+				edit func(*tracker.ChangeReviewPolicy)
+			}{
+				{"review floor", func(p *tracker.ChangeReviewPolicy) { p.RequireReview = false }},
+				{"check floor", func(p *tracker.ChangeReviewPolicy) { p.RequiredChecks = nil }},
+				{"validator floor", func(p *tracker.ChangeReviewPolicy) { p.RequiredChecks[0].Source = "customer" }},
+				{"unpinned workflow", func(p *tracker.ChangeReviewPolicy) { p.RequiredChecks[0].WorkflowSHA256 = "" }},
+				{"ungranted principal", func(p *tracker.ChangeReviewPolicy) { p.RequiredChecks[0].PrincipalID = "ungranted-ci" }},
+				{"stale repository policy", func(p *tracker.ChangeReviewPolicy) { p.PolicyID = hubTestPolicy().ID }},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					invalid := rules
+					invalid.RequiredChecks = append([]tracker.ChangeCheckSpec(nil), rules.RequiredChecks...)
+					test.edit(&invalid)
+					requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: test.name}, Policy: invalid}), http.StatusUnprocessableEntity)
+				})
+			}
+			approve := tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "approve"}, Policy: rules}
+			approve.Policy.ID = "client-supplied-identity"
+			response := f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", approve)
+			requireNativeStatus(t, response, http.StatusOK)
+			decodeHubResponse(t, response, &rules)
+			if rules.ID != changerequest.PolicyID(rules) || rules.ID == approve.Policy.ID {
+				t.Fatalf("policy identity = %q", rules.ID)
+			}
+			replay := f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", approve)
+			requireNativeStatus(t, replay, http.StatusOK)
+			if replay.Body.String() != response.Body.String() {
+				t.Fatal("policy retry changed the approval")
+			}
+			approve.IdempotencyKey = "stale-expected"
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", approve), http.StatusConflict)
+			response = f.setupRequest(t, "owner", http.MethodPost, base+"/work-items", tracker.CreateIssue{Mutation: tracker.Mutation{IdempotencyKey: "work"}, Title: "Publish a Change", State: "Todo"})
+			requireNativeStatus(t, response, http.StatusOK)
+			var issue tracker.NativeIssue
+			decodeHubResponse(t, response, &issue)
+			path := base + "/work-items/" + string(issue.WorkItemID) + "/changes"
+			response = f.setupRequest(t, "owner", http.MethodPost, path, tracker.CreateChange{Mutation: tracker.Mutation{IdempotencyKey: "change"}, Title: "Native Change"})
+			requireNativeStatus(t, response, http.StatusOK)
+			var change tracker.ChangeRequest
+			decodeHubResponse(t, response, &change)
+			path += "/" + change.ID
+			publish := tracker.PublishChangeVersion{Mutation: tracker.Mutation{IdempotencyKey: "publish"}, ChangeVersionInput: changeTestInput()}
+			publish.PolicyID = descriptor.ID
+			response = f.setupRequest(t, "owner", http.MethodPost, path+"/versions", publish)
+			requireNativeStatus(t, response, http.StatusOK)
+			var version tracker.ChangeVersion
+			decodeHubResponse(t, response, &version)
+			if version.PolicyID != descriptor.ID || version.ReviewPolicy.ID != rules.ID || len(version.Checks) != 1 || version.Checks[0].PrincipalID != principal {
+				t.Fatalf("published policy snapshot = %+v", version)
+			}
+			approve.IdempotencyKey, approve.ExpectedID = "update", rules.ID
+			approve.Policy.RequiredChecks[0].MaxAgeSeconds = 7200
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", approve), http.StatusOK)
+			response = f.setupRequest(t, "owner", http.MethodGet, path, nil)
+			requireNativeStatus(t, response, http.StatusOK)
+			var detail tracker.ChangeDetail
+			decodeHubResponse(t, response, &detail)
+			if len(detail.Versions) != 1 || detail.Versions[0].ReviewPolicy.ID != rules.ID || detail.Summary.Status != "stale_policy" {
+				t.Fatalf("changed policy rewrote published version or was not stale: %+v", detail)
+			}
+			updated := descriptor
+			updated.ConfigDigest = policy.Digest([]byte("updated-" + project))
+			updated = updated.WithID()
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/onboarding/policy", policy.Change{ExpectedID: descriptor.ID, Policy: updated}), http.StatusOK)
+			publish.IdempotencyKey, publish.ExpectedVersionID = "stale-publish", version.ID
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPost, path+"/versions", publish), http.StatusConflict)
+			publish.IdempotencyKey, publish.PolicyID = "stale-review-policy", updated.ID
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPost, path+"/versions", publish), http.StatusConflict)
+		})
+	}
+	first := "/api/v2/organizations/org_browser_preview/projects/" + f.project
+	second := "/api/v2/organizations/org_browser_preview/projects/" + f.privateProject
+	response := f.setupRequest(t, "owner", http.MethodGet, second+"/change-review-policy", nil)
+	requireNativeStatus(t, response, http.StatusOK)
+	var secondPolicy tracker.ChangeReviewPolicy
+	decodeHubResponse(t, response, &secondPolicy)
+	requireNativeStatus(t, f.form(t, "owner", "/organization/grants", url.Values{"user": {"user_browser_owner"}, "project": {f.project}, "revoke": {"true"}}), http.StatusSeeOther)
+	for _, method := range []string{http.MethodGet, http.MethodPut} {
+		t.Run("revoked project/"+method, func(t *testing.T) {
+			requireNativeStatus(t, f.setupRequest(t, "owner", method, first+"/change-review-policy", tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "cross-project"}, Policy: secondPolicy}), http.StatusNotFound)
+		})
+	}
+	response = f.setupRequest(t, "owner", http.MethodGet, second+"/change-review-policy", nil)
+	requireNativeStatus(t, response, http.StatusOK)
+	var preserved tracker.ChangeReviewPolicy
+	decodeHubResponse(t, response, &preserved)
+	if preserved.ID != secondPolicy.ID {
+		t.Fatal("revoking one project changed the other project's policy")
+	}
+	response = f.setupRequest(t, "owner", http.MethodGet, second+"/policy", nil)
+	requireNativeStatus(t, response, http.StatusOK)
+	var current policy.Approval
+	decodeHubResponse(t, response, &current)
+	secondPolicy.PolicyID = current.Policy.ID
+	command := tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "remaining-project"}, ExpectedID: secondPolicy.ID, Policy: secondPolicy}
+	requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, second+"/change-review-policy", command), http.StatusOK)
+	command.IdempotencyKey, command.ExpectedID = "other-project-ci", changerequest.PolicyID(secondPolicy)
+	command.Policy.RequiredChecks[0].PrincipalID = "ci-" + f.project
+	requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, second+"/change-review-policy", command), http.StatusUnprocessableEntity)
+}
+
+func TestHostedChangePolicyCIPrincipals(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		role    apiScope
+		revoked bool
+	}{
+		{"independent worker", apiScopeWorker, false},
+		{"revoked operator", apiScopeOperator, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			f := newHostedSecurityFixture(t)
+			owner := f.user(t, "owner", "owner", "owner@example.test", "write", "")
+			requireNativeStatus(t, f.request(t, owner, http.MethodPut, f.base+"/onboarding/policy", policy.Change{Policy: hubTestPolicy()}), http.StatusOK)
+			seedHubAPIToken(t, f.service, "ci", "ci-token", test.role)
+			if _, err := f.service.database.db.ExecContext(t.Context(), "INSERT INTO token_grants(token_id,organization_id,project_id) VALUES ('ci','org_security',?)", f.project); err != nil {
+				t.Fatal(err)
+			}
+			if test.revoked {
+				if _, err := f.service.database.db.ExecContext(t.Context(), "UPDATE api_tokens SET revoked_at = ? WHERE id = 'ci'", testTimestamp); err != nil {
+					t.Fatal(err)
+				}
+			}
+			command := tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "approve"}, Policy: tracker.ChangeReviewPolicy{PolicyID: hubTestPolicy().ID, RequiredChecks: []tracker.ChangeCheckSpec{{Name: "test", PrincipalID: "ci", WorkflowID: "ci.yml", WorkflowSHA256: policy.Digest([]byte("trusted CI")), Source: "independent", MaxAgeSeconds: 3600}}}}
+			requireNativeStatus(t, f.request(t, owner, http.MethodPut, f.base+"/change-review-policy", command), http.StatusUnprocessableEntity)
+		})
+	}
+}
+
+func TestHostedChangePolicyBoundaries(t *testing.T) {
+	t.Parallel()
+	f := newHostedSecurityFixture(t)
+	owner := f.user(t, "owner", "owner", "owner@example.test", "write", "")
+	seedHubAPIToken(t, f.service, "admin", "admin-bearer", apiScopeAdmin)
+	for _, test := range []struct {
+		name, path, csrf, bearer string
+		want                     int
+	}{
+		{"missing csrf", f.base + "/change-review-policy", "", "", http.StatusForbidden},
+		{"wrong csrf", f.base + "/change-review-policy", "wrong", "", http.StatusForbidden},
+		{"bearer with cookie", f.base + "/change-review-policy", "", "admin-bearer", http.StatusNotFound},
+		{"unrelated organization", strings.Replace(f.base, "org_security", "org_unrelated", 1) + "/change-review-policy", hostedCSRF(owner.token), "", http.StatusNotFound},
+		{"unknown project", strings.Replace(f.base, string(f.project), "prj_unknown", 1) + "/change-review-policy", hostedCSRF(owner.token), "", http.StatusNotFound},
+		{"generic policy administration", f.base + "/policy", hostedCSRF(owner.token), "", http.StatusNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPut, test.path, strings.NewReader(`{}`))
+			request.AddCookie(&http.Cookie{Name: hostedCookie, Value: owner.token})
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("X-CSRF-Token", test.csrf)
+			if test.bearer != "" {
+				request.Header.Set("Authorization", "Bearer "+test.bearer)
+			}
+			response := httptest.NewRecorder()
+			f.service.Handler().ServeHTTP(response, request)
+			requireNativeStatus(t, response, test.want)
+		})
+	}
+	for _, role := range []apiScope{apiScopeWorker, apiScopeOperator, apiScopeAdmin} {
+		t.Run("bearer only/"+string(role), func(t *testing.T) {
+			seedHubAPIToken(t, f.service, "bearer-"+string(role), string(role)+"-token", role)
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPut, f.base+"/change-review-policy", string(role)+"-token", tracker.ApproveChangeReviewPolicy{}), http.StatusNotFound)
+		})
+	}
+}
+
+type hostedChangePolicyReader struct {
+	io.Reader
+	beforeRead func()
+}
+
+func (r *hostedChangePolicyReader) Read(p []byte) (int, error) {
+	if r.beforeRead != nil {
+		r.beforeRead()
+		r.beforeRead = nil
+	}
+	return r.Reader.Read(p)
+}
+
+func TestHostedChangePolicyRevocation(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		revoke func(*testing.T, hostedSecurityFixture, hostedSecurityUser)
+	}{
+		{"role", func(t *testing.T, f hostedSecurityFixture, user hostedSecurityUser) {
+			t.Helper()
+			if err := f.provider.SetMembershipRole(t.Context(), "membership_"+user.identity.Subject, "member"); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"membership", func(t *testing.T, f hostedSecurityFixture, user hostedSecurityUser) {
+			t.Helper()
+			if err := f.provider.RevokeMembership(t.Context(), "membership_"+user.identity.Subject); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"session", func(t *testing.T, f hostedSecurityFixture, user hostedSecurityUser) {
+			t.Helper()
+			if err := f.provider.RevokeSession(t.Context(), user.identity.Hosted.SessionID); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"write grant", func(t *testing.T, f hostedSecurityFixture, user hostedSecurityUser) {
+			t.Helper()
+			f.grant(t, user, false, true)
+		}},
+		{"local membership", func(t *testing.T, f hostedSecurityFixture, user hostedSecurityUser) {
+			t.Helper()
+			if err := f.service.revokeHostedMemberLocally(t.Context(), user.identity.Subject); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		for _, replay := range []bool{false, true} {
+			t.Run(test.name+"/"+map[bool]string{false: "new", true: "replay"}[replay], func(t *testing.T) {
+				t.Parallel()
+				f := newHostedSecurityFixture(t)
+				user := f.user(t, "owner", "owner", "owner@example.test", "write", "")
+				requireNativeStatus(t, f.request(t, user, http.MethodPut, f.base+"/onboarding/policy", policy.Change{Policy: hubTestPolicy()}), http.StatusOK)
+				command := tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "approve"}, Policy: tracker.ChangeReviewPolicy{PolicyID: hubTestPolicy().ID, RequireReview: true}}
+				if replay {
+					requireNativeStatus(t, f.request(t, user, http.MethodPut, f.base+"/change-review-policy", command), http.StatusOK)
+				}
+				raw, err := json.Marshal(command)
+				if err != nil {
+					t.Fatal(err)
+				}
+				body := &hostedChangePolicyReader{Reader: strings.NewReader(string(raw)), beforeRead: func() { test.revoke(t, f, user) }}
+				request := httptest.NewRequest(http.MethodPut, f.base+"/change-review-policy", body)
+				request.AddCookie(&http.Cookie{Name: hostedCookie, Value: user.token})
+				request.Header.Set("X-CSRF-Token", hostedCSRF(user.token))
+				request.Header.Set("Content-Type", "application/json")
+				response := httptest.NewRecorder()
+				f.service.Handler().ServeHTTP(response, request)
+				if response.Code != http.StatusForbidden && response.Code != http.StatusNotFound {
+					t.Fatalf("revoked approval = %d: %s", response.Code, response.Body.String())
+				}
+				if body.beforeRead != nil {
+					t.Fatal("revocation did not run after middleware authorization")
+				}
+				var count int
+				if err := f.service.database.db.QueryRowContext(t.Context(), "SELECT count(*) FROM change_review_policies").Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				if count != map[bool]int{false: 0, true: 1}[replay] {
+					t.Fatalf("stored policies after revocation = %d", count)
+				}
+			})
+		}
+	}
+}

--- a/internal/hubserver/native_api.go
+++ b/internal/hubserver/native_api.go
@@ -22,9 +22,10 @@ import (
 const nativeBase = "/api/v2/organizations/:organization/projects/:project"
 
 type nativeScope struct {
-	organization tracker.OrganizationID
-	project      tracker.ProjectID
-	credential   apiCredential
+	organization       tracker.OrganizationID
+	project            tracker.ProjectID
+	credential         apiCredential
+	requireHostedAdmin bool
 }
 
 type nativeError struct {


### PR DESCRIPTION
## Summary

- Allow hosted owners and admins with a write grant on the target project to approve Change review policies, enabling hosted version publication.
- Recheck administrative membership, session validity and project access before mutations and cached approval responses. Preserve self-hosted authorization, generic hosted administration, CSRF, repository policy floors and pinned CI principals.

Fixes #2291

## UI Surface Contract

- [x] N/A: no visual UI changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No primary operator screen visual changes requiring browser verification.

## Test Plan

- [x] Focused hosted Change policy and existing Change tests.
- [x] `make check` passed for implementation; race tests also passed during the documentation repeat. Final full gate passed with `make check GO_TEST='env -u DETENT_API_TOKEN go test -parallel=1'` after reproducing an unrelated parallel shell-helper coverage collision tracked in #2296. No stages or tests skipped; overall coverage 80.1%.
- [x] Actual HTTP-handler onboarding through repository approval, Change policy approval and publication in two projects.
- [x] Owner/admin authorization, staff/viewer/member denial, CSRF, bearer denial, revocation during requests and cached replays, policy floors, pinned CI principals, immutable identity and stale/expected-ID conflicts.
