### PR TITLE
feat(orchestrator): configure terminal retry limit

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -575,6 +575,10 @@
 # dependencies:
 #   # dependencies.source | type: string | default: "merged" | required: No | validation: must be one of merged, native_only
 #   source: "merged"
+# # recovery | type: object | default: see child fields | required: No | validation: None
+# recovery:
+#   # recovery.terminal_attempt_retry_limit | type: integer | default: 3 | required: No | validation: must be greater than or equal to 0
+#   terminal_attempt_retry_limit: 3
 # # worker | type: object | default: see child fields | required: No | validation: None
 # worker:
 #   # worker.ssh_hosts | type: list<string> | default: [] | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,7 +39,8 @@ park on that numbered failure. Negative values are rejected. This compatibility
 rule keeps the existing default at two redispatches before parking.
 
 The zero policy persists an operator-owned hold, including the latest failure
-evidence. Restarting Detent or waiting for the breaker cooldown does not release
+evidence. It also enforces the hold from the current completion when saving the
+attempt fails or no durable attempt record is available. Restarting Detent or waiting for the breaker cooldown does not release
 that hold. If the tracker rejects the Blocked transition, Detent holds the issue
 locally and retries that transition during reconciliation without starting a worker.
 Changing the setting alone does not authorize release of an existing

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,6 +13,50 @@ configuration is documented below after the host-wide settings.
 For instance backend/route inheritance and the opt-in `sol_first` model-selection
 preset, see [Instance agent defaults](multi-project.md#instance-agent-defaults-and-sol-first-selection).
 
+## Terminal attempt recovery
+
+Set `recovery.terminal_attempt_retry_limit` in `detent.yaml` or
+`detent.local.yaml` to control recovery from consecutive terminal attempts
+without a pushed work product or linked pull request:
+
+```yaml
+recovery:
+  terminal_attempt_retry_limit: 0
+```
+
+The default is `3`. The value preserves the existing consecutive-failure
+threshold for values of `2` or greater; `1` explicitly permits one recovery
+attempt, and `0` disables automatic recovery for a qualifying failure.
+
+| Setting | Failure 1 | Failure 2 | Failure 3 | Recovery after parking |
+| --- | --- | --- | --- | --- |
+| `0` | Blocked | No automatic attempt | No automatic attempt | Operator reviews the failure and moves the issue to Todo |
+| `1` | Todo; one recovery attempt | Blocked | No attempt before recovery from parking | Existing breaker cooldown |
+| `3` (default) | Todo | Todo | Blocked | Existing breaker cooldown |
+
+Thus `1` and `2` both park on the second qualifying failure. Higher values
+park on that numbered failure. Negative values are rejected. This compatibility
+rule keeps the existing default at two redispatches before parking.
+
+The zero policy persists an operator-owned hold, including the latest failure
+evidence. Restarting Detent or waiting for the breaker cooldown does not release
+that hold. If the tracker rejects the Blocked transition, Detent holds the issue
+locally and retries that transition during reconciliation without starting a worker.
+Changing the setting alone does not authorize release of an existing
+operator-owned hold. Retry counts are reconstructed from durable issue attempt
+history after restart; successful attempts and pushed work reset the sequence.
+Service-restart recovery remains resumable and does not consume this limit.
+
+Durable provider capacity, GitHub REST capacity, and forge availability waits
+retain their existing handling and do not consume generic terminal retries.
+Transient overload failures remain qualifying terminal failures. Workspace
+preparation retains its separate fixed threshold of three failures. This policy
+is independent of automatic promotion, validators, and Rework limits.
+
+`detent doctor` reports the effective setting, the qualifying failure on which
+Detent parks, and whether parking requires external review or uses cooldown
+recovery. Local overlays preserve an explicit zero.
+
 ## Repository policy with Hub execution
 
 Connecting a project to Hub preserves its repository definition. The customer
@@ -1099,6 +1143,8 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `polling.conditional` | `boolean` | `true` | No | None |
 | `polling.interval_ms` | `integer` | `120000` | No | must be at least 60000<br>must be greater than 0 |
 | `polling.refresh_failure_threshold` | `integer` | `3` | No | must be greater than 0 |
+| `recovery` | `object` | `see child fields` | No | None |
+| `recovery.terminal_attempt_retry_limit` | `integer` | `3` | No | must be greater than or equal to 0 |
 | `release` | `object` | `see child fields` | No | None |
 | `release.enabled` | `boolean` | `false` | No | release.max_age_hours must be greater than 0 when release.enabled is true<br>release.min_merged_issues must be greater than 0 when release.enabled is true<br>release.require_green_ci must be true when release.enabled is true<br>requires tracker.kind github or github_local<br>tracker.repository must be owner/name when release.enabled is true |
 | `release.flaky_check_names` | `list<string>` | `[]` | No | must not be empty when release.rerun_flaky_once is true |

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -395,6 +395,7 @@ func checkDoctorProjectWithProgress(
 	}
 	setDoctorCurrentCheck("Project " + id + " progress brake")
 	checks = append(checks, checkDoctorProgressBrake(id, workflow.Config))
+	checks = append(checks, checkDoctorTerminalAttemptRecovery(id, workflow.Config))
 	if strings.TrimSpace(storePath) != "" {
 		setDoctorCurrentCheck("Project " + id + " lifetime limits")
 		checks = append(checks, checkDoctorLifetimeLimits(ctx, id, storePath, workflow.Config, deps))
@@ -1069,6 +1070,17 @@ func checkDoctorProgressBrake(id string, cfg workflowconfig.Config) doctorCheck 
 		Status: doctorOK,
 		Detail: detail,
 	}
+}
+
+func checkDoctorTerminalAttemptRecovery(id string, cfg workflowconfig.Config) doctorCheck {
+	limit := cfg.Recovery.EffectiveTerminalAttemptRetryLimit()
+	detail := fmt.Sprintf("recovery.terminal_attempt_retry_limit=%d; park on qualifying failure %d; workspace-preparation failure limit=3", limit, cfg.Recovery.TerminalAttemptFailureLimit())
+	if limit == 0 {
+		detail += "; external review required before another worker session; no automatic cooldown recovery"
+	} else {
+		detail += "; existing breaker cooldown recovery applies"
+	}
+	return doctorCheck{Name: "Project " + id + " terminal attempt recovery", Status: doctorOK, Detail: detail}
 }
 
 func checkDoctorDisabledBudgetCaps(id string, cfg workflowconfig.Budget) (doctorCheck, bool) {

--- a/internal/cli/doctor_project_definition_test.go
+++ b/internal/cli/doctor_project_definition_test.go
@@ -15,6 +15,40 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
+func TestDoctorTerminalAttemptRecovery(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name  string
+		local string
+		want  []string
+	}{
+		{name: "default", want: []string{"terminal_attempt_retry_limit=3", "failure 3", "cooldown recovery"}},
+		{name: "local zero", local: "0", want: []string{"terminal_attempt_retry_limit=0", "failure 1", "external review", "no automatic cooldown recovery"}},
+		{name: "local one", local: "1", want: []string{"terminal_attempt_retry_limit=1", "failure 2", "cooldown recovery"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			local := "---\n---\n"
+			if tt.local != "" {
+				local = "---\nrecovery:\n  terminal_attempt_retry_limit: " + tt.local + "\n---\n"
+			}
+			workflow, err := workflowconfig.ParseWorkflowOverlay([]byte("---\ntracker:\n  kind: memory\n---\n"), []byte(local), "detent.local.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			check := checkDoctorTerminalAttemptRecovery("example", workflow.Config)
+			if check.Status != doctorOK || check.Name != "Project example terminal attempt recovery" {
+				t.Fatalf("check = %#v", check)
+			}
+			for _, want := range append(tt.want, "workspace-preparation failure limit=3") {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("detail = %q, want %q", check.Detail, want)
+				}
+			}
+		})
+	}
+}
+
 func TestDoctorProjectDefinitionLayouts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1109,8 +1109,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "inherited spend breaker warns about billing ambiguity",
