### PR TITLE
fix(cloud): admit scoped independent Change checks

### DIFF
--- a/docs/cloud-onboarding.md
+++ b/docs/cloud-onboarding.md
@@ -90,3 +90,63 @@ returns 422, access failures require account/grant correction, and service failu
 require retrying the existing operation. The first native issue uses the ordinary
 idempotent work-item API. Its state determines whether it queues; policy and runner
 checks remain authoritative for execution.
+
+## Independent Change checks
+
+Hosted admission permits a dedicated `operator` bearer to submit only
+`POST /api/v2/organizations/ORG/projects/PROJECT/work-items/ITEM/changes/CHANGE/versions/VERSION/checks`.
+The credential must be active, belong to the hosted organization through an
+explicit current project grant, and be named by an `independent` required check
+in that project's current approved Change review policy. An administrator bearer,
+execution worker, hosted user cookie, or unapproved operator cannot substitute.
+This exception grants no reads, publication, review decisions, policy changes,
+imports, or token administration.
+
+Provision through the existing instance-administrator token APIs before enabling
+hosted serving, or during an explicitly authorized private maintenance window.
+For maintenance, the hosted process must be stopped and the sole database-owning
+Hub process must expose its non-hosted administration API only on private
+loopback. Never run a second process against the live database. Hosted serving
+intentionally does not expose these generic administration APIs.
+
+1. Create a dedicated token with `POST /api/v1/tokens`, using
+   `{"name":"project-independent-ci","scope":"operator"}`. Deliver the returned
+   secret once through the CI secret store; retain its public `id` for policy.
+2. Grant exactly the intended project with `POST /api/v2/tokens/ID/grants`, using
+   `{"organization_id":"ORG","project_id":"PROJECT"}`. This also marks the
+   token native-only. Use a separate principal per project when independent
+   revocation is needed. Restore hosted serving after maintenance.
+3. An organization owner/admin with project write access approves
+   `PUT /api/v2/organizations/ORG/projects/PROJECT/change-review-policy` using
+   their hosted session and CSRF token. Include `idempotency_key`, the current
+   `expected_review_policy_id` when replacing a policy, and `policy` containing
+   the approved repository `policy_id`, `require_review`, and `required_checks`.
+   Each check pins `name`, the credential ID as `principal_id`, `workflow_id`,
+   `workflow_sha256`, `source: "independent"`, and `max_age_seconds` (60–604800).
+   Repository review and check floors still apply.
+4. Publish a version, then deliver its exact check expectation and immutable
+   head, run, policy/configuration and workflow identities to the CI job through
+   the publishing integration. The result bearer cannot fetch them itself.
+   Submit a terminal result and evidence references with a unique idempotency
+   key to the exact version's `/checks` route.
+
+To revoke submission access immediately, the hosted project administrator
+replaces the approved review policy with an eligible replacement CI principal,
+using its current policy identity. The removed principal cannot submit or replay
+results, even for old versions. Publish a new version after policy replacement;
+old versions retain their immutable policy and display stale-policy readiness.
+For permanent credential revocation use `DELETE /api/v1/tokens/ID` through the
+private maintenance administration path. Rotation uses
+`POST /api/v1/tokens/ID/rotate`, invalidates the old secret, and preserves the
+principal ID and grants; distribute the replacement only to the authorized CI.
+A removed project grant also immediately denies submissions.
+
+Credential activity, hash, expiry, scope, project grant and current policy pin
+are rechecked within the mutation transaction before returning cached results.
+Results still validate the version's expected principal, head/run, policy/config,
+check-run ID, workflow digest, independent source and completion timestamp.
+Changed terminal results conflict; retries cannot approve another version.
+Evidence loses readiness at its freshness bound. Human-review repositories also
+need current-version human approval; automatic repositories need passing checks.
+Native `reviewed` status preserves the separate GitHub branch-protection gate and
+does not authorize an external merge.

--- a/docs/cloud-onboarding.md
+++ b/docs/cloud-onboarding.md
@@ -102,6 +102,10 @@ execution worker, hosted user cookie, or unapproved operator cannot substitute.
 This exception grants no reads, publication, review decisions, policy changes,
 imports, or token administration.
 
