### PR TITLE
fix(ci): align browser and snapshot budgets

### DIFF
--- a/.detent/validation/2310/README.md
+++ b/.detent/validation/2310/README.md
@@ -1,0 +1,90 @@
+# Browser and snapshot budget measurements
+
+Measured on 2026-09-08 from completed GitHub-hosted `ubuntu-latest` jobs,
+image `ubuntu-24.04` version `20260831.293.1`, Linux/x64, Go 1.26.6.
+[measurements.json](measurements.json) retains job IDs, source heads, URLs,
+step timestamps, conclusions, cache keys, and selected timestamped log lines.
+Job durations exclude queue time; step durations use the Actions jobs API.
+Sub-step durations use adjacent timestamped log boundaries, rounded to seconds.
+Small setup/teardown gaps mean the rounded columns need not sum to job time.
+
+## Repeated full-check evidence
+
+| Stage | [Run 34195459084](https://github.com/digitaldrywood/detent/actions/runs/34195459084) | [Run 34196736772](https://github.com/digitaldrywood/detent/actions/runs/34196736772) |
+| --- | ---: | ---: |
+| Browser whole job | 11m23s | 10m49s |
+| Checkout / setup-go / setup-node | 4s / 16s / 3s | 3s / 16s / 2s |
+| npm ci / Chromium and OS dependencies | 1s / 23s | 1s / 26s |
+| sqlc installation | 62s | 56s |
+| make build: generation / binary compilation | 25s / 19s | 23s / 18s |
+| Full Playwright step, including fixture processes | 8m41s | 8m17s |
+| Browser evidence upload | 3s | 1s |
+| Snapshot whole job | 10m3s | 10m39s |
+| Checkout / setup-go / minisign installation | 4s / 12s / 10s | 3s / 17s / 10s |
+| Snapshot action, including tool download | 9m32s | 10m3s |
+| Hook: module download | <1s | <1s |
+| Hook: sqlc installation | 59s | 61s |
+| Hook: generation | 26s | 27s |
+| Hook: Go test suite, including compilation | 2m29s | 2m44s |
+| Six-target binary compilation | 5m10s | 5m22s |
+| Archives, Linux packages, checksums, signing | 27s | 27s |
+
+Both named jobs passed in both runs. The first overall workflow was later
+cancelled for a newer PR push; its completed jobs remain usable evidence.
+Both browser runs selected the same 207 cases: 175 passed and 32 existing
+conditional skips. Neither had failed cases or retries. No test selection,
+skip, worker count, fixture lifetime, or assertion is changed by this issue.
+Snapshot logs confirm all six Darwin/Linux/Windows amd64/arm64 binaries,
+archives, deb/rpm packages, SHA-256 checksums, and minisign signatures.
+Snapshot mode retains GoReleaser's existing non-publishing behavior.
+
+## Cache state and smoke comparison
+
+All four full jobs restored the same exact setup-go primary key (329 MiB).
+Both browser jobs also restored the same npm key (10 MiB). Chromium was
+downloaded on each runner; no Playwright browser or sqlc executable cache is
+configured. An exact setup-go hit does not save newly compiled entries at
+job completion: both logs explicitly say the primary key was hit and the
+cache was not saved. A cache hit therefore does not mean the generator,
+test, or cross-compilation work is warm. The repeated sqlc installs and
+five-minute cross-build stages are direct observations, not evidence that
+cache restoration failed. No cold-cache or newly populated per-job cache
+experiment was performed; these samples cannot quantify either effect.
+
+The [non-visual PR run 34191891374](https://github.com/digitaldrywood/detent/actions/runs/34191891374/job/101951468437)
+used the same runner image and exact Go cache key. Its Browser Visual job
+passed in 48s: checkout 3s, Go setup 17s, selection 1s, binary build plus
+`--help` 21s. Node, generation, Chromium, and Playwright were not selected.
+This is a real binary smoke but provides no browser assertion coverage.
+It explains why a smoke-derived budget cannot describe full selection.
+The PR heads differ; this is a workload comparison, not a controlled speedup.
+
+## Repeated work assessment and budget decision
+
+The application binary is already built once and reused through
+`DETENT_BINARY`. `artifacts.spec.js` and `change-review.spec.js` invoke
+different `internal/web` Go test fixtures; `hosted-work.spec.js` invokes an
+`internal/hubserver` fixture. Go's build cache can reuse compilation, but
+`-count=1` is necessary to execute these server fixtures. Reusing one running
+fixture would combine distinct routes, authorization state, and shutdown
+contracts. The current logs include fixture costs inside Playwright time;
+they do not isolate compiler CPU from server startup. Precompiling fixtures
+would move that cost to setup, not establish a net saving. No fixture is
+removed or shared on this evidence.
+
+Browser and release generation run on separate runners and feed different
+binaries. Snapshot's Go tests validate the freshly generated release inputs;
+dropping that hook because Verify also tests Go would change the release
+contract. Six cross-compiled targets have different GOOS/GOARCH inputs and
+cannot be replaced with the browser binary. Generation, hooks, builds,
+packaging, and signing therefore remain intact. Dedicated generator/build
+caches are a possible future optimization, requiring measured cache-miss
+and cache-hit runs; this change makes no unmeasured speedup claim.
+
+Both documented budgets and workflow timeouts are now 15m. This gives 3m37s
+above the largest measured browser job and 4m21s above the largest snapshot
+job, including room for setup variation and browser retries. These are
+whole-job ceilings, not cold-cache guarantees. Future drift should be
+assessed from repeated full jobs with runner image, cache keys, selection,
+and per-stage timings, rather than from smoke or queue time. Required check
+names, selection logic, artifact handling, and release work are unchanged.

--- a/.detent/validation/2310/measurements.json
+++ b/.detent/validation/2310/measurements.json
@@ -1,0 +1,563 @@
+[
+  {
+    "id": 101962076772,
+    "run_id": 34195459084,
+    "head_sha": "49428fd64560656fcff3b5ae5eda324ff3e4ade0",
+    "html_url": "https://github.com/digitaldrywood/detent/actions/runs/34195459084/job/101962076772",
+    "name": "GoReleaser Snapshot",
+    "conclusion": "success",
+    "started_at": "2026-09-08T06:37:15Z",
+    "completed_at": "2026-09-08T06:47:18Z",
+    "labels": [
+      "ubuntu-latest"
+    ],
+    "runner_name": "GitHub Actions 1000050963",
+    "seconds": 603.0,
+    "steps": [
+      {
+        "name": "Set up job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:16Z",
+        "completed_at": "2026-09-08T06:37:17Z"
+      },
+      {
+        "name": "Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:17Z",
+        "completed_at": "2026-09-08T06:37:21Z"
+      },
+      {
+        "name": "Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:21Z",
+        "completed_at": "2026-09-08T06:37:33Z"
+      },
+      {
+        "name": "Install minisign",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:33Z",
+        "completed_at": "2026-09-08T06:37:43Z"
+      },
+      {
+        "name": "Prepare minisign snapshot key",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:43Z",
+        "completed_at": "2026-09-08T06:37:43Z"
+      },
+      {
+        "name": "Run GoReleaser snapshot",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:43Z",
+        "completed_at": "2026-09-08T06:47:15Z"
+      },
+      {
+        "name": "Post Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:47:15Z",
+        "completed_at": "2026-09-08T06:47:15Z"
+      },
+      {
+        "name": "Post Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:47:15Z",
+        "completed_at": "2026-09-08T06:47:16Z"
+      },
+      {
+        "name": "Complete job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:47:16Z",
+        "completed_at": "2026-09-08T06:47:16Z"
+      }
+    ],
+    "timing_log_lines": [
+      "2026-09-08T06:37:16.0485381Z Image: ubuntu-24.04",
+      "2026-09-08T06:37:16.0485885Z Version: 20260831.293.1",
+      "2026-09-08T06:37:28.5518931Z Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3",
+      "2026-09-08T06:37:45.0200881Z     \u2022 running                                        hook=go mod download",
+      "2026-09-08T06:37:45.0320345Z     \u2022 running                                        hook=go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0",
+      "2026-09-08T06:38:44.0847787Z     \u2022 running                                        hook=make generate",
+      "2026-09-08T06:39:09.9307697Z     \u2022 running                                        hook=go test ./...",
+      "2026-09-08T06:41:38.4557234Z   \u2022 building binaries",
+      "2026-09-08T06:46:48.6928019Z   \u2022 archives",
+      "2026-09-08T06:47:15.4293536Z   \u2022 calculating checksums",
+      "2026-09-08T06:47:15.5037936Z   \u2022 signing artifacts",
+      "2026-09-08T06:47:15.7837724Z   \u2022 release succeeded after 9m30s",
+      "2026-09-08T06:47:15.9557952Z Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3, not saving cache."
+    ]
+  },
+  {
+    "id": 101962076799,
+    "run_id": 34195459084,
+    "head_sha": "49428fd64560656fcff3b5ae5eda324ff3e4ade0",
+    "html_url": "https://github.com/digitaldrywood/detent/actions/runs/34195459084/job/101962076799",
+    "name": "Browser Visual",
+    "conclusion": "success",
+    "started_at": "2026-09-08T06:37:16Z",
+    "completed_at": "2026-09-08T06:48:39Z",
+    "labels": [
+      "ubuntu-latest"
+    ],
+    "runner_name": "GitHub Actions 1000050968",
+    "seconds": 683.0,
+    "steps": [
+      {
+        "name": "Set up job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:18Z",
+        "completed_at": "2026-09-08T06:37:19Z"
+      },
+      {
+        "name": "Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:19Z",
+        "completed_at": "2026-09-08T06:37:23Z"
+      },
+      {
+        "name": "Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:23Z",
+        "completed_at": "2026-09-08T06:37:39Z"
+      },
+      {
+        "name": "Detect visual-sensitive changes",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:39Z",
+        "completed_at": "2026-09-08T06:37:39Z"
+      },
+      {
+        "name": "Run actions/setup-node@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:39Z",
+        "completed_at": "2026-09-08T06:37:42Z"
+      },
+      {
+        "name": "Install Node dependencies",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:42Z",
+        "completed_at": "2026-09-08T06:37:43Z"
+      },
+      {
+        "name": "Install Playwright browsers",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:37:43Z",
+        "completed_at": "2026-09-08T06:38:06Z"
+      },
+      {
+        "name": "Install visual build generators",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:38:06Z",
+        "completed_at": "2026-09-08T06:39:08Z"
+      },
+      {
+        "name": "Build Detent visual test binary",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:39:08Z",
+        "completed_at": "2026-09-08T06:39:52Z"
+      },
+      {
+        "name": "Run full browser visual gate",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:39:52Z",
+        "completed_at": "2026-09-08T06:48:33Z"
+      },
+      {
+        "name": "Run browser smoke gate",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T06:48:33Z",
+        "completed_at": "2026-09-08T06:48:33Z"
+      },
+      {
+        "name": "Upload browser visual evidence",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:48:33Z",
+        "completed_at": "2026-09-08T06:48:36Z"
+      },
+      {
+        "name": "Upload browser visual failure artifacts",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T06:48:36Z",
+        "completed_at": "2026-09-08T06:48:36Z"
+      },
+      {
+        "name": "Post Run actions/setup-node@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:48:36Z",
+        "completed_at": "2026-09-08T06:48:36Z"
+      },
+      {
+        "name": "Post Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:48:36Z",
+        "completed_at": "2026-09-08T06:48:36Z"
+      },
+      {
+        "name": "Post Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:48:36Z",
+        "completed_at": "2026-09-08T06:48:36Z"
+      },
+      {
+        "name": "Complete job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:48:36Z",
+        "completed_at": "2026-09-08T06:48:36Z"
+      }
+    ],
+    "timing_log_lines": [
+      "2026-09-08T06:37:18.4570136Z Image: ubuntu-24.04",
+      "2026-09-08T06:37:18.4570748Z Version: 20260831.293.1",
+      "2026-09-08T06:37:32.9420180Z Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3",
+      "2026-09-08T06:37:40.7709839Z Cache hit for: node-cache-Linux-x64-npm-4de5e62afe53e7f3108e577f5202384a92b7ad10a828299132a34264ca828ac3",
+      "2026-09-08T06:39:08.7439579Z ##[group]Run make build",
+      "2026-09-08T06:39:33.8956135Z go build -ldflags \"-X main.version=v0.107.0-25-g542b94fd -X main.commit=542b94fd -X main.date=2026-09-08T06:39:33Z\" -o tmp/detent ./cmd/detent",
+      "2026-09-08T06:39:52.8966724Z ##[group]Run npm run test:visual",
+      "2026-09-08T06:39:54.6600117Z Running 207 tests using 1 worker",
+      "2026-09-08T06:48:33.4632383Z ##[notice]  32 skipped",
+      "  175 passed (8.7m)",
+      "2026-09-08T06:48:33.4645973Z   32 skipped",
+      "2026-09-08T06:48:33.4646259Z   175 passed (8.7m)",
+      "2026-09-08T06:48:36.1735309Z Cache hit occurred on the primary key node-cache-Linux-x64-npm-4de5e62afe53e7f3108e577f5202384a92b7ad10a828299132a34264ca828ac3, not saving cache.",
+      "2026-09-08T06:48:36.3227591Z Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3, not saving cache."
+    ]
+  },
+  {
+    "id": 101966105086,
+    "run_id": 34196736772,
+    "head_sha": "0be66fbee96886b2ca82e6d2206d915842dafeb3",
+    "html_url": "https://github.com/digitaldrywood/detent/actions/runs/34196736772/job/101966105086",
+    "name": "GoReleaser Snapshot",
+    "conclusion": "success",
+    "started_at": "2026-09-08T06:54:30Z",
+    "completed_at": "2026-09-08T07:05:09Z",
+    "labels": [
+      "ubuntu-latest"
+    ],
+    "runner_name": "GitHub Actions 1000050979",
+    "seconds": 639.0,
+    "steps": [
+      {
+        "name": "Set up job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:31Z",
+        "completed_at": "2026-09-08T06:54:32Z"
+      },
+      {
+        "name": "Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:32Z",
+        "completed_at": "2026-09-08T06:54:35Z"
+      },
+      {
+        "name": "Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:35Z",
+        "completed_at": "2026-09-08T06:54:52Z"
+      },
+      {
+        "name": "Install minisign",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:52Z",
+        "completed_at": "2026-09-08T06:55:02Z"
+      },
+      {
+        "name": "Prepare minisign snapshot key",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:55:02Z",
+        "completed_at": "2026-09-08T06:55:02Z"
+      },
+      {
+        "name": "Run GoReleaser snapshot",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:55:02Z",
+        "completed_at": "2026-09-08T07:05:05Z"
+      },
+      {
+        "name": "Post Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:05Z",
+        "completed_at": "2026-09-08T07:05:05Z"
+      },
+      {
+        "name": "Post Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:05Z",
+        "completed_at": "2026-09-08T07:05:05Z"
+      },
+      {
+        "name": "Complete job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:05Z",
+        "completed_at": "2026-09-08T07:05:05Z"
+      }
+    ],
+    "timing_log_lines": [
+      "2026-09-08T06:54:31.1874507Z Image: ubuntu-24.04",
+      "2026-09-08T06:54:31.1875569Z Version: 20260831.293.1",
+      "2026-09-08T06:54:45.2510679Z Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3",
+      "2026-09-08T06:55:04.3620332Z     \u2022 running                                        hook=go mod download",
+      "2026-09-08T06:55:04.3780802Z     \u2022 running                                        hook=go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0",
+      "2026-09-08T06:56:05.3190007Z     \u2022 running                                        hook=make generate",
+      "2026-09-08T06:56:32.5425187Z     \u2022 running                                        hook=go test ./...",
+      "2026-09-08T06:59:16.3952905Z   \u2022 building binaries",
+      "2026-09-08T07:04:38.8346825Z   \u2022 archives",
+      "2026-09-08T07:05:05.1297018Z   \u2022 calculating checksums",
+      "2026-09-08T07:05:05.1801172Z   \u2022 signing artifacts",
+      "2026-09-08T07:05:05.4080563Z   \u2022 release succeeded after 10m1s",
+      "2026-09-08T07:05:05.5972571Z Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3, not saving cache."
+    ]
+  },
+  {
+    "id": 101966105123,
+    "run_id": 34196736772,
+    "head_sha": "0be66fbee96886b2ca82e6d2206d915842dafeb3",
+    "html_url": "https://github.com/digitaldrywood/detent/actions/runs/34196736772/job/101966105123",
+    "name": "Browser Visual",
+    "conclusion": "success",
+    "started_at": "2026-09-08T06:54:29Z",
+    "completed_at": "2026-09-08T07:05:18Z",
+    "labels": [
+      "ubuntu-latest"
+    ],
+    "runner_name": "GitHub Actions 1000050980",
+    "seconds": 649.0,
+    "steps": [
+      {
+        "name": "Set up job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:30Z",
+        "completed_at": "2026-09-08T06:54:31Z"
+      },
+      {
+        "name": "Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:31Z",
+        "completed_at": "2026-09-08T06:54:34Z"
+      },
+      {
+        "name": "Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:34Z",
+        "completed_at": "2026-09-08T06:54:50Z"
+      },
+      {
+        "name": "Detect visual-sensitive changes",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:50Z",
+        "completed_at": "2026-09-08T06:54:51Z"
+      },
+      {
+        "name": "Run actions/setup-node@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:51Z",
+        "completed_at": "2026-09-08T06:54:53Z"
+      },
+      {
+        "name": "Install Node dependencies",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:53Z",
+        "completed_at": "2026-09-08T06:54:54Z"
+      },
+      {
+        "name": "Install Playwright browsers",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:54:54Z",
+        "completed_at": "2026-09-08T06:55:20Z"
+      },
+      {
+        "name": "Install visual build generators",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:55:20Z",
+        "completed_at": "2026-09-08T06:56:16Z"
+      },
+      {
+        "name": "Build Detent visual test binary",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:56:16Z",
+        "completed_at": "2026-09-08T06:56:57Z"
+      },
+      {
+        "name": "Run full browser visual gate",
+        "conclusion": "success",
+        "started_at": "2026-09-08T06:56:57Z",
+        "completed_at": "2026-09-08T07:05:14Z"
+      },
+      {
+        "name": "Run browser smoke gate",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T07:05:14Z",
+        "completed_at": "2026-09-08T07:05:14Z"
+      },
+      {
+        "name": "Upload browser visual evidence",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:14Z",
+        "completed_at": "2026-09-08T07:05:15Z"
+      },
+      {
+        "name": "Upload browser visual failure artifacts",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T07:05:15Z",
+        "completed_at": "2026-09-08T07:05:15Z"
+      },
+      {
+        "name": "Post Run actions/setup-node@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:15Z",
+        "completed_at": "2026-09-08T07:05:16Z"
+      },
+      {
+        "name": "Post Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:16Z",
+        "completed_at": "2026-09-08T07:05:16Z"
+      },
+      {
+        "name": "Post Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:16Z",
+        "completed_at": "2026-09-08T07:05:16Z"
+      },
+      {
+        "name": "Complete job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T07:05:16Z",
+        "completed_at": "2026-09-08T07:05:16Z"
+      }
+    ],
+    "timing_log_lines": [
+      "2026-09-08T06:54:30.3450113Z Image: ubuntu-24.04",
+      "2026-09-08T06:54:30.3450684Z Version: 20260831.293.1",
+      "2026-09-08T06:54:43.7497838Z Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3",
+      "2026-09-08T06:54:53.0611923Z Cache hit for: node-cache-Linux-x64-npm-4de5e62afe53e7f3108e577f5202384a92b7ad10a828299132a34264ca828ac3",
+      "2026-09-08T06:56:16.5228623Z ##[group]Run make build",
+      "2026-09-08T06:56:39.8000697Z go build -ldflags \"-X main.version=v0.107.0-26-g272f2700 -X main.commit=272f2700 -X main.date=2026-09-08T06:56:39Z\" -o tmp/detent ./cmd/detent",
+      "2026-09-08T06:56:57.8758381Z ##[group]Run npm run test:visual",
+      "2026-09-08T06:56:59.3924707Z Running 207 tests using 1 worker",
+      "2026-09-08T07:05:14.3308906Z ##[notice]  32 skipped",
+      "  175 passed (8.3m)",
+      "2026-09-08T07:05:14.3315660Z   32 skipped",
+      "2026-09-08T07:05:14.3316061Z   175 passed (8.3m)",
+      "2026-09-08T07:05:16.0949396Z Cache hit occurred on the primary key node-cache-Linux-x64-npm-4de5e62afe53e7f3108e577f5202384a92b7ad10a828299132a34264ca828ac3, not saving cache.",
+      "2026-09-08T07:05:16.2343647Z Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3, not saving cache."
+    ]
+  },
+  {
+    "id": 101951468437,
+    "run_id": 34191891374,
+    "head_sha": "6720ae3151045e2e688ffde17656dea08ce97ed6",
+    "html_url": "https://github.com/digitaldrywood/detent/actions/runs/34191891374/job/101951468437",
+    "name": "Browser Visual",
+    "conclusion": "success",
+    "started_at": "2026-09-08T05:46:04Z",
+    "completed_at": "2026-09-08T05:46:52Z",
+    "labels": [
+      "ubuntu-latest"
+    ],
+    "runner_name": "GitHub Actions 1000050920",
+    "seconds": 48.0,
+    "steps": [
+      {
+        "name": "Set up job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:05Z",
+        "completed_at": "2026-09-08T05:46:07Z"
+      },
+      {
+        "name": "Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:07Z",
+        "completed_at": "2026-09-08T05:46:10Z"
+      },
+      {
+        "name": "Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:10Z",
+        "completed_at": "2026-09-08T05:46:27Z"
+      },
+      {
+        "name": "Detect visual-sensitive changes",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:27Z",
+        "completed_at": "2026-09-08T05:46:28Z"
+      },
+      {
+        "name": "Run actions/setup-node@v6",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T05:46:28Z",
+        "completed_at": "2026-09-08T05:46:28Z"
+      },
+      {
+        "name": "Install Node dependencies",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T05:46:28Z",
+        "completed_at": "2026-09-08T05:46:28Z"
+      },
+      {
+        "name": "Install Playwright browsers",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T05:46:28Z",
+        "completed_at": "2026-09-08T05:46:28Z"
+      },
+      {
+        "name": "Install visual build generators",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T05:46:28Z",
+        "completed_at": "2026-09-08T05:46:28Z"
+      },
+      {
+        "name": "Build Detent visual test binary",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T05:46:28Z",
+        "completed_at": "2026-09-08T05:46:28Z"
+      },
+      {
+        "name": "Run full browser visual gate",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T05:46:28Z",
+        "completed_at": "2026-09-08T05:46:28Z"
+      },
+      {
+        "name": "Run browser smoke gate",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:28Z",
+        "completed_at": "2026-09-08T05:46:49Z"
+      },
+      {
+        "name": "Upload browser visual evidence",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:49Z",
+        "completed_at": "2026-09-08T05:46:49Z"
+      },
+      {
+        "name": "Upload browser visual failure artifacts",
+        "conclusion": "skipped",
+        "started_at": "2026-09-08T05:46:49Z",
+        "completed_at": "2026-09-08T05:46:49Z"
+      },
+      {
+        "name": "Post Run actions/setup-go@v6",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:49Z",
+        "completed_at": "2026-09-08T05:46:49Z"
+      },
+      {
+        "name": "Post Run actions/checkout@v5",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:49Z",
+        "completed_at": "2026-09-08T05:46:50Z"
+      },
+      {
+        "name": "Complete job",
+        "conclusion": "success",
+        "started_at": "2026-09-08T05:46:50Z",
+        "completed_at": "2026-09-08T05:46:50Z"
+      }
+    ],
+    "timing_log_lines": [
+      "2026-09-08T05:46:05.8904651Z Image: ubuntu-24.04",
+      "2026-09-08T05:46:05.8905273Z Version: 20260831.293.1",
+      "2026-09-08T05:46:21.0266784Z Cache hit for: setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3",
+      "2026-09-08T05:46:49.8598044Z Cache hit occurred on the primary key setup-go-Linux-x64-ubuntu24-go-1.26.6-a09195471dcc685fdb9736f7219e7e6fe6e377e9fd02622cfdd8cf8f7a8f97e3, not saving cache."
+    ]
+  }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
   browser-visual:
     name: Browser Visual
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
         with:
@@ -356,6 +357,7 @@ jobs:
   goreleaser-snapshot:
     name: GoReleaser Snapshot
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
         with:

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -42,10 +42,10 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 	},
 	{
 		name:     "Browser Visual",
-		budget:   "5m",
+		budget:   "15m",
 		jobStart: "  browser-visual:",
 		jobEnd:   "  portability-verify:",
-		markers:  []string{"name: Browser Visual", "Run full browser visual gate", "Run browser smoke gate"},
+		markers:  []string{"name: Browser Visual", "timeout-minutes: 15", "Run full browser visual gate", "Run browser smoke gate"},
 	},
 	{
 		name:     "Portability Verify (macos-latest)",
@@ -84,10 +84,10 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 	},
 	{
 		name:     "GoReleaser Snapshot",
-		budget:   "8m",
+		budget:   "15m",
 		jobStart: "  goreleaser-snapshot:",
 		jobEnd:   "",
-		markers:  []string{"name: GoReleaser Snapshot"},
+		markers:  []string{"name: GoReleaser Snapshot", "timeout-minutes: 15", "args: release --snapshot --clean", "MINISIGN_KEY_FILE: ${{ runner.temp }}/detent-minisign.key"},
 	},
 }
 
@@ -103,6 +103,34 @@ func TestCIConcurrencyKeepsMainPushRuns(t *testing.T) {
 		if !strings.Contains(concurrency, want) {
 			t.Fatalf("CI concurrency missing %q", want)
 		}
+	}
+}
+
+func TestSnapshotBudgetPreservesReleaseWork(t *testing.T) {
+	t.Parallel()
+
+	config := readNormalizedFile(t, ".goreleaser.yaml")
+	for _, tt := range []struct {
+		name    string
+		start   string
+		end     string
+		markers []string
+	}{
+		{"hooks", "before:", "\nbuilds:", []string{"go mod download", "go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0", "make generate", "go test ./..."}},
+		{"targets", "builds:", "\narchives:", []string{"CGO_ENABLED=0", "-trimpath", "- darwin", "- linux", "- windows", "- amd64", "- arm64"}},
+		{"archives", "archives:", "\nbrews:", []string{"- tar.gz", "goos: windows", "- zip", "- README.md", "- LICENSE", "- docs/**/*", "- scripts/hub-smoke.py"}},
+		{"packages", "nfpms:", "\nscoops:", []string{"- deb", "- rpm"}},
+		{"checksums", "checksum:", "\nsigns:", []string{"algorithm: sha256"}},
+		{"signing", "signs:", "\nsnapshot:", []string{"artifacts: checksum", "cmd: minisign", "${artifact}.minisig", "{{ .Env.MINISIGN_KEY_FILE }}"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			section := workflowBetween(t, config, tt.start, tt.end)
+			for _, marker := range tt.markers {
+				if !strings.Contains(section, marker) {
+					t.Errorf("release configuration missing %q", marker)
+				}
+			}
+		})
 	}
 }
 

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -130,13 +130,27 @@ Required PR merge checks, branch protection/rulesets, and
 - `Lint` - budget: `2m`
 - `Verify (ubuntu-latest)` - budget: `30m`
 - `Test Coverage` - budget: `4m`
