### PR TITLE
fix(lessons): capture bounded failure evidence

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -247,6 +247,8 @@
 #         # tracker.issues[].pull_request.checks | type: list<object> | default: [] | required: No | validation: None
 #         checks:
 #           -
+#             # tracker.issues[].pull_request.checks[].failure_detail | type: string | default: none | required: No | validation: None
+#             failure_detail: null
 #             # tracker.issues[].pull_request.checks[].id | type: integer | default: 0 when configured | required: No | validation: None
 #             id: 0
 #             # tracker.issues[].pull_request.checks[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
@@ -274,6 +276,8 @@
 #         # tracker.issues[].pull_request.slow_checks | type: list<object> | default: [] | required: No | validation: None
 #         slow_checks:
 #           -
+#             # tracker.issues[].pull_request.slow_checks[].failure_detail | type: string | default: none | required: No | validation: None
+#             failure_detail: null
 #             # tracker.issues[].pull_request.slow_checks[].id | type: integer | default: 0 when configured | required: No | validation: None
 #             id: 0
 #             # tracker.issues[].pull_request.slow_checks[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
@@ -297,6 +301,8 @@
 #         # tracker.issues[].pull_request.unstarted_checks | type: list<object> | default: [] | required: No | validation: None
 #         unstarted_checks:
 #           -
+#             # tracker.issues[].pull_request.unstarted_checks[].failure_detail | type: string | default: none | required: No | validation: None
+#             failure_detail: null
 #             # tracker.issues[].pull_request.unstarted_checks[].id | type: integer | default: 0 when configured | required: No | validation: None
 #             id: 0
 #             # tracker.issues[].pull_request.unstarted_checks[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
@@ -316,6 +322,8 @@
 #         # tracker.issues[].pull_request.stale_successful_checks | type: list<object> | default: [] | required: No | validation: None
 #         stale_successful_checks:
 #           -
+#             # tracker.issues[].pull_request.stale_successful_checks[].failure_detail | type: string | default: none | required: No | validation: None
+#             failure_detail: null
 #             # tracker.issues[].pull_request.stale_successful_checks[].id | type: integer | default: 0 when configured | required: No | validation: None
 #             id: 0
 #             # tracker.issues[].pull_request.stale_successful_checks[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
@@ -335,6 +343,8 @@
 #         # tracker.issues[].pull_request.required_check_failures | type: list<object> | default: [] | required: No | validation: None
 #         required_check_failures:
 #           -
+#             # tracker.issues[].pull_request.required_check_failures[].failure_detail | type: string | default: none | required: No | validation: None
+#             failure_detail: null
 #             # tracker.issues[].pull_request.required_check_failures[].id | type: integer | default: 0 when configured | required: No | validation: None
 #             id: 0
 #             # tracker.issues[].pull_request.required_check_failures[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
@@ -354,6 +364,8 @@
 #         # tracker.issues[].pull_request.transient_failed_checks | type: list<object> | default: [] | required: No | validation: None
 #         transient_failed_checks:
 #           -
+#             # tracker.issues[].pull_request.transient_failed_checks[].failure_detail | type: string | default: none | required: No | validation: None
+#             failure_detail: null
 #             # tracker.issues[].pull_request.transient_failed_checks[].id | type: integer | default: 0 when configured | required: No | validation: None
 #             id: 0
 #             # tracker.issues[].pull_request.transient_failed_checks[].workflow_run_id | type: integer | default: 0 when configured | required: No | validation: None
@@ -373,6 +385,8 @@
 #         # tracker.issues[].pull_request.unresolved_review_threads | type: list<object> | default: [] | required: No | validation: None
 #         unresolved_review_threads:
 #           -
+#             # tracker.issues[].pull_request.unresolved_review_threads[].body | type: string | default: none | required: No | validation: None
+#             body: null
 #             # tracker.issues[].pull_request.unresolved_review_threads[].path | type: string | default: none | required: No | validation: None
 #             path: null
 #             # tracker.issues[].pull_request.unresolved_review_threads[].line | type: integer | default: 0 when configured | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -1328,6 +1328,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.checks[].conclusion` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.checks[].details_url` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.checks[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.checks[].failure_detail` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.checks[].id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.checks[].name` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
@@ -1371,6 +1372,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.required_check_failures[].conclusion` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.required_check_failures[].details_url` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.required_check_failures[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.required_check_failures[].failure_detail` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.required_check_failures[].id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.required_check_failures[].name` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.required_check_failures[].queue_seconds` | `integer` | `0 when configured` | No | None |
@@ -1381,6 +1383,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.slow_checks[].conclusion` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.slow_checks[].details_url` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.slow_checks[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.slow_checks[].failure_detail` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.slow_checks[].id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.slow_checks[].name` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.slow_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
@@ -1390,6 +1393,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.stale_successful_checks[].conclusion` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.stale_successful_checks[].details_url` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.stale_successful_checks[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.stale_successful_checks[].failure_detail` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.stale_successful_checks[].id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.stale_successful_checks[].name` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.stale_successful_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
@@ -1401,12 +1405,14 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.transient_failed_checks[].conclusion` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].details_url` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.transient_failed_checks[].failure_detail` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].name` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].status` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.transient_failed_checks[].workflow_run_id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.unresolved_review_threads` | `list<object>` | `[]` | No | None |
+| `tracker.issues[].pull_request.unresolved_review_threads[].body` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unresolved_review_threads[].line` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.unresolved_review_threads[].path` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unstarted_check_count` | `integer` | `0 when configured` | No | None |
@@ -1414,6 +1420,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.unstarted_checks[].conclusion` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].details_url` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].duration_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.unstarted_checks[].failure_detail` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].id` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].name` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.unstarted_checks[].queue_seconds` | `integer` | `0 when configured` | No | None |

