### PR TITLE
fix(orchestrator): defer unreadable completion fences

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -422,6 +422,11 @@ WITH issue_sessions AS (
   FROM codex_sessions
   WHERE started_at IS NOT NULL
     AND completed_at IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM work_attempts AS attempt
+      WHERE attempt.id = codex_sessions.work_attempt_id
+        AND (attempt.phase = 'completion_deferred' OR NOT (COALESCE(json_extract(CASE WHEN json_valid(attempt.worker_metadata_json) THEN attempt.worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0))
+    )
 ),
 successful_issues AS (
   SELECT
@@ -651,6 +656,8 @@ LEFT JOIN work_attempts AS attempt ON attempt.id = session.work_attempt_id
 WHERE usage_events.project_id = sqlc.arg(project_id)
   AND usage_events.started_at > sqlc.arg(since)
   AND lower(trim(COALESCE(attempt.terminal_state, ''))) != 'capacity'
+  AND COALESCE(attempt.phase, '') != 'completion_deferred'
+  AND COALESCE(json_extract(CASE WHEN json_valid(attempt.worker_metadata_json) THEN attempt.worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0
   AND (
     (sqlc.arg(issue_id) != '' AND COALESCE(usage_events.issue_id, '') = sqlc.arg(issue_id))
     OR (sqlc.arg(identifier) != '' AND COALESCE(usage_events.identifier, '') = sqlc.arg(identifier))
@@ -931,6 +938,7 @@ SELECT *
 FROM work_attempts
 WHERE completed_at IS NOT NULL
   AND status = 'terminal'
+  AND COALESCE(json_extract(CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0
   AND (sqlc.arg(filter_project_id) = '' OR project_id = sqlc.arg(filter_project_id))
   AND (sqlc.arg(filter_worker_type) = '' OR worker_type = sqlc.arg(filter_worker_type))
   AND (
@@ -1416,6 +1424,7 @@ FROM work_attempts
 WHERE completed_at >= sqlc.arg(from_at)
   AND completed_at < sqlc.arg(to_at)
   AND lower(trim(COALESCE(terminal_state, ''))) IN ('failure', 'timed_out', 'no_progress', 'capacity')
+  AND COALESCE(json_extract(CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0
 GROUP BY COALESCE(NULLIF(trim(error_class), ''), 'unknown')
 ORDER BY failures DESC, error_class
 LIMIT 1;

--- a/internal/orchestrator/completion_deferral.go
+++ b/internal/orchestrator/completion_deferral.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/github"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -34,6 +35,7 @@ type deferredCompletion struct {
 	Retryable    bool                           `json:"retryable,omitempty"`
 	RetryAttempt int                            `json:"retry_attempt,omitempty"`
 	RetryDelay   time.Duration                  `json:"retry_delay,omitempty"`
+	FenceRetryAt time.Time                      `json:"fence_retry_at,omitzero"`
 	DeferredAt   time.Time                      `json:"deferred_at"`
 	Availability deferredCompletionAvailability `json:"availability"`
 	Persisted    bool                           `json:"-"`
@@ -62,7 +64,7 @@ type deferredCompletionAvailability struct {
 	Message string                             `json:"message"`
 }
 
-func newDeferredCompletion(event runpkg.Completion, running Running, availabilityErr *connector.TrackerAvailabilityError, deferredAt time.Time) deferredCompletion {
+func newDeferredCompletion(event runpkg.Completion, running Running, fenceErr error, deferredAt time.Time) deferredCompletion {
 	running.CompletionOwnershipReleased = true
 	record := deferredCompletion{
 		Schema:       deferredCompletionSchema,
@@ -76,7 +78,10 @@ func newDeferredCompletion(event runpkg.Completion, running Running, availabilit
 		RetryDelay:   event.RetryDelay,
 		DeferredAt:   deferredAt,
 	}
-	if availabilityErr != nil {
+	if fenceErr != nil {
+		record.Availability = deferredCompletionAvailability{Class: laneRevocationCompletionFenceUnavailable, Message: fenceErr.Error()}
+	}
+	if availabilityErr, ok := connector.AsTrackerAvailability(fenceErr); ok {
 		record.Availability = deferredCompletionAvailability{
 			Scope:   availabilityErr.Scope.Normalize(),
 			Class:   strings.TrimSpace(availabilityErr.Class),
@@ -141,7 +146,7 @@ func (o *Orchestrator) deferTrackerUnavailableCompletion(
 	state *State,
 	event runpkg.Completion,
 	running Running,
-	availabilityErr *connector.TrackerAvailabilityError,
+	fenceErr error,
 ) {
 	deferredAt := o.clockNow().UTC()
 	if deferredAt.IsZero() {
@@ -150,8 +155,9 @@ func (o *Orchestrator) deferTrackerUnavailableCompletion(
 	if deferredAt.IsZero() {
 		deferredAt = time.Now().UTC()
 	}
-	o.observeTrackerReadFailure(state, "", availabilityErr, deferredAt)
-	record := newDeferredCompletion(event, running, availabilityErr, deferredAt)
+	o.observeTrackerReadFailure(state, "", fenceErr, deferredAt)
+	record := newDeferredCompletion(event, running, fenceErr, deferredAt)
+	record.FenceRetryAt = o.completionFenceRetryAt(state, fenceErr, deferredAt, event.RetryDelay)
 	record.Persisted = o.persistDeferredCompletion(ctx, state, record)
 
 	if !running.CompletionOwnershipReleased {
@@ -175,14 +181,10 @@ func (o *Orchestrator) deferTrackerUnavailableCompletion(
 		state.deferredCompletions = map[string]deferredCompletion{}
 	}
 	state.deferredCompletions[event.IssueID] = record
-	delay := max(event.RetryDelay, o.cfg.PollInterval)
-	if delay < 0 {
-		delay = 0
-	}
 	state.Retry[event.IssueID] = Retry{
 		Issue:              cloneIssue(running.Issue),
 		Attempt:            running.Attempt,
-		DueAt:              deferredAt.Add(delay),
+		DueAt:              record.FenceRetryAt,
 		Error:              deferredCompletionStatus,
 		WorkerHost:         running.WorkerHost,
 		TrackerUnavailable: true,
@@ -200,6 +202,33 @@ func (o *Orchestrator) deferTrackerUnavailableCompletion(
 			Message: "retained completed result in memory for " + issueLabel(running.Issue) + " after durable persistence failed",
 		})
 	}
+}
+
+func (o *Orchestrator) completionFenceRetryAt(state *State, err error, now time.Time, retryDelay time.Duration) time.Time {
+	dueAt := now.Add(max(retryDelay, o.cfg.PollInterval, time.Second))
+	var statusErr *github.StatusError
+	if errors.As(err, &statusErr) && statusErr != nil {
+		if retryAt := now.Add(statusErr.RetryAfter); retryAt.After(dueAt) {
+			dueAt = retryAt
+		}
+		if statusErr.ResetAt.After(dueAt) {
+			dueAt = statusErr.ResetAt
+		}
+	}
+	if signal, ok := o.currentGitHubLookupSignal(state, now); ok && signal.resetAt.After(dueAt) {
+		dueAt = signal.resetAt
+	}
+	if reporter, ok := o.connector.(connector.RateLimitReporter); ok {
+		if rate, known := reporter.GraphQLRateLimit(); known && (rate.Remaining <= o.cfg.GitHubGraphQLMinReserve || rate.RetryAfter > 0) {
+			if rate.ResetAt.After(dueAt) {
+				dueAt = rate.ResetAt
+			}
+			if retryAt := now.Add(rate.RetryAfter); retryAt.After(dueAt) {
+				dueAt = retryAt
+			}
+		}
+	}
+	return dueAt
 }
 
 func (o *Orchestrator) persistDeferredCompletion(ctx context.Context, state *State, record deferredCompletion) bool {
@@ -296,7 +325,10 @@ func (o *Orchestrator) recoverDeferredCompletions(ctx context.Context, state *St
 		issueID := record.Running.Issue.ID
 		state.deferredCompletions[issueID] = record
 		dueAt := now
-		if candidate := record.DeferredAt.Add(o.cfg.PollInterval); candidate.After(dueAt) {
+		if record.FenceRetryAt.IsZero() {
+			record.FenceRetryAt = record.DeferredAt.Add(o.cfg.PollInterval)
+		}
+		if candidate := record.FenceRetryAt; candidate.After(dueAt) {
 			dueAt = candidate
 		}
 		state.Retry[issueID] = Retry{

--- a/internal/orchestrator/completion_deferral_test.go
+++ b/internal/orchestrator/completion_deferral_test.go
@@ -3,12 +3,15 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/github"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -19,26 +22,18 @@ func TestCompletionFenceDeferralOutcomes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		fenceErr         error
-		wantDeferred     bool
-		wantTerminal     store.WorkAttemptTerminalState
-		wantFetches      int
-		wantPreservedOut string
+		name     string
+		fenceErr error
 	}{
-		{
-			name:             "503 defers and preserves result",
-			fenceErr:         completionDeferralAvailabilityError(),
-			wantDeferred:     true,
-			wantFetches:      1,
-			wantPreservedOut: "validated completion",
-		},
-		{
-			name:         "403 follows existing fence rejection",
-			fenceErr:     errors.New("github graphql returned status 403"),
-			wantTerminal: store.WorkAttemptTerminalLaneRevoked,
-			wantFetches:  1,
-		},
+		{name: "503", fenceErr: completionDeferralAvailabilityError()},
+		{name: "403", fenceErr: &github.StatusError{StatusCode: 403, Err: github.ErrAuthenticationFailed}},
+		{name: "primary rate limit", fenceErr: &github.StatusError{StatusCode: 429, Err: github.ErrRateLimited}},
+		{name: "secondary rate limit", fenceErr: &github.StatusError{StatusCode: 403, Err: github.ErrRateLimited, RateLimitKind: "secondary"}},
+		{name: "GraphQL quota", fenceErr: &github.GraphQLErrorList{Err: github.ErrRateLimited, Errors: []github.GraphQLError{{Type: "RATE_LIMITED", Message: "API rate limit exceeded"}}}},
+		{name: "reserve exhausted", fenceErr: fmt.Errorf("completion lane: %w", connector.ErrResourceExhausted)},
+		{name: "timeout", fenceErr: context.DeadlineExceeded},
+		{name: "canceled read", fenceErr: context.Canceled},
+		{name: "transport", fenceErr: errors.New("connection reset by peer")},
 	}
 
 	for _, tt := range tests {
@@ -60,39 +55,35 @@ func TestCompletionFenceDeferralOutcomes(t *testing.T) {
 
 			orch.handleRunResult(t.Context(), &state, completionDeferralEvent(issue, attemptID, now))
 
-			_, deferred := state.deferredCompletions[issue.ID]
-			if deferred != tt.wantDeferred {
-				t.Fatalf("deferred completion present = %v, want %v", deferred, tt.wantDeferred)
+			record, deferred := state.deferredCompletions[issue.ID]
+			if !deferred {
+				t.Fatal("fence read failure did not defer completion")
 			}
-			if got := tracker.fetchCount(); got != tt.wantFetches {
-				t.Fatalf("completion fence fetches = %d, want %d", got, tt.wantFetches)
+			if got := tracker.fetchCount(); got != 1 {
+				t.Fatalf("completion fence fetches = %d, want 1", got)
 			}
 			receipt, err := runtimeStore.WorkAttempt(t.Context(), attemptID)
 			if err != nil {
-				t.Fatalf("WorkAttempt() error = %v", err)
+				t.Fatal(err)
 			}
-			if tt.wantDeferred {
-				if receipt.Status != store.WorkAttemptStatusActive || receipt.Phase != deferredCompletionPhase || receipt.WaitReason != connector.TrackerUnavailableCondition || receipt.NextAction != deferredCompletionNextAction {
-					t.Fatalf("deferred work attempt = %#v, want active tracker wait", receipt)
-				}
-				record := state.deferredCompletions[issue.ID]
-				if record.Result.Output != tt.wantPreservedOut || record.Result.Tokens.TotalTokens != 37 {
-					t.Fatalf("preserved result = %#v, want output %q and 37 tokens", record.Result, tt.wantPreservedOut)
-				}
-				snapshot := state.Snapshot(now)
-				if len(snapshot.Queue) != 1 || snapshot.Queue[0].QueueState != telemetry.QueueStateWaitingOnTracker {
-					t.Fatalf("snapshot queue = %#v, want waiting_on_tracker", snapshot.Queue)
-				}
-				if outcome := orch.dispatchIssueWithOutcome(t.Context(), &state, issue, 1, now, ""); outcome.dispatched || outcome.reason != dispatchSkipCompletionDeferred {
-					t.Fatalf("dispatch while completion deferred = %#v, want suppressed", outcome)
-				}
-				return
+			if receipt.Status != store.WorkAttemptStatusActive || receipt.Phase != deferredCompletionPhase || receipt.WaitReason != connector.TrackerUnavailableCondition || receipt.NextAction != deferredCompletionNextAction {
+				t.Fatalf("deferred work attempt = %#v, want active tracker wait", receipt)
 			}
-			if receipt.TerminalState != tt.wantTerminal {
-				t.Fatalf("terminal state = %q, want %q", receipt.TerminalState, tt.wantTerminal)
+			if strings.Contains(receipt.WorkerMetadataJSON, `"lane_revocation"`) || len(orch.pendingLaneRevocations) != 0 || len(tracker.comments) != 0 {
+				t.Fatalf("unreadable fence produced a revocation: %s", receipt.WorkerMetadataJSON)
 			}
-			if retry, ok := state.Retry[issue.ID]; ok && retry.CompletionDeferred {
-				t.Fatalf("Retry[%q] = %#v, want no completion deferral", issue.ID, retry)
+			if !strings.Contains(record.Availability.Message, tt.fenceErr.Error()) {
+				t.Fatalf("fence error = %q, want original error %v", record.Availability.Message, tt.fenceErr)
+			}
+			if record.Result.Output != "validated completion" || record.Result.Tokens.TotalTokens != 37 {
+				t.Fatalf("preserved result = %#v", record.Result)
+			}
+			snapshot := state.Snapshot(now)
+			if len(snapshot.Queue) != 1 || snapshot.Queue[0].QueueState != telemetry.QueueStateWaitingOnTracker {
+				t.Fatalf("snapshot queue = %#v, want waiting_on_tracker", snapshot.Queue)
+			}
+			if outcome := orch.dispatchIssueWithOutcome(t.Context(), &state, issue, 1, now, ""); outcome.dispatched || outcome.reason != dispatchSkipCompletionDeferred {
+				t.Fatalf("dispatch while completion deferred = %#v, want suppressed", outcome)
 			}
 		})
 	}
@@ -367,4 +358,80 @@ func openCompletionDeferralStoreWithoutCleanup(t *testing.T, path string) store.
 		t.Fatalf("store.Open() error = %v", err)
 	}
 	return runtimeStore
+}
+
+func TestCompletionFenceUnchangedOrUnknownLaneDefers(t *testing.T) {
+	t.Parallel()
+	for _, lane := range []string{"Blocked", "Done", ""} {
+		t.Run(lane, func(t *testing.T) {
+			now := time.Now().UTC()
+			issue := completionDeferralIssue("unchanged", lane)
+			cfg := completionDeferralConfig()
+			tracker := &completionDeferralConnector{issue: issue}
+			attempts := &recordingWorkAttemptStore{}
+			orch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, now: func() time.Time { return now }}
+			state := newState(cfg)
+			state.Running[issue.ID] = completionDeferralRunning(issue, 2297, now)
+			orch.handleRunResult(t.Context(), &state, completionDeferralEvent(issue, 2297, now))
+			if len(state.deferredCompletions) != 1 || len(orch.pendingLaneRevocations) != 0 || len(attempts.completions) != 0 || len(tracker.comments) != 0 {
+				t.Fatal("unchanged or unknown lane finalized as revoked")
+			}
+		})
+	}
+}
+
+func TestCompletionFenceRateLimitDeadlineSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name  string
+		after time.Duration
+		reset time.Duration
+		want  time.Duration
+	}{
+		{name: "reset", reset: time.Hour, want: time.Hour},
+		{name: "secondary backoff", after: 10 * time.Minute, want: 10 * time.Minute},
+		{name: "later reset", after: time.Minute, reset: time.Hour, want: time.Hour},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			issue := completionDeferralIssue("quota", "In Progress")
+			cfg := completionDeferralConfig()
+			tracker := &completionDeferralConnector{issue: issue, firstErr: &github.StatusError{Err: github.ErrRateLimited, StatusCode: 429, RetryAfter: tt.after, ResetAt: now.Add(tt.reset)}}
+			backend := openCompletionDeferralStore(t, filepath.Join(t.TempDir(), "detent.db"))
+			id := startCompletionDeferralAttempt(t, backend, issue, now)
+			orch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: backend, now: func() time.Time { return now }}
+			state := newState(cfg)
+			state.Running[issue.ID] = completionDeferralRunning(issue, id, now)
+			orch.handleRunResult(t.Context(), &state, completionDeferralEvent(issue, id, now))
+			recovered := newState(cfg)
+			orch.recoverDurableWorkAttempts(t.Context(), &recovered, now.Add(time.Second))
+			if got := recovered.Retry[issue.ID].DueAt; !got.Equal(now.Add(tt.want)) {
+				t.Fatalf("retry = %s, want %s", got, now.Add(tt.want))
+			}
+			orch.retryDeferredCompletions(t.Context(), &recovered, now.Add(tt.want-time.Second))
+			if tracker.fetchCount() != 1 {
+				t.Fatal("fence retried before quota recovered")
+			}
+		})
+	}
+}
+
+func TestCompletionFenceMissingLaneDefers(t *testing.T) {
+	t.Parallel()
+	for _, returnedID := range []string{"", "missing-lane"} {
+		t.Run(returnedID, func(t *testing.T) {
+			now := time.Now().UTC()
+			issue := completionDeferralIssue("missing-lane", "In Progress")
+			cfg := completionDeferralConfig()
+			tracker := &completionDeferralConnector{issue: connector.Issue{ID: returnedID}}
+			attempts := &recordingWorkAttemptStore{}
+			orch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, now: func() time.Time { return now }}
+			state := newState(cfg)
+			state.Running[issue.ID] = completionDeferralRunning(issue, 2297, now)
+			orch.handleRunResult(t.Context(), &state, completionDeferralEvent(issue, 2297, now))
+			if len(state.deferredCompletions) != 1 || len(attempts.completions) != 0 {
+				t.Fatal("missing tracker lane did not defer completion")
+			}
+		})
+	}
 }

--- a/internal/orchestrator/lane_mutation_test.go
+++ b/internal/orchestrator/lane_mutation_test.go
@@ -118,10 +118,22 @@ func TestLaneMutationReceiptDistinguishesEchoFromLaterReentry(t *testing.T) {
 				state.Running[issue.ID] = running
 			}
 			orch.reconcileRunningIssues(t.Context(), &state, observedAt)
-			if revoked := errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked); revoked != tt.later {
-				t.Fatalf("revoked = %v, want %v", revoked, tt.later)
+			if errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+				t.Fatal("unchanged lane timestamp revoked worker ownership")
+			}
+			if got := hasLaneRevocationEvent(state.RecentEvents, "lane_revocation_unverified"); got != tt.later {
+				t.Fatalf("unverified reentry = %v, want %v", got, tt.later)
 			}
 			if tt.later {
+				parked.State = "Blocked"
+				tracker.stateIssues = []connector.Issue{parked}
+				if tt.project {
+					orch.connector.(*workflowMetricsConnector).stateIssues = []connector.Issue{parked}
+				}
+				orch.reconcileRunningIssues(t.Context(), &state, observedAt.Add(max(cfg.PollInterval, defaultRunningReconcileInterval)))
+				if !errors.Is(context.Cause(runCtx), runpkg.ErrLaneRevoked) {
+					t.Fatal("verified subsequent lane change did not revoke worker")
+				}
 				pending := orch.pendingLaneRevocations[issue.ID]
 				if pending == nil || pending.origin != provenance.OriginIndeterminate || pending.mutation.ID != 0 {
 					t.Fatalf("later shared-token change borrowed previous Detent attribution: %#v", pending)

--- a/internal/orchestrator/lane_preservation_test.go
+++ b/internal/orchestrator/lane_preservation_test.go
@@ -44,11 +44,14 @@ func TestLaneRevocationRetainsWorkspaceForEveryWriter(t *testing.T) {
 			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{parked}}
 			attempts := &recordingWorkAttemptStore{}
 			retention := &laneRetentionProbe{t: t, result: workspace.Preservation{
-				Path: "/retained/workspace", Branch: "detent/2138", HeadSHA: "abc123", Preserved: true,
+				Path: "/retained/workspace", Branch: "detent/2138", HeadSHA: "abc123", Preserved: true, LocalChangesVerified: true,
 				UnpushedCommits: 1, TrackedPaths: []string{"implementation.go"},
 			}}
+			if tt.pushed {
+				retention.result.Delivery = &workspace.DeliverableState{CommitsAhead: 1, Remote: "origin", RemoteRef: "refs/heads/detent/2138", LocalHeadSHA: "abc123", RemoteHeadSHA: "abc123", RemoteBranchExists: true}
+			}
 			if tt.filesystem {
-				retention.result = workspace.Preservation{Path: "/retained/workspace", Preserved: true, Files: 1}
+				retention.result = workspace.Preservation{Path: "/retained/workspace", Preserved: true, LocalChangesVerified: true, Files: 1}
 			}
 			cfg := laneMutationTestConfig()
 			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, reaper: retention,
@@ -121,14 +124,14 @@ func TestLaneRevocationRetriesFailedRetentionBeforeReleasingOwnership(t *testing
 	running := Running{Issue: issue, WorkAttemptID: 2138, Generation: 38}
 	state.Running[issue.ID] = running
 	state.Claimed[issue.ID] = Claimed{Issue: issue}
-	pending := &pendingLaneRevocation{issue: issue, running: running, reapDone: true, mutationRead: true,
+	pending := &pendingLaneRevocation{issue: issue, running: running, fromState: "In Progress", toState: "Blocked", reapDone: true, mutationRead: true,
 		completion: &runpkg.Completion{IssueID: issue.ID, CompletedAt: now}}
 	orch.pendingLaneRevocations = map[string]*pendingLaneRevocation{issue.ID: pending}
 	orch.finishLaneRevocation(t.Context(), &state, pending)
 	if len(attempts.completions) != 0 || len(state.Running) != 1 || len(state.Claimed) != 1 {
 		t.Fatal("failed retention released durable ownership")
 	}
-	retention.result = workspace.Preservation{Path: "/retained/retry", Preserved: true, UnpushedCommits: 1}
+	retention.result = workspace.Preservation{Path: "/retained/retry", Preserved: true, LocalChangesVerified: true, UnpushedCommits: 1}
 	retention.err = nil
 	orch.finishLaneRevocation(t.Context(), &state, pending)
 	if len(attempts.completions) != 1 || len(state.Running) != 0 || len(state.Claimed) != 0 || retention.preserveCalls != 2 {
@@ -160,4 +163,46 @@ func (p *laneRetentionProbe) ReapWorkspace(context.Context, connector.Issue) (Wo
 	}
 	p.reapCalls++
 	return WorkspaceReapResult{}, workspace.ErrWorkspacePreserved
+}
+
+func TestLaneRevocationRequiresVerifiedWork(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		preservation *workspace.Preservation
+		pushed       bool
+		want         string
+	}{
+		{name: "output alone", want: laneRevocationUnverifiedClassification},
+		{name: "clean base", preservation: &workspace.Preservation{Preserved: true, LocalChangesVerified: true, HeadSHA: "base"}, want: laneRevocationEmptyClassification},
+		{name: "clean base with push signal", pushed: true, preservation: &workspace.Preservation{Preserved: true, LocalChangesVerified: true, HeadSHA: "base"}, want: laneRevocationEmptyClassification},
+		{name: "dirty files", preservation: &workspace.Preservation{Preserved: true, LocalChangesVerified: true, TrackedPaths: []string{"main.go"}}, want: laneRevocationPreservedClassification},
+		{name: "local commits", preservation: &workspace.Preservation{Preserved: true, LocalChangesVerified: true, UnpushedCommits: 1}, want: laneRevocationPreservedClassification},
+		{name: "failed local inspection", preservation: &workspace.Preservation{Preserved: true, HeadSHA: "base"}, want: laneRevocationUnverifiedClassification},
+		{name: "push signal only", pushed: true, want: laneRevocationUnverifiedClassification},
+		{name: "verified push", pushed: true, preservation: &workspace.Preservation{Preserved: true, LocalChangesVerified: true, Delivery: &workspace.DeliverableState{RemoteBranchExists: true, CommitsAhead: 1, Remote: "origin", RemoteRef: "refs/heads/worker", LocalHeadSHA: "work", RemoteHeadSHA: "work"}}, want: laneRevocationDeliveredClassification},
+		{name: "base pushed", pushed: true, preservation: &workspace.Preservation{Preserved: true, LocalChangesVerified: true, Delivery: &workspace.DeliverableState{RemoteBranchExists: true, Remote: "origin", RemoteRef: "refs/heads/worker", LocalHeadSHA: "base", RemoteHeadSHA: "base"}}, want: laneRevocationEmptyClassification},
+		{name: "different remote head", pushed: true, preservation: &workspace.Preservation{Preserved: true, LocalChangesVerified: true, UnpushedCommits: 1, Delivery: &workspace.DeliverableState{RemoteBranchExists: true, CommitsAhead: 1, Remote: "origin", RemoteRef: "refs/heads/worker", LocalHeadSHA: "work", RemoteHeadSHA: "old"}}, want: laneRevocationPreservedClassification},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			running := Running{WorkProductPushed: tt.pushed}
+			event := runpkg.Completion{Result: runpkg.RunResult{TurnStarted: true, Output: "completed", Tokens: TokenTotals{TotalTokens: 100}}}
+			receipt := laneRevocationReceipt(event, running, tt.preservation, time.Now())
+			outcome := classifyLaneRevocation(receipt, tt.preservation, true, laneRevocationDetentStateChanged, provenance.OriginDetent)
+			if outcome.classification != tt.want {
+				t.Fatalf("classification = %s, want %s", outcome.classification, tt.want)
+			}
+			if !outcome.comment {
+				return
+			}
+			pending := &pendingLaneRevocation{fromState: "In Progress", toState: "Blocked", reason: laneRevocationDetentStateChanged, origin: provenance.OriginDetent}
+			body := laneRevocationOutcomeComment(pending, event, running, event.Result.Tokens, outcome)
+			if !strings.Contains(body, "verified detent lane change from In Progress to Blocked") || strings.Contains(body, "the tracker moved") {
+				t.Fatalf("misleading provenance: %s", body)
+			}
+			if strings.Contains(body, "work was pushed") != (tt.want == laneRevocationDeliveredClassification) {
+				t.Fatalf("unverified delivery claim: %s", body)
+			}
+		})
+	}
 }

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -31,12 +31,15 @@ const (
 )
 
 type laneRevocationDeliveryReceipt struct {
-	Schema     int       `json:"schema"`
-	Kind       string    `json:"kind"`
-	RecordedAt time.Time `json:"recorded_at"`
-	Source     string    `json:"source"`
-	PRNumber   int       `json:"pr_number,omitempty"`
-	PRHeadSHA  string    `json:"pr_head_sha,omitempty"`
+	Schema        int       `json:"schema"`
+	Kind          string    `json:"kind"`
+	RecordedAt    time.Time `json:"recorded_at"`
+	Source        string    `json:"source"`
+	PRNumber      int       `json:"pr_number,omitempty"`
+	PRHeadSHA     string    `json:"pr_head_sha,omitempty"`
+	Remote        string    `json:"remote"`
+	RemoteRef     string    `json:"remote_ref"`
+	RemoteHeadSHA string    `json:"remote_head_sha"`
 }
 
 type laneRevocationOutcome struct {
@@ -72,6 +75,17 @@ type pendingLaneRevocation struct {
 	preservation     *workspace.Preservation
 	preservationRead bool
 	preservationErr  error
+}
+
+func laneRevocationTransitionError(fromState, toState string) error {
+	fromState, toState = strings.TrimSpace(fromState), strings.TrimSpace(toState)
+	if fromState == "" || toState == "" {
+		return errors.New("lane change cannot be verified: before or after lane is unknown")
+	}
+	if strings.EqualFold(fromState, toState) {
+		return fmt.Errorf("lane unchanged at %s; completion fence requires a verified transition", fromState)
+	}
+	return nil
 }
 
 func (o *Orchestrator) beginLaneRevocation(
@@ -133,6 +147,10 @@ func (o *Orchestrator) beginLaneRevocationWithMutation(
 		fromState = strings.TrimSpace(receipt.FromState)
 		attribution = provenance.AttributionFromSource(provenance.SourceDetentInstance, provenance.Actor{})
 		reason = strings.TrimSpace(receipt.Reason)
+	}
+	if err := laneRevocationTransitionError(fromState, refreshed.State); err != nil {
+		recordStateEvent(state, telemetry.ActivityEvent{At: now, Event: "lane_revocation_unverified", Message: err.Error()})
+		return
 	}
 	running.Issue = mergeIssueTrackerFields(running.Issue, refreshed)
 	reason = laneRevocationReason(reason, attribution)
@@ -279,6 +297,11 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 	if pending == nil || pending.completion == nil || !pending.reapDone || !pending.mutationRead {
 		return
 	}
+	if err := laneRevocationTransitionError(pending.fromState, pending.toState); err != nil {
+		delete(o.pendingLaneRevocations, pending.issue.ID)
+		o.deferTrackerUnavailableCompletion(ctx, state, *pending.completion, pending.running, err)
+		return
+	}
 	event := *pending.completion
 	running := pending.running
 	running.Issue = cloneIssue(pending.issue)
@@ -305,7 +328,7 @@ func (o *Orchestrator) finishLaneRevocation(ctx context.Context, state *State, p
 	}
 	running.Tokens = tokens
 	running.WorkProductPushed = running.WorkProductPushed || event.Result.PullRequestHeadPushed || event.Result.PullRequestUpdated
-	receipt := laneRevocationReceipt(event, running, completedAt)
+	receipt := laneRevocationReceipt(event, running, pending.preservation, completedAt)
 	workProduced := laneRevocationProducedWork(event, running, tokens) || laneRevocationLocalWork(pending.preservation)
 	outcome := classifyLaneRevocation(receipt, pending.preservation, workProduced, pending.reason, pending.origin)
 	metadata := map[string]any{"lane_revocation": map[string]any{
@@ -441,7 +464,7 @@ func (o *Orchestrator) preserveLaneRevocationWorkspace(ctx context.Context, stat
 }
 
 func laneRevocationLocalWork(preservation *workspace.Preservation) bool {
-	return preservation != nil && (preservation.Files > 0 || preservation.UnpushedCommits > 0 || len(preservation.TrackedPaths) > 0 || len(preservation.UntrackedPaths) > 0)
+	return preservation != nil && preservation.LocalChangesVerified && (preservation.Files > 0 || preservation.UnpushedCommits > 0 || len(preservation.TrackedPaths) > 0 || len(preservation.UntrackedPaths) > 0)
 }
 
 func laneRevocationAttribution(state *State, issue connector.Issue) provenance.Attribution {
@@ -473,8 +496,14 @@ func laneRevocationErrorClass(reason string, origin provenance.Origin) string {
 	return string(store.WorkAttemptTerminalLaneRevoked)
 }
 
-func laneRevocationReceipt(event runpkg.Completion, running Running, completedAt time.Time) *laneRevocationDeliveryReceipt {
-	if !running.WorkProductPushed {
+func laneRevocationReceipt(event runpkg.Completion, running Running, preservation *workspace.Preservation, completedAt time.Time) *laneRevocationDeliveryReceipt {
+	if !running.WorkProductPushed || preservation == nil || preservation.Delivery == nil {
+		return nil
+	}
+	delivery := preservation.Delivery
+	if !delivery.RemoteBranchExists || delivery.CommitsAhead <= 0 || strings.TrimSpace(delivery.Remote) == "" ||
+		strings.TrimSpace(delivery.RemoteRef) == "" || strings.TrimSpace(delivery.RemoteHeadSHA) == "" ||
+		delivery.LocalHeadSHA != delivery.RemoteHeadSHA {
 		return nil
 	}
 	source := "work_attempt"
@@ -482,10 +511,13 @@ func laneRevocationReceipt(event runpkg.Completion, running Running, completedAt
 		source = "runner_result"
 	}
 	receipt := &laneRevocationDeliveryReceipt{
-		Schema:     1,
-		Kind:       laneRevocationDeliveryReceiptKind,
-		RecordedAt: completedAt,
-		Source:     source,
+		Schema:        1,
+		Kind:          laneRevocationDeliveryReceiptKind,
+		RecordedAt:    completedAt,
+		Source:        source,
+		Remote:        delivery.Remote,
+		RemoteRef:     delivery.RemoteRef,
+		RemoteHeadSHA: delivery.RemoteHeadSHA,
 	}
 	if running.Issue.PullRequest != nil {
 		receipt.PRNumber = running.Issue.PullRequest.Number
@@ -495,7 +527,8 @@ func laneRevocationReceipt(event runpkg.Completion, running Running, completedAt
 }
 
 func classifyLaneRevocation(receipt *laneRevocationDeliveryReceipt, preservation *workspace.Preservation, workProduced bool, reason string, origin provenance.Origin) laneRevocationOutcome {
-	if receipt != nil && receipt.Schema == 1 && receipt.Kind == laneRevocationDeliveryReceiptKind {
+	if receipt != nil && receipt.Schema == 1 && receipt.Kind == laneRevocationDeliveryReceiptKind &&
+		strings.TrimSpace(receipt.Remote) != "" && strings.TrimSpace(receipt.RemoteRef) != "" && strings.TrimSpace(receipt.RemoteHeadSHA) != "" {
 		return laneRevocationOutcome{
 			classification:    laneRevocationDeliveredClassification,
 			terminalState:     store.WorkAttemptTerminalDelivered,
@@ -516,12 +549,13 @@ func classifyLaneRevocation(receipt *laneRevocationDeliveryReceipt, preservation
 		statusMessage:     "worker stopped after leaving a worker-owned lane",
 		activityEvent:     "worker_lane_revoked",
 	}
-	if workProduced {
+	localWork := laneRevocationLocalWork(preservation)
+	if localWork || workProduced && (preservation == nil || !preservation.LocalChangesVerified) {
 		outcome.classification = laneRevocationUnverifiedClassification
 		outcome.activityEvent = "worker_lane_preservation_unverified"
 		outcome.statusMessage = "worker stopped; workspace preservation could not be verified"
 		outcome.comment = true
-		if preservation != nil && preservation.Preserved {
+		if localWork && preservation.Preserved {
 			outcome.classification = laneRevocationPreservedClassification
 			outcome.activityEvent = "worker_lane_workspace_preserved"
 			outcome.statusMessage = "worker stopped; local workspace retained for recovery"
@@ -590,14 +624,21 @@ func laneRevocationOutcomeComment(
 	outcome laneRevocationOutcome,
 ) string {
 	var b strings.Builder
+	b.WriteString("Detent stopped this worker after a verified ")
+	b.WriteString(string(provenance.NormalizeOrigin(pending.origin)))
+	b.WriteString(" lane change from ")
+	b.WriteString(pending.fromState)
+	b.WriteString(" to ")
+	b.WriteString(pending.toState)
+	b.WriteString(". ")
 	if outcome.terminalState == store.WorkAttemptTerminalDelivered {
-		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. Your work was pushed but finalization was rejected; the pushed work remains available.")
+		b.WriteString("Your work was pushed but finalization was rejected; the pushed work remains available.")
 		b.WriteString("\n\n- reason: worker_lane_revocation_delivery_preserved")
 	} else if outcome.classification == laneRevocationPreservedClassification {
-		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. The local workspace is retained for recovery, including unpushed commits and uncommitted files. Finalization was rejected; the work has not been delivered.")
+		b.WriteString("The local workspace is retained for recovery, including unpushed commits and uncommitted files. Finalization was rejected; the work has not been delivered.")
 		b.WriteString("\n\n- reason: worker_lane_revocation_workspace_preserved")
 	} else {
-		b.WriteString("Detent stopped this worker after the tracker moved the issue out of a worker-owned lane. Workspace preservation could not be verified. The session's output is not evidence that local work was discarded.")
+		b.WriteString("Workspace preservation could not be verified. The session's output is not evidence that local work was discarded.")
 		b.WriteString("\n\n- reason: worker_lane_revocation_preservation_unverified")
 	}
 	b.WriteString("\n- classification: ")
@@ -711,6 +752,9 @@ func (o *Orchestrator) refreshCompletionLane(ctx context.Context, running Runnin
 	}
 	for _, issue := range issues {
 		if strings.TrimSpace(issue.ID) == strings.TrimSpace(running.Issue.ID) {
+			if strings.TrimSpace(issue.State) == "" {
+				return connector.Issue{}, fmt.Errorf("issue %s has no lane in completion fence", issueLabel(running.Issue))
+			}
 			return mergeIssueTrackerFields(running.Issue, issue), nil
 		}
 	}

--- a/internal/orchestrator/lane_revocation_test.go
+++ b/internal/orchestrator/lane_revocation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
 func TestLaneRevocationPreservesTrackerDestination(t *testing.T) {
@@ -145,6 +146,7 @@ func TestLaneRevocationPreservesPushedWork(t *testing.T) {
 	orch := &Orchestrator{
 		cfg:                    cfg,
 		connector:              tracker,
+		reaper:                 &laneRetentionProbe{t: t, result: workspace.Preservation{Preserved: true, LocalChangesVerified: true, Delivery: &workspace.DeliverableState{CommitsAhead: 1, Remote: "origin", RemoteRef: "refs/heads/detent/1998", LocalHeadSHA: "abc123", RemoteHeadSHA: "abc123", RemoteBranchExists: true}}},
 		workAttempts:           attempts,
 		pendingLaneRevocations: map[string]*pendingLaneRevocation{},
 		logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -278,7 +280,7 @@ func TestClassifyLaneRevocationDrivesAllOutcomeSurfaces(t *testing.T) {
 	}{
 		{
 			name:         "pushed work with rejected finalization",
-			receipt:      &laneRevocationDeliveryReceipt{Schema: 1, Kind: laneRevocationDeliveryReceiptKind},
+			receipt:      &laneRevocationDeliveryReceipt{Schema: 1, Kind: laneRevocationDeliveryReceiptKind, Remote: "origin", RemoteRef: "refs/heads/detent/1998", RemoteHeadSHA: "abc123"},
 			workProduced: true,
 			wantClass:    laneRevocationDeliveredClassification,
 			wantTerminal: store.WorkAttemptTerminalDelivered,

--- a/internal/orchestrator/merge_duration_test.go
+++ b/internal/orchestrator/merge_duration_test.go
@@ -429,6 +429,12 @@ func TestMergeWorkerDurationCeilingHonorsLatestTerminalState(t *testing.T) {
 			if _, ok := state.Blocked[issue.ID]; ok {
 				t.Fatalf("Blocked[%q] present after latest state became terminal", issue.ID)
 			}
+			if tt.name == "pull request merged" {
+				if len(state.deferredCompletions) != 1 || len(orch.pendingLaneRevocations) != 0 {
+					t.Fatal("PR-only terminal evidence must defer until the lane changes")
+				}
+				return
+			}
 			if _, ok := state.Completed[issue.ID]; !ok {
 				t.Fatalf("Completed[%q] missing after latest state became terminal", issue.ID)
 			}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -97,14 +97,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		refreshed, err := o.refreshCompletionLane(ctx, running)
 		if err != nil {
 			if !errors.Is(event.Err, runpkg.ErrWorkerGitHubBudgetMonitor) && !errors.Is(event.Err, runpkg.ErrWorkerGitHubTokenResolution) {
-				availabilityErr, unavailable := connector.AsTrackerAvailability(err)
-				if unavailable && availabilityErr != nil {
-					o.deferTrackerUnavailableCompletion(ctx, state, event, running, availabilityErr)
-					return
-				}
-				o.rejectWorkerCompletion(ctx, state, event, running, laneRevocationCompletionFenceUnavailable, err)
-				o.beginLaneRevocation(ctx, state, running, running.Issue, event.CompletedAt, laneRevocationCompletionFenceUnavailable)
-				o.handleLaneRevocationCompletion(ctx, state, event, running)
+				o.deferTrackerUnavailableCompletion(ctx, state, event, running, err)
 				return
 			}
 			if o.logger != nil {
@@ -114,14 +107,20 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			receiptAccepted := false
 			receipt, receiptFound, receiptErr := o.laneMutationReceipt(ctx, running, refreshed)
 			if receiptErr != nil {
-				o.rejectWorkerCompletion(ctx, state, event, running, "lane mutation receipt is unavailable", receiptErr)
+				o.deferTrackerUnavailableCompletion(ctx, state, event, running, fmt.Errorf("lane mutation receipt is unavailable: %w", receiptErr))
 				return
 			}
 			if receiptFound {
+				if receipt.Disposition == laneMutationRevokeWorker {
+					if err := laneRevocationTransitionError(receipt.FromState, refreshed.State); err != nil {
+						o.deferTrackerUnavailableCompletion(ctx, state, event, beforeRefresh, err)
+						return
+					}
+				}
 				running.laneMutation = receipt
 				consumed, consumeErr := o.consumeLaneMutationReceipt(ctx, receipt, running, refreshed.State, event.CompletedAt)
 				if consumeErr != nil {
-					o.rejectWorkerCompletion(ctx, state, event, running, "lane mutation receipt could not be consumed", consumeErr)
+					o.deferTrackerUnavailableCompletion(ctx, state, event, running, fmt.Errorf("lane mutation receipt could not be consumed: %w", consumeErr))
 					return
 				}
 				receipt = consumed
@@ -153,6 +152,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 				if accepted, ok := o.acceptCurrentAttemptCompletionLane(ctx, state, running, refreshed, event.CompletedAt); ok {
 					running = accepted
 				} else {
+					if err := laneRevocationTransitionError(beforeRefresh.Issue.State, refreshed.State); err != nil {
+						o.deferTrackerUnavailableCompletion(ctx, state, event, beforeRefresh, err)
+						return
+					}
 					o.rejectWorkerCompletion(ctx, state, event, running, "current tracker lane is not worker-owned", nil)
 					o.beginLaneRevocation(ctx, state, beforeRefresh, refreshed, event.CompletedAt, laneRevocationStateChanged)
 					o.handleLaneRevocationCompletion(ctx, state, event, beforeRefresh)

--- a/internal/store/migrations/00055_flag_completion_fence_revocations.sql
+++ b/internal/store/migrations/00055_flag_completion_fence_revocations.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+UPDATE work_attempts
+SET worker_metadata_json = json_set(
+      CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+      '$.historical_completion_fence',
+      json_object(
+        'schema', 1,
+        'migration', 55,
+        'reason', 'completion_fence_unavailable',
+        'excluded_from_worker_outcomes', json('true'),
+        'original_worker_metadata_json', worker_metadata_json
+      )
+    )
+WHERE status = 'terminal'
+  AND completed_at IS NOT NULL
+  AND (
+    lower(trim(COALESCE(error_message, ''))) = 'completion_fence_unavailable'
+    OR lower(trim(COALESCE(json_extract(
+      CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+      '$.lane_revocation.reason'
+    ), ''))) = 'completion_fence_unavailable'
+    OR lower(trim(COALESCE(json_extract(
+      CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+      '$.historical_lane_revocation.original_error_message'
+    ), ''))) = 'completion_fence_unavailable'
+    OR lower(trim(COALESCE(json_extract(
+      CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+      '$.lane_revocation_receipt_backfill.original_error_message'
+    ), ''))) = 'completion_fence_unavailable'
+  );
+
+-- +goose Down
+UPDATE work_attempts
+SET worker_metadata_json = json_extract(worker_metadata_json, '$.historical_completion_fence.original_worker_metadata_json')
+WHERE json_extract(
+  CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END,
+  '$.historical_completion_fence.migration'
+) = 55;

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -206,6 +206,11 @@ WITH issue_sessions AS (
   FROM codex_sessions
   WHERE started_at IS NOT NULL
     AND completed_at IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM work_attempts AS attempt
+      WHERE attempt.id = codex_sessions.work_attempt_id
+        AND (attempt.phase = 'completion_deferred' OR NOT (COALESCE(json_extract(CASE WHEN json_valid(attempt.worker_metadata_json) THEN attempt.worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0))
+    )
 ),
 successful_issues AS (
   SELECT
@@ -1500,6 +1505,7 @@ FROM work_attempts
 WHERE completed_at >= ?1
   AND completed_at < ?2
   AND lower(trim(COALESCE(terminal_state, ''))) IN ('failure', 'timed_out', 'no_progress', 'capacity')
+  AND COALESCE(json_extract(CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0
 GROUP BY COALESCE(NULLIF(trim(error_class), ''), 'unknown')
 ORDER BY failures DESC, error_class
 LIMIT 1
@@ -2351,6 +2357,8 @@ LEFT JOIN work_attempts AS attempt ON attempt.id = session.work_attempt_id
 WHERE usage_events.project_id = ?1
   AND usage_events.started_at > ?2
   AND lower(trim(COALESCE(attempt.terminal_state, ''))) != 'capacity'
+  AND COALESCE(attempt.phase, '') != 'completion_deferred'
+  AND COALESCE(json_extract(CASE WHEN json_valid(attempt.worker_metadata_json) THEN attempt.worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0
   AND (
     (?3 != '' AND COALESCE(usage_events.issue_id, '') = ?3)
     OR (?4 != '' AND COALESCE(usage_events.identifier, '') = ?4)
@@ -3978,6 +3986,7 @@ SELECT id, project_id, issue_id, identifier, issue_url, pr_number, repo, worker_
 FROM work_attempts
 WHERE completed_at IS NOT NULL
   AND status = 'terminal'
+  AND COALESCE(json_extract(CASE WHEN json_valid(worker_metadata_json) THEN worker_metadata_json ELSE '{}' END, '$.historical_completion_fence.excluded_from_worker_outcomes'), 0) = 0
   AND (?1 = '' OR project_id = ?1)
   AND (?2 = '' OR worker_type = ?2)
   AND (

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3611,3 +3611,124 @@ func tableIdentifier(t *testing.T, table string) string {
 		return ""
 	}
 }
+
+func TestCompletionFenceRevocationMigrationAndAccounting(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "detent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := configureSQLite(ctx, db, 0); err != nil {
+		t.Fatal(err)
+	}
+	migrationMu.Lock()
+	defer migrationMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	defer goose.SetBaseFS(nil)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatal(err)
+	}
+	if err := goose.UpToContext(ctx, db, "migrations", 54); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name, terminal, message, metadata string
+		flagged, active                   bool
+	}{
+		{name: "legacy error", terminal: "lane_revoked", message: "completion_fence_unavailable", metadata: `{}`, flagged: true},
+		{name: "delivered metadata", terminal: "delivered", metadata: `{"lane_revocation":{"reason":"completion_fence_unavailable"},"delivery_receipt":{"schema":1,"kind":"pushed_work_product"}}`, flagged: true},
+		{name: "revoked metadata", terminal: "lane_revoked", metadata: `{"lane_revocation":{"reason":"completion_fence_unavailable"}}`, flagged: true},
+		{name: "earlier migration", terminal: "delivered", metadata: `{"historical_lane_revocation":{"original_error_message":"completion_fence_unavailable"}}`, flagged: true},
+		{name: "receipt backfill", terminal: "delivered", metadata: `{"lane_revocation_receipt_backfill":{"original_error_message":"completion_fence_unavailable"}}`, flagged: true},
+		{name: "malformed legacy metadata", terminal: "lane_revoked", message: "completion_fence_unavailable", metadata: `{broken`, flagged: true},
+		{name: "verified lane change", terminal: "lane_revoked", message: "tracker_lane_changed", metadata: `{}`},
+		{name: "ordinary success", terminal: "success", metadata: `{}`},
+		{name: "active completion wait", metadata: `{}`, active: true},
+	}
+	for i, tc := range cases {
+		status, phase := "terminal", "lane_revoked"
+		var completed any = "2026-09-07T11:00:00Z"
+		if tc.active {
+			status, phase, completed = "active", "completion_deferred", nil
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO work_attempts
+		(id, project_id, issue_id, worker_type, status, started_at, completed_at, terminal_state, error_message, phase, worker_metadata_json)
+		VALUES (?, 'detent', 'issue', 'implementation', ?, '2026-09-07T10:00:00Z', ?, ?, ?, ?, ?)`, i+1, status, completed, tc.terminal, tc.message, phase, tc.metadata); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO codex_sessions (id, work_attempt_id, project_id, issue_id, started_at, completed_at, final_state)
+		VALUES (?, ?, 'detent', 'issue', '2026-09-07T10:00:00Z', '2026-09-07T11:00:00Z', 'completed')`, i+1, i+1); err != nil {
+			t.Fatal(err)
+		}
+	}
+	backend := &sqliteStore{db: db, queries: sqlc.New(db)}
+	startedAt := time.Date(2026, 9, 7, 10, 0, 0, 0, time.UTC)
+	for i := range cases {
+		if _, err := backend.RecordUsageEvent(ctx, UsageEvent{ProjectID: "detent", IssueID: "issue", SessionID: int64(i + 1), CostUSD: 50, TotalTokens: 5000, StartedAt: startedAt, FinishedAt: startedAt.Add(time.Hour), Outcome: "completed"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := goose.UpToContext(ctx, db, "migrations", 55); err != nil {
+		t.Fatal(err)
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var metadata string
+			if err := db.QueryRowContext(ctx, "SELECT worker_metadata_json FROM work_attempts WHERE id = ?", i+1).Scan(&metadata); err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Contains(metadata, `"historical_completion_fence"`); got != tc.flagged {
+				t.Fatalf("metadata = %s, flagged = %v", metadata, tc.flagged)
+			}
+		})
+	}
+	spend, err := backend.IssueSpendSince(ctx, IssueSpendSinceQuery{ProjectID: "detent", IssueID: "issue", Since: startedAt.Add(-time.Second)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spend.CostUSD != 100 || spend.TotalTokens != 10000 || spend.Sessions != 2 {
+		t.Fatalf("progress spend = %#v, want only ordinary attempts", spend)
+	}
+	history, err := backend.ListRecentTerminalWorkAttempts(ctx, WorkAttemptHistoryQuery{ProjectID: "detent", IssueID: "issue"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("progress history = %#v, want two ordinary attempts", history)
+	}
+	cycles, err := backend.CycleTimeReport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cycles.Issues) != 1 || cycles.Issues[0].Sessions != 2 {
+		t.Fatalf("completed cycles = %#v", cycles)
+	}
+	costs, err := backend.BudgetCostEvents(ctx, BudgetCostQuery{ProjectIDs: []string{"detent"}, From: startedAt.Add(-time.Second), To: startedAt.Add(2 * time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(costs) != len(cases) {
+		t.Fatalf("billing events = %d, want %d", len(costs), len(cases))
+	}
+	if got := queryInt(t, db, "SELECT COUNT(*) FROM codex_sessions WHERE final_state = 'completed'"); got != int64(len(cases)) {
+		t.Fatal("migration rewrote session history")
+	}
+	if err := goose.DownToContext(ctx, db, "migrations", 54); err != nil {
+		t.Fatal(err)
+	}
+	for i, tc := range cases {
+		var metadata string
+		if err := db.QueryRowContext(ctx, "SELECT worker_metadata_json FROM work_attempts WHERE id = ?", i+1).Scan(&metadata); err != nil {
+			t.Fatal(err)
+		}
+		if metadata != tc.metadata {
+			t.Fatalf("restored metadata = %s, want %s", metadata, tc.metadata)
+		}
+	}
+}

--- a/internal/workspace/preservation.go
+++ b/internal/workspace/preservation.go
@@ -14,14 +14,17 @@ import (
 var ErrWorkspacePreserved = errors.New("workspace retained for recovery")
 
 type Preservation struct {
-	Path            string   `json:"path"`
-	Branch          string   `json:"branch,omitempty"`
-	Preserved       bool     `json:"preserved"`
-	Files           int      `json:"files,omitempty"`
-	HeadSHA         string   `json:"head_sha,omitempty"`
-	UnpushedCommits int      `json:"unpushed_commits,omitempty"`
-	TrackedPaths    []string `json:"tracked_paths,omitempty"`
-	UntrackedPaths  []string `json:"untracked_paths,omitempty"`
+	LocalChangesVerified bool              `json:"local_changes_verified"`
+	Delivery             *DeliverableState `json:"delivery,omitempty"`
+	DeliveryError        string            `json:"delivery_error,omitempty"`
+	Path                 string            `json:"path"`
+	Branch               string            `json:"branch,omitempty"`
+	Preserved            bool              `json:"preserved"`
+	Files                int               `json:"files,omitempty"`
+	HeadSHA              string            `json:"head_sha,omitempty"`
+	UnpushedCommits      int               `json:"unpushed_commits,omitempty"`
+	TrackedPaths         []string          `json:"tracked_paths,omitempty"`
+	UntrackedPaths       []string          `json:"untracked_paths,omitempty"`
 }
 
 type IssuePreserver interface {
@@ -64,6 +67,13 @@ func (l *LocalGit) PreserveIssue(ctx context.Context, issue Issue) (Preservation
 	}
 	result.TrackedPaths = recovery.TrackedPaths
 	result.UntrackedPaths = recovery.UntrackedPaths
+	result.LocalChangesVerified = true
+	delivery, err := gitDeliveryState(ctx, info.Path, info.Branch, issue.BaseRef)
+	if err != nil {
+		result.DeliveryError = err.Error()
+	} else {
+		result.Delivery = &delivery
+	}
 	return result, nil
 }
 
@@ -184,6 +194,7 @@ func (f *Filesystem) PreserveIssue(ctx context.Context, issue Issue) (Preservati
 		return result, fmt.Errorf("inspect retained filesystem workspace: %w", err)
 	}
 	result.Files = stat.Files
+	result.LocalChangesVerified = true
 	return result, nil
 }
 

--- a/internal/workspace/preservation_test.go
+++ b/internal/workspace/preservation_test.go
@@ -236,6 +236,61 @@ func TestLocalGitPreservesRevokedWorkAcrossCleanupAndRestart(t *testing.T) {
 	}
 }
 
+func TestLocalGitPreservationVerifiesWorkEvidence(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"clean base", "dirty", "local commit", "pushed commit", "base branch pushed", "remote branch deleted"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			remote := initBareRemote(t)
+			runGit(t, source, "remote", "add", "origin", remote)
+			runGit(t, source, "push", "-u", "origin", "main")
+			base := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+			backend, err := NewLocalGit(LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := Issue{Identifier: "evidence", BaseRef: base}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changed := kind == "dirty" || kind == "local commit" || kind == "pushed commit" || kind == "remote branch deleted"
+			if changed {
+				if err := os.WriteFile(filepath.Join(info.Path, "README.md"), []byte("worker implementation\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if kind != "dirty" {
+					runGit(t, info.Path, "add", "README.md")
+					runGit(t, info.Path, "commit", "-m", "implement change")
+				}
+			}
+			if kind == "pushed commit" || kind == "base branch pushed" || kind == "remote branch deleted" {
+				runGit(t, info.Path, "push", "origin", info.Branch)
+			}
+			if kind == "remote branch deleted" {
+				runGit(t, remote, "update-ref", "-d", "refs/heads/"+info.Branch)
+			}
+			preserved, err := backend.PreserveIssue(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !preserved.LocalChangesVerified {
+				t.Fatalf("unverified local evidence: %#v", preserved)
+			}
+			localWork := preserved.UnpushedCommits > 0 || len(preserved.TrackedPaths) > 0 || len(preserved.UntrackedPaths) > 0
+			if localWork != (kind == "dirty" || kind == "local commit") {
+				t.Fatalf("local evidence = %#v", preserved)
+			}
+			delivery := preserved.Delivery
+			delivered := delivery != nil && delivery.RemoteBranchExists && delivery.CommitsAhead > 0 && delivery.LocalHeadSHA == delivery.RemoteHeadSHA
+			if delivered != (kind == "pushed commit") {
+				t.Fatalf("delivery evidence = %#v", preserved)
+			}
+		})
+	}
+}
+
 func TestLocalGitPreservationInspectionFailureKeepsFiles(t *testing.T) {
 	t.Parallel()
 	backend, err := NewLocalGit(LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: initSourceRepo(t), AutoBranch: true})


### PR DESCRIPTION
## Summary

- Defer completed results for every unreadable completion fence, retain attempt ownership across restart, and honor known quota reset/backoff deadlines. Missing or unchanged lanes cannot produce a revocation; a later verified lane change still can.
- Require verified local changes for unpushed-work preservation and a matching remote branch with commits ahead of base for delivery claims. Revocation comments identify the observed transition and its recorded origin.
- Flag historical fence revocations and exclude them from progress history, spend-breaker inputs, and completed-cycle calculations while preserving billing and original audit records. Active completion waits also stop charging no-progress spend.

Fixes #2297

## UI Surface Contract

- [x] N/A: completion orchestration, tracker comments, and accounting only.
- [x] No persistent top-of-screen messaging is added.
- [x] No operator-screen visual changes; browser verification is not applicable.

## Test Plan

- [x] Reproduced the failure before the fix for 403, primary/secondary rate limits, GraphQL quota exhaustion, reserve exhaustion, timeout, cancellation, transport errors, and a missing lane response.
- [x] Table-driven completion/restart/retry-deadline, unchanged-lane, classification, and migration up/down regressions.
- [x] Real Git fixtures verify clean base, dirty files, local commits, pushed commits, base-only pushes, and deleted remote branches.
- [x] Full orchestrator, store, and workspace suites.
- [x] `make generate`
- [x] `make check`: race suite and safety fuzz seeds pass; coverage is 80.0%, and all configured package/exact-file floors pass. No named safety-critical production file changed.
- [x] All 11 current-head CI checks pass. Windows portability passed on a failed-job rerun; the unrelated overlay deletion flake is tracked in Backlog issue #2303.
