### PR TITLE
fix(test): isolate shell helper coverage output

### DIFF
--- a/.detent/skills/subprocess-coverage-output-isolation.md
+++ b/.detent/skills/subprocess-coverage-output-isolation.md
@@ -1,0 +1,14 @@
+---
+name: subprocess-coverage-output-isolation
+description: Diagnose coverage runtime errors contaminating structured output from parallel Go test helper subprocesses.
+when_to_use: Use when a helper reexecutes a Go test binary and its output contract fails only under coverage, especially with metadata rename errors.
+---
+
+# Isolate helper subprocess coverage output
+
+- Reproduce with the reported Go toolchain and coverage enabled, retaining parallel subtests. Compare repeated coverage runs with ordinary and race runs.
+- Inspect that toolchain's `internal/coverage/cfile/hooks.go` and `emit.go`. An instrumented test helper calling `os.Exit` can run coverage exit hooks after printing its result, bypassing normal testing coverage finalization.
+- Trace the child's inherited `GOCOVERDIR`. In Go 1.26.6, temporary metadata names combine the binary hash and timestamp without exclusive creation; concurrent helpers sharing a directory can collide and report rename failures on stderr.
+- Assign an existing, unique directory to each child before starting it, such as appending `"GOCOVERDIR="+t.TempDir()` to `cmd.Env`. Keep the directory alive until the child exits. Avoid process-wide environment changes in parallel tests.
+- Apply isolation to every launch of the same helper, including platform-specific tests. Merely clearing `GOCOVERDIR` can produce a missing-directory warning; discarding stderr can hide other helper failures.
+- Keep strict output decoding and argument-boundary assertions. Repeat focused coverage runs and race tests, then run the repository gate. Before isolating coverage data, verify the helper does not exercise production code whose counters must be merged into the parent profile.

--- a/internal/shell/command_integration_test.go
+++ b/internal/shell/command_integration_test.go
@@ -77,7 +77,7 @@ func TestCommandWithArgsExecution(t *testing.T) {
 						t.Skip("Windows PowerShell uses legacy native argument parsing")
 					}
 					cmd := CommandWithArgs(t.Context(), command, shellName, tt.args)
-					cmd.Env = append(cmd.Environ(), "DETENT_SHELL_ARGUMENT_PROCESS=1", "DETENT_SHELL_VALUE=expanded", "MSYS2_ARG_CONV_EXCL=*")
+					cmd.Env = append(cmd.Environ(), "DETENT_SHELL_ARGUMENT_PROCESS=1", "DETENT_SHELL_VALUE=expanded", "MSYS2_ARG_CONV_EXCL=*", "GOCOVERDIR="+t.TempDir())
 					output, err := cmd.CombinedOutput()
 					if err != nil {
 						t.Fatalf("command failed: %v\n%s", err, output)

--- a/internal/shell/command_windows_test.go
+++ b/internal/shell/command_windows_test.go
@@ -30,7 +30,7 @@ func TestCommandWindowsConfiguredArguments(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cmd := Command(t.Context(), `"`+executable+`" -test.run=TestShellArgumentProcess -- `+tt.args, "cmd")
-			cmd.Env = append(cmd.Environ(), "DETENT_SHELL_ARGUMENT_PROCESS=1", "DETENT_SHELL_VALUE=expanded")
+			cmd.Env = append(cmd.Environ(), "DETENT_SHELL_ARGUMENT_PROCESS=1", "DETENT_SHELL_VALUE=expanded", "GOCOVERDIR="+t.TempDir())
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("command failed: %v\n%s", err, output)


### PR DESCRIPTION
## Summary

Parallel shell argument helpers can emit Go coverage metadata errors after their JSON result when they inherit the same coverage directory. Give each helper process a separate temporary coverage directory in both the cross-platform and Windows-specific suites, preserving parallel execution and strict argument checks.

Go 1.26.6 reproduction confirmed that the helper's exit hooks emit coverage metadata using timestamp-based temporary names that can collide. Include a reusable diagnostic skill draft for this subprocess failure pattern.

Fixes #2296

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, first-viewport, or responsive visibility changes.
- [x] No persistent top-of-screen messaging is added.
- [x] N/A: no visual changes to operator screens.

## Test Plan

- [x] Reproduced the original metadata rename / JSON decoding failure on Go 1.26.6/macOS with focused coverage `-count=20` before the fix.
- [x] Focused coverage `-count=20` plus five separate `-count=1` runs pass after the fix; shell coverage remains 94.3%.
- [x] Focused race tests `-count=10` pass.
- [x] Windows/amd64 shell test package cross-compiles; runtime Windows checks run in PR CI.
- [x] `GOTOOLCHAIN=go1.26.6 make check` passes: build, lint, vet, NilAway, full race suite, and coverage floors (79.3% overall).
