### PR TITLE
fix(progress): recognize meaningful local commits

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1736,6 +1736,7 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 		r.progressTicker,
 		r.logger,
 		req.Issue,
+		r.sessionProgressJournal(sessionID, resumeState.DetentSessionID),
 	)
 	defer sessionBrake.Stop()
 	req.sessionBrake = sessionBrake
@@ -2921,6 +2922,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		r.progressTicker,
 		r.logger,
 		req.Issue,
+		r.sessionProgressJournal(sessionID, 0),
 	)
 	defer sessionBrake.Stop()
 	runReq.sessionBrake = sessionBrake
@@ -3998,8 +4000,10 @@ func effectiveModel(values ...string) string {
 
 func workspaceIssue(projectID string, issue connector.Issue) workspace.Issue {
 	baseRef := ""
+	progressBaseRef := ""
 	if issue.PullRequest != nil {
 		baseRef = strings.TrimSpace(issue.PullRequest.BaseSHA)
+		progressBaseRef = strings.TrimSpace(issue.PullRequest.BaseRef)
 	}
 	return workspace.Issue{
 		ProjectID:          projectID,
@@ -4007,6 +4011,7 @@ func workspaceIssue(projectID string, issue connector.Issue) workspace.Issue {
 		Identifier:         issue.Identifier,
 		BranchName:         issue.BranchName,
 		BaseRef:            baseRef,
+		ProgressBaseRef:    progressBaseRef,
 		PullRequestHeadSHA: pullRequestHeadSHA(issue.PullRequest),
 	}
 }

--- a/internal/runner/local_progress_test.go
+++ b/internal/runner/local_progress_test.go
@@ -1,0 +1,114 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestSessionLocalCommitProgress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		change       func(*testing.T, string, string)
+		wantProgress bool
+	}{
+		{name: "new implementation commit", wantProgress: true, change: func(t *testing.T, path, _ string) {
+			writeLocalProgressFile(t, path, "implementation.txt", "second implementation\n")
+			runRunnerGit(t, path, "commit", "-am", "implement second change")
+		}},
+		{name: "amended implementation", wantProgress: true, change: func(t *testing.T, path, _ string) {
+			writeLocalProgressFile(t, path, "implementation.txt", "amended implementation\n")
+			runRunnerGit(t, path, "commit", "--amend", "-am", "amend implementation")
+		}},
+		{name: "whitespace implementation", wantProgress: true, change: func(t *testing.T, path, _ string) {
+			writeLocalProgressFile(t, path, "implementation.txt", " first implementation\n")
+			runRunnerGit(t, path, "commit", "-am", "adjust whitespace")
+		}},
+		{name: "tracked implementation edit", wantProgress: true, change: func(t *testing.T, path, _ string) {
+			writeLocalProgressFile(t, path, "implementation.txt", "tracked implementation\n")
+		}},
+		{name: "committed handoff only", change: func(t *testing.T, path, _ string) {
+			if err := os.MkdirAll(filepath.Join(path, ".detent"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			writeLocalProgressFile(t, path, ".detent/notes.md", "handoff\n")
+			runRunnerGit(t, path, "add", "-f", ".detent/notes.md")
+			runRunnerGit(t, path, "commit", "-m", "update handoff")
+		}},
+		{name: "unchanged observation", change: func(*testing.T, string, string) {}},
+		{name: "empty commit", change: func(t *testing.T, path, _ string) {
+			runRunnerGit(t, path, "commit", "--allow-empty", "-m", "empty")
+		}},
+		{name: "commit metadata churn", change: func(t *testing.T, path, _ string) {
+			runRunnerGit(t, path, "commit", "--amend", "--date=2001-01-01T00:00:00Z", "-m", "renamed commit")
+		}},
+		{name: "untracked noise", change: func(t *testing.T, path, _ string) {
+			writeLocalProgressFile(t, path, "unrelated.log", "unrelated output\n")
+		}},
+		{name: "base only rebase", change: func(t *testing.T, path, source string) {
+			writeLocalProgressFile(t, source, "README.md", "upstream change\n")
+			runRunnerGit(t, source, "commit", "-am", "update base")
+			runRunnerGit(t, path, "rebase", "main")
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := initRunnerSourceRepo(t)
+			backend, err := workspace.NewBackend(workspace.KindLocalGit, workspace.LocalGitOptions{
+				Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := workspace.Issue{Identifier: "local-progress", BaseRef: "main"}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeLocalProgressFile(t, info.Path, "implementation.txt", "first implementation\n")
+			runRunnerGit(t, info.Path, "add", "implementation.txt")
+			runRunnerGit(t, info.Path, "commit", "-m", "implement first change")
+			runner := &Runner{}
+			probe := func(ctx context.Context) (sessionProgressSnapshot, error) {
+				return runner.sessionProgressSnapshot(ctx, backend, info, issue, nil)
+			}
+			before, err := probe(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			tt.change(t, info.Path, source)
+			started := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			controller := &sessionBrakeController{
+				startedAt: started, lastProgressAt: started, noProgressTimeout: time.Minute,
+				initial: before, current: before, probe: probe, cancelSession: cancel,
+				now: func() time.Time { return started.Add(time.Minute) },
+			}
+			observation := sessionProgressObservation(before, started)
+			controller.observation = &observation
+			controller.checkProgress(ctx, started.Add(time.Minute))
+			if got := controller.lastProgressAt.After(started); got != tt.wantProgress {
+				t.Fatalf("progress = %t, want %t; before=%+v after=%+v", got, tt.wantProgress, before, controller.current)
+			}
+			controller.checkProgress(ctx, controller.lastProgressAt.Add(time.Minute))
+			if controller.breach == nil {
+				t.Fatal("unchanged observation did not expire")
+			}
+		})
+	}
+}
+
+func writeLocalProgressFile(t *testing.T, path, name, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(path, name), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/runner/session_brake.go
+++ b/internal/runner/session_brake.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
@@ -119,6 +120,7 @@ func newSessionProgressTicker(interval time.Duration) sessionProgressTicker {
 }
 
 type sessionProgressSnapshot struct {
+	LocalProgress        *workspace.LocalProgress
 	DiffStats            DiffStats
 	HeadSHA              string
 	WorkspaceFingerprint string
@@ -164,6 +166,8 @@ type sessionBrakeController struct {
 	issue               connector.Issue
 	watchCancel         context.CancelFunc
 	watchDone           chan struct{}
+	journal             *sessionProgressJournal
+	observation         *store.SessionProgress
 }
 
 func newSessionBrakeController(
@@ -178,6 +182,7 @@ func newSessionBrakeController(
 	tickerFactory sessionProgressTickerFactory,
 	logger *slog.Logger,
 	issue connector.Issue,
+	journals ...*sessionProgressJournal,
 ) *sessionBrakeController {
 	if sessionDuration <= 0 && maxTurns <= 0 && noProgressTimeout <= 0 {
 		return nil
@@ -203,6 +208,9 @@ func newSessionBrakeController(
 		logger:            logger,
 		issue:             issue,
 	}
+	if len(journals) > 0 {
+		controller.journal = journals[0]
+	}
 	if noProgressTimeout <= 0 || probe == nil {
 		return controller
 	}
@@ -212,6 +220,9 @@ func newSessionBrakeController(
 	} else {
 		controller.initial = snapshot
 		controller.current = snapshot
+		if err := controller.observeSnapshotLocked(ctx, snapshot, startedAt); err != nil {
+			controller.logProbeFailure(err)
+		}
 	}
 	watchCtx, watchCancel := context.WithCancel(ctx)
 	controller.watchCancel = watchCancel
@@ -238,7 +249,6 @@ func (c *sessionBrakeController) checkProgress(ctx context.Context, at time.Time
 	snapshot, err := c.probe(ctx)
 	if err != nil {
 		c.logProbeFailure(err)
-		return
 	}
 	if at.IsZero() {
 		at = c.now()
@@ -250,14 +260,12 @@ func (c *sessionBrakeController) checkProgress(ctx context.Context, at time.Time
 		c.mu.Unlock()
 		return
 	}
-	if snapshot.fingerprint() != c.current.fingerprint() {
+	if err == nil {
 		c.current = snapshot
-		c.lastProgressAt = at
-		c.workProductProgress = true
-		c.mu.Unlock()
-		return
+		if err := c.observeSnapshotLocked(ctx, snapshot, at); err != nil {
+			c.logProbeFailure(err)
+		}
 	}
-	c.current = snapshot
 	if at.Sub(c.lastProgressAt) < c.noProgressTimeout {
 		c.mu.Unlock()
 		return
@@ -312,9 +320,8 @@ func (c *sessionBrakeController) refreshSnapshot(ctx context.Context) {
 		return
 	}
 	c.mu.Lock()
-	if snapshot.fingerprint() != c.current.fingerprint() {
-		c.workProductProgress = true
-		c.lastProgressAt = c.now().UTC()
+	if err := c.observeSnapshotLocked(ctx, snapshot, c.now().UTC()); err != nil {
+		c.logProbeFailure(err)
 	}
 	c.current = snapshot
 	c.mu.Unlock()
@@ -493,6 +500,14 @@ func (r *Runner) sessionProgressSnapshot(
 		}
 	}
 	var externalErr error
+	if provider, ok := backend.(workspace.LocalProgressProvider); ok {
+		local, err := provider.LocalProgress(ctx, info, issue)
+		if err != nil {
+			workspaceErr = errors.Join(workspaceErr, err)
+		} else {
+			snapshot.LocalProgress = &local
+		}
+	}
 	if external != nil {
 		snapshot.WorkpadFingerprint, externalErr = external(ctx)
 		snapshot.WorkpadFingerprint = strings.TrimSpace(snapshot.WorkpadFingerprint)

--- a/internal/runner/session_brake_boundaries_test.go
+++ b/internal/runner/session_brake_boundaries_test.go
@@ -1,0 +1,160 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestSessionBrakeProbeInitialization(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name               string
+		probeErr, storeErr error
+	}{
+		{name: "initial read failure", probeErr: errors.New("unavailable")},
+		{name: "initial journal failure", storeErr: errors.New("unavailable")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			controller := newSessionBrakeController(ctx, time.Time{}, 0, 0, time.Minute, cancel,
+				func(context.Context) (sessionProgressSnapshot, error) { return sessionProgressSnapshot{}, tt.probeErr },
+				func() time.Time { return at }, newControlledSessionTickerFactory().New,
+				slog.New(slog.NewTextHandler(io.Discard, nil)), connector.Issue{},
+				&sessionProgressJournal{store: &progressJournalStore{readErr: tt.storeErr}, sessionID: 1},
+			)
+			defer controller.Stop()
+			controller.checkProgress(ctx, at.Add(time.Minute))
+			if !errors.Is(context.Cause(ctx), ErrSessionNoProgress) {
+				t.Fatalf("cause=%v", context.Cause(ctx))
+			}
+		})
+	}
+	if got := newSessionBrakeController(t.Context(), at, 0, 0, 0, nil, nil, nil, nil, nil, connector.Issue{}); got != nil {
+		t.Fatal("disabled brake created")
+	}
+	controller := newSessionBrakeController(t.Context(), at, time.Minute, 0, 0, nil, nil, nil, nil, nil, connector.Issue{})
+	if controller == nil || controller.watchDone != nil {
+		t.Fatal("duration-only controller starts progress watch")
+	}
+}
+
+func TestLocalProgressCannotExtendAbsoluteBounds(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		limit error
+	}{
+		{name: "duration", limit: ErrSessionDurationExceeded},
+		{name: "turn count", limit: ErrSessionTurnLimitExceeded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			before := sessionProgressSnapshot{LocalProgress: &workspace.LocalProgress{HeadSHA: "old", CommitFingerprint: "old"}}
+			observation := sessionProgressObservation(before, at)
+			controller := &sessionBrakeController{
+				startedAt: at, lastProgressAt: at, maxTurns: 1, observation: &observation, cancelSession: cancel,
+				now: func() time.Time { return at.Add(time.Minute) },
+				probe: func(context.Context) (sessionProgressSnapshot, error) {
+					return sessionProgressSnapshot{LocalProgress: &workspace.LocalProgress{HeadSHA: "new", CommitFingerprint: "new"}}, nil
+				},
+			}
+			var err error
+			if errors.Is(tt.limit, ErrSessionDurationExceeded) {
+				err = controller.wrapDuration(ctx, tt.limit, time.Minute)
+			} else {
+				err = controller.observe(ctx, 2, 100)
+			}
+			if !errors.Is(err, tt.limit) || !controller.lastProgressAt.Equal(at.Add(time.Minute)) {
+				t.Fatalf("bound=%v, progress=%v", err, controller.lastProgressAt)
+			}
+			if !errors.Is(controller.observe(ctx, 3, 200), tt.limit) {
+				t.Fatal("breached controller resumed")
+			}
+		})
+	}
+}
+
+func TestSessionProgressSnapshotReadFailures(t *testing.T) {
+	t.Parallel()
+	failed := errors.New("read failed")
+	tests := []struct {
+		name    string
+		backend workspace.Backend
+		wantErr bool
+	}{
+		{name: "recovery failure", backend: &fakeWorkspaceBackend{recoveryErr: failed}, wantErr: true},
+		{name: "diff fallback failure", backend: diffOnlyProgressBackend{&fakeWorkspaceBackend{diffErr: failed}}, wantErr: true},
+		{name: "diff fallback", backend: diffOnlyProgressBackend{&fakeWorkspaceBackend{diffStat: workspace.DiffStat{Files: 1, Fingerprint: "tracked"}}}},
+		{name: "local failure", backend: failingLocalProgressBackend{&fakeWorkspaceBackend{}}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &Runner{}
+			_, err := runner.sessionProgressSnapshot(t.Context(), tt.backend, workspace.Info{}, workspace.Issue{}, nil)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error=%v, want error %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSessionBrakeErrorBoundaries(t *testing.T) {
+	t.Parallel()
+	var empty *SessionBrakeError
+	if empty.Error() == "" || empty.Unwrap() != nil || empty.Is(ErrSessionNoProgress) || sessionBrakeFingerprint(empty) != "" {
+		t.Fatal("invalid nil error behavior")
+	}
+	if (&SessionBrakeError{}).Error() == "" {
+		t.Fatal("missing error description")
+	}
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	controller := &sessionBrakeController{startedAt: at, lastProgressAt: at}
+	brake := controller.memoryCeiling(&SessionMemoryCeilingError{RSSBytes: 200, CeilingBytes: 100}, at.Add(-time.Second))
+	if brake.Elapsed != 0 || brake.RSSBytes != 200 || !brake.Is(ErrSessionMemoryCeilingExceeded) {
+		t.Fatalf("memory brake=%+v", brake)
+	}
+	if controller.memoryCeiling(nil, at) != nil {
+		t.Fatal("nil memory cause accepted")
+	}
+	if !(&SessionBrakeError{cause: io.EOF}).Is(io.EOF) {
+		t.Fatal("wrapped cause lost")
+	}
+	if sessionProgressCheckInterval(time.Hour) != 5*time.Minute {
+		t.Fatal("progress interval not bounded")
+	}
+	controller.probe = func(context.Context) (sessionProgressSnapshot, error) { return sessionProgressSnapshot{}, io.EOF }
+	controller.refreshSnapshot(t.Context())
+	if !controller.lastProgressAt.Equal(at) {
+		t.Fatal("failed refresh advanced clock")
+	}
+	controller.journal = &sessionProgressJournal{sessionID: 1, store: &progressJournalStore{readErr: io.EOF}}
+	controller.probe = func(context.Context) (sessionProgressSnapshot, error) { return sessionProgressSnapshot{}, nil }
+	controller.now = func() time.Time { return at }
+	controller.refreshSnapshot(t.Context())
+	if !controller.lastProgressAt.Equal(at) {
+		t.Fatal("failed journal refresh advanced clock")
+	}
+}
+
+type diffOnlyProgressBackend struct{ workspace.Backend }
+
+type failingLocalProgressBackend struct{ *fakeWorkspaceBackend }
+
+func (failingLocalProgressBackend) LocalProgress(context.Context, workspace.Info, workspace.Issue) (workspace.LocalProgress, error) {
+	return workspace.LocalProgress{}, errors.New("local progress unavailable")
+}

--- a/internal/runner/session_progress.go
+++ b/internal/runner/session_progress.go
@@ -1,0 +1,94 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+type sessionProgressJournal struct {
+	store     store.SessionProgressStore
+	sessionID int64
+	resumeID  int64
+	loaded    bool
+	saved     bool
+}
+
+func (r *Runner) sessionProgressJournal(sessionID, resumeID int64) *sessionProgressJournal {
+	progressStore, ok := r.store.(store.SessionProgressStore)
+	if !ok || sessionID <= 0 {
+		return nil
+	}
+	return &sessionProgressJournal{store: progressStore, sessionID: sessionID, resumeID: resumeID}
+}
+
+func (j *sessionProgressJournal) load(ctx context.Context) (store.SessionProgress, error) {
+	progress, err := j.store.SessionProgress(ctx, j.sessionID)
+	if err == nil {
+		j.saved = true
+	}
+	if errors.Is(err, store.ErrNotFound) && j.resumeID > 0 {
+		return j.store.SessionProgress(ctx, j.resumeID)
+	}
+	return progress, err
+}
+
+func sessionProgressObservation(snapshot sessionProgressSnapshot, at time.Time) store.SessionProgress {
+	observation := store.SessionProgress{
+		HeadSHA: snapshot.HeadSHA, WorkpadFingerprint: snapshot.WorkpadFingerprint,
+		WorkspaceFingerprint: snapshot.fingerprint(), LastProgressAt: at,
+	}
+	if local := snapshot.LocalProgress; local != nil {
+		observation.Local = true
+		observation.HeadSHA = local.HeadSHA
+		observation.CommitFingerprint = local.CommitFingerprint
+		observation.TrackedFingerprint = local.TrackedFingerprint
+		observation.WorkspaceFingerprint = ""
+	}
+	return observation
+}
+
+func sessionProgressAdvanced(previous, current store.SessionProgress) bool {
+	if previous.Local != current.Local {
+		return false
+	}
+	if previous.WorkpadFingerprint != current.WorkpadFingerprint {
+		return true
+	}
+	if current.Local {
+		return (current.CommitFingerprint != "" && current.CommitFingerprint != previous.CommitFingerprint) ||
+			(current.TrackedFingerprint != "" && current.TrackedFingerprint != previous.TrackedFingerprint)
+	}
+	return previous.WorkspaceFingerprint != current.WorkspaceFingerprint
+}
+
+func (c *sessionBrakeController) observeSnapshotLocked(ctx context.Context, snapshot sessionProgressSnapshot, at time.Time) error {
+	if c.journal != nil && !c.journal.loaded {
+		previous, err := c.journal.load(ctx)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return err
+		}
+		if err == nil {
+			c.observation = &previous
+			c.lastProgressAt = previous.LastProgressAt
+		}
+		c.journal.loaded = true
+	}
+	next := sessionProgressObservation(snapshot, c.lastProgressAt)
+	advanced := c.observation != nil && sessionProgressAdvanced(*c.observation, next)
+	if advanced && at.After(c.lastProgressAt) {
+		next.LastProgressAt = at
+	}
+	if c.journal != nil && (!c.journal.saved || c.observation == nil || *c.observation != next) {
+		if err := c.journal.store.SaveSessionProgress(ctx, c.journal.sessionID, next); err != nil {
+			return err
+		}
+		c.journal.saved = true
+	}
+	c.observation = &next
+	c.lastProgressAt = next.LastProgressAt
+	c.workProductProgress = c.workProductProgress || advanced
+	return nil
+}

--- a/internal/runner/session_progress_test.go
+++ b/internal/runner/session_progress_test.go
@@ -1,0 +1,159 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestSessionProgressResume(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "progress.db")
+	db, err := store.Open(t.Context(), store.Config{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	sessionID, err := db.StartSession(t.Context(), store.SessionStart{StartedAt: at})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := sessionProgressSnapshot{LocalProgress: &workspace.LocalProgress{HeadSHA: "first", CommitFingerprint: "first-patch"}}
+	runner := &Runner{store: db}
+	controller := &sessionBrakeController{lastProgressAt: at, journal: runner.sessionProgressJournal(sessionID, 0)}
+	if err := controller.observeSnapshotLocked(t.Context(), snapshot, at); err != nil {
+		t.Fatal(err)
+	}
+	snapshot.LocalProgress = &workspace.LocalProgress{HeadSHA: "second", CommitFingerprint: "second-patch"}
+	if err := controller.observeSnapshotLocked(t.Context(), snapshot, at.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err = store.Open(t.Context(), store.Config{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.store = db
+	for _, name := range []string{"restart same session", "resume new session", "resume again"} {
+		t.Run(name, func(t *testing.T) {
+			resumeID := int64(0)
+			if name != "restart same session" {
+				resumeID = sessionID
+				sessionID, err = db.StartSession(t.Context(), store.SessionStart{StartedAt: at.Add(2 * time.Minute), ResumedFromSessionID: resumeID})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			controller = &sessionBrakeController{
+				startedAt: at.Add(2 * time.Minute), lastProgressAt: at.Add(2 * time.Minute), noProgressTimeout: time.Minute,
+				journal: runner.sessionProgressJournal(sessionID, resumeID), cancelSession: cancel,
+				probe: func(context.Context) (sessionProgressSnapshot, error) { return snapshot, nil },
+			}
+			controller.checkProgress(ctx, at.Add(2*time.Minute))
+			if controller.breach == nil || !controller.lastProgressAt.Equal(at.Add(time.Minute)) {
+				t.Fatalf("restart recredited same head: last=%v breach=%v", controller.lastProgressAt, controller.breach)
+			}
+			got, err := db.(store.SessionProgressStore).SessionProgress(t.Context(), sessionID)
+			if err != nil || got.HeadSHA != "second" || !got.LastProgressAt.Equal(at.Add(time.Minute)) {
+				t.Fatalf("durable progress = %+v, %v", got, err)
+			}
+		})
+	}
+}
+
+func TestSessionProgressObservationFailures(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	initial := sessionProgressSnapshot{LocalProgress: &workspace.LocalProgress{HeadSHA: "first", CommitFingerprint: "first-patch"}}
+	changed := sessionProgressSnapshot{LocalProgress: &workspace.LocalProgress{HeadSHA: "second", CommitFingerprint: "second-patch"}}
+	tests := []struct {
+		name                       string
+		readErr, saveErr, probeErr error
+		missing                    bool
+	}{
+		{name: "journal read failure", readErr: errors.New("read failed")},
+		{name: "journal write failure", saveErr: errors.New("write failed")},
+		{name: "probe read failure", probeErr: errors.New("git read failed")},
+		{name: "first successful probe establishes baseline", missing: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			memory := &progressJournalStore{readErr: tt.readErr, saveErr: tt.saveErr}
+			if !tt.missing {
+				observation := sessionProgressObservation(initial, at)
+				memory.progress = &observation
+			}
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			controller := &sessionBrakeController{
+				startedAt: at, lastProgressAt: at, noProgressTimeout: time.Minute, cancelSession: cancel,
+				journal: &sessionProgressJournal{store: memory, sessionID: 1},
+				probe:   func(context.Context) (sessionProgressSnapshot, error) { return changed, tt.probeErr },
+			}
+			controller.checkProgress(ctx, at.Add(time.Minute))
+			if controller.breach == nil || !controller.lastProgressAt.Equal(at) {
+				t.Fatalf("failed read/write extended clock: %+v", controller)
+			}
+		})
+	}
+}
+
+func TestSessionProgressAdvancement(t *testing.T) {
+	t.Parallel()
+	previous := store.SessionProgress{Local: true, HeadSHA: "first", CommitFingerprint: "patch", TrackedFingerprint: "dirty"}
+	tests := []struct {
+		name    string
+		current store.SessionProgress
+		want    bool
+	}{
+		{name: "same", current: previous},
+		{name: "head only", current: store.SessionProgress{Local: true, HeadSHA: "second", CommitFingerprint: "patch", TrackedFingerprint: "dirty"}},
+		{name: "committed", current: store.SessionProgress{Local: true, CommitFingerprint: "new"}, want: true},
+		{name: "tracked edit", current: store.SessionProgress{Local: true, TrackedFingerprint: "new"}, want: true},
+		{name: "cleared evidence", current: store.SessionProgress{Local: true}},
+		{name: "new workpad", current: store.SessionProgress{Local: true, WorkpadFingerprint: "new"}, want: true},
+		{name: "backend changed", current: store.SessionProgress{WorkspaceFingerprint: "new"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sessionProgressAdvanced(previous, tt.current); got != tt.want {
+				t.Fatalf("advance=%t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+type progressJournalStore struct {
+	progress *store.SessionProgress
+	readErr  error
+	saveErr  error
+}
+
+func (s *progressJournalStore) SessionProgress(context.Context, int64) (store.SessionProgress, error) {
+	if s.readErr != nil {
+		return store.SessionProgress{}, s.readErr
+	}
+	if s.progress == nil {
+		return store.SessionProgress{}, store.ErrNotFound
+	}
+	return *s.progress, nil
+}
+
+func (s *progressJournalStore) SaveSessionProgress(_ context.Context, _ int64, progress store.SessionProgress) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	s.progress = &progress
+	return nil
+}

--- a/internal/store/migrations/00056_add_session_progress.sql
+++ b/internal/store/migrations/00056_add_session_progress.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+CREATE TABLE session_progress (
+  session_id INTEGER PRIMARY KEY REFERENCES codex_sessions(id) ON DELETE CASCADE,
+  observation_json TEXT NOT NULL
+);
+
+-- +goose Down
+DROP TABLE session_progress;

--- a/internal/store/session_progress.go
+++ b/internal/store/session_progress.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type SessionProgressStore interface {
+	SessionProgress(context.Context, int64) (SessionProgress, error)
+	SaveSessionProgress(context.Context, int64, SessionProgress) error
+}
+
+type SessionProgress struct {
+	HeadSHA              string    `json:"head_sha,omitempty"`
+	CommitFingerprint    string    `json:"commit_fingerprint,omitempty"`
+	TrackedFingerprint   string    `json:"tracked_fingerprint,omitempty"`
+	WorkspaceFingerprint string    `json:"workspace_fingerprint,omitempty"`
+	WorkpadFingerprint   string    `json:"workpad_fingerprint,omitempty"`
+	Local                bool      `json:"local,omitempty"`
+	LastProgressAt       time.Time `json:"last_progress_at"`
+}
+
+func (s *sqliteStore) SessionProgress(ctx context.Context, sessionID int64) (SessionProgress, error) {
+	var data string
+	err := s.db.QueryRowContext(ctx, "SELECT observation_json FROM session_progress WHERE session_id = ?", sessionID).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return SessionProgress{}, ErrNotFound
+	}
+	if err != nil {
+		return SessionProgress{}, fmt.Errorf("read session progress: %w", err)
+	}
+	var progress SessionProgress
+	if err := json.Unmarshal([]byte(data), &progress); err != nil {
+		return SessionProgress{}, fmt.Errorf("decode session progress: %w", err)
+	}
+	if progress.LastProgressAt.IsZero() {
+		return SessionProgress{}, errors.New("session progress timestamp is required")
+	}
+	return progress, nil
+}
+
+func (s *sqliteStore) SaveSessionProgress(ctx context.Context, sessionID int64, progress SessionProgress) error {
+	if sessionID <= 0 {
+		return ErrNotFound
+	}
+	if progress.LastProgressAt.IsZero() {
+		return errors.New("session progress timestamp is required")
+	}
+	data, err := json.Marshal(progress)
+	if err != nil {
+		return fmt.Errorf("encode session progress: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO session_progress (session_id, observation_json) VALUES (?, ?)
+ON CONFLICT(session_id) DO UPDATE SET observation_json = excluded.observation_json
+`, sessionID, string(data))
+	if err != nil {
+		return fmt.Errorf("save session progress: %w", err)
+	}
+	return nil
+}

--- a/internal/store/session_progress_test.go
+++ b/internal/store/session_progress_test.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSessionProgressPersists(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "progress.db")
+	db := openParkTestStore(t, path)
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	id, err := db.StartSession(t.Context(), SessionStart{StartedAt: at})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.SessionProgress(t.Context(), id); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing observation error = %v", err)
+	}
+	for _, head := range []string{"first", "second"} {
+		want := SessionProgress{HeadSHA: head, CommitFingerprint: "patch", Local: true, LastProgressAt: at}
+		if err := db.SaveSessionProgress(t.Context(), id, want); err != nil {
+			t.Fatal(err)
+		}
+		got, err := db.SessionProgress(t.Context(), id)
+		if err != nil || got != want {
+			t.Fatalf("progress = %+v, %v, want %+v", got, err, want)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db = openParkTestStore(t, path)
+	got, err := db.SessionProgress(t.Context(), id)
+	if err != nil || got.HeadSHA != "second" || !got.LastProgressAt.Equal(at) {
+		t.Fatalf("restarted progress = %+v, %v", got, err)
+	}
+}
+
+func TestSessionProgressFailures(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		check func(*testing.T, *sqliteStore, int64)
+	}{
+		{name: "invalid session", check: func(t *testing.T, db *sqliteStore, _ int64) {
+			if err := db.SaveSessionProgress(t.Context(), 0, SessionProgress{LastProgressAt: at}); !errors.Is(err, ErrNotFound) {
+				t.Fatal(err)
+			}
+		}},
+		{name: "missing timestamp", check: func(t *testing.T, db *sqliteStore, id int64) {
+			if err := db.SaveSessionProgress(t.Context(), id, SessionProgress{}); err == nil {
+				t.Fatal("missing timestamp accepted")
+			}
+		}},
+		{name: "invalid timestamp", check: func(t *testing.T, db *sqliteStore, id int64) {
+			if err := db.SaveSessionProgress(t.Context(), id, SessionProgress{LastProgressAt: time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC)}); err == nil {
+				t.Fatal("invalid timestamp accepted")
+			}
+		}},
+		{name: "missing parent session", check: func(t *testing.T, db *sqliteStore, id int64) {
+			if err := db.SaveSessionProgress(t.Context(), id+100, SessionProgress{LastProgressAt: at}); err == nil {
+				t.Fatal("missing session accepted")
+			}
+		}},
+		{name: "closed database", check: func(t *testing.T, db *sqliteStore, id int64) {
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.SessionProgress(t.Context(), id); err == nil {
+				t.Fatal("read closed database")
+			}
+			if err := db.SaveSessionProgress(t.Context(), id, SessionProgress{LastProgressAt: at}); err == nil {
+				t.Fatal("wrote closed database")
+			}
+		}},
+		{name: "corrupt observation", check: func(t *testing.T, db *sqliteStore, id int64) {
+			for _, data := range []string{"invalid", "{}"} {
+				if _, err := db.db.ExecContext(t.Context(), "INSERT OR REPLACE INTO session_progress VALUES (?, ?)", id, data); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := db.SessionProgress(t.Context(), id); err == nil {
+					t.Fatal("corrupt observation accepted")
+				}
+			}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db := openParkTestStore(t, filepath.Join(t.TempDir(), "progress.db"))
+			id, err := db.StartSession(t.Context(), SessionStart{StartedAt: at})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tt.check(t, db, id)
+		})
+	}
+}

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -447,6 +447,11 @@ type SecurityAuditRun struct {
 	RecordedAt         string         `json:"recorded_at"`
 }
 
+type SessionProgress struct {
+	SessionID       int64  `json:"session_id"`
+	ObservationJson string `json:"observation_json"`
+}
+
 type StalenessWarningState struct {
 	ProjectID      string         `json:"project_id"`
 	WarningID      string         `json:"warning_id"`

--- a/internal/workspace/local_progress.go
+++ b/internal/workspace/local_progress.go
@@ -1,0 +1,111 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type LocalProgressProvider interface {
+	LocalProgress(context.Context, Info, Issue) (LocalProgress, error)
+}
+
+type LocalProgress struct {
+	HeadSHA            string `json:"head_sha"`
+	CommitFingerprint  string `json:"commit_fingerprint"`
+	TrackedFingerprint string `json:"tracked_fingerprint"`
+}
+
+func (l *LocalGit) LocalProgress(ctx context.Context, info Info, issue Issue) (LocalProgress, error) {
+	normalized, err := l.normalizeInfo(info, issue)
+	if err != nil {
+		return LocalProgress{}, err
+	}
+	head, err := runGitAt(ctx, normalized.Path, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return LocalProgress{}, err
+	}
+	head = strings.TrimSpace(head)
+	base, err := l.localProgressBase(ctx, normalized.Path, issue)
+	if err != nil {
+		return LocalProgress{}, err
+	}
+	ancestor, err := runGitAt(ctx, normalized.Path, "merge-base", base, head)
+	if err != nil {
+		return LocalProgress{}, err
+	}
+	committed, err := gitProgressPatch(ctx, normalized.Path, strings.TrimSpace(ancestor), head)
+	if err != nil {
+		return LocalProgress{}, err
+	}
+	tracked, err := gitProgressPatch(ctx, normalized.Path, head)
+	if err != nil {
+		return LocalProgress{}, err
+	}
+	verifiedHead, err := runGitAt(ctx, normalized.Path, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return LocalProgress{}, err
+	}
+	if strings.TrimSpace(verifiedHead) != head {
+		return LocalProgress{}, errors.New("workspace head changed during progress observation")
+	}
+	return LocalProgress{HeadSHA: head, CommitFingerprint: committed, TrackedFingerprint: tracked}, nil
+}
+
+func (l *LocalGit) localProgressBase(ctx context.Context, path string, issue Issue) (string, error) {
+	if branch := strings.TrimSpace(issue.ProgressBaseRef); branch != "" {
+		for _, ref := range []string{"refs/remotes/origin/" + branch, "refs/heads/" + branch} {
+			if base, err := runGitAt(ctx, path, "rev-parse", "--verify", ref+"^{commit}"); err == nil {
+				return strings.TrimSpace(base), nil
+			}
+		}
+		return "", fmt.Errorf("local progress base branch %q is unavailable", branch)
+	}
+	if ref := strings.TrimSpace(issue.BaseRef); ref != "" {
+		base, err := runGitAt(ctx, path, "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
+		return strings.TrimSpace(base), err
+	}
+	if base, err := l.runGit(ctx, "rev-parse", "--verify", "refs/remotes/origin/HEAD^{commit}"); err == nil {
+		return strings.TrimSpace(base), nil
+	}
+	base, err := l.runGit(ctx, "rev-parse", "--verify", "HEAD")
+	return strings.TrimSpace(base), err
+}
+
+func gitProgressPatch(ctx context.Context, path string, revisions ...string) (string, error) {
+	args := []string{"-C", path, "diff", "--no-ext-diff", "--no-textconv", "--no-renames", "--no-color", "--no-relative", "--diff-algorithm=myers", "--binary", "--full-index", "--unified=0", "--src-prefix=a/", "--dst-prefix=b/"}
+	args = append(args, revisions...)
+	args = append(args, "--", ".")
+	for _, exclude := range detentHandoffDiffExcludes {
+		args = append(args, ":(exclude)"+exclude)
+	}
+	diff := exec.CommandContext(ctx, "git")
+	diff.Args = append(diff.Args, args...)
+	diff.WaitDelay = workspaceCommandWaitDelay
+	var diffError bytes.Buffer
+	diff.Stderr = &diffError
+	patch, err := diff.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	if err := diff.Start(); err != nil {
+		return "", err
+	}
+	identity := exec.CommandContext(ctx, "git", "-C", path, "patch-id", "--verbatim")
+	identity.WaitDelay = workspaceCommandWaitDelay
+	identity.Stdin = patch
+	output, patchErr := identity.Output()
+	closeErr := patch.Close()
+	diffErr := diff.Wait()
+	if err := errors.Join(patchErr, closeErr, diffErr); err != nil {
+		return "", fmt.Errorf("read local progress patch: %w: %s", err, strings.TrimSpace(diffError.String()))
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 {
+		return "", nil
+	}
+	return fields[0], nil
+}

--- a/internal/workspace/local_progress.go
+++ b/internal/workspace/local_progress.go
@@ -5,8 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
+	"time"
+)
+
+const (
+	localProgressTimeout    = 5 * time.Second
+	localProgressPatchLimit = 8 << 20
 )
 
 type LocalProgressProvider interface {
@@ -20,6 +27,8 @@ type LocalProgress struct {
 }
 
 func (l *LocalGit) LocalProgress(ctx context.Context, info Info, issue Issue) (LocalProgress, error) {
+	ctx, cancel := context.WithTimeout(ctx, localProgressTimeout)
+	defer cancel()
 	normalized, err := l.normalizeInfo(info, issue)
 	if err != nil {
 		return LocalProgress{}, err
@@ -76,6 +85,12 @@ func (l *LocalGit) localProgressBase(ctx context.Context, path string, issue Iss
 }
 
 func gitProgressPatch(ctx context.Context, path string, revisions ...string) (string, error) {
+	return gitProgressPatchBounded(ctx, path, localProgressPatchLimit, revisions...)
+}
+
+func gitProgressPatchBounded(ctx context.Context, path string, limit int64, revisions ...string) (string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	args := []string{"-C", path, "diff", "--no-ext-diff", "--no-textconv", "--no-renames", "--no-color", "--no-relative", "--diff-algorithm=myers", "--binary", "--full-index", "--unified=0", "--src-prefix=a/", "--dst-prefix=b/"}
 	args = append(args, revisions...)
 	args = append(args, "--", ".")
@@ -94,10 +109,18 @@ func gitProgressPatch(ctx context.Context, path string, revisions ...string) (st
 	if err := diff.Start(); err != nil {
 		return "", err
 	}
-	identity := exec.CommandContext(ctx, "git", "-C", path, "patch-id", "--verbatim")
+	identity := exec.CommandContext(ctx, "git", "patch-id", "--verbatim")
+	identity.Dir = path
 	identity.WaitDelay = workspaceCommandWaitDelay
-	identity.Stdin = patch
+	bounded := &io.LimitedReader{R: patch, N: limit + 1}
+	identity.Stdin = bounded
 	output, patchErr := identity.Output()
+	if bounded.N == 0 {
+		patchErr = errors.Join(patchErr, errors.New("local progress patch exceeds observation limit"))
+	}
+	if patchErr != nil {
+		cancel()
+	}
 	closeErr := patch.Close()
 	diffErr := diff.Wait()
 	if err := errors.Join(patchErr, closeErr, diffErr); err != nil {

--- a/internal/workspace/local_progress_test.go
+++ b/internal/workspace/local_progress_test.go
@@ -1,0 +1,163 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalProgressBase(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		issue   Issue
+		remote  bool
+		wantErr bool
+	}{
+		{name: "no upstream"},
+		{name: "named local base", issue: Issue{ProgressBaseRef: "main"}},
+		{name: "named remote base", issue: Issue{ProgressBaseRef: "main"}, remote: true},
+		{name: "cached default remote", remote: true},
+		{name: "explicit base", issue: Issue{BaseRef: "main"}},
+		{name: "missing named base", issue: Issue{ProgressBaseRef: "missing"}, wantErr: true},
+		{name: "missing explicit base", issue: Issue{BaseRef: "missing"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			base := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+			if tt.remote {
+				runGit(t, source, "update-ref", "refs/remotes/origin/main", base)
+				runGit(t, source, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+			}
+			local := &LocalGit{sourceRoot: source}
+			got, err := local.localProgressBase(t.Context(), source, tt.issue)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("missing base accepted")
+				}
+				return
+			}
+			if err != nil || got != base {
+				t.Fatalf("base=%q, %v, want %q", got, err, base)
+			}
+		})
+	}
+}
+
+func TestLocalProgressRebaseSameFile(t *testing.T) {
+	t.Parallel()
+	source := initSourceRepo(t)
+	path := filepath.Join(t.TempDir(), "worker")
+	lines := strings.Repeat("unchanged\n", 15)
+	if err := os.WriteFile(filepath.Join(source, "code.txt"), []byte("original\n"+lines+"end\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "add", "code.txt")
+	runGit(t, source, "commit", "-m", "create source")
+	runGit(t, source, "worktree", "add", "-b", "worker", path)
+	if err := os.WriteFile(filepath.Join(path, "code.txt"), []byte("original\n"+lines+"implemented\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, path, "commit", "-am", "implement")
+	oldBase := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+	oldHead := strings.TrimSpace(runGit(t, path, "rev-parse", "HEAD"))
+	before, err := gitProgressPatch(t.Context(), path, oldBase, oldHead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "code.txt"), []byte("base added a line\noriginal\n"+lines+"end\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "commit", "-am", "advance base")
+	runGit(t, path, "rebase", "main")
+	after, err := gitProgressPatch(t.Context(), path, "main", "HEAD")
+	if err != nil || after == "" || after != before {
+		t.Fatalf("rebased patch=%q, %v, want %q", after, err, before)
+	}
+	if oldHead == strings.TrimSpace(runGit(t, path, "rev-parse", "HEAD")) {
+		t.Fatal("rebase did not change head")
+	}
+}
+
+func TestLocalProgressPatchFailures(t *testing.T) {
+	t.Parallel()
+	source := initSourceRepo(t)
+	tests := []struct {
+		name     string
+		path     string
+		revision string
+		canceled bool
+	}{
+		{name: "missing workspace", path: filepath.Join(t.TempDir(), "missing"), revision: "HEAD"},
+		{name: "missing revision", path: source, revision: "missing"},
+		{name: "canceled read", path: source, revision: "HEAD", canceled: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if tt.canceled {
+				cancel()
+			}
+			if _, err := gitProgressPatch(ctx, tt.path, tt.revision); err == nil {
+				t.Fatal("failed read accepted")
+			}
+		})
+	}
+}
+
+func TestLocalProgressObservation(t *testing.T) {
+	t.Parallel()
+	source := initSourceRepo(t)
+	root := t.TempDir()
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	issue := Issue{Identifier: "progress"}
+	info, err := backend.Create(t.Context(), issue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	local := backend.(LocalProgressProvider)
+	before, err := local.LocalProgress(t.Context(), info, issue)
+	if err != nil || before.HeadSHA == "" || before.CommitFingerprint != "" || before.TrackedFingerprint != "" {
+		t.Fatalf("initial observation=%+v, %v", before, err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "binary.dat"), []byte{0, 1, 2, 3}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, info.Path, "add", "binary.dat")
+	runGit(t, info.Path, "commit", "-m", "add binary implementation")
+	after, err := local.LocalProgress(t.Context(), info, issue)
+	if err != nil || after.CommitFingerprint == "" || before.HeadSHA == after.HeadSHA {
+		t.Fatalf("commit observation=%+v, %v", after, err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "binary.dat"), []byte{0, 1, 3, 4}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dirty, err := local.LocalProgress(t.Context(), info, issue)
+	if err != nil || dirty.TrackedFingerprint == "" || dirty.CommitFingerprint != after.CommitFingerprint {
+		t.Fatalf("tracked observation=%+v, %v", dirty, err)
+	}
+	tests := []struct {
+		name  string
+		info  Info
+		issue Issue
+	}{
+		{name: "invalid path", info: Info{Path: filepath.Join(root, "..", "outside")}, issue: issue},
+		{name: "missing workspace", info: Info{Path: filepath.Join(root, "missing")}, issue: issue},
+		{name: "missing base", info: info, issue: Issue{Identifier: "progress", BaseRef: "missing"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := local.LocalProgress(t.Context(), tt.info, tt.issue); err == nil {
+				t.Fatal("failed observation accepted")
+			}
+		})
+	}
+}

--- a/internal/workspace/local_progress_test.go
+++ b/internal/workspace/local_progress_test.go
@@ -110,6 +110,40 @@ func TestLocalProgressPatchFailures(t *testing.T) {
 	}
 }
 
+func TestLocalProgressPatchLimit(t *testing.T) {
+	t.Parallel()
+	source := initSourceRepo(t)
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte(strings.Repeat("implementation\n", 1024)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	patch := runGit(t, source, "diff", "--binary", "--full-index", "--unified=0", "HEAD", "--", ".")
+	size := int64(len(patch))
+	tests := []struct {
+		name    string
+		limit   int64
+		wantErr bool
+	}{
+		{name: "below limit", limit: size + 1},
+		{name: "exact limit", limit: size},
+		{name: "over limit", limit: size - 1, wantErr: true},
+		{name: "truncated header", limit: 1, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fingerprint, err := gitProgressPatchBounded(t.Context(), source, tt.limit, "HEAD")
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "exceeds observation limit") || fingerprint != "" {
+					t.Fatalf("oversized patch = %q, %v", fingerprint, err)
+				}
+				return
+			}
+			if err != nil || fingerprint == "" {
+				t.Fatalf("bounded patch = %q, %v", fingerprint, err)
+			}
+		})
+	}
+}
+
 func TestLocalProgressObservation(t *testing.T) {
 	t.Parallel()
 	source := initSourceRepo(t)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -202,6 +202,7 @@ type Issue struct {
 	Identifier         string
 	BranchName         string
 	BaseRef            string
+	ProgressBaseRef    string
 	PullRequestHeadSHA string
 }
 

--- a/scripts/coverage-exceptions.txt
+++ b/scripts/coverage-exceptions.txt
@@ -15,6 +15,10 @@ github.com/digitaldrywood/detent/internal/orchestrator/ranking.go 90 # Safety-cr
 github.com/digitaldrywood/detent/internal/orchestrator/required_gate.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/snapshot.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/spend_progress.go 90 # Safety-critical spend progress brake.
+github.com/digitaldrywood/detent/internal/runner/session_brake.go 90
+github.com/digitaldrywood/detent/internal/runner/session_progress.go 90
+github.com/digitaldrywood/detent/internal/store/session_progress.go 90
+github.com/digitaldrywood/detent/internal/workspace/local_progress.go 90
 github.com/digitaldrywood/detent/internal/scheduler/global_gate.go 90 # Safety-critical fleet-wide dispatch gate.
 github.com/digitaldrywood/detent/internal/scheduler/pool_registry.go 90 # Safety-critical agent-pool dispatch control.
 github.com/digitaldrywood/detent/internal/tracker/normalize.go 90


### PR DESCRIPTION
## Summary

- Local implementation commits already advanced the session clock, but empty commits, metadata rewrites, untracked output, and base-only rebases also counted. Use verified content fingerprints so those observations cannot renew the no-progress window.
- Bound each local probe to five seconds and each patch stream to 8 MiB. Oversized or expired observations fail without crediting partial evidence.
- Persist the observed head and progress time across restart and session resume; repeated observations and read/write failures do not renew the clock.
- Preserve absolute duration, turn, spending, completion cleanliness, and remote-delivery requirements. Historical incidents from #2133 are preserved in the issue Workpad and are not claimed as reproduced on current main.

Fixes #2312

## UI Surface Contract

- [x] N/A: this change has no UI surface or layout effects.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens.

## Test Plan

- [x] Full runner, workspace, and store suites, including deterministic Git, restart/resume, missing upstream, read failure, repeated observation, and absolute-bound regressions.
- [x] Exact-file safety coverage: session brake 98.2%, session progress 100%, persisted progress 100%, local Git progress 92.0%.
- [x] FuzzSafetyCriticalOrchestratorBoundaries seeds and 30-second fuzz pass (719,577 executions).
- [x] `make security` and deterministic patch-size boundary tests.
- [x] `make check` (80.2% aggregate coverage; all package and file floors passed).
