### PR TITLE
fix(checklock): prevent validation waiter starvation

### DIFF
--- a/.detent/skills/fifo-file-lock-admission.md
+++ b/.detent/skills/fifo-file-lock-admission.md
@@ -1,0 +1,30 @@
+---
+name: fifo-file-lock-admission
+description: Add fair admission to a cross-process lock without weakening its exclusion or stale-owner recovery.
+when_to_use: Use when periodic nonblocking lock retries allow new processes to overtake older live waiters across worktrees.
+---
+
+- Reproduce overtaking by pausing an older contender after its waiting handshake,
+  releasing the holder, and starting new contenders before resuming the older one.
+  New contenders must acknowledge queueing; a successful acquisition at that point
+  is the regression. Avoid scheduler sleeps as ordering assertions.
+- Keep the existing exclusive lock as the execution authority. Introduce a short
+  metadata mutex for FIFO ticket assignment and a distinct OS lock per live waiter.
+  Derive ordering from serialized numeric tickets rather than wall-clock times.
+- Serialize publication, stale inspection, pruning, and ticket reuse under the
+  same mutex. Never unlink a live lock or the shared metadata mutex: replacing its
+  inode can split ownership across processes. Do not infer death from ticket age.
+- Account for unlock-before-close windows: Windows can reject deleting an
+  unlocked file whose handle has not closed yet. Bound deletion retries, retain
+  cancellation, and surface persistent errors instead of deleting live entries.
+- Close a canceled waiter's liveness lock without needing to regain the metadata
+  mutex. Later operations can prune it. Bound both admission count and waiting;
+  keep the wait deadline separate from the active command lifetime.
+- Test crash recovery with helper subprocesses that acknowledge acquiring their
+  OS lock, then exit on an explicit pipe handshake without application cleanup.
+  Cover registration crashes, queued crashes, live holders, and owner handoff.
+- Give each instrumented helper a unique existing GOCOVERDIR. Use fake time for
+  deadline policy and generous real deadlines only to detect stuck OS handshakes.
+  Run focused race tests, Windows compilation/runtime tests, and the full gate.
+- State the rollout boundary: older clients retain exclusion on the original
+  lock but cannot participate in the new fairness protocol.

--- a/tools/checklock/README.md
+++ b/tools/checklock/README.md
@@ -26,9 +26,10 @@ excess invocations fail explicitly instead of growing it without a bound.
 
 `-wait-timeout` (15 minutes by default) bounds registration and queue waiting.
 Interrupt/termination signals cancel waiting. Once validation starts, this wait
-budget does not limit execution; the wrapper retains the lock until the child
-exits, including if the wrapper's context is canceled during execution. The
-validation command controls its own active timeouts and shutdown.
+budget does not limit execution. Parent cancellation and termination signals
+stop the active command through the shared process-group helper. The wrapper
+retains the lock until command exit and process-group cleanup finish. The
+validation command controls its own active timeouts.
 
 Waiting diagnostics report queue position, queue size, elapsed wait, and the
 active owner's PID/acquisition time when available. They refresh when the queue

