### PR TITLE
fix(watcher): reconcile reload errors at expiry

### DIFF
--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -509,31 +509,40 @@ func (w *FileWatcher[T]) reload(ctx context.Context) FileUpdate[T] {
 }
 
 func (w *FileWatcher[T]) load(ctx context.Context) (T, error) {
+	if err := ctx.Err(); err != nil {
+		var zero T
+		return zero, err
+	}
 	value, err := w.loader(w.path)
 	if err == nil {
 		return value, nil
 	}
-	lastErr := err
-
 	deadline := time.NewTimer(w.debounce)
 	defer deadline.Stop()
 	retry := time.NewTicker(retryInterval(w.debounce))
 	defer retry.Stop()
 
 	for {
+		finalAttempt := false
 		select {
 		case <-ctx.Done():
 			var zero T
 			return zero, ctx.Err()
 		case <-deadline.C:
-			var zero T
-			return zero, lastErr
+			finalAttempt = true
 		case <-retry.C:
-			value, err := w.loader(w.path)
-			if err == nil {
-				return value, nil
-			}
-			lastErr = err
+		}
+		if err := ctx.Err(); err != nil {
+			var zero T
+			return zero, err
+		}
+		value, err := w.loader(w.path)
+		if err == nil {
+			return value, nil
+		}
+		if finalAttempt {
+			var zero T
+			return zero, err
 		}
 	}
 }

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -258,6 +260,159 @@ func TestWatchReloadsLocalWorkflowOverlayLifecycle(t *testing.T) {
 	}
 	if deleted.Workflow.Overlay.Path != "" {
 		t.Fatalf("delete Overlay = %#v, want inactive", deleted.Workflow.Overlay)
+	}
+}
+
+func TestWatchReconcilesOverlayDeletionErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		deniedFor time.Duration
+		wantErr   bool
+	}{
+		{name: "immediately absent"},
+		{name: "settles between last retry and expiry", deniedFor: 11 * time.Millisecond},
+		{name: "settles at expiry", deniedFor: 12 * time.Millisecond},
+		{name: "persistent permission error", deniedFor: time.Hour, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				runtime := newControlledFileRuntime()
+				path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+				localPath := workflowconfig.LocalWorkflowPath(path)
+				writeWorkflow(t, path, 60000, "shared")
+				var deniedUntil time.Time
+				var deniedReads int
+				w, err := New(path, WithDebounce(12*time.Millisecond),
+					withFileOptions(runtime.option()),
+					WithLoader(func(path string) (workflowconfig.Workflow, error) {
+						if time.Now().Before(deniedUntil) {
+							deniedReads++
+							return workflowconfig.Workflow{}, fmt.Errorf("read local workflow overlay: %w", &os.PathError{
+								Op: "open", Path: localPath, Err: os.ErrPermission,
+							})
+						}
+						return workflowconfig.LoadWorkflow(path)
+					}),
+				)
+				if err != nil {
+					t.Fatalf("New() error = %v", err)
+				}
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				updates, err := w.Watch(ctx)
+				if err != nil {
+					t.Fatalf("Watch() error = %v", err)
+				}
+				steps := []struct {
+					name     string
+					interval int
+					prompt   string
+					remove   bool
+				}{
+					{name: "create", interval: 61000, prompt: "local first"},
+					{name: "edit", interval: 62000, prompt: "local second"},
+					{name: "delete", interval: 60000, prompt: "shared", remove: true},
+					{name: "recreate", interval: 63000, prompt: "local third"},
+				}
+				for _, step := range steps {
+					synctest.Wait()
+					deniedUntil = time.Time{}
+					if step.remove {
+						if err := os.Remove(localPath); err != nil {
+							t.Fatalf("Remove() error = %v", err)
+						}
+						deniedUntil = time.Now().Add(test.deniedFor)
+					} else {
+						writeWorkflow(t, localPath, step.interval, step.prompt)
+					}
+					runtime.sendEvent(t, localPath)
+					runtime.waitForReset(t)
+					runtime.fireTimer(t)
+					update := receiveUpdate(t, updates)
+					if step.remove && test.wantErr {
+						if !errors.Is(update.Err, os.ErrPermission) {
+							t.Fatalf("%s error = %v, want permission error", step.name, update.Err)
+						}
+					} else {
+						if update.Err != nil {
+							t.Fatalf("%s error = %v", step.name, update.Err)
+						}
+						if update.Workflow.Config.Polling.IntervalMS != step.interval || !strings.Contains(update.Workflow.Prompt, step.prompt+"\n") {
+							t.Fatalf("%s workflow = %#v, want interval %d and prompt %q", step.name, update.Workflow, step.interval, step.prompt)
+						}
+						if step.remove && (update.Workflow.Overlay.Path != "" || update.Workflow.Prompt != "shared\n") {
+							t.Fatalf("deleted workflow = %#v, want shared workflow with inactive overlay", update.Workflow)
+						}
+						if !step.remove && update.Workflow.Overlay.Path == "" {
+							t.Fatalf("%s overlay is inactive", step.name)
+						}
+					}
+					synctest.Wait()
+					select {
+					case extra := <-updates:
+						t.Fatalf("%s extra update = %#v", step.name, extra)
+					default:
+					}
+				}
+				if test.deniedFor > 0 && deniedReads == 0 {
+					t.Fatal("deletion did not exercise an access-denied read")
+				}
+				cancel()
+				synctest.Wait()
+				if _, ok := <-updates; ok {
+					t.Fatal("updates remained open after cancellation")
+				}
+				runtime.waitForClosed(t)
+				runtime.poll.waitForStopped(t)
+			})
+		})
+	}
+}
+
+func TestFileWatcherLoadCancellation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cancelAt  time.Duration
+		wantReads int
+	}{
+		{name: "before initial read", wantReads: 0},
+		{name: "during retry wait", cancelAt: 2 * time.Millisecond, wantReads: 1},
+		{name: "before final reconciliation", cancelAt: 11 * time.Millisecond, wantReads: 3},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				if test.cancelAt == 0 {
+					cancel()
+				} else {
+					timer := time.AfterFunc(test.cancelAt, cancel)
+					defer timer.Stop()
+				}
+				reads := 0
+				w, err := NewFile("WORKFLOW.md", func(string) (string, error) {
+					reads++
+					return "", os.ErrPermission
+				}, WithFileDebounce(12*time.Millisecond))
+				if err != nil {
+					t.Fatalf("NewFile() error = %v", err)
+				}
+				if _, err := w.load(ctx); !errors.Is(err, context.Canceled) {
+					t.Fatalf("load() error = %v, want cancellation", err)
+				}
+				if reads != test.wantReads {
+					t.Fatalf("loader reads = %d, want %d", reads, test.wantReads)
+				}
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reconcile once more when the workflow reload retry window expires. If an overlay deletion settles after the last periodic retry, the watcher now restores the shared workflow instead of publishing a stale access-denied error. Persistent read errors still surface.
- Check cancellation before initial and retry/final reads. Add deterministic table-driven coverage for overlay create/edit/delete/recreate ordering, permission failures, and cancellation; retain the real filesystem lifecycle test.

The controlled reproduction fails on the previous implementation when deletion settles at 11 or 12 ms in a 12 ms retry window: the last periodic read was at 10 ms. This establishes a stale-error path consistent with the Windows failure; the recorded CI log does not establish the exact kernel/event ordering.

Fixes #2303

## UI Surface Contract

- [x] N/A — filesystem watcher reconciliation only.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes; browser verification is not applicable.

## Test Plan

- [x] Reproduce the settling cases and pre-canceled read failure before the fix.
- [x] `go test -race ./internal/config/watcher -count=10`
- [x] 100 race-enabled repetitions of the new deterministic regression tests.
- [x] Cross-compile the watcher tests for Windows/amd64.
- [x] `make check` — all checks passed; aggregate coverage 80.1%, configured package/file floors passed.
- [x] [Current-head CI](https://github.com/digitaldrywood/detent/actions/runs/34190348425) — all 11 jobs passed, including Windows portability and Linux race verification.
