### PR TITLE
test(orchestrator): await recovered stop snapshot

### DIFF
--- a/internal/orchestrator/stop_run_integration_test.go
+++ b/internal/orchestrator/stop_run_integration_test.go
@@ -297,7 +297,7 @@ func TestStopRunAcknowledgesBeforeTrackerTransitionCompletes(t *testing.T) {
 
 func TestStopRunRecoveryReconcilesDurableHoldBeforeDispatch(t *testing.T) {
 	issue := testIssue("issue-stop-recovery", "digitaldrywood/detent#1311", "In Progress")
-	tracker := newFakeConnector(issue)
+	tracker := &operatorStopRecoveryConnector{fakeConnector: newFakeConnector(issue), stateUpdated: make(chan struct{}), releaseStateUpdate: make(chan struct{})}
 	runner := &operatorStopBlockingRunner{started: make(chan orchestrator.RunRequest, 1)}
 	runtimeStore, err := store.Open(t.Context(), store.Config{Backend: store.BackendSQLite, Path: filepath.Join(t.TempDir(), "detent.db")})
 	if err != nil {
@@ -322,9 +322,42 @@ func TestStopRunRecoveryReconcilesDurableHoldBeforeDispatch(t *testing.T) {
 	}
 	stop := runOrchestrator(t, orch)
 	defer stop()
-	state := waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
-		return len(tracker.stateUpdateCalls()) > 0 && len(state.Running) == 0 && len(state.Blocked) == 0
-	})
+	releaseStateUpdate := sync.OnceFunc(func() { close(tracker.releaseStateUpdate) })
+	defer releaseStateUpdate()
+	select {
+	case <-tracker.stateUpdated:
+	case <-time.After(operatorStopIntegrationWaitTimeout):
+		t.Fatal("timed out waiting for recovered tracker transition")
+	}
+	state, err := orch.State(t.Context())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if len(tracker.stateUpdateCalls()) == 0 || len(state.Running) != 0 {
+		t.Fatal("want tracker update with no running items while reconciliation is paused")
+	}
+	if attempt, ok := workAttemptSnapshot(state, attemptID); !ok || attempt.Phase != "operator_stop_transition_failed" || attempt.NextAction != "retry tracker transition to Blocked" {
+		t.Fatalf("work attempt snapshot = %#v, %v, want unreconciled operator stop while transition is paused", attempt, ok)
+	}
+	recovered := func(state orchestrator.State) bool {
+		attempt, ok := workAttemptSnapshot(state, attemptID)
+		return ok && attempt.Phase == "operator_stop_succeeded" && attempt.NextAction == "await operator resume" && len(state.Running) == 0 && len(state.Blocked) == 0
+	}
+	for _, tt := range []struct {
+		name  string
+		state orchestrator.State
+	}{
+		{name: "paused tracker transition", state: state},
+		{name: "published collections ahead of receipt", state: orchestrator.State{WorkAttempts: state.WorkAttempts}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if recovered(tt.state) {
+				t.Fatal("recovery predicate accepted the unreconciled operator stop snapshot")
+			}
+		})
+	}
+	releaseStateUpdate()
+	state = waitForOperatorStopState(t, orch, recovered)
 	if attempt, ok := workAttemptSnapshot(state, attemptID); !ok || attempt.Phase != "operator_stop_succeeded" || attempt.NextAction != "await operator resume" {
 		t.Fatalf("work attempt snapshot = %#v, %v, want reconciled operator stop", attempt, ok)
 	}
@@ -497,6 +530,26 @@ func (s *operatorStopCompletionStore) RecordWorkflowPhaseEvent(ctx context.Conte
 		return eventID, nil
 	case <-ctx.Done():
 		return eventID, ctx.Err()
+	}
+}
+
+type operatorStopRecoveryConnector struct {
+	*fakeConnector
+	stateUpdated       chan struct{}
+	releaseStateUpdate chan struct{}
+	stateUpdateOnce    sync.Once
+}
+
+func (c *operatorStopRecoveryConnector) UpdateIssueState(ctx context.Context, issueID string, state string) error {
+	if err := c.fakeConnector.UpdateIssueState(ctx, issueID, state); err != nil {
+		return err
+	}
+	c.stateUpdateOnce.Do(func() { close(c.stateUpdated) })
+	select {
+	case <-c.releaseStateUpdate:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 


### PR DESCRIPTION
## Summary

- Wait for the recovered operator-stop attempt to report `operator_stop_succeeded` and `await operator resume` in the same returned snapshot before asserting completion.
- Pause a tracker transition with a channel barrier to observe the unreconciled receipt after the tracker update. Replay the recorded empty running/blocked collections with that receipt in a table case; the original predicate deterministically accepts this stale snapshot. The narrow cross-atomic publication interleaving is modeled, rather than forced by the connector barrier.
- Preserve the no-redispatch and durable SQLite receipt assertions. Production behavior is unchanged.

Fixes #2305

## UI Surface Contract

- [x] N/A: test synchronization only; no UI changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A: no visual changes requiring browser verification.

## Test Plan

- [x] Original predicate fails the recorded-snapshot regression case.
- [x] `go test -race ./internal/orchestrator -run '^TestStopRunRecoveryReconcilesDurableHoldBeforeDispatch$' -count=50 -timeout=10m` (38.115s).
- [x] `make check` (80.1% coverage; package and file floors passed).