+Enrolled runners retain their existing `collaborate` operation for expected
+`customer` checks. They cannot satisfy an `independent` check or change the
+source pinned by the immutable version.
+
 Provision through the existing instance-administrator token APIs before enabling
 hosted serving, or during an explicitly authorized private maintenance window.
 For maintenance, the hosted process must be stopped and the sole database-owning

--- a/internal/hubserver/api_auth.go
+++ b/internal/hubserver/api_auth.go
@@ -91,7 +91,7 @@ func (s *Service) requireAPIScope(allowed ...apiScope) echo.MiddlewareFunc {
 				return c.JSON(status, apiErrorResponse{Code: "unauthorized", Message: "Valid scoped API token is required"})
 			}
 			if s.config.Hosted != nil {
-				if credential.Hosted == nil && credential.Runner.RunnerID == "" && !s.hostedArtifactPublisher(c, credential) {
+				if credential.Hosted == nil && credential.Runner.RunnerID == "" && !s.hostedArtifactPublisher(c, credential) && !s.hostedChangeCheckPrincipal(c, credential) {
 					return s.nativeAPIError(c, nativeNotFound())
 				}
 				if credential.Hosted != nil && (!strings.HasPrefix(c.Path(), nativeBase) || strings.HasSuffix(c.Path(), "/checks") || strings.Contains(c.Path(), "/imports")) {

--- a/internal/hubserver/change_evidence.go
+++ b/internal/hubserver/change_evidence.go
@@ -59,6 +59,9 @@ func (s *Service) submitChangeCheck(c echo.Context) error {
 	if err := decodeAPIJSON(c, &request); err != nil {
 		return invalidAPIRequest(c, err)
 	}
+	if s.config.Hosted != nil && request.Source != "independent" {
+		return s.nativeAPIError(c, nativeNotFound())
+	}
 	return s.nativeMutation(c, request.Mutation, request, func(ctx context.Context, tx *sql.Tx, scope nativeScope, now time.Time) (any, error) {
 		change, err := readChange(ctx, tx, scope, c.Param("item"), c.Param("change"))
 		if err != nil {

--- a/internal/hubserver/change_evidence.go
+++ b/internal/hubserver/change_evidence.go
@@ -59,7 +59,7 @@ func (s *Service) submitChangeCheck(c echo.Context) error {
 	if err := decodeAPIJSON(c, &request); err != nil {
 		return invalidAPIRequest(c, err)
 	}
-	if s.config.Hosted != nil && request.Source != "independent" {
+	if s.config.Hosted != nil && nativeRequestScope(c).credential.Runner.RunnerID == "" && request.Source != "independent" {
 		return s.nativeAPIError(c, nativeNotFound())
 	}
 	return s.nativeMutation(c, request.Mutation, request, func(ctx context.Context, tx *sql.Tx, scope nativeScope, now time.Time) (any, error) {

--- a/internal/hubserver/changes.go
+++ b/internal/hubserver/changes.go
@@ -18,6 +18,55 @@ import (
 
 const changeBase = nativeBase + "/work-items/:item/changes"
 
+func changeCheckRequest(c echo.Context) bool {
+	return c.Request().Method == http.MethodPost && c.Path() == changeBase+"/:change/versions/:version/checks"
+}
+
+func (s *Service) hostedChangeCheckPrincipal(c echo.Context, credential apiCredential) bool {
+	if !changeCheckRequest(c) {
+		return false
+	}
+	scope := nativeScope{organization: tracker.OrganizationID(c.Param("organization")), project: tracker.ProjectID(c.Param("project")), credential: credential}
+	return s.requireHostedChangeCheckPrincipal(c.Request().Context(), s.database.db, scope) == nil
+}
+
+func (s *Service) requireHostedChangeCheckPrincipal(ctx context.Context, query nativeQueryer, scope nativeScope) error {
+	credential := scope.credential
+	if credential.Scope != apiScopeOperator || credential.Hosted != nil || credential.Runner.RunnerID != "" || string(scope.organization) != s.config.Hosted.OrganizationID {
+		return nativeNotFound()
+	}
+	var created string
+	var expires sql.NullString
+	err := query.QueryRowContext(ctx, `SELECT t.created_at, t.expires_at FROM api_tokens t
+JOIN token_grants g ON g.token_id = t.id
+WHERE t.id = ? AND t.token_hash = ? AND t.scope = 'operator' AND t.revoked_at IS NULL
+AND g.organization_id = ? AND g.project_id = ?
+AND NOT EXISTS (SELECT 1 FROM runner_identities r WHERE r.token_id = t.id)`, credential.ID, credential.Hash, scope.organization, scope.project).Scan(&created, &expires)
+	if err != nil {
+		return err
+	}
+	if expires.Valid && !runnerTimeValid(s.config.now(), created, expires.String) {
+		return nativeNotFound()
+	}
+	rules, err := readChangePolicy(ctx, query, scope)
+	if err != nil {
+		return err
+	}
+	approved, err := readProjectPolicy(ctx, query, string(scope.organization)+"/"+string(scope.project))
+	if err != nil {
+		return err
+	}
+	if rules.PolicyID != approved.Policy.ID {
+		return nativeNotFound()
+	}
+	for _, check := range rules.RequiredChecks {
+		if check.PrincipalID == credential.ID && check.Source == "independent" {
+			return nil
+		}
+	}
+	return nativeNotFound()
+}
+
 func (s *Service) registerChangeRoutes(e *echo.Echo) {
 	read := s.requireNativeScope(apiScopeWorker, apiScopeOperator)
 	write := s.requireNativeScope(apiScopeWorker, apiScopeOperator)

--- a/internal/hubserver/hosted_change_checks_test.go
+++ b/internal/hubserver/hosted_change_checks_test.go
@@ -1,0 +1,240 @@
+package hubserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func TestHostedIndependentChangeChecks(t *testing.T) {
+	t.Parallel()
+	f := newBrowserHostedFixture(t, true)
+	for _, test := range []struct {
+		name, project string
+		review        bool
+	}{
+		{"human review", f.project, true},
+		{"automatic", f.privateProject, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			base := "/api/v2/organizations/org_browser_preview/projects/" + test.project
+			requireNativeStatus(t, f.form(t, "owner", "/organization/grants", url.Values{"user": {"user_browser_owner"}, "project": {test.project}, "write": {"true"}}), http.StatusSeeOther)
+			descriptor := hubTestPolicy()
+			descriptor.ConfigDigest = policy.Digest([]byte(test.project))
+			descriptor.Gates.Kind = "command"
+			if test.review {
+				descriptor.Gates.Kind = "human_review"
+			}
+			descriptor.Gates.RequiredChecks, descriptor.Gates.Validator, descriptor.Gates.AutomatedReview = 1, true, ""
+			if !test.review {
+				descriptor.Gates.AutomatedReview = "off"
+				descriptor.Gates.AutoPromote = true
+			}
+			descriptor = descriptor.WithID()
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/onboarding/policy", policy.Change{Policy: descriptor}), http.StatusOK)
+			principal, token := "ci-"+test.project, "credential-"+test.project
+			seedHubAPIToken(t, f.service, principal, token, apiScopeOperator)
+			if _, err := f.service.database.db.ExecContext(t.Context(), "INSERT INTO token_grants VALUES (?, 'org_browser_preview', ?)", principal, test.project); err != nil {
+				t.Fatal(err)
+			}
+			rules := tracker.ChangeReviewPolicy{PolicyID: descriptor.ID, RequireReview: test.review, RequiredChecks: []tracker.ChangeCheckSpec{{Name: "test", PrincipalID: principal, WorkflowID: "ci.yml", WorkflowSHA256: policy.Digest([]byte("trusted CI")), Source: "independent", MaxAgeSeconds: 3600}}}
+			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "rules"}, Policy: rules}), http.StatusOK)
+			response := f.setupRequest(t, "owner", http.MethodPost, base+"/work-items", tracker.CreateIssue{Mutation: tracker.Mutation{IdempotencyKey: "work"}, Title: "Independent CI", State: "Todo"})
+			requireNativeStatus(t, response, http.StatusOK)
+			var issue tracker.NativeIssue
+			decodeHubResponse(t, response, &issue)
+			path := base + "/work-items/" + string(issue.WorkItemID) + "/changes"
+			response = f.setupRequest(t, "owner", http.MethodPost, path, tracker.CreateChange{Mutation: tracker.Mutation{IdempotencyKey: "change"}, Title: "Independent CI"})
+			requireNativeStatus(t, response, http.StatusOK)
+			var change tracker.ChangeRequest
+			decodeHubResponse(t, response, &change)
+			path += "/" + change.ID
+			input := changeTestInput()
+			input.PolicyID = descriptor.ID
+			input.External = &tracker.ChangeExternalReference{Provider: "github", ID: "123", URL: "https://github.com/example/repo/pull/123"}
+			response = f.setupRequest(t, "owner", http.MethodPost, path+"/versions", tracker.PublishChangeVersion{Mutation: tracker.Mutation{IdempotencyKey: "publish"}, ChangeVersionInput: input})
+			requireNativeStatus(t, response, http.StatusOK)
+			var version tracker.ChangeVersion
+			decodeHubResponse(t, response, &version)
+			checkPath := path + "/versions/" + version.ID + "/checks"
+			detail := func() tracker.ChangeDetail {
+				t.Helper()
+				response := f.setupRequest(t, "owner", http.MethodGet, path, nil)
+				requireNativeStatus(t, response, http.StatusOK)
+				var result tracker.ChangeDetail
+				decodeHubResponse(t, response, &result)
+				return result
+			}
+			if summary := detail().Summary; summary.Checks != "missing" || summary.Status != "needs_evidence" {
+				t.Fatalf("before checks: %+v", summary)
+			}
+			testHostedCheckBoundaries(t, f, base, checkPath, principal, token, version)
+			testHostedCheckRevocation(t, f, base, checkPath, principal, token, version, false)
+			for _, invalid := range []struct {
+				name string
+				edit func(*tracker.SubmitChangeCheck)
+				want int
+			}{
+				{"head", func(r *tracker.SubmitChangeCheck) { r.HeadSHA = strings.Repeat("f", 40) }, 422},
+				{"run", func(r *tracker.SubmitChangeCheck) { r.RunID = "wrong" }, 422},
+				{"check run", func(r *tracker.SubmitChangeCheck) { r.CheckRunID = "wrong" }, 422},
+				{"policy", func(r *tracker.SubmitChangeCheck) { r.PolicyID = "wrong" }, 422},
+				{"config", func(r *tracker.SubmitChangeCheck) { r.ConfigDigest = "wrong" }, 422},
+				{"workflow", func(r *tracker.SubmitChangeCheck) { r.WorkflowID = "wrong" }, 422},
+				{"workflow digest", func(r *tracker.SubmitChangeCheck) { r.WorkflowSHA256 = "wrong" }, 422},
+				{"source", func(r *tracker.SubmitChangeCheck) { r.Source = "customer" }, 404},
+				{"old completion", func(r *tracker.SubmitChangeCheck) { r.CompletedAt = version.CreatedAt.Add(-time.Second) }, 422},
+				{"future completion", func(r *tracker.SubmitChangeCheck) { r.CompletedAt = time.Now().Add(time.Hour) }, 422},
+			} {
+				t.Run(invalid.name, func(t *testing.T) {
+					request := changeTestResult(version)
+					request.IdempotencyKey = invalid.name
+					invalid.edit(&request)
+					requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, checkPath, token, request), invalid.want)
+				})
+			}
+			request := changeTestResult(version)
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, checkPath, token, request), http.StatusOK)
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, checkPath, token, request), http.StatusOK)
+			testHostedCheckRevocation(t, f, base, checkPath, principal, token, version, true)
+			request.Conclusion = "failure"
+			for _, key := range []string{"check", "changed-result"} {
+				request.IdempotencyKey = key
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, checkPath, token, request), http.StatusConflict)
+			}
+			current := detail()
+			if len(current.Checks) != 1 || current.Summary.Checks != "success" {
+				t.Fatalf("accepted checks: %+v", current)
+			}
+			if test.review {
+				if current.Summary.Status != "needs_evidence" || current.Summary.NativeReview != "pending" {
+					t.Fatalf("review bypassed: %+v", current.Summary)
+				}
+				requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPost, path+"/versions/"+version.ID+"/reviews", tracker.ReviewChange{Mutation: tracker.Mutation{IdempotencyKey: "approve"}, Decision: "approved"}), http.StatusOK)
+			}
+			if summary := detail().Summary; summary.Status != "reviewed" || summary.ExternalReview != "external_gate" {
+				t.Fatalf("readiness or external protection changed: %+v", summary)
+			}
+			now := f.service.config.now
+			f.service.config.now = func() time.Time { return version.CreatedAt.Add(time.Hour) }
+			if summary := detail().Summary; summary.Checks != "stale" || summary.Status != "needs_evidence" {
+				t.Fatalf("freshness bypassed: %+v", summary)
+			}
+			f.service.config.now = now
+		})
+	}
+}
+
+func testHostedCheckBoundaries(t *testing.T, f *browserHostedFixture, base, path, principal, token string, version tracker.ChangeVersion) {
+	t.Helper()
+	for _, scope := range []apiScope{apiScopeWorker, apiScopeOperator, apiScopeAdmin} {
+		id := principal + "-" + string(scope)
+		seedHubAPIToken(t, f.service, id, id, scope)
+		if _, err := f.service.database.db.ExecContext(t.Context(), "INSERT INTO token_grants VALUES (?, 'org_browser_preview', ?)", id, strings.TrimPrefix(base, "/api/v2/organizations/org_browser_preview/projects/")); err != nil {
+			t.Fatal(err)
+		}
+		t.Run("unapproved "+string(scope), func(t *testing.T) {
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, id, changeTestResult(version)), http.StatusNotFound)
+		})
+	}
+	requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPost, path, changeTestResult(version)), http.StatusNotFound)
+	for _, test := range []struct{ name, method, path string }{
+		{"change read", http.MethodGet, strings.Split(path, "/versions/")[0]},
+		{"review", http.MethodPost, strings.TrimSuffix(path, "checks") + "reviews"},
+		{"publish", http.MethodPost, strings.Split(path, "/versions/")[0] + "/versions"},
+		{"policy", http.MethodPut, base + "/change-review-policy"},
+		{"token administration", http.MethodPost, "/api/v1/tokens"},
+		{"grant administration", http.MethodPost, "/api/v2/tokens/" + principal + "/grants"},
+		{"wrong organization", http.MethodPost, strings.Replace(path, "org_browser_preview", "org_other", 1)},
+		{"wrong project", http.MethodPost, strings.Replace(path, base, "/api/v2/organizations/org_browser_preview/projects/prj_unknown", 1)},
+		{"wrong item", http.MethodPost, strings.Replace(path, "/work-items/", "/work-items/other", 1)},
+		{"wrong version", http.MethodPost, strings.Replace(path, version.ID, "version_other", 1)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, test.method, test.path, token, changeTestResult(version)), http.StatusNotFound)
+		})
+	}
+}
+
+func testHostedCheckRevocation(t *testing.T, f *browserHostedFixture, base, path, principal, token string, version tracker.ChangeVersion, replay bool) {
+	t.Helper()
+	ctx := t.Context()
+	project := strings.TrimPrefix(base, "/api/v2/organizations/org_browser_preview/projects/")
+	var rules string
+	if err := f.service.database.db.QueryRowContext(ctx, "SELECT policy_json FROM change_review_policies WHERE project_id=?", project).Scan(&rules); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name, statement, restore string
+		args, restoreArgs        []any
+		want                     int
+	}{
+		{"revoked", "UPDATE api_tokens SET revoked_at=created_at WHERE id=?", "UPDATE api_tokens SET revoked_at=NULL WHERE id=?", []any{principal}, []any{principal}, 401},
+		{"rotated", "UPDATE api_tokens SET token_hash='ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' WHERE id=?", "UPDATE api_tokens SET token_hash=? WHERE id=?", []any{principal}, nil, 401},
+		{"expired", "UPDATE api_tokens SET expires_at=created_at WHERE id=?", "UPDATE api_tokens SET expires_at=NULL WHERE id=?", []any{principal}, []any{principal}, 401},
+		{"role changed", "UPDATE api_tokens SET scope='admin' WHERE id=?", "UPDATE api_tokens SET scope='operator' WHERE id=?", []any{principal}, []any{principal}, 404},
+		{"project grant", "DELETE FROM token_grants WHERE token_id=? AND project_id=?", "INSERT INTO token_grants VALUES (?, 'org_browser_preview', ?)", []any{principal, project}, []any{principal, project}, 404},
+		{"policy principal", "UPDATE change_review_policies SET policy_json=json_set(policy_json,'$.required_checks[0].principal_id','other') WHERE project_id=?", "UPDATE change_review_policies SET policy_json=? WHERE project_id=?", []any{project}, []any{rules, project}, 404},
+		{"policy source", "UPDATE change_review_policies SET policy_json=json_set(policy_json,'$.required_checks[0].source','customer') WHERE project_id=?", "UPDATE change_review_policies SET policy_json=? WHERE project_id=?", []any{project}, []any{rules, project}, 404},
+		{"repository policy", "UPDATE change_review_policies SET policy_json=json_set(policy_json,'$.policy_id','other') WHERE project_id=?", "UPDATE change_review_policies SET policy_json=? WHERE project_id=?", []any{project}, []any{rules, project}, 404},
+	} {
+		for _, during := range []bool{false, true} {
+			name := test.name + "/admission"
+			if during {
+				name = test.name + "/transaction"
+			}
+			if replay {
+				name += "/replay"
+			}
+			t.Run(name, func(t *testing.T) {
+				if test.name == "rotated" {
+					var hash string
+					if err := f.service.database.db.QueryRowContext(ctx, "SELECT token_hash FROM api_tokens WHERE id=?", principal).Scan(&hash); err != nil {
+						t.Fatal(err)
+					}
+					test.restoreArgs = []any{hash, principal}
+				}
+				mutate := func() {
+					if _, err := f.service.database.db.ExecContext(ctx, test.statement, test.args...); err != nil {
+						t.Fatal(err)
+					}
+				}
+				t.Cleanup(func() {
+					if _, err := f.service.database.db.ExecContext(ctx, test.restore, test.restoreArgs...); err != nil {
+						t.Error(err)
+					}
+				})
+				raw, err := json.Marshal(changeTestResult(version))
+				if err != nil {
+					t.Fatal(err)
+				}
+				body := &hostedChangePolicyReader{Reader: strings.NewReader(string(raw))}
+				if during {
+					body.beforeRead = mutate
+				} else {
+					mutate()
+				}
+				request := httptest.NewRequest(http.MethodPost, path, body)
+				request.Header.Set("Authorization", "Bearer "+token)
+				request.Header.Set("Content-Type", "application/json")
+				response := httptest.NewRecorder()
+				f.service.Handler().ServeHTTP(response, request)
+				want := test.want
+				if during {
+					want = http.StatusNotFound
+				}
+				requireNativeStatus(t, response, want)
+				if body.beforeRead != nil {
+					t.Fatal("transaction revocation was not exercised")
+				}
+			})
+		}
+	}
+}