--- a/tools/checklock/README.md
+++ b/tools/checklock/README.md
@@ -1,0 +1,49 @@
+# Validation queue
+
+`make check` passes the repository's Git common-directory lock to checklock,
+so all worktrees share one validation gate. Checklock registers a FIFO ticket
+before attempting that existing lock. Once registered, a live waiter cannot be
+overtaken by later registrations, including when the head waiter is descheduled.
+Concurrent registrations are ordered by acquisition of a short queue mutex.
+
+The queue uses two kinds of OS locks supplied by `internal/instancelock`:
+
+- `<lock>.queue.lock` serializes ticket registration, inspection, and pruning.
+  It is released before waiting or running validation and is never removed.
+- `<lock>.queue/<ticket>.lock` stays locked while its waiter is queued. Only the
+  lowest live ticket may attempt the original validation lock. After acquisition
+  or cancellation, its waiter lock closes; the next queue operation prunes the
+  released entry. The original validation lock stays held until the command exits.
+
+The queue mutex prevents a ticket from being opened or reused between its
+liveness inspection and removal. A crashed process releases its OS locks, making
+its tickets recoverable without PID checks, age thresholds, or deleting a live
+lock. Pruning retries transient deletion failures up to five times with
+cancellation-aware polling, allowing an unlocked Windows file handle to finish
+closing. Partial receipts left by a crash are also recoverable. Numeric tickets
+avoid wall-clock ordering assumptions. The queue admits up to 1024 live waiters;
+excess invocations fail explicitly instead of growing it without a bound.
+
+`-wait-timeout` (15 minutes by default) bounds registration and queue waiting.
+Interrupt/termination signals cancel waiting. Once validation starts, this wait
+budget does not limit execution; the wrapper retains the lock until the child
+exits, including if the wrapper's context is canceled during execution. The
+validation command controls its own active timeouts and shutdown.
+
+Waiting diagnostics report queue position, queue size, elapsed wait, and the
+active owner's PID/acquisition time when available. They refresh when the queue
+or owner changes and at least every 30 seconds while polling the validation
+queue. Timeout messages identify waiting before validation has started. Normal
+diagnostics omit repository paths and owner hostnames.
+
+Older checklock binaries still contend on the original exclusive validation
+lock, so exclusivity is preserved during rollout. FIFO ordering applies to
+invocations using this queue protocol; older polling binaries cannot honor it.
+
+Validation:
+
+```sh
+go test -race ./tools/checklock ./internal/instancelock -count=10
+GOOS=windows GOARCH=amd64 go test -c -o tmp/checklock-windows.test.exe ./tools/checklock
+make check
+```

--- a/tools/checklock/main.go
+++ b/tools/checklock/main.go
@@ -11,6 +11,8 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
 )
 
 const validationLockPollInterval = 100 * time.Millisecond
@@ -77,10 +79,14 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		Stdout: stdout,
 		Stderr: stderr,
 	}
-	commandErr := cmd.Run()
+	commandErr := runValidationCommand(ctx, cmd)
 	closeErr := lock.Close()
 	if closeErr != nil {
 		fmt.Fprintf(stderr, "release validation lock: %v\n", closeErr)
+	}
+	if err := ctx.Err(); err != nil {
+		fmt.Fprintf(stderr, "validation command canceled: %v\n", errors.Join(err, commandErr))
+		return 1
 	}
 	if commandErr != nil {
 		var exitErr *exec.ExitError
@@ -94,4 +100,28 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		return 1
 	}
 	return 0
+}
+
+func runValidationCommand(ctx context.Context, cmd *exec.Cmd) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	procgroup.Configure(ctx, cmd)
+	terminate := cmd.Cancel
+	cmd.Cancel = nil
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	groupID := procgroup.GroupID(cmd)
+	terminated := make(chan struct{})
+	var terminationErr error
+	stop := context.AfterFunc(ctx, func() {
+		terminationErr = terminate()
+		close(terminated)
+	})
+	waitErr := cmd.Wait()
+	if !stop() {
+		<-terminated
+	}
+	return errors.Join(waitErr, terminationErr, procgroup.Cleanup(groupID))
 }

--- a/tools/checklock/main.go
+++ b/tools/checklock/main.go
@@ -8,15 +8,18 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
 	"time"