--- a/internal/claudecode/stream.go
+++ b/internal/claudecode/stream.go
@@ -87,6 +87,7 @@ type claudeUsage struct {
 }
 
 type turnState struct {
+	commandItems    map[string]bool
 	sessionID       string
 	model           string
 	partialItemID   string
@@ -245,11 +246,12 @@ func (s *turnState) applyAssistant(
 	if event.Message.ID != "" {
 		s.partialItemID = event.Message.ID
 	}
-	if !includePartialMessages {
-		for _, block := range event.Message.Content {
-			if err := s.emitContentBlock(block, event.Message.ID, onUpdate); err != nil {
-				return err
-			}
+	for _, block := range event.Message.Content {
+		if includePartialMessages && (claudeBlockCommand(block) == "" || s.commandItems[strings.TrimSpace(block.ID)]) {
+			continue
+		}
+		if err := s.emitContentBlock(block, event.Message.ID, onUpdate); err != nil {
+			return err
 		}
 	}
 	if event.Message.Usage != nil && !event.Message.Usage.empty() {
@@ -330,7 +332,15 @@ func (s *turnState) emitContentBlock(block contentBlock, fallbackItemID string, 
 			Model:    s.model,
 		})
 	case "tool_use":
+		command := claudeBlockCommand(block)
+		if command != "" {
+			if s.commandItems == nil {
+				s.commandItems = make(map[string]bool)
+			}
+			s.commandItems[itemID] = true
+		}
 		return emitUpdate(onUpdate, runner.AgentUpdate{
+			Command:  command,
 			Type:     runner.AgentUpdateToolStarted,
 			ThreadID: s.sessionID,
 			TurnID:   s.sessionID,
@@ -354,6 +364,19 @@ func (s *turnState) emitContentBlock(block contentBlock, fallbackItemID string, 
 	default:
 		return nil
 	}
+}
+
+func claudeBlockCommand(block contentBlock) string {
+	if block.Type != "tool_use" || !strings.EqualFold(strings.TrimSpace(block.Name), "Bash") {
+		return ""
+	}
+	var input struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(block.Input, &input); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(input.Command)
 }
 
 func claudeBlockContent(raw json.RawMessage) string {

--- a/internal/claudecode/stream_activity_test.go
+++ b/internal/claudecode/stream_activity_test.go
@@ -111,3 +111,47 @@ func TestTurnStateDoesNotRepeatPartialToolStart(t *testing.T) {
 		t.Fatalf("updates = %#v, want one tool start and one result", updates)
 	}
 }
+
+func TestTurnStatePreservesShellCommands(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, tool, input, want string
+		partial                 bool
+	}{
+		{name: "complete", tool: "Bash", input: `{"command":"go test ./..."}`, want: "go test ./..."},
+		{name: "partial input completes", tool: "Bash", input: `{"command":"go test ./..."}`, want: "go test ./...", partial: true},
+		{name: "non-command tool", tool: "Read", input: `{"command":"not a shell invocation"}`},
+		{name: "missing command", tool: "Bash", input: `{}`},
+		{name: "invalid command", tool: "Bash", input: `{"command":42}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state := turnState{sessionID: "session"}
+			block := contentBlock{ID: "tool-1", Type: "tool_use", Name: tt.tool, Input: json.RawMessage(tt.input)}
+			var commands []string
+			handler := func(update runner.AgentUpdate) error {
+				if update.Command != "" {
+					commands = append(commands, update.Command)
+				}
+				return nil
+			}
+			if tt.partial {
+				start := block
+				start.Input = json.RawMessage(`{}`)
+				if err := state.apply(claudeEvent{Type: "stream_event", StreamEvent: &streamEvent{ContentBlock: &start}}, true, handler); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := state.apply(claudeEvent{Type: "assistant", Message: &claudeMessage{Content: []contentBlock{block}}}, tt.partial, handler); err != nil {
+				t.Fatal(err)
+			}
+			if tt.want == "" {
+				if len(commands) != 0 {
+					t.Fatalf("unexpected commands: %v", commands)
+				}
+			} else if len(commands) != 1 || commands[0] != tt.want {
+				t.Fatalf("commands = %v, want %q once", commands, tt.want)
+			}
+		})
+	}
+}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -5168,7 +5168,7 @@ func TestConnectorFetchPullRequestReviewThreads(t *testing.T) {
 		{
 			method: http.MethodPost,
 			path:   "/",
-			body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"head-sha","reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[{"isResolved":false,"path":"internal/orchestrator/autopromote.go","line":181,"originalLine":180},{"isResolved":true,"path":"internal/connector/issue.go","line":107,"originalLine":107}]}}}}}`,
+			body:   `{"data":{"repository":{"pullRequest":{"headRefOid":"head-sha","reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[{"isResolved":false,"path":"internal/orchestrator/autopromote.go","line":181,"originalLine":180,"comments":{"nodes":[{"body":"Preserve cancellation evidence."}]}},{"isResolved":true,"path":"internal/connector/issue.go","line":107,"originalLine":107}]}}}}}`,
 		},
 		{
 			method: http.MethodPost,
@@ -5183,7 +5183,7 @@ func TestConnectorFetchPullRequestReviewThreads(t *testing.T) {
 		t.Fatalf("fetchPullRequestReviewThreads() error = %v", err)
 	}
 	want := []connector.PullRequestReviewThread{
-		{Path: "internal/orchestrator/autopromote.go", Line: 181},
+		{Path: "internal/orchestrator/autopromote.go", Line: 181, Body: "Preserve cancellation evidence."},
 		{Path: "internal/connector/github/pull_requests.go", Line: 1092},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -7055,5 +7055,28 @@ func TestProjectFieldsRefreshUsesTargetedQueryOnlyForChangedCard(t *testing.T) {
 	query, _ := requests[0]["query"].(string)
 	if !strings.Contains(query, "DetentGitHubProjectItemForIssue") {
 		t.Fatalf("query = %q, want targeted refresh", query)
+	}
+}
+
+func TestCheckRunFailureEvidence(t *testing.T) {
+	for _, tt := range []struct {
+		name, annotations, text, want string
+	}{
+		{name: "first assertion", annotations: `[{"annotation_level":"warning","message":"not a failure"},{"annotation_level":"failure","path":"worker_test.go","message":"want released slot"},{"annotation_level":"failure","message":"later assertion"}]`, want: "worker_test.go: want released slot"},
+		{name: "output fallback", annotations: `[]`, text: "Run make check: TestWorker failed", want: "Run make check: TestWorker failed"},
+		{name: "no evidence", annotations: `[]`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{method: http.MethodGet, path: "/repos/example/repo/check-runs/1/annotations?per_page=100", body: tt.annotations}})
+			c := newGitHubTestConnector(t, server, Config{})
+			runs := []restCheckRun{{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: checkRunOutput{Text: tt.text}}}
+			if _, err := c.transientCheckRunFailures(t.Context(), pullRequestRepo{Owner: "example", Name: "repo"}, runs); err != nil {
+				t.Fatal(err)
+			}
+			inventory := pullRequestCheckInventory(runs, nil)
+			if len(inventory) != 1 || inventory[0].FailureDetail != tt.want {
+				t.Fatalf("failure evidence = %#v, want %q", inventory, tt.want)
+			}
+		})
 	}
 }

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 )
 
 type checkRunTelemetrySummary struct {
@@ -91,6 +92,7 @@ func pullRequestCheckInventory(checkRuns []restCheckRun, statuses []restCommitSt
 		}
 		seen[key] = struct{}{}
 		checks = append(checks, connector.PullRequestCheck{
+			FailureDetail: checkRun.FailureDetail,
 			ID:            checkRun.ID,
 			WorkflowRunID: checkRunWorkflowRunID(checkRun),
 			Name:          name,
@@ -125,6 +127,7 @@ func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequ
 			continue
 		}
 		text := checkRunTransientText(checkRun)
+		detail := firstNonBlank(checkRun.Output.Text, checkRun.Output.Summary, checkRun.Output.Title)
 		if checkRun.ID > 0 {
 			annotations, err := fetchRESTCheckRunAnnotations(ctx, c.client, restCheckRunAnnotationsPath(repo, checkRun.ID))
 			if err != nil {
@@ -136,6 +139,17 @@ func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequ
 				}
 			} else {
 				text = strings.TrimSpace(text + "\n" + checkRunAnnotationTransientText(annotations))
+				for _, annotation := range annotations {
+					if strings.EqualFold(annotation.AnnotationLevel, "failure") && strings.TrimSpace(annotation.Message) != "" {
+						detail = strings.TrimSpace(annotation.Path + ": " + annotation.Message)
+						break
+					}
+				}
+			}
+		}
+		for index := range checkRuns {
+			if checkRuns[index].ID == checkRun.ID && checkRuns[index].Name == checkRun.Name {
+				checkRuns[index].FailureDetail = runtimeoutput.Truncate(detail, 2048).Value
 			}
 		}
 		if !transientCheckFailureText(text) && !transientCheckConclusion(checkRun.Conclusion) {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -62,7 +62,7 @@ query DetentGitHubPullRequestReviewThreads($owner: String!, $name: String!, $num
 			headRefOid
 			reviewThreads(first: 100, after: $after) {
 				pageInfo { hasNextPage endCursor }
-				nodes { isResolved isOutdated path line originalLine }
+				nodes { isResolved isOutdated path line originalLine comments(first: 1) { nodes { body } } }
 			}
 		}
 	}
@@ -1327,7 +1327,12 @@ func (c *Connector) fetchPullRequestReviewThreads(
 			if line <= 0 {
 				line = thread.OriginalLine
 			}
+			body := ""
+			if len(thread.Comments.Nodes) > 0 {
+				body = thread.Comments.Nodes[0].Body
+			}
 			threads = append(threads, connector.PullRequestReviewThread{
+				Body: body,
 				Path: strings.TrimSpace(thread.Path),
 				Line: line,
 			})

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -194,6 +194,9 @@ type pullRequestReview struct {
 }
 
 type pullRequestReviewThread struct {
+	Comments nodeConnection[struct {
+		Body string `json:"body"`
+	}] `json:"comments"`
 	IsResolved   bool   `json:"isResolved"`
 	IsOutdated   bool   `json:"isOutdated"`
 	Path         string `json:"path"`
@@ -318,16 +321,17 @@ type restCheckRuns struct {
 }
 
 type restCheckRun struct {
-	ID          int64          `json:"id"`
-	Status      string         `json:"status"`
-	Conclusion  string         `json:"conclusion"`
-	Name        string         `json:"name"`
-	DetailsURL  string         `json:"details_url"`
-	HTMLURL     string         `json:"html_url"`
-	Output      checkRunOutput `json:"output"`
-	CreatedAt   *time.Time     `json:"created_at"`
-	StartedAt   *time.Time     `json:"started_at"`
-	CompletedAt *time.Time     `json:"completed_at"`
+	FailureDetail string         `json:"-"`
+	ID            int64          `json:"id"`
+	Status        string         `json:"status"`
+	Conclusion    string         `json:"conclusion"`
+	Name          string         `json:"name"`
+	DetailsURL    string         `json:"details_url"`
+	HTMLURL       string         `json:"html_url"`
+	Output        checkRunOutput `json:"output"`
+	CreatedAt     *time.Time     `json:"created_at"`
+	StartedAt     *time.Time     `json:"started_at"`
+	CompletedAt   *time.Time     `json:"completed_at"`
 }
 
 type checkRunOutput struct {

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -167,6 +167,7 @@ const (
 )
 
 type PullRequestCheck struct {
+	FailureDetail   string `json:"failure_detail,omitempty" yaml:"failure_detail,omitempty"`
 	ID              int64  `json:"id,omitempty" yaml:"id,omitempty"`
 	WorkflowRunID   int64  `json:"workflow_run_id,omitempty" yaml:"workflow_run_id,omitempty"`
 	Name            string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -185,6 +186,7 @@ type PullRequestFinding struct {
 }
 
 type PullRequestReviewThread struct {
+	Body string `json:"body,omitempty" yaml:"body,omitempty"`
 	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 	Line int    `json:"line,omitempty" yaml:"line,omitempty"`
 }

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -8,11 +8,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 )
 
 const (
 	DefaultPath       = ".detent/lessons.md"
 	DefaultMaxEntries = 50
+	MaxFileBytes      = 16 * 1024
+	MaxEntryBytes     = 4 * 1024
 )
 
 type Entry struct {
@@ -25,6 +29,7 @@ type Entry struct {
 	Hypothesis  string
 	Hint        string
 	CaptureKey  string
+	Evidence    []string
 }
 
 type AppendOptions struct {
@@ -110,11 +115,12 @@ func appendEntryTo(path string, entry Entry, opts AppendOptions, entries []strin
 
 	rendered := renderEntry(entry, date)
 	entries = append([]string{rendered}, entries...)
+	truncated := len(entries) > maxEntries
 	if len(entries) > maxEntries {
 		entries = entries[:maxEntries]
 	}
 
-	return writeEntries(path, entries)
+	return writeEntries(path, entries, truncated)
 }
 
 func Recent(path string, count int) ([]string, error) {
@@ -206,8 +212,17 @@ func renderEntry(entry Entry, date time.Time) string {
 		"- **Issue:** " + field(entry.IssueRef, issueRef(entry)),
 		"- **Pull request:** " + field(entry.PullRequest, "<unavailable>"),
 		"- **Symptom:** " + field(entry.Symptom, "<unavailable>"),
-		"- **Hypothesis (Detent):** " + field(entry.Hypothesis, "<unavailable>"),
-		"- **Hint for next time:** " + field(entry.Hint, "<unavailable>"),
+	}
+	for _, evidence := range entry.Evidence {
+		if value := field(evidence, ""); value != "" {
+			lines = append(lines, "- **Evidence:** "+value)
+		}
+	}
+	if value := field(entry.Hypothesis, ""); value != "" {
+		lines = append(lines, "- **Hypothesis (Detent):** "+value)
+	}
+	if value := field(entry.Hint, ""); value != "" {
+		lines = append(lines, "- **Hint for next time:** "+value)
 	}
 	if captureKey := strings.TrimSpace(entry.CaptureKey); captureKey != "" {
 		lines = append(lines, "- **Capture key:** "+field(captureKey, ""))
@@ -303,10 +318,26 @@ func renderedEntryCapturedAt(entry string) (time.Time, bool) {
 	return capturedAt.UTC(), true
 }
 
-func writeEntries(path string, entries []string) error {
+func writeEntries(path string, entries []string, truncated bool) error {
+	const marker = "> [truncated: older lessons omitted]\n\n"
+	size := len(marker)
+	for index, entry := range entries {
+		entry = runtimeoutput.Truncate(entry, MaxEntryBytes).Value
+		if size+len(entry)+2 > MaxFileBytes {
+			entries = entries[:index]
+			truncated = true
+			break
+		}
+		entries[index] = entry
+		size += len(entry) + 2
+	}
+	content := strings.Join(entries, "\n\n") + "\n"
+	if truncated {
+		content = marker + content
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 
-	return os.WriteFile(path, []byte(strings.Join(entries, "\n\n")+"\n"), 0o600)
+	return os.WriteFile(path, []byte(content), 0o600)
 }

--- a/internal/lessons/lessons_test.go
+++ b/internal/lessons/lessons_test.go
@@ -1,11 +1,13 @@
 package lessons
 
 import (
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestReadAllAndRecentTreatMissingFileAsEmpty(t *testing.T) {
@@ -135,8 +137,6 @@ func TestAppendRendersFallbacksAndEscapesTitleQuotes(t *testing.T) {
 		"- **Issue:** issue MT-9",
 		"- **Pull request:** <unavailable>",
 		"- **Symptom:** command failed before diff",
-		"- **Hypothesis (Detent):** <unavailable>",
-		"- **Hint for next time:** <unavailable>",
 	} {
 		if !strings.Contains(entry, want) {
 			t.Fatalf("entry missing %q:\n%s", want, entry)
@@ -257,5 +257,77 @@ func TestReadAllReturnsReadErrors(t *testing.T) {
 	}
 	if err := Append(root, Entry{Title: "cannot append"}, AppendOptions{}); err == nil {
 		t.Fatal("Append() error = nil, want error")
+	}
+}
+
+func TestAppendBoundsRetainedContent(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		count      int
+		maxEntries int
+		body       string
+		wantCount  int
+	}{
+		{name: "entry count", count: 5, maxEntries: 3, body: "specific failure", wantCount: 3},
+		{name: "default count", count: 60, body: "specific failure", wantCount: DefaultMaxEntries},
+		{name: "byte limit", count: 10, maxEntries: 100, body: strings.Repeat("failure ", 400), wantCount: 4},
+		{name: "oversized unicode", count: 1, body: strings.Repeat("界", MaxFileBytes), wantCount: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "lessons.md")
+			for index := range tt.count {
+				entry := Entry{IssueNumber: strconv.Itoa(index), Evidence: []string{tt.body}, CaptureKey: "key-" + strconv.Itoa(index)}
+				if err := Append(path, entry, AppendOptions{MaxEntries: tt.maxEntries}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(data) > MaxFileBytes || !utf8.Valid(data) || !strings.Contains(string(data), "truncated") {
+				t.Fatalf("retained file: bytes=%d valid=%t marker=%t", len(data), utf8.Valid(data), strings.Contains(string(data), "truncated"))
+			}
+			entries, err := ReadAll(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != tt.wantCount || !strings.Contains(entries[0], "issue #"+strconv.Itoa(tt.count-1)) {
+				t.Fatalf("retained entries = %d, want %d and newest first", len(entries), tt.wantCount)
+			}
+			for _, entry := range entries {
+				if len(entry) > MaxEntryBytes {
+					t.Fatalf("entry bytes = %d", len(entry))
+				}
+			}
+			appended, err := AppendUnique(path, Entry{CaptureKey: "key-" + strconv.Itoa(tt.count-1)}, AppendOptions{})
+			if err != nil || appended {
+				t.Fatalf("retained newest deduplication = %t, %v", appended, err)
+			}
+		})
+	}
+}
+
+func TestAppendOmitsEmptyAdvice(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, hypothesis, hint string
+		want                   bool
+	}{
+		{name: "absent"},
+		{name: "whitespace", hypothesis: " \n ", hint: "\t"},
+		{name: "explicit advice", hypothesis: "The assertion lacks an await", hint: "Wait for the event", want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			text := renderEntry(Entry{Hypothesis: tt.hypothesis, Hint: tt.hint}, time.Now())
+			for _, label := range []string{"Hypothesis (Detent)", "Hint for next time"} {
+				if strings.Contains(text, label) != tt.want {
+					t.Fatalf("unexpected %s in %s", label, text)
+				}
+			}
+		})
 	}
 }

--- a/internal/orchestrator/lesson_capture.go
+++ b/internal/orchestrator/lesson_capture.go
@@ -8,11 +8,17 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 )
 
 const reworkTransitionFailureKind = "rework_transition"
 
-func (o *Orchestrator) captureReworkLesson(issue connector.Issue, at time.Time, reason string) {
+type reworkLessonEvidence struct {
+	LastCommand   string
+	ConflictPaths []string
+}
+
+func (o *Orchestrator) captureReworkLesson(issue connector.Issue, at time.Time, reason string, evidence ...reworkLessonEvidence) {
 	if o == nil || !o.cfg.Lessons.Enabled || strings.TrimSpace(o.cfg.Lessons.Path) == "" {
 		return
 	}
@@ -23,7 +29,10 @@ func (o *Orchestrator) captureReworkLesson(issue connector.Issue, at time.Time, 
 			at = time.Now()
 		}
 	}
-	entry := reworkLessonEntry(o.workflowMetricsProjectID(), issue, at.UTC(), reason)
+	entry := reworkLessonEntry(o.workflowMetricsProjectID(), issue, at.UTC(), reason, evidence...)
+	if len(entry.Evidence) == 0 {
+		return
+	}
 	appended, err := lessons.AppendUnique(o.cfg.Lessons.Path, entry, lessons.AppendOptions{
 		Date:       at.UTC(),
 		MaxEntries: o.cfg.Lessons.MaxEntries,
@@ -39,20 +48,90 @@ func (o *Orchestrator) captureReworkLesson(issue connector.Issue, at time.Time, 
 	}
 }
 
-func reworkLessonEntry(projectID string, issue connector.Issue, at time.Time, reason string) lessons.Entry {
-	failedChecks := autoPromoteFailedChecksFromPullRequest(issue.PullRequest)
-	reviewSummary := reworkReviewSummary(issue.PullRequest)
-	return lessons.Entry{
+func reworkLessonEntry(projectID string, issue connector.Issue, at time.Time, reason string, evidence ...reworkLessonEvidence) lessons.Entry {
+	checks := reworkFailedChecks(issue.PullRequest)
+	names := make([]string, 0, len(checks))
+	for _, check := range checks {
+		names = append(names, check.Name)
+	}
+	kind := reworkFailureKind(reason, issue.PullRequest, names)
+	entry := lessons.Entry{
 		IssueNumber: reworkIssueNumber(issue),
 		IssueRef:    strings.TrimSpace(issue.Identifier),
 		PullRequest: reworkPullRequestRef(issue),
 		Title:       issue.Title,
-		FailureKind: reworkFailureKind(reason, issue.PullRequest, failedChecks),
-		Symptom:     reworkLessonSymptom(issue, reason, failedChecks, reviewSummary),
-		Hypothesis:  "the previous attempt did not satisfy the workflow gate or review expectations",
-		Hint:        "use the captured checks and review context to strengthen the next attempt and prevent the same bounce",
+		FailureKind: kind,
+		Symptom:     reworkLessonSymptom(issue, reason),
 		CaptureKey:  reworkLessonCaptureKey(projectID, issue, at),
 	}
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "stranded_active_recovery", "backend_capacity_pause":
+		return entry
+	}
+	var signals reworkLessonEvidence
+	if len(evidence) > 0 {
+		signals = evidence[0]
+	}
+	switch kind {
+	case "session_duration_exceeded":
+		if command := strings.TrimSpace(signals.LastCommand); command != "" {
+			entry.Evidence = append(entry.Evidence, "last command: "+command)
+		}
+	case "merge_conflict":
+		if paths := uniqueStrings(signals.ConflictPaths); len(paths) > 0 {
+			entry.Evidence = append(entry.Evidence, "conflicting paths: "+strings.Join(paths, ", "))
+		}
+	default:
+		if len(names) > 0 {
+			entry.Evidence = append(entry.Evidence, "failed checks: "+strings.Join(names, ", "))
+		}
+		for _, check := range checks {
+			if detail := strings.TrimSpace(check.FailureDetail); detail != "" {
+				entry.Evidence = append(entry.Evidence, check.Name+": "+detail)
+				break
+			}
+		}
+		if review := reworkReviewSummary(issue.PullRequest); review != "" {
+			entry.Evidence = append(entry.Evidence, "review: "+review)
+		}
+	}
+	for index, signal := range entry.Evidence {
+		entry.Evidence[index] = runtimeoutput.Truncate(strings.Join(strings.Fields(signal), " "), 1024).Value
+	}
+	return entry
+}
+
+func reworkFailedChecks(pr *connector.PullRequest) []connector.PullRequestCheck {
+	if pr == nil {
+		return nil
+	}
+	checks := append([]connector.PullRequestCheck{}, pr.Checks...)
+	checks = append(checks, pr.RequiredCheckFailures...)
+	checks = append(checks, pr.TransientFailedChecks...)
+	checks = append(checks, pr.SlowChecks...)
+	failures := []connector.PullRequestCheck{}
+	seen := map[string]int{}
+	for _, check := range checks {
+		check.Name = strings.TrimSpace(check.Name)
+		if check.Name == "" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(check.Conclusion)) {
+		case "failure", "failed", "error", "timed_out", "startup_failure", "action_required":
+		default:
+			continue
+		}
+		key := strings.ToLower(check.Name)
+		if index, ok := seen[key]; ok {
+			if failures[index].FailureDetail == "" {
+				failures[index].FailureDetail = check.FailureDetail
+			}
+			continue
+		}
+		seen[key] = len(failures)
+		failures = append(failures, check)
+	}
+	return failures
 }
 
 func reworkIssueNumber(issue connector.Issue) string {
@@ -63,11 +142,12 @@ func reworkIssueNumber(issue connector.Issue) string {
 }
 
 func reworkFailureKind(reason string, pullRequest *connector.PullRequest, failedChecks []string) string {
-	if len(failedChecks) > 0 {
-		return "ci_failure"
-	}
 	reason = strings.ToLower(strings.TrimSpace(reason))
 	switch reason {
+	case "session_duration_exceeded":
+		return reason
+	case mergeFallbackRequiresReworkReason, "merge_conflict":
+		return "merge_conflict"
 	case string(AutoPromoteReasonCINotGreen):
 		return "ci_failure"
 	case mergeWorkerRequiredChecksMissingReason, mergeWorkerFastPathNotReadyReason:
@@ -83,6 +163,9 @@ func reworkFailureKind(reason string, pullRequest *connector.PullRequest, failed
 	case string(AutoPromoteReasonWorkpadStatusInvalid):
 		return "invalid_workpad_status"
 	}
+	if len(failedChecks) > 0 {
+		return "ci_failure"
+	}
 	if pullRequest != nil {
 		reviewState := strings.ToUpper(strings.TrimSpace(pullRequest.CodexReviewState))
 		if reviewState == "CHANGES_REQUESTED" || reviewState == "REQUESTED_CHANGES" || reviewState == "P1" {
@@ -95,7 +178,7 @@ func reworkFailureKind(reason string, pullRequest *connector.PullRequest, failed
 	return strings.ReplaceAll(reason, " ", "_")
 }
 
-func reworkLessonSymptom(issue connector.Issue, reason string, failedChecks []string, reviewSummary string) string {
+func reworkLessonSymptom(issue connector.Issue, reason string) string {
 	transition := reworkIssueRef(issue) + " was observed entering Rework"
 	if sourceState := displayStateName(issue.State); sourceState != "" {
 		transition = fmt.Sprintf("%s entered Rework from %s", reworkIssueRef(issue), sourceState)
@@ -104,12 +187,6 @@ func reworkLessonSymptom(issue connector.Issue, reason string, failedChecks []st
 	if reason = strings.TrimSpace(reason); reason != "" {
 		parts = append(parts, "reason: "+reason)
 	}
-	if len(failedChecks) > 0 {
-		parts = append(parts, "failed checks: "+strings.Join(failedChecks, ", "))
-	}
-	if reviewSummary != "" {
-		parts = append(parts, "review: "+reviewSummary)
-	}
 	return strings.Join(parts, "; ")
 }
 
@@ -117,19 +194,27 @@ func reworkReviewSummary(pullRequest *connector.PullRequest) string {
 	if pullRequest == nil {
 		return ""
 	}
-	parts := make([]string, 0, len(pullRequest.CodexReviewFindings)+1)
-	if state := strings.TrimSpace(pullRequest.CodexReviewState); state != "" {
-		parts = append(parts, state)
+	for _, thread := range pullRequest.UnresolvedReviewThreads {
+		if body := strings.TrimSpace(thread.Body); body != "" {
+			if location := pullRequestReviewThreadLocation(thread); location != "" {
+				return location + ": " + body
+			}
+			return body
+		}
 	}
 	for _, finding := range pullRequest.CodexReviewFindings {
-		if body := strings.Join(strings.Fields(finding.Body), " "); body != "" {
-			parts = append(parts, body)
-		}
-		if len(parts) == 4 {
-			break
+		if body := strings.TrimSpace(finding.Body); body != "" {
+			parts := []string{}
+			if state := strings.TrimSpace(pullRequest.CodexReviewState); state != "" {
+				parts = append(parts, state)
+			}
+			if path := strings.TrimSpace(finding.Path); path != "" {
+				parts = append(parts, path)
+			}
+			return strings.Join(append(parts, body), ": ")
 		}
 	}
-	return strings.Join(parts, ": ")
+	return ""
 }
 
 func reworkPullRequestRef(issue connector.Issue) string {

--- a/internal/orchestrator/lesson_capture_test.go
+++ b/internal/orchestrator/lesson_capture_test.go
@@ -1,0 +1,184 @@
+package orchestrator
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/lessons"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+func TestReworkLessonRequiresEvidence(t *testing.T) {
+	t.Parallel()
+	for _, reason := range []string{"tracker_state_observed", "stranded_active_recovery", "backend_capacity_pause", "ci_not_green", "session_duration_exceeded", "merge_conflicts"} {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "lessons.md")
+			o := &Orchestrator{cfg: Config{Lessons: LessonCaptureConfig{Enabled: true, Path: path}}}
+			o.captureReworkLesson(connector.Issue{ID: "one"}, time.Now(), reason)
+			entries, err := lessons.ReadAll(path)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("evidence-free capture = %v, %v; want no entries", entries, err)
+			}
+		})
+	}
+}
+
+func TestReworkLessonOmitsBoilerplate(t *testing.T) {
+	t.Parallel()
+	entry := reworkLessonEntry("project", connector.Issue{ID: "one"}, time.Now(), "ci_not_green")
+	if strings.TrimSpace(entry.Hypothesis) != "" || strings.TrimSpace(entry.Hint) != "" {
+		t.Fatalf("capture invents hypothesis or hint: %#v", entry)
+	}
+}
+
+func TestReworkLessonConcreteEvidence(t *testing.T) {
+	t.Parallel()
+	checks := &connector.PullRequest{
+		Checks: []connector.PullRequestCheck{
+			{Name: "test", Conclusion: "failure", FailureDetail: "worker_test.go: assertion: want released slot"},
+			{Name: "passing", Conclusion: "success", FailureDetail: "must not appear"},
+			{Name: "neutral", Conclusion: "neutral", FailureDetail: "must not appear"},
+			{Name: "missing", Conclusion: "missing", FailureDetail: "must not appear"},
+		},
+		RequiredCheckFailures: []connector.PullRequestCheck{{Name: "test", Conclusion: "failure"}, {Name: "lint", Conclusion: "failure"}},
+	}
+	review := &connector.PullRequest{CodexReviewState: "COMMENTED", UnresolvedReviewThreads: []connector.PullRequestReviewThread{
+		{Path: "worker.go", Line: 42, Body: "Release the slot after cancellation."},
+		{Path: "later.go", Body: "later thread must not appear"},
+	}}
+	for _, tt := range []struct {
+		name, reason, kind string
+		pr                 *connector.PullRequest
+		evidence           reworkLessonEvidence
+		want               []string
+	}{
+		{name: "CI assertions", reason: "ci_not_green", kind: "ci_failure", pr: checks, want: []string{"failed checks: test, lint", "worker_test.go: assertion: want released slot"}},
+		{name: "commented transition", reason: "tracker_state_observed", kind: "rework_transition", pr: review, want: []string{"worker.go:42", "Release the slot after cancellation."}},
+		{name: "review request", reason: string(AutoPromoteReasonUnresolvedReviewThreads), kind: "changes_requested", pr: review, want: []string{"worker.go:42", "Release the slot"}},
+		{name: "duration ignores unrelated CI", reason: "session_duration_exceeded", kind: "session_duration_exceeded", pr: checks, evidence: reworkLessonEvidence{LastCommand: "go test ./internal/runner -race"}, want: []string{"last command: go test ./internal/runner -race"}},
+		{name: "conflicts", reason: "merge_conflicts", kind: "merge_conflict", evidence: reworkLessonEvidence{ConflictPaths: []string{"worker.go", "go.mod", "worker.go", " "}}, want: []string{"conflicting paths: worker.go, go.mod"}},
+		{name: "merge fallback", reason: mergeFallbackRequiresReworkReason, kind: "merge_conflict", evidence: reworkLessonEvidence{ConflictPaths: []string{"worker.go"}}, want: []string{"conflicting paths: worker.go"}},
+		{name: "validator with evidence", reason: string(AutoPromoteReasonValidatorRework), kind: "validator_rework", pr: review, want: []string{"Release the slot"}},
+		{name: "artifact with evidence", reason: string(AutoPromoteReasonArtifactStatusRework), kind: "artifact_rework", pr: review, want: []string{"Release the slot"}},
+		{name: "workpad with evidence", reason: string(AutoPromoteReasonWorkpadStatusInvalid), kind: "invalid_workpad_status", pr: review, want: []string{"Release the slot"}},
+		{name: "missing signal with review evidence", reason: mergeWorkerRequiredChecksMissingReason, kind: "ci_signal_missing", pr: review, want: []string{"Release the slot"}},
+		{name: "operator with review evidence", reason: "operator_rework", kind: "operator_rework", pr: review, want: []string{"Release the slot"}},
+		{name: "neutral check alone", reason: "tracker_state_observed", pr: &connector.PullRequest{Checks: []connector.PullRequestCheck{{Name: "optional", Conclusion: "neutral"}}}},
+		{name: "state alone", reason: "tracker_state_observed", pr: &connector.PullRequest{CodexReviewState: "COMMENTED"}},
+		{name: "thread location alone", reason: "tracker_state_observed", pr: &connector.PullRequest{UnresolvedReviewThreads: []connector.PullRequestReviewThread{{Path: "worker.go", Line: 42}}}},
+		{name: "recovery ignores stale evidence", reason: "stranded_active_recovery", pr: checks},
+		{name: "capacity ignores stale evidence", reason: "backend_capacity_pause", pr: review},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "lessons.md")
+			o := &Orchestrator{cfg: Config{Lessons: LessonCaptureConfig{Enabled: true, Path: path}}}
+			issue := connector.Issue{ID: "one", Identifier: "repo#1", PullRequest: tt.pr}
+			at := time.Now()
+			o.captureReworkLesson(issue, at, tt.reason, tt.evidence)
+			o.captureReworkLesson(issue, at, tt.reason, tt.evidence)
+			entries, err := lessons.ReadAll(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tt.want) == 0 {
+				if len(entries) != 0 {
+					t.Fatalf("unexpected capture: %v", entries)
+				}
+				return
+			}
+			if len(entries) != 1 {
+				t.Fatalf("entries=%d, want one deduplicated capture", len(entries))
+			}
+			for _, want := range append(tt.want, "**Failure kind:** "+tt.kind) {
+				if !strings.Contains(entries[0], want) {
+					t.Errorf("missing %q in %s", want, entries[0])
+				}
+			}
+			for _, unwanted := range []string{"Hypothesis", "Hint for next time", "must not appear"} {
+				if strings.Contains(entries[0], unwanted) {
+					t.Errorf("unexpected %q in %s", unwanted, entries[0])
+				}
+			}
+		})
+	}
+}
+
+func TestReworkLessonProjectIsolation(t *testing.T) {
+	t.Parallel()
+	at := time.Now()
+	issue := connector.Issue{ID: "same-id", PullRequest: &connector.PullRequest{Checks: []connector.PullRequestCheck{{Name: "test", Conclusion: "failure"}}}}
+	paths := []string{filepath.Join(t.TempDir(), "lessons.md"), filepath.Join(t.TempDir(), "lessons.md")}
+	for index, path := range paths {
+		o := &Orchestrator{cfg: Config{Project: scheduler.ProjectCandidate{ID: fmt.Sprintf("project-%d", index)}, Lessons: LessonCaptureConfig{Enabled: true, Path: path}}}
+		o.captureReworkLesson(issue, at, "ci_not_green")
+		entries, err := lessons.ReadAll(path)
+		if err != nil || len(entries) != 1 || !strings.Contains(entries[0], fmt.Sprintf("rework|project-%d|", index)) {
+			t.Fatalf("project capture = %v, %v", entries, err)
+		}
+	}
+}
+
+func TestSessionBrakeLessonUsesLastCommand(t *testing.T) {
+	t.Parallel()
+	for _, command := range []string{"", "go test ./internal/runner -race"} {
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "lessons.md")
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Todo", "In Progress", "Rework"}, Lessons: LessonCaptureConfig{Enabled: true, Path: path}})
+			o := &Orchestrator{cfg: cfg, connector: &workflowMetricsConnector{}}
+			state := newState(cfg)
+			running := Running{Issue: connector.Issue{ID: "one", State: "In Progress"}, LastCommand: command}
+			completion := runpkg.Completion{IssueID: "one", CompletedAt: time.Now(), Err: &runpkg.SessionBrakeError{Reason: runpkg.SessionBrakeReasonDuration, Resumable: true}}
+			if !o.handleSessionBrake(t.Context(), &state, completion, running) {
+				t.Fatal("session brake was not handled")
+			}
+			entries, err := lessons.ReadAll(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if command == "" {
+				if len(entries) != 0 {
+					t.Fatalf("capture without command = %v", entries)
+				}
+			} else if len(entries) != 1 || !strings.Contains(entries[0], command) {
+				t.Fatalf("capture missing last command: %v", entries)
+			}
+		})
+	}
+}
+
+func TestMergeReworkLessonUsesPrecheckPaths(t *testing.T) {
+	t.Parallel()
+	for _, paths := range [][]string{nil, {"README.md", "internal/worker.go"}} {
+		t.Run(fmt.Sprint(paths), func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "lessons.md")
+			cfg := normalizeConfig(Config{Lessons: LessonCaptureConfig{Enabled: true, Path: path}})
+			issue := connector.Issue{ID: "one", State: "Merging"}
+			o := &Orchestrator{cfg: cfg, connector: &workflowMetricsConnector{}, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			state := newState(cfg)
+			completion := runpkg.Completion{IssueID: "one", CompletedAt: time.Now(), Result: runpkg.RunResult{MergePrecheck: &runpkg.MergePrecheck{Status: "conflict", ConflictPaths: paths}}}
+			o.reworkMergeWorkerResult(t.Context(), &state, completion, Running{Issue: issue}, issue, mergeFallbackRequiresReworkReason, nil, "")
+			entries, err := lessons.ReadAll(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(paths) == 0 {
+				if len(entries) != 0 {
+					t.Fatalf("capture without paths = %v", entries)
+				}
+			} else if len(entries) != 1 || !strings.Contains(entries[0], "conflicting paths: README.md, internal/worker.go") {
+				t.Fatalf("capture missing conflict paths: %v", entries)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -2429,7 +2429,11 @@ func (o *Orchestrator) reworkMergeWorkerResult(
 ) {
 	issueID := strings.TrimSpace(event.IssueID)
 	running.Issue = issue
-	if err := o.updateIssueStateByID(ctx, state, issueID, issue, autoPromoteReworkState, event.CompletedAt, reason, laneMutationAcceptCompletion); err != nil {
+	metadata := workflowLaneMetadata{}
+	if event.Result.MergePrecheck != nil {
+		metadata.LessonEvidence.ConflictPaths = event.Result.MergePrecheck.ConflictPaths
+	}
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, autoPromoteReworkState, event.CompletedAt, reason, metadata, laneMutationAcceptCompletion); err != nil {
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "merge_worker_rework_failed", err)
 		return
 	}

--- a/internal/orchestrator/session_brake.go
+++ b/internal/orchestrator/session_brake.go
@@ -113,6 +113,7 @@ func (o *Orchestrator) handleSessionBrake(
 
 	issue := cloneIssue(running.Issue)
 	metadata := workflowLaneMetadata{
+		LessonEvidence: reworkLessonEvidence{LastCommand: running.LastCommand},
 		BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
 			Owner:            blockedRecoveryOwnerOrchestrator,
 			Cause:            brake.Reason,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -164,6 +164,7 @@ type Running struct {
 	TurnCount                   int
 	LastEventAt                 time.Time
 	LastEvent                   string
+	LastCommand                 string
 	LastMessage                 string
 	LastMessageTruncation       *runtimeoutput.Truncation
 	RecentEvents                []telemetry.ActivityEvent
@@ -620,6 +621,7 @@ func cloneMergePrecheck(precheck *runpkg.MergePrecheck) *runpkg.MergePrecheck {
 		return nil
 	}
 	cloned := *precheck
+	cloned.ConflictPaths = append([]string(nil), precheck.ConflictPaths...)
 	return &cloned
 }
 

--- a/internal/orchestrator/worker_progress.go
+++ b/internal/orchestrator/worker_progress.go
@@ -63,6 +63,9 @@ func applyRunningUsage(running Running, update runpkg.UsageUpdate) Running {
 	if update.LastEvent != "" {
 		running.LastEvent = update.LastEvent
 	}
+	if update.LastCommand != "" {
+		running.LastCommand = update.LastCommand
+	}
 	if update.LastMessage != "" {
 		running.LastMessage = update.LastMessage
 		running.LastMessageTruncation = runtimeoutput.CloneTruncation(update.LastMessageTruncation)
@@ -110,6 +113,7 @@ func (r Running) withProgress() Running {
 		TurnCount:             p.TurnCount,
 		LastEventAt:           p.LastEventAt,
 		LastEvent:             p.LastEvent,
+		LastCommand:           p.LastCommand,
 		LastMessage:           p.LastMessage,
 		LastMessageTruncation: p.LastMessageTruncation,
 		RecentEvents:          p.RecentEvents,

--- a/internal/orchestrator/worker_progress_test.go
+++ b/internal/orchestrator/worker_progress_test.go
@@ -31,11 +31,11 @@ func TestWorkerProgressCheckpointPersistence(t *testing.T) {
 			base := store.WorkAttemptHeartbeat{AttemptID: running.WorkAttemptID, HeartbeatAt: now, LeaseExpiresAt: now.Add(time.Minute)}
 			progress := newWorkerProgress(running, base, attempts, 4096)
 			running.progress = progress
-			update := runpkg.UsageUpdate{SessionID: "session", LastMessage: "tests running", DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{WorkspaceDiffAvailable: true}}
+			update := runpkg.UsageUpdate{LastCommand: "go test ./...", SessionID: "session", LastMessage: "tests running", DispatchLoopStart: &runpkg.DispatchLoopStartSnapshot{WorkspaceDiffAvailable: true}}
 			if err := progress.observe(t.Context(), update); !errors.Is(err, tt.err) {
 				t.Fatalf("observe() = %v, want %v", err, tt.err)
 			}
-			if got := running.withProgress(); got.DispatchLoopStart.Persisted != (tt.err == nil) || got.LastMessage != update.LastMessage {
+			if got := running.withProgress(); got.DispatchLoopStart.Persisted != (tt.err == nil) || got.LastMessage != update.LastMessage || got.LastCommand != update.LastCommand {
 				t.Fatalf("progress = %#v", got)
 			}
 			if got := progress.persisted.Load(); (got != nil) != (tt.err == nil) {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -37,6 +37,7 @@ type WorkflowMetricsMetadataUpdater interface {
 }
 
 type workflowLaneMetadata struct {
+	LessonEvidence        reworkLessonEvidence                       `json:"-"`
 	Reconciliation        string                                     `json:"reconciliation,omitempty"`
 	PullRequest           *workflowLanePullRequestMetadata           `json:"pull_request,omitempty"`
 	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`
@@ -225,7 +226,7 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 	}
 	o.recordLaneTransition(ctx, issue, targetState, at, reason, metadata)
 	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) && normalizeState(issue.State) != normalizeState(targetState) {
-		o.captureReworkLesson(issue, at, reason)
+		o.captureReworkLesson(issue, at, reason, metadata.LessonEvidence)
 	}
 	if leased {
 		o.applyLaneMutationDisposition(ctx, state, running, receipt, issue, transitionAt)

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -734,12 +734,6 @@ func TestUpdateIssueStateByIDCapturesReworkLesson(t *testing.T) {
 			wantFailureKind: "changes_requested",
 			wantContext:     []string{"CHANGES_REQUESTED: Add rollback coverage.", "PR #1402"},
 		},
-		{
-			name:            "generic transition keeps a non-empty kind",
-			reason:          "operator_rework",
-			wantFailureKind: "operator_rework",
-			wantContext:     []string{"reason: operator_rework"},
-		},
 	}
 
 	for _, tt := range tests {
@@ -800,6 +794,7 @@ func TestRefreshCurrentLaneEntriesCapturesObservedReworkOnce(t *testing.T) {
 		Identifier:     "digitaldrywood/detent#1397",
 		Number:         1397,
 		Title:          "Capture observed rework",
+		PullRequest:    &connector.PullRequest{UnresolvedReviewThreads: []connector.PullRequestReviewThread{{Path: "worker.go", Body: "Preserve command evidence."}}},
 		State:          "Rework",
 		StageUpdatedAt: &enteredAt,
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -695,11 +695,12 @@ func (r *Runner) prepareMergeFastPath(
 
 func mergePrecheckFromWorkspace(precheck workspace.MergePrepareResult) MergePrecheck {
 	return MergePrecheck{
-		Status:      string(precheck.Status),
-		Message:     precheck.Message,
-		DiffStats:   diffStatsFromWorkspace(precheck.DiffStat),
-		HeadChanged: precheck.HeadChanged,
-		HeadSHA:     precheck.HeadSHA,
+		ConflictPaths: append([]string(nil), precheck.ConflictPaths...),
+		Status:        string(precheck.Status),
+		Message:       precheck.Message,
+		DiffStats:     diffStatsFromWorkspace(precheck.DiffStat),
+		HeadChanged:   precheck.HeadChanged,
+		HeadSHA:       precheck.HeadSHA,
 	}
 }
 
@@ -766,6 +767,7 @@ func cloneMergePrecheck(precheck *MergePrecheck) *MergePrecheck {
 		return nil
 	}
 	cloned := *precheck
+	cloned.ConflictPaths = append([]string(nil), precheck.ConflictPaths...)
 	return &cloned
 }
 
@@ -4115,6 +4117,7 @@ type agentRunProgress struct {
 	output                    *runtimeoutput.Buffer
 	lastEventAt               time.Time
 	lastEvent                 string
+	lastCommand               string
 	lastMessage               string
 	lastMessageTruncation     *runtimeoutput.Truncation
 	recentEvents              []telemetry.ActivityEvent
@@ -4227,6 +4230,9 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 	case AgentUpdateRuntimeIdentity:
 		eventMessage = "agent route selected"
 	case AgentUpdateToolStarted:
+		if command := strings.TrimSpace(update.Command); command != "" {
+			p.lastCommand = runtimeoutput.Truncate(command, 2048).Value
+		}
 		p.recordDeliverableToolStart(update)
 	case AgentUpdateToolOutput:
 		p.recordDeliverableToolOutput(update)
@@ -4899,6 +4905,7 @@ func (r *Runner) publishRunUpdate(
 		TurnCount:             progress.turnCount(),
 		LastEventAt:           progress.lastEventAt,
 		LastEvent:             progress.lastEvent,
+		LastCommand:           progress.lastCommand,
 		LastMessage:           progress.lastMessage,
 		LastMessageTruncation: runtimeoutput.CloneTruncation(progress.lastMessageTruncation),
 		RecentEvents:          progress.recentActivity(),

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -7188,3 +7188,39 @@ func writeSkill(t *testing.T, workspacePath, name, skillName, description, whenT
 		t.Fatalf("write skill: %v", err)
 	}
 }
+
+func TestAgentRunProgressRetainsLastCommand(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		updates []AgentUpdate
+		want    string
+	}{
+		{name: "no command", updates: []AgentUpdate{{Type: AgentUpdateMessageDelta, Delta: "go test ./..."}}},
+		{name: "latest command survives messages", updates: []AgentUpdate{
+			{Type: AgentUpdateToolStarted, Command: "go build ./..."},
+			{Type: AgentUpdateToolStarted, Command: "go test ./..."},
+			{Type: AgentUpdateMessageDelta, Delta: "waiting for tests"},
+			{Type: AgentUpdateTokenUsage},
+			{Type: AgentUpdateToolStarted, Tool: "read_file"},
+		}, want: "go test ./..."},
+		{name: "bounded command", updates: []AgentUpdate{{Type: AgentUpdateToolStarted, Command: strings.Repeat("x", 8192)}}, want: runtimeoutput.Truncate(strings.Repeat("x", 8192), 2048).Value},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			progress := newAgentRunProgress(runtimeoutput.Policy{}, "", "", 0, "", 0)
+			for _, update := range tt.updates {
+				progress.apply(update, time.Now())
+			}
+			var usage UsageUpdate
+			runner := &Runner{}
+			err := runner.publishRunUpdate(t.Context(), RunRequest{Admission: &AdmissionRequest{}, OnUsageUpdate: func(update UsageUpdate) error { usage = update; return nil }}, workspace.Info{}, workspace.Issue{}, progress, RunResult{}, time.Now(), time.Now(), 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if usage.LastCommand != tt.want {
+				t.Fatalf("last command = %q, want %q", usage.LastCommand, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -619,11 +619,12 @@ type SessionProgressProbe func(context.Context) (string, error)
 type ModelPermitAcquirer func(context.Context) error
 
 type MergePrecheck struct {
-	HeadSHA     string
-	Status      string
-	Message     string
-	DiffStats   DiffStats
-	HeadChanged bool
+	ConflictPaths []string
+	HeadSHA       string
+	Status        string
+	Message       string
+	DiffStats     DiffStats
+	HeadChanged   bool
 }
 
 type RoutineRequest struct {
@@ -774,6 +775,7 @@ type AgentActivityUpdate struct {
 }
 
 type UsageUpdate struct {
+	LastCommand           string
 	DetentSessionID       int64
 	SessionID             string
 	ProcessIdentity       string

--- a/internal/workspace/merge.go
+++ b/internal/workspace/merge.go
@@ -55,6 +55,11 @@ func (l *LocalGit) PrepareMerge(
 		)
 	}
 	if _, err := runGitAt(ctx, normalized.Path, "rebase", targetRef); err != nil {
+		conflicts, conflictErr := runGitAt(ctx, normalized.Path, "diff", "--name-only", "--diff-filter=U", "-z")
+		var conflictPaths []string
+		if conflictErr == nil && conflicts != "" {
+			conflictPaths = strings.Split(strings.TrimSuffix(conflicts, "\x00"), "\x00")
+		}
 		abortErr := abortRebaseIfInProgress(ctx, normalized.Path)
 		if abortErr != nil {
 			return MergePrepareResult{}, errors.Join(
@@ -63,8 +68,9 @@ func (l *LocalGit) PrepareMerge(
 			)
 		}
 		return MergePrepareResult{
-			Status:  MergePrepareStatusConflict,
-			Message: commandErrorOutput(err),
+			ConflictPaths: conflictPaths,
+			Status:        MergePrepareStatusConflict,
+			Message:       commandErrorOutput(err),
 		}, nil
 	}
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -151,11 +151,12 @@ type MergePrepareOptions struct {
 }
 
 type MergePrepareResult struct {
-	HeadSHA     string
-	Status      MergePrepareStatus
-	DiffStat    DiffStat
-	Message     string
-	HeadChanged bool
+	ConflictPaths []string
+	HeadSHA       string
+	Status        MergePrepareStatus
+	DiffStat      DiffStat
+	Message       string
+	HeadChanged   bool
 }
 
 type MergePrepareStatus string

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -956,6 +956,9 @@ func TestLocalGitPrepareMergeAbortsConflictingRebase(t *testing.T) {
 	if result.Status != MergePrepareStatusConflict {
 		t.Fatalf("PrepareMerge() status = %q, want conflict", result.Status)
 	}
+	if len(result.ConflictPaths) != 1 || result.ConflictPaths[0] != "README.md" {
+		t.Fatalf("conflict paths = %v, want README.md", result.ConflictPaths)
+	}
 	if got := strings.TrimSpace(runGit(t, info.Path, "status", "--short")); got != "" {
 		t.Fatalf("status after aborted rebase = %q, want clean", got)
 	}


### PR DESCRIPTION
## Summary

- Capture concrete failure evidence: failing CI jobs and available annotations, the first unresolved review body and location, the last worker command on duration expiry for Codex and Claude (including partial streams), and conflicting paths before rebase cleanup.
- Suppress captures without evidence and recovery/capacity pauses; omit generic Hypothesis/Hint prose.
- Retain newest lessons within the configured count and 16 KiB file / 4 KiB entry bounds, with explicit truncation and capture-key deduplication.

Fixes #2132

## UI Surface Contract

- [x] N/A: no UI surface or layout changes.
- [x] No persistent top-of-screen messaging added.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Focused stdlib table-driven regressions for concrete evidence, absent evidence, deduplication, bounded retention, and project isolation.
- [x] Evidence plumbing tests for CI annotations, review threads, worker commands, session expiry, and merge conflicts.
- [x] `make generate` and config-reference tests.
- [x] `make check` (80.1% overall coverage; all package/file floors passed).
