### PR TITLE
fix(orchestrator): preserve cross-host recovery parks

### DIFF
--- a/internal/orchestrator/cross_host_park.go
+++ b/internal/orchestrator/cross_host_park.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -19,6 +20,8 @@ type trackerRecoveryPark struct {
 	Owner            string `json:"owner"`
 	Cause            string `json:"cause"`
 	CauseFingerprint string `json:"cause_fingerprint"`
+	OperationID      string `json:"operation_id,omitempty"`
+	Phase            string `json:"phase,omitempty"`
 }
 
 func protectedRecoveryPark(park workflowLaneBlockedRecoveryMetadata) bool {
@@ -34,18 +37,50 @@ func protectedRecoveryPark(park workflowLaneBlockedRecoveryMetadata) bool {
 	}
 }
 
-func (o *Orchestrator) publishTrackerRecoveryPark(ctx context.Context, issueID, targetState string, metadata workflowLaneMetadata) {
+func newTrackerRecoveryPark(targetState string, metadata workflowLaneMetadata) *trackerRecoveryPark {
 	park := metadata.BlockedRecovery
 	if normalizeState(targetState) != normalizeState(blockedStatusState) || park == nil || !protectedRecoveryPark(*park) {
-		return
+		return nil
 	}
-	data, err := json.Marshal(trackerRecoveryPark{Schema: 1, Owner: park.Owner, Cause: park.Cause, CauseFingerprint: park.CauseFingerprint})
-	if err == nil {
-		err = o.connector.CreateComment(ctx, issueID, trackerRecoveryParkPrefix+string(data)+"\n```\n\nDependency reconciliation must preserve this recovery park.")
+	return &trackerRecoveryPark{Schema: 1, Owner: park.Owner, Cause: park.Cause, CauseFingerprint: park.CauseFingerprint, OperationID: rand.Text(), Phase: "pending"}
+}
+
+func (o *Orchestrator) publishTrackerRecoveryPark(ctx context.Context, issueID string, park *trackerRecoveryPark) error {
+	if park == nil {
+		return nil
 	}
-	if err != nil && o.logger != nil {
-		o.logger.Warn("publish tracker recovery park failed", "issue_id", issueID, "error", err)
+	data, err := json.Marshal(park)
+	if err != nil {
+		return fmt.Errorf("encode tracker recovery park: %w", err)
 	}
+	if err := o.connector.CreateComment(ctx, issueID, trackerRecoveryParkPrefix+string(data)+"\n```\n\nDependency reconciliation must preserve this recovery park."); err != nil {
+		return fmt.Errorf("publish tracker recovery park: %w", err)
+	}
+	return nil
+}
+
+func (o *Orchestrator) finishTrackerRecoveryPark(ctx context.Context, issueID string, park *trackerRecoveryPark, phase string) error {
+	if park == nil {
+		return nil
+	}
+	park.Phase = phase
+	return o.publishTrackerRecoveryPark(ctx, issueID, park)
+}
+
+func parseTrackerRecoveryPark(body string) (trackerRecoveryPark, bool) {
+	raw, recognized := strings.CutPrefix(strings.TrimSpace(body), trackerRecoveryParkPrefix)
+	data, _, complete := strings.Cut(raw, "\n```")
+	var park trackerRecoveryPark
+	valid := recognized && complete && json.Unmarshal([]byte(data), &park) == nil && park.Schema == 1
+	return park, valid
+}
+
+func (o *Orchestrator) trackerRecoveryParkAuthorAuthorized(comment connector.IssueComment) bool {
+	if comment.AuthorAuthorized {
+		return true
+	}
+	identity, ok := o.connector.(connector.InstanceIdentifier)
+	return ok && strings.TrimSpace(identity.InstanceLogin()) != "" && strings.EqualFold(strings.TrimSpace(comment.AuthorLogin), strings.TrimSpace(identity.InstanceLogin()))
 }
 
 func (o *Orchestrator) trackerRecoveryParkHold(ctx context.Context, issue connector.Issue) string {
@@ -57,18 +92,33 @@ func (o *Orchestrator) trackerRecoveryParkHold(ctx context.Context, issue connec
 			return "tracker_recovery_park_unavailable"
 		}
 	}
+	settled := map[string]bool{}
 	for _, comment := range comments {
-		if !comment.AuthorAuthorized {
+		park, valid := parseTrackerRecoveryPark(comment.Body)
+		if valid && park.OperationID != "" && (park.Phase == "applied" || park.Phase == "cancelled") && o.trackerRecoveryParkAuthorAuthorized(comment) {
+			settled[park.OperationID] = true
+		}
+	}
+	for _, comment := range comments {
+		if !o.trackerRecoveryParkAuthorAuthorized(comment) {
+			continue
+		}
+		park, valid := parseTrackerRecoveryPark(comment.Body)
+		if valid && park.Phase == "pending" {
+			if !settled[park.OperationID] {
+				return "tracker_recovery_park"
+			}
+			continue
+		}
+		if valid && park.Phase == "cancelled" {
 			continue
 		}
 		if comment.CreatedAt != nil && !blockedEntryMatchesCurrent(issue, *comment.CreatedAt) {
 			continue
 		}
 		body := strings.TrimSpace(comment.Body)
-		if raw, ok := strings.CutPrefix(body, trackerRecoveryParkPrefix); ok {
-			data, _, complete := strings.Cut(raw, "\n```")
-			var park trackerRecoveryPark
-			if !complete || json.Unmarshal([]byte(data), &park) != nil || park.Schema != 1 {
+		if strings.HasPrefix(body, trackerRecoveryParkPrefix) {
+			if !valid {
 				return "tracker_recovery_park_unavailable"
 			}
 			if protectedRecoveryPark(workflowLaneBlockedRecoveryMetadata{Owner: park.Owner, Cause: park.Cause}) {
@@ -78,16 +128,16 @@ func (o *Orchestrator) trackerRecoveryParkHold(ctx context.Context, issue connec
 		if !strings.HasPrefix(body, "Routed this issue to Blocked") {
 			continue
 		}
-		var park workflowLaneBlockedRecoveryMetadata
+		var legacyPark workflowLaneBlockedRecoveryMetadata
 		for line := range strings.SplitSeq(body, "\n") {
 			if value, ok := strings.CutPrefix(strings.TrimSpace(line), "- reason: "); ok {
-				park.Cause = strings.TrimSpace(value)
+				legacyPark.Cause = strings.TrimSpace(value)
 			}
 			if value, ok := strings.CutPrefix(strings.TrimSpace(line), "- owner: "); ok {
-				park.Owner = strings.TrimSpace(value)
+				legacyPark.Owner = strings.TrimSpace(value)
 			}
 		}
-		if protectedRecoveryPark(park) {
+		if protectedRecoveryPark(legacyPark) {
 			return "tracker_recovery_park"
 		}
 	}

--- a/internal/orchestrator/cross_host_park.go
+++ b/internal/orchestrator/cross_host_park.go
@@ -1,0 +1,180 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+const trackerRecoveryParkPrefix = "## Detent recovery park\n\n```detent-park\n"
+
+type trackerRecoveryPark struct {
+	Schema           int    `json:"schema"`
+	Owner            string `json:"owner"`
+	Cause            string `json:"cause"`
+	CauseFingerprint string `json:"cause_fingerprint"`
+}
+
+func protectedRecoveryPark(park workflowLaneBlockedRecoveryMetadata) bool {
+	if strings.EqualFold(strings.TrimSpace(park.Owner), blockedRecoveryOwnerHuman) ||
+		strings.EqualFold(strings.TrimSpace(park.Owner), blockedRecoveryOwnerOperator) {
+		return true
+	}
+	switch strings.TrimSpace(park.Cause) {
+	case spendProgressReason, dispatchLoopDetectedReason, noProgressLimitReason:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o *Orchestrator) publishTrackerRecoveryPark(ctx context.Context, issueID, targetState string, metadata workflowLaneMetadata) {
+	park := metadata.BlockedRecovery
+	if normalizeState(targetState) != normalizeState(blockedStatusState) || park == nil || !protectedRecoveryPark(*park) {
+		return
+	}
+	data, err := json.Marshal(trackerRecoveryPark{Schema: 1, Owner: park.Owner, Cause: park.Cause, CauseFingerprint: park.CauseFingerprint})
+	if err == nil {
+		err = o.connector.CreateComment(ctx, issueID, trackerRecoveryParkPrefix+string(data)+"\n```\n\nDependency reconciliation must preserve this recovery park.")
+	}
+	if err != nil && o.logger != nil {
+		o.logger.Warn("publish tracker recovery park failed", "issue_id", issueID, "error", err)
+	}
+}
+
+func (o *Orchestrator) trackerRecoveryParkHold(ctx context.Context, issue connector.Issue) string {
+	comments := issue.Comments
+	if reader, ok := o.connector.(connector.IssueCommentReader); ok {
+		var err error
+		comments, err = reader.FetchIssueComments(ctx, issue)
+		if err != nil {
+			return "tracker_recovery_park_unavailable"
+		}
+	}
+	for _, comment := range comments {
+		if !comment.AuthorAuthorized {
+			continue
+		}
+		if comment.CreatedAt != nil && !blockedEntryMatchesCurrent(issue, *comment.CreatedAt) {
+			continue
+		}
+		body := strings.TrimSpace(comment.Body)
+		if raw, ok := strings.CutPrefix(body, trackerRecoveryParkPrefix); ok {
+			data, _, complete := strings.Cut(raw, "\n```")
+			var park trackerRecoveryPark
+			if !complete || json.Unmarshal([]byte(data), &park) != nil || park.Schema != 1 {
+				return "tracker_recovery_park_unavailable"
+			}
+			if protectedRecoveryPark(workflowLaneBlockedRecoveryMetadata{Owner: park.Owner, Cause: park.Cause}) {
+				return "tracker_recovery_park"
+			}
+		}
+		if !strings.HasPrefix(body, "Routed this issue to Blocked") {
+			continue
+		}
+		var park workflowLaneBlockedRecoveryMetadata
+		for line := range strings.SplitSeq(body, "\n") {
+			if value, ok := strings.CutPrefix(strings.TrimSpace(line), "- reason: "); ok {
+				park.Cause = strings.TrimSpace(value)
+			}
+			if value, ok := strings.CutPrefix(strings.TrimSpace(line), "- owner: "); ok {
+				park.Owner = strings.TrimSpace(value)
+			}
+		}
+		if protectedRecoveryPark(park) {
+			return "tracker_recovery_park"
+		}
+	}
+	return ""
+}
+
+func (o *Orchestrator) retainUnacknowledgedRecoveryParks(ctx context.Context, state *State, issues []connector.Issue) {
+	for _, issue := range issues {
+		if !stateIn(issue.State, o.cfg.ActiveStates) {
+			continue
+		}
+		if _, running := state.Running[issue.ID]; running {
+			continue
+		}
+		timeline, ok := o.issueWorkflowTimeline(ctx, issue)
+		if !ok {
+			if _, available := o.workflowMetrics.(WorkflowMetricsTimelineReader); available {
+				state.Blocked[issue.ID] = Blocked{Issue: cloneIssue(issue), Source: BlockedSourceProjectStatus, Reason: "recovery_park_history_unavailable"}
+			}
+			continue
+		}
+		var park *workflowLaneBlockedRecoveryMetadata
+		var parkedAt time.Time
+		for _, event := range timeline.Events {
+			if event.PhaseType != store.WorkflowPhaseTypeLane || event.Status != "entered" || !recoveryParkEventMatchesIssue(event, issue) {
+				continue
+			}
+			metadata, _ := workflowLaneMetadataFromJSON(event.MetadataJSON)
+			if normalizeState(event.PhaseName) == normalizeState(blockedStatusState) {
+				candidate := metadata.BlockedRecovery
+				if candidate == nil && protectedRecoveryPark(workflowLaneBlockedRecoveryMetadata{Cause: event.Reason}) {
+					candidate = &workflowLaneBlockedRecoveryMetadata{Owner: blockedRecoveryOwnerHuman, Cause: event.Reason}
+				}
+				if candidate != nil && protectedRecoveryPark(*candidate) {
+					park = candidate
+					parkedAt = workflowLaneTransitionAt(event)
+				}
+				continue
+			}
+			if park != nil && recoveryParkAcknowledged(event, metadata, *park) {
+				park = nil
+			}
+		}
+		if park == nil {
+			if blocked, ok := state.Blocked[issue.ID]; ok && (blocked.RecoveryReason == "park_acknowledgement_required" || blocked.Reason == "recovery_park_history_unavailable") {
+				delete(state.Blocked, issue.ID)
+			}
+			continue
+		}
+		state.Blocked[issue.ID] = Blocked{
+			Issue: cloneIssue(issue), Source: BlockedSourceProjectStatus, BlockedAt: parkedAt,
+			Reason: park.Cause, Recovery: park, RecoveryAction: "hold", RecoveryReason: "park_acknowledgement_required",
+			RecoveryRemedy: fmt.Sprintf("Use an explicit Detent work-item move to acknowledge the %s park before retrying.", park.Cause),
+		}
+		o.recordBlockedRecoveryDecision(ctx, state, issue, "hold", "park_acknowledgement_required", park, park.CauseFingerprint)
+	}
+}
+
+func recoveryParkEventMatchesIssue(event store.WorkflowPhaseEvent, issue connector.Issue) bool {
+	if event.IssueID != "" && issue.ID != "" {
+		return event.IssueID == issue.ID
+	}
+	if event.Identifier != "" && issue.Identifier != "" {
+		return strings.EqualFold(event.Identifier, issue.Identifier)
+	}
+	return event.IssueURL != "" && event.IssueURL == issue.URL
+}
+
+func recoveryParkAcknowledged(event store.WorkflowPhaseEvent, metadata workflowLaneMetadata, park workflowLaneBlockedRecoveryMetadata) bool {
+	if metadata.Provenance.Initiator == provenance.InitiatorHuman && metadata.Provenance.Basis == provenance.BasisAuthenticatedHuman {
+		return true
+	}
+	switch event.Reason {
+	case "kanban_move", "kanban_move_field":
+		return true
+	}
+	if metadata.Provenance.Initiator != provenance.InitiatorDetentInstance {
+		return false
+	}
+	switch event.Reason {
+	case workflowActionCauseBlockedRecovery:
+		return park.Owner == blockedRecoveryOwnerOrchestrator
+	case workflowActionBlockedReadyPRReconciliation:
+		return blockedReadyPullRequestRecoverableCause(park)
+	case "obsolete_artifact_spend_recovery":
+		return park.Cause == spendProgressReason
+	default:
+		return false
+	}
+}

--- a/internal/orchestrator/cross_host_park_test.go
+++ b/internal/orchestrator/cross_host_park_test.go
@@ -1,0 +1,317 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestCrossHostParkRecovery(t *testing.T) {
+	t.Parallel()
+	for _, cause := range []string{spendProgressReason, dispatchLoopDetectedReason, noProgressLimitReason, "operator_investigation"} {
+		t.Run(cause, func(t *testing.T) {
+			t.Parallel()
+			parkedAt := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("2131", "In Progress")
+			blocker := dependencyAutoUnblockIssue("2108", "Done")
+			issue.BlockedBy = []connector.BlockedRef{{Identifier: blocker.Identifier, State: blocker.State, Source: connector.BlockedRefSourceNative}}
+			tracker := &crossHostParkConnector{
+				dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}, blockers: []connector.Issue{blocker}},
+				now:                            parkedAt,
+			}
+			pathA := filepath.Join(t.TempDir(), "host-a.db")
+			storeA := openCompletionDeferralStoreWithoutCleanup(t, pathA)
+			storeB := openValidatorMemoStore(t)
+			newHost := func(db store.Store) *Orchestrator {
+				cfg := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true}).cfg
+				host, err := New(cfg, Dependencies{Connector: tracker})
+				if err != nil {
+					t.Fatal(err)
+				}
+				host.workflowMetrics = db
+				return host
+			}
+			hostA, hostB := newHost(storeA), newHost(storeB)
+			stateA, stateB := newState(hostA.cfg), newState(hostB.cfg)
+			park := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{
+				Owner: blockedRecoveryOwnerHuman, Cause: cause, CauseFingerprint: "current-park", TargetState: "Todo",
+			}}
+			if err := hostA.updateIssueStateByIDStrictWithMetadata(t.Context(), &stateA, issue.ID, issue, "Blocked", parkedAt, cause, park); err != nil {
+				t.Fatal(err)
+			}
+			if err := tracker.CreateComment(t.Context(), issue.ID, "Routed this issue to Blocked because resource consumption continued without any PR evidence.\n\n- reason: "+cause); err != nil {
+				t.Fatal(err)
+			}
+			tracker.now = parkedAt.Add(57 * time.Second)
+			if got := hostA.recoverBlockedIssues(t.Context(), &stateA, tracker.stateIssues, tracker.now); len(got) != 0 {
+				t.Fatalf("parking host released human-owned park: %v", got)
+			}
+			if got := hostA.autoUnblockDependencyIssues(t.Context(), &stateA, tracker.stateIssues, tracker.now); len(got) != 0 {
+				t.Fatalf("parking host cleared park through dependencies: %v", got)
+			}
+			if got := hostB.autoUnblockDependencyIssues(t.Context(), &stateB, tracker.stateIssues, tracker.now); len(got) != 0 {
+				t.Errorf("peer unparked human-owned %s: %v", cause, got)
+			}
+			if err := tracker.UpdateIssueState(t.Context(), issue.ID, "Todo"); err != nil {
+				t.Fatal(err)
+			}
+			if err := tracker.CreateComment(t.Context(), issue.ID, "Dependency blockers cleared. Moved this issue from Blocked to Todo. Cleared dependencies: #2108 (state: Done)"); err != nil {
+				t.Fatal(err)
+			}
+			stateA.Pipeline = cloneIssues(tracker.stateIssues)
+			hostA.refreshCurrentLaneEntries(t.Context(), &stateA, parkedAt.Add(5*time.Minute))
+			if err := storeA.Close(); err != nil {
+				t.Fatal(err)
+			}
+			hostA = newHost(openCompletionDeferralStore(t, pathA))
+			stateA = newState(hostA.cfg)
+			hostA.dispatchReadyIssues(t.Context(), &stateA, tracker.stateIssues, parkedAt.Add(5*time.Minute))
+			if len(stateA.Running) != 0 {
+				t.Fatalf("restarted parking host redispatched unacknowledged park: %v", stateA.Running)
+			}
+			blocked := cloneIssue(tracker.stateIssues[0])
+			blocked.State = "Blocked"
+			hostA.recordLaneTransition(t.Context(), blocked, "Todo", parkedAt.Add(6*time.Minute), "operator_kanban_move", workflowLaneMetadata{
+				Provenance: provenance.AttributionFromSource(provenance.SourceHumanSession, provenance.Actor{Login: "shared-user", Kind: "User"}),
+			})
+			stateA = newState(hostA.cfg)
+			hostA.dispatchReadyIssues(t.Context(), &stateA, tracker.stateIssues, parkedAt.Add(7*time.Minute))
+			if len(stateA.Running) != 1 {
+				t.Fatalf("explicit human acknowledgement did not permit dispatch: blocked=%v retry=%v", stateA.Blocked, stateA.Retry)
+			}
+			<-hostA.runResults
+		})
+	}
+}
+
+type crossHostParkConnector struct {
+	*dependencyAutoUnblockConnector
+	now        time.Time
+	commentErr error
+}
+
+func (c *crossHostParkConnector) UpdateIssueState(ctx context.Context, issueID, state string) error {
+	if err := c.dependencyAutoUnblockConnector.UpdateIssueState(ctx, issueID, state); err != nil {
+		return err
+	}
+	for i := range c.stateIssues {
+		if c.stateIssues[i].ID == issueID {
+			c.stateIssues[i].State = state
+			c.stateIssues[i].StageUpdatedAt = timePointer(c.now)
+			c.stateIssues[i].StageUpdatedActor = connector.IssueActor{Login: "shared-user", Kind: "User"}
+		}
+	}
+	return nil
+}
+
+func (c *crossHostParkConnector) CreateComment(ctx context.Context, issueID, body string) error {
+	if err := c.dependencyAutoUnblockConnector.CreateComment(ctx, issueID, body); err != nil {
+		return err
+	}
+	for i := range c.stateIssues {
+		if c.stateIssues[i].ID == issueID {
+			c.stateIssues[i].Comments = append(c.stateIssues[i].Comments, connector.IssueComment{
+				Body: body, AuthorLogin: "shared-user", AuthorKind: "User", AuthorAuthorized: true, CreatedAt: timePointer(c.now),
+			})
+		}
+	}
+	return nil
+}
+
+func (c *crossHostParkConnector) FetchIssueComments(_ context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	if c.commentErr != nil {
+		return nil, c.commentErr
+	}
+	for _, current := range c.stateIssues {
+		if current.ID == issue.ID {
+			return cloneIssueComments(current.Comments), nil
+		}
+	}
+	return nil, nil
+}
+
+func TestCrossHostDependencyRecoveryControls(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		body       string
+		authorized bool
+		age        time.Duration
+		readErr    error
+		wantHold   bool
+	}{
+		{name: "ordinary dependency"},
+		{name: "legacy spend park", body: "Routed this issue to Blocked because resource consumption continued without any PR evidence.\n\n- reason: " + spendProgressReason, authorized: true, wantHold: true},
+		{name: "legacy loop park", body: "Routed this issue to Blocked: loop detected after 3 dispatches.\n\n- reason: " + dispatchLoopDetectedReason, authorized: true, wantHold: true},
+		{name: "legacy no progress park", body: "Routed this issue to Blocked because the implement worker completed repeatedly without deliverable progress.\n\n- reason: " + noProgressLimitReason, authorized: true, wantHold: true},
+		{name: "legacy human owner", body: "Routed this issue to Blocked.\n\n- reason: investigate\n- owner: human", authorized: true, wantHold: true},
+		{name: "untrusted marker", body: trackerRecoveryParkPrefix + `{"schema":1,"owner":"human"}` + "\n```"},
+		{name: "prior park occupancy", body: trackerRecoveryParkPrefix + `{"schema":1,"owner":"human"}` + "\n```", authorized: true, age: time.Hour},
+		{name: "malformed marker", body: trackerRecoveryParkPrefix + "invalid\n```", authorized: true, wantHold: true},
+		{name: "unsupported marker", body: trackerRecoveryParkPrefix + `{"schema":2,"owner":"human"}` + "\n```", authorized: true, wantHold: true},
+		{name: "incomplete marker", body: trackerRecoveryParkPrefix + `{"schema":1`, authorized: true, wantHold: true},
+		{name: "dependency marker", body: trackerRecoveryParkPrefix + `{"schema":1,"owner":"orchestrator","cause":"dependency"}` + "\n```", authorized: true},
+		{name: "comment read unavailable", readErr: errors.New("tracker unavailable"), wantHold: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("2131", "Blocked")
+			issue.StageUpdatedAt = &now
+			blocker := dependencyAutoUnblockIssue("2108", "Done")
+			issue.BlockedBy = []connector.BlockedRef{{Identifier: blocker.Identifier, State: blocker.State}}
+			issue.Comments = []connector.IssueComment{{Body: tt.body, AuthorAuthorized: tt.authorized, CreatedAt: timePointer(now.Add(-tt.age))}}
+			tracker := &crossHostParkConnector{dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}, blockers: []connector.Issue{blocker}}, now: now.Add(57 * time.Second), commentErr: tt.readErr}
+			host := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+			host.connector = tracker
+			host.workflowMetrics = openValidatorMemoStore(t)
+			state := newState(host.cfg)
+			got := host.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, tracker.now)
+			if (len(got) == 0) != tt.wantHold {
+				t.Fatalf("transitions = %v, wantHold = %t", got, tt.wantHold)
+			}
+		})
+	}
+}
+
+func TestRecoveryParkAcknowledgementBoundaries(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		owner  string
+		reason string
+		source provenance.Source
+		want   bool
+	}{
+		{name: "shared identity observation", owner: "human", reason: "tracker_state_observed", source: provenance.SourceTrackerObservation},
+		{name: "peer dependency transition", owner: "human", reason: "dependency_auto_unblock", source: provenance.SourceDetentInstance},
+		{name: "human action", owner: "human", reason: "operator_kanban_move", source: provenance.SourceHumanSession, want: true},
+		{name: "explicit CLI move", owner: "human", reason: "kanban_move", source: provenance.SourceExternalAutomation, want: true},
+		{name: "explicit field move", owner: "human", reason: "kanban_move_field", source: provenance.SourceHumanSession, want: true},
+		{name: "configured cooldown", owner: "orchestrator", reason: workflowActionCauseBlockedRecovery, source: provenance.SourceDetentInstance, want: true},
+		{name: "cooldown cannot acknowledge human park", owner: "human", reason: workflowActionCauseBlockedRecovery, source: provenance.SourceDetentInstance},
+		{name: "spend park is not ready PR recovery", owner: "orchestrator", reason: workflowActionBlockedReadyPRReconciliation, source: provenance.SourceDetentInstance},
+		{name: "obsolete artifact recovery", owner: "orchestrator", reason: "obsolete_artifact_spend_recovery", source: provenance.SourceDetentInstance, want: true},
+		{name: "dependency cannot acknowledge cooldown park", owner: "orchestrator", reason: "dependency_auto_unblock", source: provenance.SourceDetentInstance},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := recoveryParkAcknowledged(store.WorkflowPhaseEvent{Reason: tt.reason}, workflowLaneMetadata{Provenance: provenance.AttributionFromSource(tt.source, provenance.Actor{Login: "shared-user", Kind: "User"})}, workflowLaneBlockedRecoveryMetadata{Owner: tt.owner, Cause: spendProgressReason})
+			if got != tt.want {
+				t.Fatalf("acknowledged = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecoveryParkMarkerIncludesFingerprint(t *testing.T) {
+	t.Parallel()
+	tracker := &dependencyAutoUnblockConnector{}
+	host := blockedCauseTestOrchestrator(tracker)
+	host.publishTrackerRecoveryPark(t.Context(), "2131", "Blocked", workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Owner: "human", Cause: "investigate", CauseFingerprint: "current-fingerprint"}})
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, `"cause_fingerprint":"current-fingerprint"`) {
+		t.Fatalf("comments = %v, want tracker-visible park fingerprint", tracker.comments)
+	}
+}
+
+func TestRecoveryParkAcknowledgementRearmsForNextPark(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	issue := dependencyAutoUnblockIssue("2131", "In Progress")
+	host := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+	host.workflowMetrics = openValidatorMemoStore(t)
+	state := newState(host.cfg)
+	park := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Owner: "human", Cause: dispatchLoopDetectedReason, CauseFingerprint: "same-cause-fingerprint"}}
+	for cycle := range 2 {
+		at := now.Add(time.Duration(cycle) * time.Hour)
+		host.recordLaneTransition(t.Context(), issue, "Blocked", at, dispatchLoopDetectedReason, park)
+		candidate := cloneIssue(issue)
+		candidate.State = "Todo"
+		observedAt := at.Add(time.Minute)
+		candidate.StageUpdatedAt = &observedAt
+		host.recordObservedLaneEntry(t.Context(), candidate, observedAt, provenance.AttributionFromSource(provenance.SourceTrackerObservation, provenance.Actor{Login: "shared-user", Kind: "User"}))
+		host.retainUnacknowledgedRecoveryParks(t.Context(), &state, []connector.Issue{candidate})
+		if _, held := state.Blocked[issue.ID]; !held {
+			t.Fatalf("cycle %d reused an old acknowledgement", cycle)
+		}
+		blocked := cloneIssue(candidate)
+		blocked.State = "Blocked"
+		host.recordLaneTransition(t.Context(), blocked, "Todo", at.Add(2*time.Minute), "kanban_move", workflowLaneMetadata{})
+		host.retainUnacknowledgedRecoveryParks(t.Context(), &state, []connector.Issue{candidate})
+		if _, held := state.Blocked[issue.ID]; held {
+			t.Fatalf("cycle %d retained explicitly acknowledged park", cycle)
+		}
+	}
+}
+
+func TestCrossHostParkPreservesConfiguredCooldownRecovery(t *testing.T) {
+	t.Parallel()
+	for _, cause := range []string{spendProgressReason, dispatchLoopDetectedReason, noProgressLimitReason} {
+		t.Run(cause, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("2131", "Todo")
+			tracker := &crossHostParkConnector{dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}}, now: now}
+			host := blockedCauseTestOrchestrator(tracker.dependencyAutoUnblockConnector)
+			host.connector = tracker
+			host.workflowMetrics = openValidatorMemoStore(t)
+			host.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "unchanged", Health: "ready"}}
+			state := newState(host.cfg)
+			metadata := host.newBlockedRecoveryMetadata(t.Context(), issue, RunModeImplement, cause, blockedRecoveryPredicateFingerprintChange, "Todo", DiffStats{})
+			if err := host.updateIssueStateByIDStrictWithMetadata(t.Context(), &state, issue.ID, issue, "Blocked", now, cause, metadata); err != nil {
+				t.Fatal(err)
+			}
+			tracker.now = now.Add(defaultBreakerParkCooldown)
+			if got := host.recoverBlockedIssues(t.Context(), &state, tracker.stateIssues, tracker.now); len(got) != 1 {
+				t.Fatalf("configured cooldown did not recover: %v", state.Blocked)
+			}
+			host.retainUnacknowledgedRecoveryParks(t.Context(), &state, tracker.stateIssues)
+			if _, held := state.Blocked[issue.ID]; held {
+				t.Fatal("dispatch guard rejected configured cooldown recovery")
+			}
+		})
+	}
+}
+
+func TestRecoveryParkEventIdentity(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name  string
+		event store.WorkflowPhaseEvent
+		want  bool
+	}{
+		{name: "same id", event: store.WorkflowPhaseEvent{IssueID: "2131"}, want: true},
+		{name: "other id sharing URL", event: store.WorkflowPhaseEvent{IssueID: "other", IssueURL: "https://tracker.test/issue"}},
+		{name: "identifier fallback", event: store.WorkflowPhaseEvent{Identifier: "DIGITALDRYWOOD/DETENT#2131"}, want: true},
+		{name: "other identifier sharing URL", event: store.WorkflowPhaseEvent{Identifier: "digitaldrywood/detent#2108", IssueURL: "https://tracker.test/issue"}},
+		{name: "URL fallback", event: store.WorkflowPhaseEvent{IssueURL: "https://tracker.test/issue"}, want: true},
+		{name: "no identity"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := connector.Issue{ID: "2131", Identifier: "digitaldrywood/detent#2131", URL: "https://tracker.test/issue"}
+			if got := recoveryParkEventMatchesIssue(tt.event, issue); got != tt.want {
+				t.Fatalf("matches = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func (c *crossHostParkConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
+	var issues []connector.Issue
+	for _, id := range ids {
+		for _, issue := range c.stateIssues {
+			if issue.ID == id {
+				issues = append(issues, cloneIssue(issue))
+			}
+		}
+	}
+	return issues, nil
+}

--- a/internal/orchestrator/cross_host_park_test.go
+++ b/internal/orchestrator/cross_host_park_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -94,11 +95,24 @@ func TestCrossHostParkRecovery(t *testing.T) {
 
 type crossHostParkConnector struct {
 	*dependencyAutoUnblockConnector
-	now        time.Time
-	commentErr error
+	now            time.Time
+	commentErr     error
+	instanceLogin  string
+	updateDelay    time.Duration
+	afterUpdate    func()
+	updateErr      error
+	commentFailure func(string) error
+}
+
+func (c *crossHostParkConnector) InstanceLogin() string {
+	return c.instanceLogin
 }
 
 func (c *crossHostParkConnector) UpdateIssueState(ctx context.Context, issueID, state string) error {
+	if c.updateErr != nil {
+		return c.updateErr
+	}
+	c.now = c.now.Add(c.updateDelay)
 	if err := c.dependencyAutoUnblockConnector.UpdateIssueState(ctx, issueID, state); err != nil {
 		return err
 	}
@@ -109,10 +123,18 @@ func (c *crossHostParkConnector) UpdateIssueState(ctx context.Context, issueID, 
 			c.stateIssues[i].StageUpdatedActor = connector.IssueActor{Login: "shared-user", Kind: "User"}
 		}
 	}
+	if c.afterUpdate != nil {
+		c.afterUpdate()
+	}
 	return nil
 }
 
 func (c *crossHostParkConnector) CreateComment(ctx context.Context, issueID, body string) error {
+	if c.commentFailure != nil {
+		if err := c.commentFailure(body); err != nil {
+			return err
+		}
+	}
 	if err := c.dependencyAutoUnblockConnector.CreateComment(ctx, issueID, body); err != nil {
 		return err
 	}
@@ -141,12 +163,14 @@ func (c *crossHostParkConnector) FetchIssueComments(_ context.Context, issue con
 func TestCrossHostDependencyRecoveryControls(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name       string
-		body       string
-		authorized bool
-		age        time.Duration
-		readErr    error
-		wantHold   bool
+		name          string
+		body          string
+		authorized    bool
+		age           time.Duration
+		readErr       error
+		wantHold      bool
+		author        string
+		instanceLogin string
 	}{
 		{name: "ordinary dependency"},
 		{name: "legacy spend park", body: "Routed this issue to Blocked because resource consumption continued without any PR evidence.\n\n- reason: " + spendProgressReason, authorized: true, wantHold: true},
@@ -154,6 +178,8 @@ func TestCrossHostDependencyRecoveryControls(t *testing.T) {
 		{name: "legacy no progress park", body: "Routed this issue to Blocked because the implement worker completed repeatedly without deliverable progress.\n\n- reason: " + noProgressLimitReason, authorized: true, wantHold: true},
 		{name: "legacy human owner", body: "Routed this issue to Blocked.\n\n- reason: investigate\n- owner: human", authorized: true, wantHold: true},
 		{name: "untrusted marker", body: trackerRecoveryParkPrefix + `{"schema":1,"owner":"human"}` + "\n```"},
+		{name: "own integration marker", body: trackerRecoveryParkPrefix + `{"schema":1,"owner":"human"}` + "\n```", author: "detent[bot]", instanceLogin: "detent[bot]", wantHold: true},
+		{name: "other integration marker", body: trackerRecoveryParkPrefix + `{"schema":1,"owner":"human"}` + "\n```", author: "other[bot]", instanceLogin: "detent[bot]"},
 		{name: "prior park occupancy", body: trackerRecoveryParkPrefix + `{"schema":1,"owner":"human"}` + "\n```", authorized: true, age: time.Hour},
 		{name: "malformed marker", body: trackerRecoveryParkPrefix + "invalid\n```", authorized: true, wantHold: true},
 		{name: "unsupported marker", body: trackerRecoveryParkPrefix + `{"schema":2,"owner":"human"}` + "\n```", authorized: true, wantHold: true},
@@ -168,8 +194,9 @@ func TestCrossHostDependencyRecoveryControls(t *testing.T) {
 			issue.StageUpdatedAt = &now
 			blocker := dependencyAutoUnblockIssue("2108", "Done")
 			issue.BlockedBy = []connector.BlockedRef{{Identifier: blocker.Identifier, State: blocker.State}}
-			issue.Comments = []connector.IssueComment{{Body: tt.body, AuthorAuthorized: tt.authorized, CreatedAt: timePointer(now.Add(-tt.age))}}
+			issue.Comments = []connector.IssueComment{{Body: tt.body, AuthorAuthorized: tt.authorized, AuthorLogin: tt.author, CreatedAt: timePointer(now.Add(-tt.age))}}
 			tracker := &crossHostParkConnector{dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}, blockers: []connector.Issue{blocker}}, now: now.Add(57 * time.Second), commentErr: tt.readErr}
+			tracker.instanceLogin = tt.instanceLogin
 			host := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
 			host.connector = tracker
 			host.workflowMetrics = openValidatorMemoStore(t)
@@ -177,6 +204,45 @@ func TestCrossHostDependencyRecoveryControls(t *testing.T) {
 			got := host.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues, tracker.now)
 			if (len(got) == 0) != tt.wantHold {
 				t.Fatalf("transitions = %v, wantHold = %t", got, tt.wantHold)
+			}
+		})
+	}
+}
+
+func TestCrossHostParkProtectsVisibleTransition(t *testing.T) {
+	t.Parallel()
+	for _, delay := range []time.Duration{0, 2 * time.Minute} {
+		t.Run(delay.String(), func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("2131", "In Progress")
+			blocker := dependencyAutoUnblockIssue("2108", "Done")
+			issue.BlockedBy = []connector.BlockedRef{{Identifier: blocker.Identifier, State: blocker.State}}
+			tracker := &crossHostParkConnector{dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}, blockers: []connector.Issue{blocker}}, now: now, updateDelay: delay}
+			hostA := blockedCauseTestOrchestrator(tracker.dependencyAutoUnblockConnector)
+			hostA.connector = tracker
+			hostA.workflowMetrics = openValidatorMemoStore(t)
+			hostB := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+			hostB.connector = tracker
+			hostB.workflowMetrics = openValidatorMemoStore(t)
+			stateA, stateB := newState(hostA.cfg), newState(hostB.cfg)
+			observed := false
+			tracker.afterUpdate = func() {
+				tracker.afterUpdate = nil
+				observed = true
+				if got := hostB.autoUnblockDependencyIssues(t.Context(), &stateB, tracker.stateIssues, tracker.now); len(got) != 0 {
+					t.Error("peer unparked the visible transition before marker completion")
+				}
+			}
+			metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Owner: "human", Cause: spendProgressReason, CauseFingerprint: "current-park"}}
+			if err := hostA.updateIssueStateByIDStrictWithMetadata(t.Context(), &stateA, issue.ID, issue, "Blocked", now, spendProgressReason, metadata); err != nil {
+				t.Fatal(err)
+			}
+			if !observed {
+				t.Fatal("peer never observed the visible transition")
+			}
+			if got := hostB.autoUnblockDependencyIssues(t.Context(), &stateB, tracker.stateIssues, tracker.now); len(got) != 0 {
+				t.Fatal("peer unparked completed recovery marker")
 			}
 		})
 	}