-
-	"github.com/digitaldrywood/detent/internal/instancelock"
 )
 
 const validationLockPollInterval = 100 * time.Millisecond
 
 func main() {
-	os.Exit(run(context.Background(), os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	code := run(ctx, os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
+	stop()
+	os.Exit(code)
 }
 
 func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
@@ -51,8 +54,12 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		fmt.Fprintf(stderr, "acquire validation lock: %v\n", err)
 		return 1
 	}
+	if err := ctx.Err(); err != nil {
+		fmt.Fprintf(stderr, "validation canceled before command start: %v\n", errors.Join(err, lock.Close()))
+		return 1
+	}
 	if waited {
-		fmt.Fprintf(stderr, "validation gate acquired shared lock: %s\n", *lockPath)
+		fmt.Fprintln(stderr, "validation gate acquired shared lock; starting validation (wait timeout no longer applies)")
 	}
 
 	commandPath, commandPathErr := exec.LookPath(command[0])
@@ -87,31 +94,4 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		return 1
 	}
 	return 0
-}
-
-func acquireValidationLock(ctx context.Context, path string, stderr io.Writer) (*instancelock.Lock, bool, error) {
-	waited := false
-	for {
-		lock, err := instancelock.Acquire(path)
-		if err == nil {
-			return lock, waited, nil
-		}
-		if !errors.Is(err, instancelock.ErrHeld) {
-			return nil, waited, err
-		}
-		if !waited {
-			fmt.Fprintf(stderr, "validation gate waiting for another worktree: %s\n", path)
-			waited = true
-		}
-
-		timer := time.NewTimer(validationLockPollInterval)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
-			return nil, waited, ctx.Err()
-		case <-timer.C:
-		}
-	}
 }

--- a/tools/checklock/main_test.go
+++ b/tools/checklock/main_test.go
@@ -307,3 +307,66 @@ func (w *pausedWriter) Write(data []byte) (int, error) {
 func (w *pausedWriter) release() {
 	w.closed.Do(func() { close(w.resume) })
 }
+
+func TestRunCancellationStopsActiveValidation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+	defer cancel()
+	path := filepath.Join(t.TempDir(), "validation.lock")
+	criticalPath := filepath.Join(t.TempDir(), "critical.lock")
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		reader.Close()
+		writer.Close()
+	})
+	ready := newNotifyingWriter()
+	var stderr bytes.Buffer
+	commandCtx, stopCommand := context.WithCancel(ctx)
+	defer stopCommand()
+	done := make(chan int, 1)
+	go func() {
+		done <- run(commandCtx, []string{
+			"-lock", path, "--", os.Args[0], "-test.run=^TestValidationCancellationHelper$",
+			"--", "checklock-cancel-child", criticalPath,
+		}, reader, ready, &stderr)
+	}()
+	select {
+	case <-ready.notified:
+	case code := <-done:
+		t.Fatalf("command exited before readiness: %d: %s", code, &stderr)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	for _, heldPath := range []string{path, criticalPath} {
+		inspection, err := instancelock.Inspect(heldPath)
+		if err != nil || inspection.Status != instancelock.StatusHeld {
+			t.Fatalf("validation was not active before cancellation: %+v, %v", inspection, err)
+		}
+	}
+	stopCommand()
+	select {
+	case code := <-done:
+		if code == 0 {
+			t.Fatalf("canceled command returned success: %s", &stderr)
+		}
+	case <-ctx.Done():
+		t.Fatal("active validation ignored cancellation")
+	}
+	for _, releasedPath := range []string{path, criticalPath} {
+		acquireTestLock(t, releasedPath)
+	}
+}
+
+func TestValidationCancellationHelper(t *testing.T) {
+	if len(os.Args) < 3 || os.Args[len(os.Args)-2] != "checklock-cancel-child" {
+		t.Skip("helper process")
+	}
+	acquireTestLock(t, os.Args[len(os.Args)-1])
+	fmt.Fprintln(os.Stdout, "ready")
+	if _, err := io.ReadFull(os.Stdin, make([]byte, 1)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tools/checklock/main_test.go
+++ b/tools/checklock/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -211,4 +212,98 @@ func waitForPath(t *testing.T, ctx context.Context, path string) {
 		case <-ticker.C:
 		}
 	}
+}
+
+func TestValidationWaiterCannotBeOvertaken(t *testing.T) {
+	t.Parallel()
+	for _, arrivals := range []int{1, 8} {
+		t.Run(fmt.Sprintf("%d new arrivals", arrivals), func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+			defer cancel()
+			path := filepath.Join(t.TempDir(), "validation.lock")
+			holder, err := instancelock.Acquire(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { holder.Close() })
+			paused := &pausedWriter{ready: make(chan struct{}), resume: make(chan struct{})}
+			t.Cleanup(func() { paused.release() })
+			older := startValidationWaiter(ctx, path, paused)
+			select {
+			case <-paused.ready:
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			if err := holder.Close(); err != nil {
+				t.Fatal(err)
+			}
+			newcomers := make([]<-chan validationResult, 0, arrivals)
+			for range arrivals {
+				writer := newNotifyingWriter()
+				newcomer := startValidationWaiter(ctx, path, writer)
+				select {
+				case <-writer.notified:
+				case result := <-newcomer:
+					if result.lock != nil {
+						result.lock.Close()
+					}
+					t.Fatalf("new arrival overtook a registered older waiter: %v", result.err)
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				}
+				newcomers = append(newcomers, newcomer)
+			}
+			paused.release()
+			for _, waiter := range append([]<-chan validationResult{older}, newcomers...) {
+				select {
+				case result := <-waiter:
+					if result.err != nil {
+						t.Fatal(result.err)
+					}
+					if _, err := instancelock.Acquire(path); !errors.Is(err, instancelock.ErrHeld) {
+						t.Fatalf("active owner lost exclusivity: %v", err)
+					}
+					if err := result.lock.Close(); err != nil {
+						t.Fatal(err)
+					}
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				}
+			}
+		})
+	}
+}
+
+type validationResult struct {
+	lock *instancelock.Lock
+	err  error
+}
+
+func startValidationWaiter(ctx context.Context, path string, writer io.Writer) <-chan validationResult {
+	done := make(chan validationResult, 1)
+	go func() {
+		lock, _, err := acquireValidationLock(ctx, path, writer)
+		done <- validationResult{lock: lock, err: err}
+	}()
+	return done
+}
+
+type pausedWriter struct {
+	ready  chan struct{}
+	resume chan struct{}
+	once   sync.Once
+	closed sync.Once
+}
+
+func (w *pausedWriter) Write(data []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.ready)
+		<-w.resume
+	})
+	return len(data), nil
+}
+
+func (w *pausedWriter) release() {
+	w.closed.Do(func() { close(w.resume) })
 }