--- a/internal/hubserver/hosted_change_checks_test.go
+++ b/internal/hubserver/hosted_change_checks_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/policy"
+	"github.com/digitaldrywood/detent/internal/runnerauth"
 	"github.com/digitaldrywood/detent/internal/tracker"
 )
 
@@ -236,5 +237,39 @@ func testHostedCheckRevocation(t *testing.T, f *browserHostedFixture, base, path
 				}
 			})
 		}
+	}
+}
+
+func TestHostedRunnerChangeChecks(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		source string
+		want   int
+	}{
+		{"customer", http.StatusOK},
+		{"independent", http.StatusUnprocessableEntity},
+	} {
+		t.Run(test.source, func(t *testing.T) {
+			t.Parallel()
+			f := newChangeFixture(t, nil)
+			runner := prepareRunner(t, f.nativeFixture, runnerauth.Collaborate)
+			runner.enroll(t)
+			if test.source == "customer" {
+				rules := f.rules
+				rules.RequiredChecks[0].PrincipalID = runner.identity.RunnerID
+				rules.RequiredChecks[0].Source = test.source
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPut, f.base+"/change-review-policy", testHubAdminToken, tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "customer-policy"}, ExpectedID: f.rules.ID, Policy: rules}), http.StatusOK)
+			}
+			version := f.publish(t, "v1", "")
+			f.service.config.Hosted = &HostedConfig{OrganizationID: string(f.project.OrganizationID)}
+			path := f.path + "/versions/" + version.ID + "/checks"
+			request := changeTestResult(version)
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, runner.redemption.Credential, request), test.want)
+			if test.source == "customer" {
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, runner.redemption.Credential, request), http.StatusOK)
+				request.IdempotencyKey, request.Source = "forged-independent", "independent"
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, runner.redemption.Credential, request), http.StatusUnprocessableEntity)
+			}
+		})
 	}
 }