@@ -216,7 +282,10 @@ func TestRecoveryParkMarkerIncludesFingerprint(t *testing.T) {
 	t.Parallel()
 	tracker := &dependencyAutoUnblockConnector{}
 	host := blockedCauseTestOrchestrator(tracker)
-	host.publishTrackerRecoveryPark(t.Context(), "2131", "Blocked", workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Owner: "human", Cause: "investigate", CauseFingerprint: "current-fingerprint"}})
+	park := newTrackerRecoveryPark("Blocked", workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Owner: "human", Cause: "investigate", CauseFingerprint: "current-fingerprint"}})
+	if err := host.publishTrackerRecoveryPark(t.Context(), "2131", park); err != nil {
+		t.Fatal(err)
+	}
 	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, `"cause_fingerprint":"current-fingerprint"`) {
 		t.Fatalf("comments = %v, want tracker-visible park fingerprint", tracker.comments)
 	}
@@ -314,4 +383,99 @@ func (c *crossHostParkConnector) FetchIssueStatesByIDs(_ context.Context, ids []
 		}
 	}
 	return issues, nil
+}
+
+func TestTrackerRecoveryParkOperationSettlement(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name        string
+		phase       string
+		operationID string
+		authorized  bool
+		current     bool
+		wantHold    bool
+	}{
+		{name: "pending protects slow transition", wantHold: true},
+		{name: "applied current park", phase: "applied", operationID: "park", authorized: true, current: true, wantHold: true},
+		{name: "applied prior occupancy", phase: "applied", operationID: "park", authorized: true},
+		{name: "cancelled transition", phase: "cancelled", operationID: "park", authorized: true},
+		{name: "untrusted cancellation", phase: "cancelled", operationID: "park", wantHold: true},
+		{name: "other operation cancellation", phase: "cancelled", operationID: "other", authorized: true, wantHold: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("2131", "Blocked")
+			issue.StageUpdatedAt = &now
+			marker := trackerRecoveryPark{Schema: 1, Owner: "human", Cause: spendProgressReason, OperationID: "park", Phase: "pending"}
+			encode := func(marker trackerRecoveryPark) string {
+				t.Helper()
+				data, err := json.Marshal(marker)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return trackerRecoveryParkPrefix + string(data) + "\n```"
+			}
+			issue.Comments = []connector.IssueComment{{Body: encode(marker), AuthorAuthorized: true, CreatedAt: timePointer(now.Add(-time.Hour))}}
+			if tt.phase != "" {
+				marker.Phase, marker.OperationID = tt.phase, tt.operationID
+				at := now.Add(-time.Hour)
+				if tt.current {
+					at = now
+				}
+				issue.Comments = append(issue.Comments, connector.IssueComment{Body: encode(marker), AuthorAuthorized: tt.authorized, CreatedAt: &at})
+			}
+			host := blockedCauseTestOrchestrator(&dependencyAutoUnblockConnector{})
+			if got := host.trackerRecoveryParkHold(t.Context(), issue); (got != "") != tt.wantHold {
+				t.Fatalf("hold = %q, wantHold = %t", got, tt.wantHold)
+			}
+		})
+	}
+}
+
+func TestTrackerRecoveryParkPublicationFailures(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name        string
+		failPhase   string
+		updateErr   error
+		wantUpdates int
+		wantHold    bool
+	}{
+		{name: "pending publication fails", failPhase: "pending"},
+		{name: "applied publication fails", failPhase: "applied", wantUpdates: 1, wantHold: true},
+		{name: "ambiguous transition failure", updateErr: errors.New("connection lost"), wantHold: true},
+		{name: "known rejected transition", updateErr: connector.ErrStateUpdateBlocked},
+		{name: "cancellation publication fails", updateErr: connector.ErrStateUpdateBlocked, failPhase: "cancelled", wantHold: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+			issue := dependencyAutoUnblockIssue("2131", "In Progress")
+			tracker := &crossHostParkConnector{dependencyAutoUnblockConnector: &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{issue}}, now: now, updateErr: tt.updateErr}
+			tracker.commentFailure = func(body string) error {
+				if tt.failPhase != "" && strings.Contains(body, `"phase":"`+tt.failPhase+`"`) {
+					return errors.New("comment unavailable")
+				}
+				return nil
+			}
+			host := blockedCauseTestOrchestrator(tracker.dependencyAutoUnblockConnector)
+			host.connector = tracker
+			host.workflowMetrics = openValidatorMemoStore(t)
+			state := newState(host.cfg)
+			metadata := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Owner: "human", Cause: spendProgressReason}}
+			if err := host.updateIssueStateByIDStrictWithMetadata(t.Context(), &state, issue.ID, issue, "Blocked", now, spendProgressReason, metadata); err == nil {
+				t.Fatal("expected publication or transition failure")
+			}
+			if len(tracker.updates) != tt.wantUpdates {
+				t.Fatalf("updates = %v, want %d", tracker.updates, tt.wantUpdates)
+			}
+			candidate := cloneIssue(tracker.stateIssues[0])
+			candidate.State = "Blocked"
+			candidate.StageUpdatedAt = timePointer(now.Add(time.Hour))
+			if got := host.trackerRecoveryParkHold(t.Context(), candidate); (got != "") != tt.wantHold {
+				t.Fatalf("hold = %q, wantHold = %t", got, tt.wantHold)
+			}
+		})
+	}
 }

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -136,6 +136,10 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if len(hydrated.BlockedBy) == 0 {
 			continue
 		}