-- `Browser Visual` - budget: `5m`
+- `Browser Visual` - budget: `15m`
 - `Portability Verify (macos-latest)` - budget: `8m`
 - `Portability Verify (windows-latest)` - budget: `45m`
 - `Windows Core` - budget: `4m`
 - `Installer Smoke (ubuntu-latest)` - budget: `6m`
 - `Installer Smoke (windows-latest)` - budget: `6m`
-- `GoReleaser Snapshot` - budget: `8m`
+- `GoReleaser Snapshot` - budget: `15m`
+
+Browser and snapshot budgets are whole-job ceilings, enforced with
+`timeout-minutes: 15`, including setup and artifact handling. Repeated hosted
+Linux measurements put full browser jobs at `10m49s`–`11m23s` and snapshot jobs
+at `10m3s`–`10m39s`, even with Go cache hits. The full Playwright step alone
+took `8m17s`–`8m41s`; a non-visual PR's binary smoke took `21s` in a `48s` job
+and is not a basis for the full-check budget. The ceilings leave more than
+three minutes above the observed maxima for runner variation and retries;
+they are bounds, not predicted runtimes or measured cold-cache guarantees.
+See [browser and snapshot measurements](../.detent/validation/2310/README.md)
+for runner/cache provenance, generation and compilation costs, packaging
+costs, and the assessment of repeated build and fixture work. Full browser
+selection, release hooks, all six release targets, archives, Linux packages,
+checksums, and minisign signing remain required work.
 
 The required portability checks are limited to build, vet, and the non-race
 test suite. Windows runs packages sequentially with four-way test parallelism


### PR DESCRIPTION
## Summary

Browser Visual and GoReleaser Snapshot repeatedly exceeded their documented 5m/8m budgets despite passing with Go cache hits. Align both budgets and explicit workflow ceilings at 15m, retaining the full browser selection and complete snapshot release pipeline.

Retain two hosted full-run stage measurements and a same-image/cache binary-smoke comparison. Contract tests protect the budgets, snapshot invocation, release hooks, six build targets, packaging, checksums, and signing. No measured evidence justifies sharing distinct browser fixtures or removing release validation, so those remain intact.

Fixes #2310

## UI Surface Contract

- [x] N/A: no product UI, layout, density, first-viewport, or responsive visibility changes.
- [x] No persistent top-of-screen messaging is added.
- [x] No visual changes to primary operator screens; existing browser assertions remain selected as before.

## Test Plan

- [x] Focused workflow budget, no-op, browser, and snapshot preservation contracts.
- [x] Two completed hosted full browser and snapshot jobs, plus a same-cache binary smoke; timing evidence is retained in the repository.
- [x] `make check`
- [x] Current-head CI: all 11 checks passed; full Browser Visual 11m35s (175 passed, 32 unchanged conditional skips), GoReleaser Snapshot 10m35s. Codex review completed without findings.