--- a/tools/checklock/queue.go
+++ b/tools/checklock/queue.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+const validationQueueLimit = 1024
+
+type validationWaiter struct {
+	name string
+	lock *instancelock.Lock
+}
+
+func acquireValidationLock(ctx context.Context, path string, stderr io.Writer) (*instancelock.Lock, bool, error) {
+	started := time.Now()
+	waiter, err := registerValidationWaiter(ctx, path)
+	if err != nil {
+		return nil, false, fmt.Errorf("register validation waiter after %s: %w", time.Since(started).Round(time.Millisecond), err)
+	}
+	defer func() {
+		if err := waiter.lock.Close(); err != nil {
+			fmt.Fprintf(stderr, "release validation waiter: %v\n", err)
+		}
+	}()
+
+	waited := false
+	lastDiagnostic := ""
+	lastReport := time.Time{}
+	for {
+		position, size, err := validationPosition(ctx, path, waiter.name)
+		if err != nil {
+			return nil, waited, fmt.Errorf("wait for validation queue after %s: %w", time.Since(started).Round(time.Millisecond), err)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, waited, err
+		}
+		if position == 1 {
+			lock, err := instancelock.Acquire(path)
+			if err == nil {
+				return lock, waited, nil
+			}
+			if !errors.Is(err, instancelock.ErrHeld) {
+				return nil, waited, err
+			}
+		}
+		owner, err := instancelock.Inspect(path)
+		if err != nil {
+			return nil, waited, err
+		}
+		diagnostic := fmt.Sprintf("position=%d queued=%d owner=%s", position, size, owner.Status)
+		if owner.Status == instancelock.StatusHeld && owner.MetadataError == nil {
+			diagnostic += fmt.Sprintf(" owner_pid=%d owner_since=%s", owner.Owner.PID, owner.Owner.StartedAt.Format(time.RFC3339Nano))
+		}
+		if diagnostic != lastDiagnostic || time.Since(lastReport) >= 30*time.Second {
+			fmt.Fprintf(stderr, "validation gate waiting: %s waited=%s\n", diagnostic, time.Since(started).Round(time.Millisecond))
+			lastDiagnostic = diagnostic
+			lastReport = time.Now()
+		}
+		waited = true
+		if err := waitValidationPoll(ctx); err != nil {
+			return nil, waited, fmt.Errorf("validation queue wait ended (%s waited=%s; validation has not started): %w", diagnostic, time.Since(started).Round(time.Millisecond), err)
+		}
+	}
+}
+
+func registerValidationWaiter(ctx context.Context, path string) (validationWaiter, error) {
+	var waiter validationWaiter
+	err := withValidationQueue(ctx, path, func() error {
+		if err := os.MkdirAll(path+".queue", 0o700); err != nil {
+			return err
+		}
+		names, err := liveValidationWaiters(ctx, path)
+		if err != nil {
+			return err
+		}
+		if len(names) >= validationQueueLimit {
+			return fmt.Errorf("validation queue is full (limit=%d)", validationQueueLimit)
+		}
+		var ticket uint64
+		if len(names) != 0 {
+			ticket, err = strconv.ParseUint(strings.TrimSuffix(names[len(names)-1], ".lock"), 10, 64)
+			if err != nil {
+				return err
+			}
+		}
+		if ticket == ^uint64(0) {
+			return errors.New("validation queue ticket space exhausted")
+		}
+		waiter.name = fmt.Sprintf("%020d.lock", ticket+1)
+		waiter.lock, err = instancelock.Acquire(filepath.Join(path+".queue", waiter.name))
+		return err
+	})
+	if err != nil {
+		return validationWaiter{}, errors.Join(err, waiter.lock.Close())
+	}
+	return waiter, nil
+}
+
+func validationPosition(ctx context.Context, path, name string) (int, int, error) {
+	position, size := 0, 0
+	err := withValidationQueue(ctx, path, func() error {
+		names, err := liveValidationWaiters(ctx, path)
+		if err != nil {
+			return err
+		}
+		size = len(names)
+		for i, candidate := range names {
+			if candidate == name {
+				position = i + 1
+				return nil
+			}
+		}
+		return errors.New("validation waiter missing from queue")
+	})
+	return position, size, err
+}
+
+func liveValidationWaiters(ctx context.Context, path string) ([]string, error) {
+	entries, err := os.ReadDir(path + ".queue")
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if len(name) != 25 || !strings.HasSuffix(name, ".lock") || entry.Type() != 0 {
+			return nil, errors.New("invalid validation queue entry")
+		}
+		if _, err := strconv.ParseUint(strings.TrimSuffix(name, ".lock"), 10, 64); err != nil {
+			return nil, errors.New("invalid validation queue ticket")
+		}
+		waiterPath := filepath.Join(path+".queue", name)
+		inspection, err := instancelock.Inspect(waiterPath)
+		if err != nil {
+			return nil, err
+		}
+		if inspection.Status == instancelock.StatusHeld {
+			names = append(names, name)
+			continue
+		}
+		if err := pruneValidationWaiter(ctx, waiterPath, os.Remove); err != nil {
+			return nil, err
+		}
+	}
+	return names, nil
+}
+
+func pruneValidationWaiter(ctx context.Context, path string, remove func(string) error) error {
+	for attempt := range 5 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := remove(path)
+		if err == nil || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if attempt == 4 {
+			return err
+		}
+		if waitErr := waitValidationPoll(ctx); waitErr != nil {
+			return errors.Join(err, waitErr)
+		}
+	}
+	return nil
+}
+
+func withValidationQueue(ctx context.Context, path string, action func() error) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		guard, err := instancelock.Acquire(path + ".queue.lock")
+		if err == nil {
+			if err := ctx.Err(); err != nil {
+				return errors.Join(err, guard.Close())
+			}
+			return errors.Join(action(), guard.Close())
+		}
+		if !errors.Is(err, instancelock.ErrHeld) {
+			return err
+		}
+		if err := waitValidationPoll(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func waitValidationPoll(ctx context.Context) error {
+	timer := time.NewTimer(validationLockPollInterval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/tools/checklock/queue_test.go
+++ b/tools/checklock/queue_test.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+func TestValidationQueueCancellation(t *testing.T) {
+	t.Parallel()
+	for _, olderWaiter := range []bool{false, true} {
+		t.Run(fmt.Sprintf("older_waiter=%t", olderWaiter), func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+			defer cancel()
+			path := filepath.Join(t.TempDir(), "validation.lock")
+			holder := acquireTestLock(t, path)
+			if olderWaiter {
+				older, err := registerValidationWaiter(ctx, path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { older.lock.Close() })
+			}
+			waitingCtx, stopWaiting := context.WithCancel(ctx)
+			defer stopWaiting()
+			writer := newNotifyingWriter()
+			done := startValidationWaiter(waitingCtx, path, writer)
+			select {
+			case <-writer.notified:
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			stopWaiting()
+			select {
+			case result := <-done:
+				if !errors.Is(result.err, context.Canceled) || result.lock != nil {
+					t.Fatalf("canceled waiter = %+v", result)
+				}
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			inspection, err := instancelock.Inspect(path)
+			if err != nil || inspection.Status != instancelock.StatusHeld {
+				t.Fatalf("holder after waiter cancellation = %+v, %v", inspection, err)
+			}
+			next, err := registerValidationWaiter(ctx, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { next.lock.Close() })
+			position, size, err := validationPosition(ctx, path, next.name)
+			want := 1
+			if olderWaiter {
+				want = 2
+			}
+			if err != nil || position != want || size != want {
+				t.Fatalf("queue after cancellation = (%d, %d, %v), want (%d, %d, nil)", position, size, err, want, want)
+			}
+			if err := holder.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidationQueueDeadlines(t *testing.T) {
+	t.Parallel()
+	for _, stage := range []string{"registration", "validation"} {
+		t.Run(stage, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "validation.lock")
+				heldPath := path
+				if stage == "registration" {
+					heldPath += ".queue.lock"
+				}
+				acquireTestLock(t, heldPath)
+				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				defer cancel()
+				var stderr bytes.Buffer
+				lock, _, err := acquireValidationLock(ctx, path, &stderr)
+				if !errors.Is(err, context.DeadlineExceeded) || lock != nil {
+					t.Fatalf("deadline result = %v, %v", lock, err)
+				}
+				if !strings.Contains(err.Error(), "wait") {
+					t.Fatalf("deadline lacks waiting context: %v", err)
+				}
+				inspection, err := instancelock.Inspect(heldPath)
+				if err != nil || inspection.Status != instancelock.StatusHeld {
+					t.Fatalf("deadline released live lock: %+v, %v", inspection, err)
+				}
+			})
+		})
+	}
+}
+
+func TestValidationQueueCanceledBeforeAcquisition(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	path := filepath.Join(t.TempDir(), "validation.lock")
+	lock, _, err := acquireValidationLock(ctx, path, io.Discard)
+	if !errors.Is(err, context.Canceled) || lock != nil {
+		t.Fatalf("already canceled acquisition = %v, %v", lock, err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("already canceled invocation touched validation lock: %v", err)
+	}
+}
+
+func TestValidationWaitDeadlineDoesNotReleaseActiveLock(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "validation.lock")
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		lock, _, err := acquireValidationLock(ctx, path, io.Discard)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lock.Close()
+		<-ctx.Done()
+		inspection, err := instancelock.Inspect(path)
+		if err != nil || inspection.Status != instancelock.StatusHeld {
+			t.Fatalf("wait deadline released active validation: %+v, %v", inspection, err)
+		}
+	})
+}
+
+func TestValidationQueueProcessRecovery(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"waiter", "registration", "holder", "crashed holder"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+			defer cancel()
+			path := filepath.Join(t.TempDir(), "validation.lock")
+			command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestValidationQueueProcessHelper$")
+			command.Env = append(os.Environ(), "DETENT_CHECKLOCK_QUEUE_HELPER="+path, "DETENT_CHECKLOCK_QUEUE_MODE="+mode, "GOCOVERDIR="+t.TempDir())
+			ready := newNotifyingWriter()
+			var stderr bytes.Buffer
+			command.Stdout, command.Stderr = ready, &stderr
+			input, err := command.StdinPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := command.Start(); err != nil {
+				t.Fatal(err)
+			}
+			processDone := make(chan struct{})
+			var processErr error
+			go func() {
+				processErr = command.Wait()
+				close(processDone)
+			}()
+			t.Cleanup(func() {
+				input.Close()
+				cancel()
+				<-processDone
+			})
+			select {
+			case <-ready.notified:
+			case <-processDone:
+				t.Fatalf("helper exited before acquiring: %v: %s", processErr, &stderr)
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			if mode != "registration" {
+				waiter, err := registerValidationWaiter(ctx, path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				position, _, err := validationPosition(ctx, path, waiter.name)
+				want := 1
+				if mode == "waiter" {
+					want = 2
+				}
+				if err != nil || position != want {
+					t.Fatalf("live helper queue position = %d, %v, want %d", position, err, want)
+				}
+				waiter.lock.Close()
+			}
+			if mode == "holder" || mode == "crashed holder" {
+				inspection, err := instancelock.Inspect(path)
+				if err != nil || inspection.Status != instancelock.StatusHeld || inspection.Owner.PID != command.Process.Pid {
+					t.Fatalf("active process owner = %+v, %v", inspection, err)
+				}
+			}
+			if _, err := io.WriteString(input, "exit\n"); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-processDone:
+				if processErr != nil {
+					t.Fatalf("helper failed: %v: %s", processErr, &stderr)
+				}
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			lock, _, err := acquireValidationLock(ctx, path, io.Discard)
+			if err != nil {
+				t.Fatalf("acquire after helper exit: %v", err)
+			}
+			defer lock.Close()
+			inspection, err := instancelock.Inspect(path)
+			if err != nil || inspection.Owner.PID != os.Getpid() {
+				t.Fatalf("owner handoff = %+v, %v", inspection, err)
+			}
+		})
+	}
+}
+
+func TestValidationQueueProcessHelper(t *testing.T) {
+	path := os.Getenv("DETENT_CHECKLOCK_QUEUE_HELPER")
+	if path == "" {
+		t.Skip("helper process")
+	}
+	mode := os.Getenv("DETENT_CHECKLOCK_QUEUE_MODE")
+	var lock *instancelock.Lock
+	var err error
+	switch mode {
+	case "waiter":
+		var waiter validationWaiter
+		waiter, err = registerValidationWaiter(t.Context(), path)
+		lock = waiter.lock
+	case "registration":
+		lock, err = instancelock.Acquire(path + ".queue.lock")
+	default:
+		lock, err = instancelock.Acquire(path)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Fprintln(os.Stdout, "ready")
+	if _, err := io.ReadFull(os.Stdin, make([]byte, len("exit\n"))); err != nil {
+		t.Fatal(err)
+	}
+	if mode == "holder" {
+		if err := lock.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	os.Exit(0)
+}
+
+func TestValidationQueueDiagnostics(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+	defer cancel()
+	path := filepath.Join(t.TempDir(), "validation.lock")
+	acquireTestLock(t, path)
+	waitingCtx, stop := context.WithCancel(ctx)
+	defer stop()
+	writer := newNotifyingWriter()
+	done := startValidationWaiter(waitingCtx, path, writer)
+	select {
+	case <-writer.notified:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	stop()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	output := writer.data.String()
+	for _, field := range []string{"position=1", "queued=1", "owner=held", fmt.Sprintf("owner_pid=%d", os.Getpid()), "owner_since=", "waited="} {
+		if !strings.Contains(output, field) {
+			t.Errorf("diagnostic %q missing %q", output, field)
+		}
+	}
+	if strings.Contains(output, filepath.Dir(path)) {
+		t.Fatalf("diagnostic exposes repository path: %q", output)
+	}
+}
+
+func acquireTestLock(t *testing.T, path string) *instancelock.Lock {
+	t.Helper()
+	lock, err := instancelock.Acquire(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := lock.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return lock
+}
+
+func TestValidationQueueCapacity(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "validation.lock")
+	for i := range validationQueueLimit {
+		acquireTestLock(t, filepath.Join(path+".queue", fmt.Sprintf("%020d.lock", i+1)))
+	}
+	if _, err := registerValidationWaiter(t.Context(), path); err == nil || !strings.Contains(err.Error(), "queue is full") {
+		t.Fatalf("full queue registration error = %v", err)
+	}
+}
+
+func TestValidationWaiterPruning(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		failures  int
+		cancel    bool
+		wantCalls int
+		wantErr   error
+	}{
+		{name: "removed", wantCalls: 1},
+		{name: "unlocked handle still closing", failures: 1, wantCalls: 2},
+		{name: "permanent failure", failures: 5, wantCalls: 5, wantErr: os.ErrPermission},
+		{name: "canceled retry", failures: 1, cancel: true, wantCalls: 1, wantErr: context.Canceled},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				calls := 0
+				err := pruneValidationWaiter(ctx, "waiter.lock", func(string) error {
+					calls++
+					if tt.cancel {
+						cancel()
+					}
+					if calls <= tt.failures {
+						return os.ErrPermission
+					}
+					return nil
+				})
+				if !errors.Is(err, tt.wantErr) || calls != tt.wantCalls {
+					t.Fatalf("pruning = (%d calls, %v), want (%d calls, %v)", calls, err, tt.wantCalls, tt.wantErr)
+				}
+			})
+		})
+	}
+}
+
+func TestValidationWaiterPruningOpenHandle(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "waiter.lock")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { file.Close() })
+	calls := 0
+	err = pruneValidationWaiter(t.Context(), path, func(path string) error {
+		calls++
+		err := os.Remove(path)
+		if calls == 1 {
+			if closeErr := file.Close(); closeErr != nil {
+				t.Fatal(closeErr)
+			}
+		}
+		return err
+	})
+	wantCalls := 1
+	if runtime.GOOS == "windows" {
+		wantCalls = 2
+	}
+	if err != nil || calls != wantCalls {
+		t.Fatalf("prune open handle = %v after %d attempts, want nil after %d", err, calls, wantCalls)
+	}
+}
+
+func TestValidationQueueRejectsInvalidState(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"unexpected", "xxxxxxxxxxxxxxxxxxxx.lock", "00000000000000000001.lock"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "validation.lock")
+			if err := os.MkdirAll(filepath.Join(path+".queue", name), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := registerValidationWaiter(t.Context(), path); err == nil || !strings.Contains(err.Error(), "invalid validation queue") {
+				t.Fatalf("invalid queue registration error = %v", err)
+			}
+			guard := acquireTestLock(t, path+".queue.lock")
+			if err := guard.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Prevent newer validation invocations from overtaking registered live waiters with bounded FIFO admission shared across worktrees.
- Recover canceled and crashed waiter tickets through OS-lock liveness while preserving the original exclusive validation gate and keeping queue deadlines separate from active execution.
- Propagate parent cancellation to active validation and retain the gate through command exit and process-group cleanup.
- Report queue position, elapsed waiting, and active owner details; document the rollout behavior for older polling clients.

Fixes #2317

## UI Surface Contract

- [x] N/A: no UI surface changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Reproduced newcomer overtaking with a controlled lock regression before implementing the fix.
- [x] Repeated focused race tests (10 runs) pass for validation queueing and instance locks.
- [x] Final full gate: 80.1% total coverage and all package/file floors pass.
- [x] Windows amd64 cross-compilation passes for both affected test packages.
- [x] Controlled and subprocess tests cover FIFO handoffs, cancellation, crashes, owner liveness, queue bounds, distinct wait deadlines, Windows open-handle pruning retries, and active command cancellation.
- [x] `make check` (final contents, including the Windows pruning refinement)