+		if reason := o.trackerRecoveryParkHold(ctx, hydrated); reason != "" {
+			o.logDependencyAutoUnblockDecision(hydrated, "hold", reason, nil, "")
+			continue
+		}
 		o.logDependencyProseOnly(hydrated)
 		blockers := o.resolveDependencyBlockers(ctx, hydrated)
 		workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -134,6 +134,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	}
 	rankingIssues := issues
 	issues = o.filterImplementDependencyDeferrals(ctx, issues)
+	o.retainUnacknowledgedRecoveryParks(ctx, state, issues)
 	o.enforceLifetimeLimits(ctx, state, issues, now)
 	o.observePullRequestHydrationRecovery(state, issues, now)
 	planner := o.dispatchPlanner()

--- a/internal/orchestrator/dispatch_loop_test.go
+++ b/internal/orchestrator/dispatch_loop_test.go
@@ -419,7 +419,7 @@ func TestHandleRunResultTripsDispatchLoopAfterFailures(t *testing.T) {
 	if blocked, ok := state.Blocked[issue.ID]; !ok || blocked.Reason != dispatchLoopDetectedReason {
 		t.Fatalf("Blocked[%q] = %#v, %v", issue.ID, blocked, ok)
 	}
-	if len(tracker.comments) != 2 || tracker.comments[1].body == "" {
+	if len(tracker.comments) != 3 || tracker.comments[2].body == "" {
 		t.Fatalf("comments = %#v, want loop-specific park comment", tracker.comments)
 	}
 }

--- a/internal/orchestrator/dispatch_loop_test.go
+++ b/internal/orchestrator/dispatch_loop_test.go
@@ -419,7 +419,7 @@ func TestHandleRunResultTripsDispatchLoopAfterFailures(t *testing.T) {
 	if blocked, ok := state.Blocked[issue.ID]; !ok || blocked.Reason != dispatchLoopDetectedReason {
 		t.Fatalf("Blocked[%q] = %#v, %v", issue.ID, blocked, ok)
 	}
-	if len(tracker.comments) != 1 || tracker.comments[0].body == "" {
+	if len(tracker.comments) != 2 || tracker.comments[1].body == "" {
 		t.Fatalf("comments = %#v, want loop-specific park comment", tracker.comments)
 	}
 }

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -753,7 +753,11 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 						t.Fatalf("Blocked[%q].Recovery = %#v, want durable human acknowledgement", tt.runningIssue.ID, blocked.Recovery)
 					}
 				}