--- a/internal/hubserver/hosted_changes_test.go
+++ b/internal/hubserver/hosted_changes_test.go
@@ -126,6 +126,7 @@ func TestHostedChangePolicyJourney(t *testing.T) {
 			if version.PolicyID != descriptor.ID || version.ReviewPolicy.ID != rules.ID || len(version.Checks) != 1 || version.Checks[0].PrincipalID != principal {
 				t.Fatalf("published policy snapshot = %+v", version)
 			}
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path+"/versions/"+version.ID+"/checks", "credential-"+project, changeTestResult(version)), http.StatusOK)
 			approve.IdempotencyKey, approve.ExpectedID = "update", rules.ID
 			approve.Policy.RequiredChecks[0].MaxAgeSeconds = 7200
 			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", approve), http.StatusOK)

--- a/internal/hubserver/native_api.go
+++ b/internal/hubserver/native_api.go
@@ -234,7 +234,7 @@ func (s *Service) nativeMutation(c echo.Context, command tracker.Mutation, input
 	if err := s.recheckHostedMutation(ctx, tx, scope); err != nil {
 		return s.nativeAPIError(c, err)
 	}
-	if s.config.Hosted != nil && scope.credential.Hosted == nil && changeCheckRequest(c) {
+	if s.config.Hosted != nil && scope.credential.Hosted == nil && scope.credential.Runner.RunnerID == "" && changeCheckRequest(c) {
 		if err := s.requireHostedChangeCheckPrincipal(ctx, tx, scope); err != nil {
 			return s.nativeAPIError(c, err)
 		}

--- a/internal/hubserver/native_api.go
+++ b/internal/hubserver/native_api.go
@@ -234,6 +234,11 @@ func (s *Service) nativeMutation(c echo.Context, command tracker.Mutation, input
 	if err := s.recheckHostedMutation(ctx, tx, scope); err != nil {
 		return s.nativeAPIError(c, err)
 	}
+	if s.config.Hosted != nil && scope.credential.Hosted == nil && changeCheckRequest(c) {
+		if err := s.requireHostedChangeCheckPrincipal(ctx, tx, scope); err != nil {
+			return s.nativeAPIError(c, err)
+		}
+	}
 	var storedHash, response string
 	err = tx.QueryRowContext(ctx, `SELECT request_hash, response_json FROM native_commands WHERE organization_id = ? AND actor_id = ? AND operation = ? AND command_key = ?`, scope.organization, scope.credential.ID, operationID, command.IdempotencyKey).Scan(&storedHash, &response)
 	if err == nil {


### PR DESCRIPTION
## Summary

Hosted Change checks currently return 404 even for a project-granted operator explicitly approved as independent CI. Admit that credential only on the exact version check-result route, and recheck its activity, secret hash, expiry, scope, tenant, project grant and current independent policy pin inside the transaction before cached replay.

Preserve enrolled runners’ existing customer-check callbacks, immutable result identities, replay conflicts, freshness and external branch protections. Document private operator provisioning/rotation/revocation and immediate hosted policy replacement. Pilot #2199 / PR #2292 should refresh its known-gap evidence after this fix merges; this PR does not claim the public launch gate is complete.

Fixes #2299

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, first-viewport, or responsive visibility changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens; browser screenshots are not applicable.

## Test Plan

- [x] Reproduced the original 404 in both hosted projects before the fix.
- [x] Focused hosted policy journey, independent check security/readiness and existing forged/replayed-result tests.
- [x] Stdlib tables cover scoped admission, unrelated principals/routes, forged immutable identities, revocation before and after middleware on new/replayed requests, human/automatic readiness, freshness and retained external protections.
- [x] Regression for enrolled runner customer checks and continued denial of independent runner checks.
- [x] `make check` (build, lint, vet, NilAway, race tests, coverage gates)