@@ -1118,8 +1118,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: omittedBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -1128,8 +1128,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
-			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
+			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
 		},
 		{
 			name: "all progress brakes disabled",
@@ -1137,8 +1137,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledProgressWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "billing_mode=subscription", "no effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "billing_mode=subscription", "no effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -1146,8 +1146,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "effective cross-session progress brake", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,6 +161,7 @@ type Config struct {
 	Workpad           Workpad              `yaml:"workpad,omitempty"`
 	Deliverable       Deliverable          `yaml:"deliverable,omitempty"`
 	Dependencies      Dependencies         `yaml:"dependencies,omitempty"`
+	Recovery          Recovery             `yaml:"recovery,omitempty"`
 	Worker            Worker               `yaml:"worker"`
 	Agent             Agent                `yaml:"agent"`
 	Agents            Agents               `yaml:"agents"`
@@ -179,6 +180,25 @@ type Config struct {
 	BacklogAdmission  BacklogAdmission     `yaml:"backlog_admission,omitempty"`
 
 	configuredFields map[string]struct{}
+}
+
+type Recovery struct {
+	TerminalAttemptRetryLimit *int `yaml:"terminal_attempt_retry_limit,omitempty"`
+}
+
+func (r Recovery) EffectiveTerminalAttemptRetryLimit() int {
+	if r.TerminalAttemptRetryLimit == nil {
+		return 3
+	}
+	return *r.TerminalAttemptRetryLimit
+}
+
+func (r Recovery) TerminalAttemptFailureLimit() int {
+	limit := r.EffectiveTerminalAttemptRetryLimit()
+	if limit == 0 {
+		return 1
+	}
+	return max(2, limit)
 }
 
 type Tracker struct {
@@ -1346,6 +1366,7 @@ func Default() Config {
 	budget := defaultBudget()
 
 	return Config{
+		Recovery: Recovery{TerminalAttemptRetryLimit: new(3)},
 		Tracker: Tracker{
 			Endpoint:                    defaultLinearEndpoint,
 			HTTPMaxIdleConns:            100,
@@ -1564,6 +1585,7 @@ func (c *Config) Validate() error {
 	problems = append(problems, c.ActiveHours.Validate("active_hours")...)
 	c.validateTracker(&problems)
 	problems = append(problems, c.Dependencies.Validate("dependencies")...)
+	validateNonNegative("recovery.terminal_attempt_retry_limit", c.Recovery.EffectiveTerminalAttemptRetryLimit(), &problems)
 	validatePollingInterval(c.Polling.IntervalMS, &problems)
 	validatePositive("polling.refresh_failure_threshold", c.Polling.RefreshFailureThreshold, &problems)
 	c.Workspace.validate(&problems)

--- a/internal/config/project_definition_test.go
+++ b/internal/config/project_definition_test.go
@@ -9,6 +9,64 @@ import (
 	"testing"
 )
 
+func TestLoadProjectDefinitionTerminalAttemptRecovery(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		shared   string
+		local    string
+		want     int
+		failures int
+		wantErr  string
+	}{
+		{name: "default", want: 3, failures: 3},
+		{name: "shared zero", shared: "0", failures: 1},
+		{name: "shared one", shared: "1", want: 1, failures: 2},
+		{name: "shared three", shared: "3", want: 3, failures: 3},
+		{name: "overlay zero", shared: "3", local: "0", failures: 1},
+		{name: "overlay one", shared: "0", local: "1", want: 1, failures: 2},
+		{name: "overlay three", shared: "0", local: "3", want: 3, failures: 3},
+		{name: "higher limit", shared: "6", want: 6, failures: 6},
+		{name: "negative shared", shared: "-1", wantErr: "recovery.terminal_attempt_retry_limit must be greater than or equal to 0"},
+		{name: "negative overlay", shared: "3", local: "-1", wantErr: "recovery.terminal_attempt_retry_limit must be greater than or equal to 0"},
+		{name: "invalid type", shared: "false", wantErr: "cannot unmarshal"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			workflowPath := filepath.Join(dir, "WORKFLOW.md")
+			writeProjectDefinitionTestFile(t, workflowPath, "Implement the issue.\n", 0o644)
+			shared := "schema: 1\ntracker:\n  kind: memory\n"
+			if tt.shared != "" {
+				shared += "recovery:\n  terminal_attempt_retry_limit: " + tt.shared + "\n"
+			}
+			writeProjectDefinitionTestFile(t, filepath.Join(dir, "detent.yaml"), shared, 0o644)
+			if tt.local != "" {
+				writeProjectDefinitionTestFile(t, filepath.Join(dir, "detent.local.yaml"), "schema: 1\nrecovery:\n  terminal_attempt_retry_limit: "+tt.local+"\n", 0o600)
+			}
+			workflow, err := LoadProjectDefinition(workflowPath)
+			if err == nil {
+				err = workflow.Config.Validate()
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("LoadProjectDefinition() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := workflow.Config.Recovery.EffectiveTerminalAttemptRetryLimit(); got != tt.want {
+				t.Fatalf("effective limit = %d, want %d", got, tt.want)
+			}
+			if got := workflow.Config.Recovery.TerminalAttemptFailureLimit(); got != tt.failures {
+				t.Fatalf("failure limit = %d, want %d", got, tt.failures)
+			}
+		})
+	}
+}
+
 func TestLoadProjectDefinitionLayouts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -43,6 +43,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		StopRunPriorityNames:       stopRunPriorityNames(cfg.Tracker.PriorityMap),
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
+		Recovery:                   cfg.Recovery,
 		OverloadRetryDelay:         durationFromMillis(cfg.Agent.OverloadRetryDelayMS),
 		NoProgressTokenLimit:       cfg.Agent.NoProgressTokenLimit,
 		NoProgressSpendLimitUSD:    cfg.Agent.NoProgressSpendLimitUSD,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -96,6 +96,7 @@ type Config struct {
 	StopRunPriorityNames          map[int]string
 	MaxConcurrentAgentsPerHost    int
 	MaxRetryBackoff               time.Duration
+	Recovery                      workflowconfig.Recovery
 	OverloadRetryDelay            time.Duration
 	NoProgressTokenLimit          int64
 	NoProgressSpendLimitUSD       float64

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -468,6 +468,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 				running.Mode,
 				running.DiffStats,
 				event.CompletedAt,
+				terminalAttemptFailureEvidence(running, terminalState, errorClass, errorMessage, event.CompletedAt),
 			)
 			if parked {
 				return

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -38,6 +38,7 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 	runMode string,
 	diffStats DiffStats,
 	at time.Time,
+	currentAttempts ...telemetry.WorkAttempt,
 ) (connector.Issue, bool, bool) {
 	if o == nil || o.connector == nil ||
 		normalizeState(issue.State) != normalizeState(planImplementationState) ||
@@ -46,9 +47,18 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 		o.terminalAttemptClaimBlocksDemotion(ctx, issue, at) {
 		return issue, false, false
 	}
-	if durable {
+	operatorReview := retryCause == terminalAttemptRetryLimitCause && o.cfg.Recovery.EffectiveTerminalAttemptRetryLimit() == 0
+	if !durable && operatorReview && state != nil && len(currentAttempts) > 0 {
+		current := currentAttempts[0]
+		if current.AttemptID > 0 {
+			o.upsertWorkAttemptSnapshot(state, current)
+		} else {
+			state.WorkAttempts = append([]telemetry.WorkAttempt{current}, state.WorkAttempts...)
+		}
+	}
+	if durable || operatorReview && len(currentAttempts) > 0 {
 		historyReader := o
-		if retryCause == terminalAttemptRetryLimitCause && o.cfg.Recovery.EffectiveTerminalAttemptRetryLimit() == 0 {
+		if operatorReview {
 			historyReader = &Orchestrator{cfg: o.cfg}
 		}
 		count, latest, known := historyReader.consecutiveRetryCycleCount(ctx, state, issue, retryCause, at)
@@ -111,6 +121,21 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 		)
 	}
 	return issue, true, false
+}
+
+func terminalAttemptFailureEvidence(running Running, terminalState store.WorkAttemptTerminalState, errorClass, errorMessage string, at time.Time) telemetry.WorkAttempt {
+	return telemetry.WorkAttempt{
+		AttemptID:          running.WorkAttemptID,
+		AttemptNumber:      running.Attempt,
+		IssueID:            running.Issue.ID,
+		Identifier:         running.Issue.Identifier,
+		Status:             string(store.WorkAttemptStatusTerminal),
+		TerminalState:      string(terminalState),
+		ErrorClass:         errorClass,
+		ErrorMessage:       errorMessage,
+		CompletedAt:        &at,
+		WorkerMetadataJSON: runningWorkAttemptMetadataJSON(running, nil),
+	}
 }
 
 func (o *Orchestrator) retryCycleFailureLimit(cause string) int {

--- a/internal/orchestrator/terminal_attempt_retry.go
+++ b/internal/orchestrator/terminal_attempt_retry.go
@@ -47,11 +47,15 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 		return issue, false, false
 	}
 	if durable {
-		count, latest, known := o.consecutiveRetryCycleCount(ctx, state, issue, retryCause, at)
+		historyReader := o
+		if retryCause == terminalAttemptRetryLimitCause && o.cfg.Recovery.EffectiveTerminalAttemptRetryLimit() == 0 {
+			historyReader = &Orchestrator{cfg: o.cfg}
+		}
+		count, latest, known := historyReader.consecutiveRetryCycleCount(ctx, state, issue, retryCause, at)
 		switch {
 		case !known:
 			o.recordRetryCycleHistoryUnavailable(state, issue, retryCause, at)
-		case count >= consecutiveRetryCycleLimit:
+		case count >= o.retryCycleFailureLimit(retryCause):
 			parked, ok := o.parkRetryCycleLimit(ctx, state, issue, runMode, diffStats, retryCause, count, latest, at)
 			if ok {
 				return parked, true, true
@@ -109,6 +113,13 @@ func (o *Orchestrator) demoteTerminalAttemptRetry(
 	return issue, true, false
 }
 
+func (o *Orchestrator) retryCycleFailureLimit(cause string) int {
+	if strings.TrimSpace(cause) == terminalAttemptRetryLimitCause {
+		return o.cfg.Recovery.TerminalAttemptFailureLimit()
+	}
+	return consecutiveRetryCycleLimit
+}
+
 func (o *Orchestrator) consecutiveRetryCycleCount(
 	ctx context.Context,
 	state *State,
@@ -116,7 +127,8 @@ func (o *Orchestrator) consecutiveRetryCycleCount(
 	cause string,
 	at time.Time,
 ) (int, telemetry.WorkAttempt, bool) {
-	for limit := consecutiveRetryCycleLimit; ; limit *= 2 {
+	failureLimit := o.retryCycleFailureLimit(cause)
+	for limit := failureLimit; ; limit *= 2 {
 		attempts, ok := o.recentIssueTerminalAttempts(ctx, state, issue, limit, at)
 		if !ok {
 			return 0, telemetry.WorkAttempt{}, false
@@ -135,7 +147,7 @@ func (o *Orchestrator) consecutiveRetryCycleCount(
 				latest = attempt
 			}
 			count++
-			if count >= consecutiveRetryCycleLimit {
+			if count >= failureLimit {
 				return count, latest, true
 			}
 		}
@@ -260,14 +272,23 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		diffStats,
 	)
 	attemptError := retryCycleAttemptError(o, latest)
+	operatorReview := cause == terminalAttemptRetryLimitCause && o.cfg.Recovery.EffectiveTerminalAttemptRetryLimit() == 0
+	if operatorReview {
+		metadata.BlockedRecovery.Owner = blockedRecoveryOwnerOperator
+		metadata.BlockedRecovery.HoldReason = "terminal_attempt_external_review"
+		metadata.BlockedRecovery.IntentResumable = false
+	}
 	metadata.BlockedRecovery.WorkAttemptID = latest.AttemptID
 	metadata.BlockedRecovery.AttemptNumber = latest.AttemptNumber
 	metadata.BlockedRecovery.AttemptError = attemptError
-	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, at, cause, metadata, laneMutationRevokeWorker); err != nil {
+	transitionErr := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, targetState, at, cause, metadata, laneMutationRevokeWorker)
+	if transitionErr != nil {
 		if o.logger != nil {
-			o.logger.Error("retry cycle limit state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "target_state", targetState, "error", err)
+			o.logger.Error("retry cycle limit state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "target_state", targetState, "error", transitionErr)
 		}
-		return issue, false
+		if !operatorReview {
+			return issue, false
+		}
 	}
 	issue.State = targetState
 	if err := o.abandonClaim(ctx, issue.ID); err != nil && o.logger != nil {
@@ -295,8 +316,18 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		WorkAttemptID:           latest.AttemptID,
 		Recovery:                metadata.BlockedRecovery,
 	}
-	if o.connector != nil {
-		comment := retryCycleLimitComment(issue, cause, count, targetState, latest, attemptError)
+	if operatorReview {
+		blocked := state.Blocked[issue.ID]
+		blocked.RecoveryAction = "hold"
+		blocked.RecoveryReason = metadata.BlockedRecovery.HoldReason
+		blocked.RecoveryRemedy = "Review the terminal attempt, then move the issue to Todo to authorize another worker session."
+		blocked.RecoveryReachability = blockedRecoveryReachability("hold")
+		blocked.RecoveryIntentResumable = false
+		blocked.NeedsHumanAttention = true
+		state.Blocked[issue.ID] = blocked
+	}
+	if o.connector != nil && transitionErr == nil {
+		comment := retryCycleLimitComment(issue, cause, count, targetState, latest, attemptError, operatorReview)
 		if err := o.connector.CreateComment(ctx, issue.ID, comment); err != nil && o.logger != nil {
 			o.logger.Warn("retry cycle limit comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "cause", cause, "error", err)
 		}
@@ -311,7 +342,7 @@ func (o *Orchestrator) parkRetryCycleLimit(
 		telemetry.LogLifecycleMessage(o.logger, slog.LevelError, telemetry.LifecycleSafetyControl, event, "retry cycle limit reached", o.issueLifecycleCorrelation(issue),
 			"cause", cause,
 			"consecutive_attempts", count,
-			"limit", consecutiveRetryCycleLimit,
+			"limit", o.retryCycleFailureLimit(cause),
 			"target_state", targetState,
 		)
 	}
@@ -333,13 +364,19 @@ func retryCycleLimitComment(
 	targetState string,
 	attempt telemetry.WorkAttempt,
 	attemptError string,
+	operatorReview bool,
 ) string {
+	recovery := "until the configured breaker cooldown ends, then Detent returns it to its prior lane automatically."
+	if operatorReview {
+		recovery = "for external review because recovery.terminal_attempt_retry_limit is 0. Review the terminal attempt, then move the issue to Todo to authorize another worker session."
+	}
 	comment := fmt.Sprintf(
-		"Detent stopped retrying %s after %d consecutive %s attempts. The issue is parked in `%s` until the configured breaker cooldown ends, then Detent returns it to its prior lane automatically.",
+		"Detent stopped retrying %s after %d consecutive %s attempts. The issue is parked in `%s` %s",
 		issueLabel(issue),
 		count,
 		retryCycleDescription(cause),
 		targetState,
+		recovery,
 	)
 	if attemptError == "" {
 		return comment

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -33,12 +33,22 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 		name            string
 		limit           *int
 		wantBlocked     bool
+		completionErr   bool
+		noStore         bool
+		noAttemptID     bool
 		issue           connector.Issue
 		result          runpkg.RunResult
 		runError        error
 		wantState       string
 		wantTransitions []string
 	}{
+		{name: "zero parks failed persistence", limit: new(0), issue: terminalRetryTestIssue("zero-store-error"), runError: errors.New("runner failed"), completionErr: true, wantBlocked: true},
+		{name: "zero parks missing store", limit: new(0), issue: terminalRetryTestIssue("zero-no-store"), runError: errors.New("runner failed"), noStore: true, wantBlocked: true},
+		{name: "zero parks missing attempt ID", limit: new(0), issue: terminalRetryTestIssue("zero-no-id"), runError: errors.New("runner failed"), noAttemptID: true, wantBlocked: true},
+		{name: "zero parks overload without store", limit: new(0), issue: terminalRetryTestIssue("zero-overload-no-store"), runError: backendcapacity.NewError(scope, backendcapacity.Details{Type: backendcapacity.ErrorTypeTransientOverload, Kind: "serverOverloaded"}, errors.New("provider overloaded")), noStore: true, wantBlocked: true},
+		{name: "zero preserves capacity without store", limit: new(0), issue: terminalRetryTestIssue("zero-capacity-no-store"), runError: backendcapacity.NewError(scope, backendcapacity.Details{Kind: "usageLimitExceeded", ResetAt: &capacityReset}, errors.New("provider usage limit reached")), noStore: true, wantState: "Todo", wantTransitions: []string{"Todo"}},
+		{name: "zero preserves pushed work without store", limit: new(0), issue: terminalRetryTestIssue("zero-pushed-no-store"), result: runpkg.RunResult{PullRequestHeadPushed: true}, runError: errors.New("runner failed"), noStore: true, wantState: "In Progress"},
+		{name: "default preserves failed persistence retry", issue: terminalRetryTestIssue("default-store-error"), runError: errors.New("runner failed"), completionErr: true, wantState: "Todo", wantTransitions: []string{"Todo"}},
 		{name: "zero parks runner failure", limit: new(0), issue: terminalRetryTestIssue("zero-failure"), runError: errors.New("runner failed"), wantBlocked: true},
 		{name: "zero parks transient overload", limit: new(0), issue: terminalRetryTestIssue("zero-overload"), runError: backendcapacity.NewError(scope, backendcapacity.Details{Type: backendcapacity.ErrorTypeTransientOverload, Kind: "serverOverloaded"}, errors.New("provider overloaded")), wantBlocked: true},
 		{name: "zero preserves capacity wait", limit: new(0), issue: terminalRetryTestIssue("zero-capacity"), runError: backendcapacity.NewError(scope, backendcapacity.Details{Kind: "usageLimitExceeded", ResetAt: &capacityReset}, errors.New("provider usage limit reached")), wantState: "Todo", wantTransitions: []string{"Todo"}},
@@ -94,6 +104,9 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 			now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
 			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{tt.issue.ID: cloneIssue(tt.issue)}}
 			attempts := &terminalRetryWorkAttemptStore{}
+			if tt.completionErr {
+				attempts.completionErr = errors.New("store unavailable")
+			}
 			cfg := normalizeConfig(Config{
 				Recovery:              workflowconfig.Recovery{TerminalAttemptRetryLimit: tt.limit},
 				ActiveStates:          []string{"Todo", "In Progress"},
@@ -102,6 +115,9 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 				FailureRetryBaseDelay: time.Second,
 			})
 			o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			if tt.noStore {
+				o.workAttempts = nil
+			}
 			state := newState(cfg)
 			state.Running[tt.issue.ID] = Running{
 				Issue:         cloneIssue(tt.issue),
@@ -111,6 +127,11 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 				StartedAt:     now.Add(-time.Minute),
 			}
 			state.Claimed[tt.issue.ID] = Claimed{Issue: cloneIssue(tt.issue), ClaimedAt: now.Add(-time.Minute)}
+			if tt.noAttemptID {
+				running := state.Running[tt.issue.ID]
+				running.WorkAttemptID = 0
+				state.Running[tt.issue.ID] = running
+			}
 
 			o.handleRunResult(t.Context(), &state, runpkg.Completion{
 				IssueID:      tt.issue.ID,
@@ -143,6 +164,12 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 			}
 			if got := tracker.transitionStates(); !slices.Equal(got, tt.wantTransitions) {
 				t.Fatalf("state transitions = %v, want %v", got, tt.wantTransitions)
+			}
+			if tt.noStore || tt.noAttemptID {
+				if len(attempts.completions) != 0 {
+					t.Fatal("unexpected completion persistence")
+				}
+				return
 			}
 			if len(attempts.completions) != 1 {
 				t.Fatalf("work attempt completions = %d, want 1", len(attempts.completions))
@@ -1169,6 +1196,7 @@ func (c *terminalRetryConnector) transitionStates() []string {
 }
 
 type terminalRetryWorkAttemptStore struct {
+	completionErr  error
 	completions    []store.WorkAttemptCompletion
 	history        []store.WorkAttempt
 	historyErr     error
@@ -1189,7 +1217,7 @@ func (s *terminalRetryWorkAttemptStore) RecordWorkAttemptHeartbeat(context.Conte
 
 func (s *terminalRetryWorkAttemptStore) CompleteWorkAttempt(_ context.Context, completion store.WorkAttemptCompletion) error {
 	s.completions = append(s.completions, completion)
-	return nil
+	return s.completionErr
 }
 
 func (s *terminalRetryWorkAttemptStore) TimeoutExpiredWorkAttempts(context.Context, store.WorkAttemptTimeout) ([]store.WorkAttempt, error) {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -28,12 +31,19 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 	capacityReset := time.Date(2026, 7, 18, 16, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name            string
+		limit           *int
+		wantBlocked     bool
 		issue           connector.Issue
 		result          runpkg.RunResult
 		runError        error
 		wantState       string
 		wantTransitions []string
 	}{
+		{name: "zero parks runner failure", limit: new(0), issue: terminalRetryTestIssue("zero-failure"), runError: errors.New("runner failed"), wantBlocked: true},
+		{name: "zero parks transient overload", limit: new(0), issue: terminalRetryTestIssue("zero-overload"), runError: backendcapacity.NewError(scope, backendcapacity.Details{Type: backendcapacity.ErrorTypeTransientOverload, Kind: "serverOverloaded"}, errors.New("provider overloaded")), wantBlocked: true},
+		{name: "zero preserves capacity wait", limit: new(0), issue: terminalRetryTestIssue("zero-capacity"), runError: backendcapacity.NewError(scope, backendcapacity.Details{Kind: "usageLimitExceeded", ResetAt: &capacityReset}, errors.New("provider usage limit reached")), wantState: "Todo", wantTransitions: []string{"Todo"}},
+		{name: "zero preserves pushed work", limit: new(0), issue: terminalRetryTestIssue("zero-pushed"), result: runpkg.RunResult{PullRequestHeadPushed: true}, runError: errors.New("runner failed"), wantState: "In Progress"},
+		{name: "zero preserves linked PR", limit: new(0), issue: terminalRetryTestIssueWithPullRequest("zero-pr"), runError: errors.New("runner failed"), wantState: "In Progress"},
 		{
 			name:            "no pushed work returns to todo",
 			issue:           terminalRetryTestIssue("empty"),
@@ -85,6 +95,7 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{tt.issue.ID: cloneIssue(tt.issue)}}
 			attempts := &terminalRetryWorkAttemptStore{}
 			cfg := normalizeConfig(Config{
+				Recovery:              workflowconfig.Recovery{TerminalAttemptRetryLimit: tt.limit},
 				ActiveStates:          []string{"Todo", "In Progress"},
 				TerminalStates:        []string{"Done"},
 				MaxRetryBackoff:       time.Minute,
@@ -110,6 +121,16 @@ func TestHandleRunResultRoutesTerminalRetryByWorkProduct(t *testing.T) {
 				RetryDelay:   time.Minute,
 			})
 
+			if tt.wantBlocked {
+				blocked, ok := state.Blocked[tt.issue.ID]
+				if !ok || blocked.Reason != terminalAttemptRetryLimitCause || blocked.Recovery.Owner != blockedRecoveryOwnerOperator {
+					t.Fatalf("Blocked = %#v, want operator-owned terminal failure", blocked)
+				}
+				if len(state.Retry) != 0 || len(state.Claimed) != 0 || !slices.Equal(tracker.transitionStates(), []string{"Blocked"}) {
+					t.Fatal("parked failure retained retry/claim or transitioned to Todo")
+				}
+				return
+			}
 			retry, ok := state.Retry[tt.issue.ID]
 			if !ok {
 				t.Fatalf("Retry[%q] missing", tt.issue.ID)
@@ -264,90 +285,117 @@ func TestHandleRunResultPersistsPublishedPushCommandEvidence(t *testing.T) {
 func TestHandleRunResultParksTerminalRetryAtDurableLimit(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 8, 20, 13, 0, 0, 0, time.UTC)
-	issue := terminalRetryTestIssue("runtime-limit")
-	tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
-	attempts := &terminalRetryWorkAttemptStore{}
-	cfg := normalizeConfig(Config{
-		ActiveStates:          []string{"Todo", "In Progress"},
-		ObservedStates:        []string{"Blocked"},
-		TerminalStates:        []string{"Done"},
-		MaxRetryBackoff:       time.Minute,
-		FailureRetryBaseDelay: time.Second,
-	})
-	o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
-	metrics := &autoPromoteWorkflowMetricsRecorder{}
-	o.workflowMetrics = metrics
-	state := newState(cfg)
-
-	for attempt := 1; attempt <= consecutiveRetryCycleLimit; attempt++ {
-		completedAt := now.Add(time.Duration(attempt) * time.Minute)
-		issue.State = planImplementationState
-		tracker.issues[issue.ID] = cloneIssue(issue)
-		state.Running[issue.ID] = Running{
-			Issue:         cloneIssue(issue),
-			Attempt:       attempt,
-			WorkAttemptID: int64(attempt),
-			Mode:          runpkg.RunModePlan,
-			StartedAt:     completedAt.Add(-time.Minute),
-		}
-		state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: completedAt.Add(-time.Minute)}
-		o.upsertWorkAttemptSnapshot(&state, telemetry.WorkAttempt{
-			AttemptID: int64(attempt), IssueID: issue.ID, Identifier: issue.Identifier,
-			Status: string(store.WorkAttemptStatusActive), StartedAt: completedAt.Add(-time.Minute),
-		})
-
-		o.handleRunResult(t.Context(), &state, runpkg.Completion{
-			IssueID:      issue.ID,
-			Request:      runpkg.RunRequest{Mode: runpkg.RunModePlan},
-			Err:          fmt.Errorf("runner failed on attempt %d before producing work", attempt),
-			CompletedAt:  completedAt,
-			RetryAttempt: attempt + 1,
-			RetryDelay:   time.Second,
-		})
-
-		if attempt < consecutiveRetryCycleLimit {
-			if retry, ok := state.Retry[issue.ID]; !ok || retry.Issue.State != "Todo" {
-				t.Fatalf("attempt %d Retry[%q] = %#v, want Todo retry", attempt, issue.ID, retry)
+	for _, tt := range []struct {
+		name     string
+		limit    *int
+		failures int
+	}{
+		{name: "default", failures: 3},
+		{name: "zero", limit: new(0), failures: 1},
+		{name: "one", limit: new(1), failures: 2},
+		{name: "three", limit: new(3), failures: 3},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 8, 20, 13, 0, 0, 0, time.UTC)
+			issue := terminalRetryTestIssue("runtime-limit")
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			attempts := &terminalRetryWorkAttemptStore{}
+			if tt.limit != nil && *tt.limit == 0 {
+				attempts.historyErr = errors.New("history unavailable")
 			}
-		}
-	}
+			cfg := normalizeConfig(Config{
+				Recovery:              workflowconfig.Recovery{TerminalAttemptRetryLimit: tt.limit},
+				ActiveStates:          []string{"Todo", "In Progress"},
+				ObservedStates:        []string{"Blocked"},
+				TerminalStates:        []string{"Done"},
+				MaxRetryBackoff:       time.Minute,
+				FailureRetryBaseDelay: time.Second,
+			})
+			o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			o.workflowMetrics = metrics
+			state := newState(cfg)
 
-	blocked, ok := state.Blocked[issue.ID]
-	if !ok || blocked.Reason != terminalAttemptRetryLimitCause || blocked.Recovery == nil {
-		t.Fatalf("Blocked[%q] = %#v, want terminal retry limit park", issue.ID, blocked)
-	}
-	wantError := "runner failed on attempt 3 before producing work"
-	if blocked.AttemptError != wantError || blocked.WorkAttemptID != 3 {
-		t.Fatalf("Blocked[%q] attempt evidence = %q/%d, want %q/3", issue.ID, blocked.AttemptError, blocked.WorkAttemptID, wantError)
-	}
-	if blocked.Recovery.AttemptError != wantError || blocked.Recovery.WorkAttemptID != 3 {
-		t.Fatalf("Blocked[%q].Recovery attempt evidence = %q/%d, want %q/3", issue.ID, blocked.Recovery.AttemptError, blocked.Recovery.WorkAttemptID, wantError)
-	}
-	if _, ok := state.Retry[issue.ID]; ok {
-		t.Fatalf("Retry[%q] present after durable terminal retry limit", issue.ID)
-	}
-	if len(attempts.completions) != consecutiveRetryCycleLimit {
-		t.Fatalf("work attempt completions = %d, want %d", len(attempts.completions), consecutiveRetryCycleLimit)
-	}
-	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], wantError) {
-		t.Fatalf("retry-limit comments = %#v, want latest parked-attempt error", tracker.comments)
-	}
+			for attempt := 1; attempt <= tt.failures; attempt++ {
+				completedAt := now.Add(time.Duration(attempt) * time.Minute)
+				issue.State = planImplementationState
+				tracker.issues[issue.ID] = cloneIssue(issue)
+				state.Running[issue.ID] = Running{
+					Issue:         cloneIssue(issue),
+					Attempt:       attempt,
+					WorkAttemptID: int64(attempt),
+					Mode:          runpkg.RunModePlan,
+					StartedAt:     completedAt.Add(-time.Minute),
+				}
+				state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: completedAt.Add(-time.Minute)}
+				o.upsertWorkAttemptSnapshot(&state, telemetry.WorkAttempt{
+					AttemptID: int64(attempt), IssueID: issue.ID, Identifier: issue.Identifier,
+					Status: string(store.WorkAttemptStatusActive), StartedAt: completedAt.Add(-time.Minute),
+				})
 
-	hydratedIssue := cloneIssue(issue)
-	hydratedIssue.State = blockedStatusState
-	parkedAt := now.Add(consecutiveRetryCycleLimit * time.Minute)
-	hydratedIssue.StageUpdatedAt = &parkedAt
-	restarted := &Orchestrator{cfg: cfg, workflowMetrics: metrics}
-	restartedState := newState(cfg)
-	restarted.setBlockedStatusIssue(t.Context(), &restartedState, hydratedIssue, parkedAt.Add(time.Minute))
-	restartedBlocked := restartedState.Blocked[issue.ID]
-	if restartedBlocked.Reason != terminalAttemptRetryLimitCause || restartedBlocked.AttemptError != wantError || restartedBlocked.WorkAttemptID != 3 {
-		t.Fatalf("restarted Blocked[%q] = %#v, want durable cause and attempt evidence", issue.ID, restartedBlocked)
-	}
-	snapshot := blockedSnapshots(restartedState.Blocked, nil, parkedAt.Add(time.Minute), nil)
-	if len(snapshot) != 1 || snapshot[0].Error != terminalAttemptRetryLimitCause || snapshot[0].AttemptError != wantError || snapshot[0].WorkAttemptID != 3 {
-		t.Fatalf("restarted blocked snapshot = %#v, want durable cause and attempt evidence", snapshot)
+				o.handleRunResult(t.Context(), &state, runpkg.Completion{
+					IssueID:      issue.ID,
+					Request:      runpkg.RunRequest{Mode: runpkg.RunModePlan},
+					Err:          fmt.Errorf("runner failed on attempt %d before producing work", attempt),
+					CompletedAt:  completedAt,
+					RetryAttempt: attempt + 1,
+					RetryDelay:   time.Second,
+				})
+
+				if attempt < tt.failures {
+					if retry, ok := state.Retry[issue.ID]; !ok || retry.Issue.State != "Todo" {
+						t.Fatalf("attempt %d Retry[%q] = %#v, want Todo retry", attempt, issue.ID, retry)
+					}
+				}
+			}
+
+			blocked, ok := state.Blocked[issue.ID]
+			if !ok || blocked.Reason != terminalAttemptRetryLimitCause || blocked.Recovery == nil {
+				t.Fatalf("Blocked[%q] = %#v, want terminal retry limit park", issue.ID, blocked)
+			}
+			wantError := fmt.Sprintf("runner failed on attempt %d before producing work", tt.failures)
+			if blocked.AttemptError != wantError || blocked.WorkAttemptID != int64(tt.failures) {
+				t.Fatalf("Blocked[%q] attempt evidence = %q/%d, want %q/%d", issue.ID, blocked.AttemptError, blocked.WorkAttemptID, wantError, tt.failures)
+			}
+			if blocked.Recovery.AttemptError != wantError || blocked.Recovery.WorkAttemptID != int64(tt.failures) {
+				t.Fatalf("Blocked[%q].Recovery attempt evidence = %q/%d, want %q/%d", issue.ID, blocked.Recovery.AttemptError, blocked.Recovery.WorkAttemptID, wantError, tt.failures)
+			}
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatalf("Retry[%q] present after durable terminal retry limit", issue.ID)
+			}
+			if len(attempts.completions) != tt.failures {
+				t.Fatalf("work attempt completions = %d, want %d", len(attempts.completions), tt.failures)
+			}
+			if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], wantError) {
+				t.Fatalf("retry-limit comments = %#v, want latest parked-attempt error", tracker.comments)
+			}
+
+			hydratedIssue := cloneIssue(issue)
+			hydratedIssue.State = blockedStatusState
+			parkedAt := now.Add(time.Duration(tt.failures) * time.Minute)
+			hydratedIssue.StageUpdatedAt = &parkedAt
+			restarted := &Orchestrator{cfg: cfg, workflowMetrics: metrics}
+			restartedState := newState(cfg)
+			restarted.setBlockedStatusIssue(t.Context(), &restartedState, hydratedIssue, parkedAt.Add(time.Minute))
+			restartedBlocked := restartedState.Blocked[issue.ID]
+			if restartedBlocked.Reason != terminalAttemptRetryLimitCause || restartedBlocked.AttemptError != wantError || restartedBlocked.WorkAttemptID != int64(tt.failures) {
+				t.Fatalf("restarted Blocked[%q] = %#v, want durable cause and attempt evidence", issue.ID, restartedBlocked)
+			}
+			snapshot := blockedSnapshots(restartedState.Blocked, nil, parkedAt.Add(time.Minute), nil)
+			if len(snapshot) != 1 || snapshot[0].Error != terminalAttemptRetryLimitCause || snapshot[0].AttemptError != wantError || snapshot[0].WorkAttemptID != int64(tt.failures) {
+				t.Fatalf("restarted blocked snapshot = %#v, want durable cause and attempt evidence", snapshot)
+			}
+
+			if tt.limit != nil && *tt.limit == 0 {
+				if blocked.Recovery.Owner != blockedRecoveryOwnerOperator || !blocked.NeedsHumanAttention || blocked.RecoveryIntentResumable {
+					t.Fatalf("zero policy park = %#v, want operator-owned hold", blocked)
+				}
+				if !strings.Contains(tracker.comments[0], "external review") || strings.Contains(tracker.comments[0], "automatically") {
+					t.Fatalf("zero policy comment = %q", tracker.comments[0])
+				}
+			}
+		})
 	}
 }
 
@@ -1029,6 +1077,7 @@ func terminalRetryTestIssueWithPullRequest(suffix string) connector.Issue {
 }
 
 type terminalRetryConnector struct {
+	updateErrors     map[string]error
 	issues           map[string]connector.Issue
 	transitions      []string
 	comments         []string
@@ -1101,6 +1150,9 @@ func (c *terminalRetryConnector) CreateComment(_ context.Context, _ string, body
 }
 
 func (c *terminalRetryConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	if err := c.updateErrors[state]; err != nil {
+		return err
+	}
 	issue := c.issues[issueID]
 	issue.State = state
 	c.issues[issueID] = issue
@@ -1167,6 +1219,136 @@ func (s *terminalRetryWorkAttemptStore) ListRecentSchedulerDecisions(context.Con
 
 func terminalRetryMetadataPushed(raw string) bool {
 	return workAttemptMetadataHasPushedProduct(raw)
+}
+
+func TestConfiguredTerminalRetryAfterStoreRestart(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		limit     *int
+		sequence  string
+		wantState string
+	}{
+		{name: "zero first failure", limit: new(0), sequence: "F", wantState: "Blocked"},
+		{name: "one permits recovery", limit: new(1), sequence: "F", wantState: "Todo"},
+		{name: "one bounds recovery", limit: new(1), sequence: "FRF", wantState: "Blocked"},
+		{name: "default permits two", sequence: "FF", wantState: "Todo"},
+		{name: "default bounds recovery", sequence: "FRFRF", wantState: "Blocked"},
+		{name: "three bounds recovery", limit: new(3), sequence: "FFF", wantState: "Blocked"},
+		{name: "larger configured limit", limit: new(6), sequence: "FFRRFFRRFF", wantState: "Blocked"},
+		{name: "zero capacity wait", limit: new(0), sequence: "C", wantState: "In Progress"},
+		{name: "zero GitHub wait", limit: new(0), sequence: "G", wantState: "In Progress"},
+		{name: "zero forge wait", limit: new(0), sequence: "A", wantState: "In Progress"},
+		{name: "zero service restart", limit: new(0), sequence: "RRR", wantState: "Todo"},
+		{name: "capacity does not consume", limit: new(1), sequence: "CCF", wantState: "Todo"},
+		{name: "GitHub does not consume", limit: new(1), sequence: "GGF", wantState: "Todo"},
+		{name: "forge does not consume", limit: new(1), sequence: "AAF", wantState: "Todo"},
+		{name: "capacity retains reset behavior", limit: new(1), sequence: "FCF", wantState: "Todo"},
+		{name: "success resets", limit: new(1), sequence: "FSF", wantState: "Todo"},
+		{name: "pushed work resets", limit: new(1), sequence: "FPF", wantState: "Todo"},
+		{name: "pushed work prevents retry", limit: new(0), sequence: "P", wantState: "In Progress"},
+		{name: "workspace still retries", limit: new(0), sequence: "WW", wantState: "Todo"},
+		{name: "workspace still parks at three", limit: new(0), sequence: "WWW", wantState: "Blocked"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			issue := terminalRetryTestIssue("configured-restart")
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: cloneIssue(issue)}}
+			workflow, err := workflowconfig.ParseWorkflow([]byte("---\ntracker:\n  kind: memory\n---\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			workflow.Config.Recovery.TerminalAttemptRetryLimit = tt.limit
+			cfg := normalizeConfig(ConfigFromWorkflow(workflow.Config))
+			cfg.Project.ID = "detent"
+			path := filepath.Join(t.TempDir(), "attempts.db")
+			db, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+			var latestID int64
+			for index, kind := range tt.sequence {
+				at := now.Add(time.Duration(index) * time.Minute)
+				id, err := db.StartWorkAttempt(ctx, store.WorkAttemptStart{
+					ProjectID: "detent", IssueID: issue.ID, Identifier: issue.Identifier,
+					WorkerType: "implement", StartedAt: at.Add(-time.Second), LeaseExpiresAt: at.Add(time.Hour),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				latestID = id
+				completion := store.WorkAttemptCompletion{AttemptID: id, CompletedAt: at, TerminalState: store.WorkAttemptTerminalFailure, ErrorClass: workAttemptErrorRunner, ErrorMessage: "worker failed"}
+				switch kind {
+				case 'R':
+					completion.TerminalState = store.WorkAttemptTerminalAbandoned
+					completion.ErrorClass = "service_restart"
+				case 'C':
+					completion.TerminalState = store.WorkAttemptTerminalCapacity
+					completion.ErrorClass = backendcapacity.ErrorClass
+				case 'G':
+					completion.TerminalState = store.WorkAttemptTerminalCapacity
+					completion.ErrorClass = githubRESTCapacityError
+					completion.WorkerMetadataJSON = `{"github_rest_wait":{"consumer":"shared_pool","credential_identity":"github-rest:worker","remaining":0,"limit":5000,"reserve":1250,"reset_at":"2026-09-08T18:00:00Z","retry_at":"2026-09-08T18:01:00Z"}}`
+				case 'A':
+					completion.ErrorClass = forgeUnavailableErrorClass
+				case 'W':
+					completion.ErrorClass = workAttemptErrorWorkspace
+				case 'S':
+					completion.TerminalState = store.WorkAttemptTerminalSuccess
+				case 'P':
+					completion.WorkerMetadataJSON = `{"work_product_pushed":true}`
+				}
+				if err := db.CompleteWorkAttempt(ctx, completion); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			db, err = store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: path})
+			if err != nil {
+				t.Fatal(err)
+			}
+			latest, err := db.WorkAttempt(ctx, latestID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			o := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: db, workflowMetrics: metrics}
+			state := newState(cfg)
+			state.WorkAttempts = []telemetry.WorkAttempt{telemetryWorkAttempt(latest, now)}
+			at := now.Add(24 * time.Hour)
+			o.reconcileTerminalAttemptRetryStates(ctx, &state, []connector.Issue{issue}, at)
+			if got := tracker.issues[issue.ID].State; got != tt.wantState {
+				t.Fatalf("state after reopening store = %q, want %q", got, tt.wantState)
+			}
+			if tt.limit == nil || *tt.limit != 0 || tt.sequence != "F" {
+				return
+			}
+			blockedIssue := tracker.issues[issue.ID]
+			blockedIssue.StageUpdatedAt = &at
+			restarted := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: db, workflowMetrics: metrics}
+			restartedState := newState(cfg)
+			restarted.setBlockedStatusIssue(ctx, &restartedState, blockedIssue, at.Add(time.Hour))
+			if restarted.recoverCauseBlockedIssue(ctx, &restartedState, blockedIssue, at.Add(30*24*time.Hour)) {
+				t.Fatal("zero policy released operator hold after restart and cooldown")
+			}
+			blocked := restartedState.Blocked[issue.ID]
+			if blocked.Recovery == nil || blocked.Recovery.Owner != blockedRecoveryOwnerOperator || blocked.RecoveryAction != "hold" || !blocked.NeedsHumanAttention || blocked.WorkAttemptID != latestID {
+				t.Fatalf("restarted operator hold = %#v", blocked)
+			}
+			if len(restartedState.Retry) != 0 {
+				t.Fatal("operator hold scheduled a retry")
+			}
+		})
+	}
 }
 
 func TestConsecutiveRetryCycleCountAcrossServiceRestarts(t *testing.T) {
@@ -1333,6 +1515,62 @@ func TestServiceRestartsRecoverRetainedWorkAndDispatch(t *testing.T) {
 				t.Fatalf("retained work = %q, error = %v", retained, err)
 			}
 			state.Running[issue.ID].cancel()
+		})
+	}
+}
+
+func TestTerminalRetryTransitionFailures(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		limit      *int
+		failState  string
+		wantState  string
+		wantParked bool
+	}{
+		{name: "zero holds locally when tracker park fails", limit: new(0), failState: "Blocked", wantState: "Blocked", wantParked: true},
+		{name: "default preserves retry when tracker park fails", failState: "Blocked", wantState: "Todo"},
+		{name: "retry transition failure retains original lane", failState: "Todo", wantState: "In Progress"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			issue := terminalRetryTestIssue(tt.name)
+			tracker := &terminalRetryConnector{issues: map[string]connector.Issue{issue.ID: issue}, updateErrors: map[string]error{tt.failState: errors.New("tracker unavailable")}}
+			cfg := normalizeConfig(Config{Recovery: workflowconfig.Recovery{TerminalAttemptRetryLimit: tt.limit}, ActiveStates: []string{"Todo", "In Progress"}})
+			o := &Orchestrator{cfg: cfg, connector: tracker, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			state := newState(cfg)
+			count := 3
+			if tt.failState == "Todo" {
+				count = 1
+			}
+			for i := 1; i <= count; i++ {
+				state.WorkAttempts = append(state.WorkAttempts, telemetry.WorkAttempt{AttemptID: int64(i), IssueID: issue.ID, Status: string(store.WorkAttemptStatusTerminal), TerminalState: string(store.WorkAttemptTerminalFailure), ErrorClass: workAttemptErrorRunner})
+			}
+			updated, _, parked := o.demoteTerminalAttemptRetry(t.Context(), &state, issue, false, terminalAttemptRetryLimitCause, true, RunModeImplement, DiffStats{}, now)
+			if updated.State != tt.wantState || parked != tt.wantParked {
+				t.Fatalf("state/parked = %s/%t, want %s/%t", updated.State, parked, tt.wantState, tt.wantParked)
+			}
+			if tt.wantParked {
+				if len(state.Retry) != 0 || state.Blocked[issue.ID].Recovery.Owner != blockedRecoveryOwnerOperator {
+					t.Fatal("failed tracker park did not retain a local operator hold")
+				}
+				if tracker.issues[issue.ID].State != "In Progress" {
+					t.Fatal("failed tracker park changed the remote lane")
+				}
+				if len(tracker.comments) != 0 {
+					t.Fatal("failed tracker park published a success comment")
+				}
+				o.trackCandidateBlockedStatusIssues(t.Context(), &state, []connector.Issue{updated}, now)
+				if _, held := state.Blocked[issue.ID]; !held {
+					t.Fatal("candidate reconciliation cleared the local hold")
+				}
+				delete(tracker.updateErrors, "Blocked")
+				transitions := o.reconcileTerminalAttemptRetryStates(t.Context(), &state, []connector.Issue{tracker.issues[issue.ID]}, now.Add(time.Minute))
+				if len(transitions) != 1 || tracker.issues[issue.ID].State != "Blocked" || len(state.Retry) != 0 {
+					t.Fatal("reconciliation did not complete the park without redispatch")
+				}
+			}
 		})
 	}
 }

--- a/internal/orchestrator/transient_overload.go
+++ b/internal/orchestrator/transient_overload.go
@@ -89,6 +89,7 @@ func (o *Orchestrator) handleTransientOverload(
 		running.Mode,
 		running.DiffStats,
 		event.CompletedAt,
+		terminalAttemptFailureEvidence(running, terminalState, errorClass, event.Err.Error(), event.CompletedAt),
 	)
 	if parked {
 		return


### PR DESCRIPTION
## Summary

- Add `recovery.terminal_attempt_retry_limit` to project configuration and machine overlays, and expose the effective policy in `detent doctor`.
- Preserve default `3` (park on failure three); `1` permits one redispatch and `0` parks the first qualifying failure for external review, with a durable hold across restart and cooldown, enforced even when attempt persistence is unavailable.
- Document the exact transition table and preserve workspace-preparation retries, capacity waits, and pushed-work/linked-PR protections.

Fixes #2249

## UI Surface Contract

- [x] N/A: no graphical UI surface, layout, density, first-viewport, or responsive visibility changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] `make check` — 80.1% overall coverage; configured package/file floors pass.
- [x] Focused table-driven config, overlay, doctor, runtime, SQLite reopen, restart/cooldown, capacity-wait, work-product, and workspace retry tests.
- [x] `FuzzSafetyCriticalOrchestratorBoundaries` seeds.
- [x] Terminal retry exact-file coverage: 92.19%; fault injection verifies tracker failures retain the zero-policy hold until reconciliation completes the park.
- [x] Failed completion writes, missing store/attempt ID, and transient-overload regressions; capacity and pushed-work exclusions preserved.