-				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, tt.wantComment) {
+				wantComments := 1
+				if tt.wantBlockReason == noProgressLimitReason || tt.wantBlockReason == dispatchLoopDetectedReason || tt.wantBlockReason == "workpad_blocked_unactioned" {
+					wantComments = 2
+				}
+				if len(tracker.comments) != wantComments || !strings.Contains(tracker.comments[wantComments-1].body, tt.wantComment) {
 					t.Fatalf("comments = %#v, want comment containing %q", tracker.comments, tt.wantComment)
 				}
 				if _, ok := state.Retry[tt.runningIssue.ID]; ok {

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -755,7 +755,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 				}
 				wantComments := 1
 				if tt.wantBlockReason == noProgressLimitReason || tt.wantBlockReason == dispatchLoopDetectedReason || tt.wantBlockReason == "workpad_blocked_unactioned" {
-					wantComments = 2
+					wantComments = 3
 				}
 				if len(tracker.comments) != wantComments || !strings.Contains(tracker.comments[wantComments-1].body, tt.wantComment) {
 					t.Fatalf("comments = %#v, want comment containing %q", tracker.comments, tt.wantComment)

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -515,8 +515,8 @@ func TestAutoPromoteParksIssueAfterRepeatedIdenticalMergeRevocations(t *testing.
 	if len(tracker.updates) != 1 || tracker.updates[0] != (autoPromoteTickUpdate{issueID: issue.ID, state: blockedStatusState}) {
 		t.Fatalf("updates = %#v, want Blocked transition", tracker.updates)
 	}
-	if len(tracker.comments) != 2 {
-		t.Fatalf("comments = %#v, want park marker and explanation", tracker.comments)
+	if len(tracker.comments) != 3 {
+		t.Fatalf("comments = %#v, want pending and applied park markers and explanation", tracker.comments)
 	}
 	for _, fragment := range []string{
 		"reason: merge_revocation_limit",
@@ -524,8 +524,8 @@ func TestAutoPromoteParksIssueAfterRepeatedIdenticalMergeRevocations(t *testing.
 		"consecutive_revocations: 3",
 		"human_action:",
 	} {
-		if !strings.Contains(tracker.comments[1].body, fragment) {
-			t.Fatalf("comment = %q, missing %q", tracker.comments[1].body, fragment)
+		if !strings.Contains(tracker.comments[2].body, fragment) {
+			t.Fatalf("comment = %q, missing %q", tracker.comments[2].body, fragment)
 		}
 	}
 	for _, fragment := range []string{

--- a/internal/orchestrator/merge_revocation_test.go
+++ b/internal/orchestrator/merge_revocation_test.go
@@ -515,8 +515,8 @@ func TestAutoPromoteParksIssueAfterRepeatedIdenticalMergeRevocations(t *testing.
 	if len(tracker.updates) != 1 || tracker.updates[0] != (autoPromoteTickUpdate{issueID: issue.ID, state: blockedStatusState}) {
 		t.Fatalf("updates = %#v, want Blocked transition", tracker.updates)
 	}
-	if len(tracker.comments) != 1 {
-		t.Fatalf("comments = %#v, want one parking comment", tracker.comments)
+	if len(tracker.comments) != 2 {
+		t.Fatalf("comments = %#v, want park marker and explanation", tracker.comments)
 	}
 	for _, fragment := range []string{
 		"reason: merge_revocation_limit",
@@ -524,8 +524,8 @@ func TestAutoPromoteParksIssueAfterRepeatedIdenticalMergeRevocations(t *testing.
 		"consecutive_revocations: 3",
 		"human_action:",
 	} {
-		if !strings.Contains(tracker.comments[0].body, fragment) {
-			t.Fatalf("comment = %q, missing %q", tracker.comments[0].body, fragment)
+		if !strings.Contains(tracker.comments[1].body, fragment) {
+			t.Fatalf("comment = %q, missing %q", tracker.comments[1].body, fragment)
 		}
 	}
 	for _, fragment := range []string{

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -178,7 +178,7 @@ func TestHandleRunResultParksBudgetProjectionFailureWithoutRetry(t *testing.T) {
 	if len(tracker.updates) != 1 || tracker.updates[0].state != blockedStatusState {
 		t.Fatalf("state updates = %#v, want one Blocked transition", tracker.updates)
 	}
-	if len(tracker.comments) != 2 || !strings.Contains(tracker.comments[1].body, "40.250000") || !strings.Contains(tracker.comments[1].body, "10.000000") || !strings.Contains(tracker.comments[1].body, "historical") {
+	if len(tracker.comments) != 3 || !strings.Contains(tracker.comments[2].body, "40.250000") || !strings.Contains(tracker.comments[2].body, "10.000000") || !strings.Contains(tracker.comments[2].body, "historical") {
 		t.Fatalf("comments = %#v, want observed and projected cost", tracker.comments)
 	}
 	for _, want := range []string{"worker_budget_projection_ceiling_tripped", "estimate_source=historical"} {

--- a/internal/orchestrator/run_completion_token_ceiling_test.go
+++ b/internal/orchestrator/run_completion_token_ceiling_test.go
@@ -178,7 +178,7 @@ func TestHandleRunResultParksBudgetProjectionFailureWithoutRetry(t *testing.T) {
 	if len(tracker.updates) != 1 || tracker.updates[0].state != blockedStatusState {
 		t.Fatalf("state updates = %#v, want one Blocked transition", tracker.updates)
 	}
-	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "40.250000") || !strings.Contains(tracker.comments[0].body, "10.000000") || !strings.Contains(tracker.comments[0].body, "historical") {
+	if len(tracker.comments) != 2 || !strings.Contains(tracker.comments[1].body, "40.250000") || !strings.Contains(tracker.comments[1].body, "10.000000") || !strings.Contains(tracker.comments[1].body, "historical") {
 		t.Fatalf("comments = %#v, want observed and projected cost", tracker.comments)
 	}
 	for _, want := range []string{"worker_budget_projection_ceiling_tripped", "estimate_source=historical"} {

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -832,12 +832,12 @@ func TestHandleRunResultTripsTokenProgressBreakerOnSubscription(t *testing.T) {
 	if !ok || blocked.Reason != spendProgressReason {
 		t.Fatalf("Blocked[%q] = %#v, want spend breaker", issue.ID, blocked)
 	}
-	if len(tracker.comments) != 2 {
-		t.Fatalf("comments = %#v, want park marker and explanation", tracker.comments)
+	if len(tracker.comments) != 3 {
+		t.Fatalf("comments = %#v, want pending and applied park markers and explanation", tracker.comments)
 	}
 	for _, want := range []string{"blocked_by: tokens", "25000000", "usd_breaker: inert", "Shrink the task", "first tool action"} {
-		if !strings.Contains(tracker.comments[1].body, want) {
-			t.Fatalf("comment missing %q:\n%s", want, tracker.comments[1].body)
+		if !strings.Contains(tracker.comments[2].body, want) {
+			t.Fatalf("comment missing %q:\n%s", want, tracker.comments[2].body)
 		}
 	}
 	if len(attempts.completions) != 1 {

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -832,12 +832,12 @@ func TestHandleRunResultTripsTokenProgressBreakerOnSubscription(t *testing.T) {
 	if !ok || blocked.Reason != spendProgressReason {
 		t.Fatalf("Blocked[%q] = %#v, want spend breaker", issue.ID, blocked)
 	}
-	if len(tracker.comments) != 1 {
-		t.Fatalf("comments = %#v, want one", tracker.comments)
+	if len(tracker.comments) != 2 {
+		t.Fatalf("comments = %#v, want park marker and explanation", tracker.comments)
 	}
 	for _, want := range []string{"blocked_by: tokens", "25000000", "usd_breaker: inert", "Shrink the task", "first tool action"} {
-		if !strings.Contains(tracker.comments[0].body, want) {
-			t.Fatalf("comment missing %q:\n%s", want, tracker.comments[0].body)
+		if !strings.Contains(tracker.comments[1].body, want) {
+			t.Fatalf("comment missing %q:\n%s", want, tracker.comments[1].body)
 		}
 	}
 	if len(attempts.completions) != 1 {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -638,8 +638,8 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 				if !strings.Contains(blocked.Reason, branch) || !strings.Contains(blocked.Reason, tt.wantReason) {
 					t.Fatalf("Blocked[%q].Reason = %q, want branch and %q", issue.ID, blocked.Reason, tt.wantReason)
 				}
-				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], "local commits ahead: ") ||
-					!strings.Contains(tracker.comments[0], "remote branch exists: ") || !strings.Contains(tracker.comments[0], tt.wantReason) {
+				if len(tracker.comments) != 2 || !strings.Contains(tracker.comments[1], "local commits ahead: ") ||
+					!strings.Contains(tracker.comments[1], "remote branch exists: ") || !strings.Contains(tracker.comments[1], tt.wantReason) {
 					t.Fatalf("comments = %#v, want delivery diagnostics containing %q", tracker.comments, tt.wantReason)
 				}
 				if got := tracker.transitionStates(); !slices.Equal(got, []string{blockedStatusState}) {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -394,7 +394,11 @@ func TestHandleRunResultParksTerminalRetryAtDurableLimit(t *testing.T) {
 			if len(attempts.completions) != tt.failures {
 				t.Fatalf("work attempt completions = %d, want %d", len(attempts.completions), tt.failures)
 			}
-			if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0], wantError) {
+			wantComments := 1
+			if tt.limit != nil && *tt.limit == 0 {
+				wantComments = 3
+			}
+			if len(tracker.comments) != wantComments || !strings.Contains(tracker.comments[wantComments-1], wantError) {
 				t.Fatalf("retry-limit comments = %#v, want latest parked-attempt error", tracker.comments)
 			}
 
@@ -418,8 +422,8 @@ func TestHandleRunResultParksTerminalRetryAtDurableLimit(t *testing.T) {
 				if blocked.Recovery.Owner != blockedRecoveryOwnerOperator || !blocked.NeedsHumanAttention || blocked.RecoveryIntentResumable {
 					t.Fatalf("zero policy park = %#v, want operator-owned hold", blocked)
 				}
-				if !strings.Contains(tracker.comments[0], "external review") || strings.Contains(tracker.comments[0], "automatically") {
-					t.Fatalf("zero policy comment = %q", tracker.comments[0])
+				if !strings.Contains(tracker.comments[wantComments-1], "external review") || strings.Contains(tracker.comments[wantComments-1], "automatically") {
+					t.Fatalf("zero policy comment = %q", tracker.comments[wantComments-1])
 				}
 			}
 		})
@@ -1586,8 +1590,12 @@ func TestTerminalRetryTransitionFailures(t *testing.T) {
 				if tracker.issues[issue.ID].State != "In Progress" {
 					t.Fatal("failed tracker park changed the remote lane")
 				}
-				if len(tracker.comments) != 0 {
-					t.Fatal("failed tracker park published a success comment")
+				if len(tracker.comments) != 1 {
+					t.Fatalf("failed tracker park comments = %v, want pending marker", tracker.comments)
+				}
+				marker, valid := parseTrackerRecoveryPark(tracker.comments[0])
+				if !valid || marker.Phase != "pending" {
+					t.Fatalf("failed tracker park marker = %#v, want pending operation", marker)
 				}
 				o.trackCandidateBlockedStatusIssues(t.Context(), &state, []connector.Issue{updated}, now)
 				if _, held := state.Blocked[issue.ID]; !held {

--- a/internal/orchestrator/terminal_attempt_retry_test.go
+++ b/internal/orchestrator/terminal_attempt_retry_test.go
@@ -638,8 +638,8 @@ func TestHandleRunResultReconcilesDeliverableRecoveryExactHead(t *testing.T) {
 				if !strings.Contains(blocked.Reason, branch) || !strings.Contains(blocked.Reason, tt.wantReason) {
 					t.Fatalf("Blocked[%q].Reason = %q, want branch and %q", issue.ID, blocked.Reason, tt.wantReason)
 				}
-				if len(tracker.comments) != 2 || !strings.Contains(tracker.comments[1], "local commits ahead: ") ||
-					!strings.Contains(tracker.comments[1], "remote branch exists: ") || !strings.Contains(tracker.comments[1], tt.wantReason) {
+				if len(tracker.comments) != 3 || !strings.Contains(tracker.comments[2], "local commits ahead: ") ||
+					!strings.Contains(tracker.comments[2], "remote branch exists: ") || !strings.Contains(tracker.comments[2], tt.wantReason) {
 					t.Fatalf("comments = %#v, want delivery diagnostics containing %q", tracker.comments, tt.wantReason)
 				}
 				if got := tracker.transitionStates(); !slices.Equal(got, []string{blockedStatusState}) {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -225,6 +225,7 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		issue.ID = issueID
 	}
 	o.recordLaneTransition(ctx, issue, targetState, at, reason, metadata)
+	o.publishTrackerRecoveryPark(ctx, issueID, targetState, metadata)
 	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) && normalizeState(issue.State) != normalizeState(targetState) {
 		o.captureReworkLesson(issue, at, reason, metadata.LessonEvidence)
 	}

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -182,7 +182,15 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 	if err != nil {
 		return err
 	}
+	park := newTrackerRecoveryPark(targetState, metadata)
+	if err := o.publishTrackerRecoveryPark(ctx, issueID, park); err != nil {
+		return errors.Join(err, o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerFailed, at, err))
+	}
 	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
+		var parkErr error
+		if errors.Is(err, connector.ErrStateUpdateBlocked) {
+			parkErr = o.finishTrackerRecoveryPark(ctx, issueID, park, "cancelled")
+		}
 		if errors.Is(err, connector.ErrStateUpdateBlocked) && !strict {
 			if receiptErr := o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerBlocked, at, err); receiptErr != nil {
 				return receiptErr
@@ -190,9 +198,9 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 			if o.logger != nil {
 				o.logger.Debug("skip blocked issue state update", "issue_id", issueID, "target_state", targetState, "error", err)
 			}
-			return nil
+			return parkErr
 		}
-		return errors.Join(err, o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerFailed, at, err))
+		return errors.Join(err, parkErr, o.resolveLaneMutation(ctx, receipt, store.LaneMutationTrackerFailed, at, err))
 	}
 	transitionAt := at
 	if normalizeState(issue.State) != normalizeState(targetState) {
@@ -225,7 +233,7 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadataMode(
 		issue.ID = issueID
 	}
 	o.recordLaneTransition(ctx, issue, targetState, at, reason, metadata)
-	o.publishTrackerRecoveryPark(ctx, issueID, targetState, metadata)
+	receiptErr = errors.Join(receiptErr, o.finishTrackerRecoveryPark(ctx, issueID, park, "applied"))
 	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) && normalizeState(issue.State) != normalizeState(targetState) {
 		o.captureReworkLesson(issue, at, reason, metadata.LessonEvidence)
 	}


### PR DESCRIPTION
## Summary

- Preserve human-owned recovery parks when another Detent host sees satisfied dependencies on the same board. Publish a pending park marker before exposing Blocked, then an applied marker after the transition. Recognize the authenticated Detent identity, including GitHub Apps, and existing breaker comments for the current Blocked occupancy.
- Retain the parking host’s durable hold across ambiguous Todo observations and restarts until an explicit operator acknowledgement or existing cause-specific recovery permits dispatch.
- Reproduce the recorded ordering with separate SQLite stores sharing one tracker identity; preserve ordinary dependency recovery, explicit operator moves, and configured cooldowns.

Fixes #2131

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, viewport, or responsive changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Original production hooks fail the deterministic two-host regression at peer unpark and restarted-host redispatch for all four park causes.
- [x] Cross-host regressions and acknowledgement, dependency, and cooldown controls pass. Added deterministic interleavings during immediate/delayed state updates, own-App identity controls, and marker failure/settlement cases.
- [x] `FuzzSafetyCriticalOrchestratorBoundaries` seeds pass.
- [x] `GOTOOLCHAIN=go1.26.6 make check CHECK_LOCK_WAIT=2h` on `a833e0e8` (79.5% overall coverage; all configured package/file floors pass)

No named safety-critical production files changed.

Uncertain tracker transitions or marker-finalization failures retain the pending hold. Known rejected transitions cancel their marker; completed markers retain the existing occupancy boundary.

## Integration validation

Integrated main `a862df33`, including prerequisite #2327 / PR #2331, without changing the three issue commits (verified by git range-diff). Artifact authorization regressions pass 25 race repetitions; cross-host regressions and safety fuzz seeds pass with the race detector. All 11 current-head CI checks passed on `a833e0e85966afc4405cc12e66e89b46ae4334d3`: https://github.com/digitaldrywood/detent/actions/runs/34265763811. Exact-file coverage: cross_host_park.go 97.5%, dispatch.go 93.1%; all named orchestrator safety files exceed 90%.
