### PR TITLE
fix(recovery): checkpoint work at session limits

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -627,6 +627,8 @@
 #   max_session_duration_ms: 7200000
 #   # agent.no_progress_timeout_ms | type: integer | default: 5400000 | required: No | validation: must be greater than or equal to 0
 #   no_progress_timeout_ms: 5400000
+#   # agent.checkpoint_interval_ms | type: integer | default: 0 | required: No | validation: must be greater than or equal to 0
+#   checkpoint_interval_ms: 0
 #   # agent.merge_worker_startup_timeout_ms | type: integer | default: 240000 | required: No | validation: must be greater than 0
 #   merge_worker_startup_timeout_ms: 240000
 #   # agent.merge_worker_max_duration_ms | type: integer | default: 21600000 | required: No | validation: must be greater than 0

--- a/docs/config.md
+++ b/docs/config.md
@@ -547,6 +547,21 @@ fallback when `agents.backends` is empty. A Codex backend inherits omitted
 values from it. Claude Code backend options are interpreted only when the
 backend `kind` is `claude_code`.
 
+Implementation workers on automatically owned Git branches request a bounded
+recovery checkpoint when a duration, turn, or no-progress limit stops them.
+`agent.checkpoint_interval_ms` also enables periodic checkpoints; `0` disables
+the periodic trigger. Each checkpoint allows up to two minutes for a read-only
+worker to select reviewed issue files and for Detent to commit and publish them
+with lease and remote checks. Periodic checkpoints retain the session deadline
+and accumulated budget usage. Identical work does not create new commits.
+
+Checkpoint publication may associate a draft PR and never satisfies completion,
+review, or CI gates. If delivery is unavailable, the owned workspace remains
+recoverable. Its Git metadata contains `detent-checkpoint.json`, written before
+worker execution, so an interrupted or killed worker does not imply that a
+checkpoint epilogue ran. Human branches and backends without the handshake
+continue to rely on local workspace recovery.
+
 `agent.auto_promote` and `gate` work together. Auto-promotion decides when an
 item may leave its source state; the gate decides whether CI, automated review,
 human approval, a validator, or an artifact status is sufficient. `plan`
@@ -835,6 +850,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `agent.budget.per_issue_max_usd` | `number` | `5` | No | must be greater than 0 |
 | `agent.budget.pricing_path` | `string` | `"priv/pricing/models.yaml"` | No | is required |
 | `agent.budget.refusal_cooldown_seconds` | `integer` | `3600` | No | must be greater than or equal to 0 |
+| `agent.checkpoint_interval_ms` | `integer` | `0` | No | must be greater than or equal to 0 |
 | `agent.dispatch_priority_by_label` | `list<string>` | `[]` | No | labels must not be blank |
 | `agent.dispatch_priority_by_state` | `list<string>` | `[]` | No | state names must be unique<br>state names must not be blank |
 | `agent.effort` | `object` | `see child fields` | No | None |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,6 +342,7 @@ type Agent struct {
 	MaxTurnDurationMS            int                          `yaml:"max_turn_duration_ms"`
 	MaxSessionDurationMS         int                          `yaml:"max_session_duration_ms"`
 	NoProgressTimeoutMS          int                          `yaml:"no_progress_timeout_ms"`
+	CheckpointIntervalMS         int                          `yaml:"checkpoint_interval_ms"`
 	MergeWorkerStartupTimeoutMS  int                          `yaml:"merge_worker_startup_timeout_ms"`
 	MergeWorkerMaxDurationMS     int                          `yaml:"merge_worker_max_duration_ms"`
 	MergeFallbackMaxDurationMS   int                          `yaml:"merge_fallback_max_duration_ms"`
@@ -2271,6 +2272,9 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	}
 	if a.NoProgressTimeoutMS < 0 {
 		*problems = append(*problems, prefix+".no_progress_timeout_ms must be greater than or equal to 0")
+	}
+	if a.CheckpointIntervalMS < 0 {
+		*problems = append(*problems, prefix+".checkpoint_interval_ms must be greater than or equal to 0")
 	}
 	validatePositive(prefix+".merge_worker_startup_timeout_ms", a.MergeWorkerStartupTimeoutMS, problems)
 	validatePositive(prefix+".merge_worker_max_duration_ms", a.MergeWorkerMaxDurationMS, problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4513,3 +4513,27 @@ func TestReleaseConfigValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckpointIntervalConfiguration(t *testing.T) {
+	t.Parallel()
+	for _, interval := range []int{-1, 0, 60000} {
+		t.Run(strconv.Itoa(interval), func(t *testing.T) {
+			t.Parallel()
+			workflow, err := ParseWorkflow(fmt.Appendf(nil, "---\nagent:\n  checkpoint_interval_ms: %d\n---\n", interval))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var problems []string
+			workflow.Config.Agent.validate("agent", &problems)
+			if interval < 0 {
+				if !strings.Contains(strings.Join(problems, "\n"), "agent.checkpoint_interval_ms") {
+					t.Fatalf("negative interval accepted: %v", problems)
+				}
+				return
+			}
+			if len(problems) != 0 || workflow.Config.Agent.CheckpointIntervalMS != interval {
+				t.Fatalf("interval = %d, problems = %v", workflow.Config.Agent.CheckpointIntervalMS, problems)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/checkpoint.go
+++ b/internal/orchestrator/checkpoint.go
@@ -1,0 +1,51 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func (o *Orchestrator) checkpointValidator(issueID string, attemptID int64, generation uint64) func(context.Context) error {
+	return func(ctx context.Context) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		runtime := o.latestRuntimeState.Load()
+		if runtime == nil {
+			return runner.ErrExecutionAuthorityUnavailable
+		}
+		running, ok := runtime.Running[issueID]
+		if !ok || running.WorkAttemptID != attemptID || running.Generation != generation || running.Mode != runner.RunModeImplement {
+			return runner.ErrExecutionAuthorityUnavailable
+		}
+		if o.workAttempts == nil || o.connector == nil {
+			return runner.ErrExecutionAuthorityUnavailable
+		}
+		attempt, err := o.workAttempts.WorkAttempt(ctx, attemptID)
+		if err != nil {
+			return err
+		}
+		if attempt.IssueID != issueID || attempt.Status != store.WorkAttemptStatusActive || !attempt.LeaseExpiresAt.After(o.clockNow()) {
+			return runner.ErrExecutionAuthorityUnavailable
+		}
+		issue, err := o.refreshCompletionLane(ctx, running)
+		if err != nil {
+			return err
+		}
+		if normalizeState(issue.State) != normalizeState(running.Issue.State) {
+			return fmt.Errorf("%w: checkpoint lane changed", runner.ErrExecutionAuthorityUnavailable)
+		}
+		current := o.latestRuntimeState.Load()
+		if current == nil {
+			return runner.ErrExecutionAuthorityUnavailable
+		}
+		owned, ok := current.Running[issueID]
+		if !ok || owned.WorkAttemptID != attemptID || owned.Generation != generation || owned.Mode != runner.RunModeImplement || !attempt.LeaseExpiresAt.After(o.clockNow()) {
+			return runner.ErrExecutionAuthorityUnavailable
+		}
+		return ctx.Err()
+	}
+}

--- a/internal/orchestrator/checkpoint_test.go
+++ b/internal/orchestrator/checkpoint_test.go
@@ -1,0 +1,95 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+type checkpointAttemptStore struct {
+	recordingWorkAttemptStore
+	attempt store.WorkAttempt
+	err     error
+}
+
+func (s *checkpointAttemptStore) WorkAttempt(context.Context, int64) (store.WorkAttempt, error) {
+	return s.attempt, s.err
+}
+
+type checkpointLaneConnector struct {
+	backendCapacityTestConnector
+	read func() ([]connector.Issue, error)
+}
+
+func (c checkpointLaneConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return c.read()
+}
+
+func TestCheckpointValidator(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"owned", "cancelled", "no runtime", "no running", "wrong attempt", "wrong generation", "wrong mode", "no store", "no tracker", "store unavailable", "wrong issue", "terminal attempt", "expired lease", "tracker unavailable", "lane changed", "ownership lost during lookup", "runtime lost during lookup", "lease expires during lookup"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			issue := connector.Issue{ID: "checkpoint", State: "In Progress"}
+			attempts := &checkpointAttemptStore{attempt: store.WorkAttempt{IssueID: issue.ID, Status: store.WorkAttemptStatusActive, LeaseExpiresAt: now.Add(time.Minute)}}
+			orch := &Orchestrator{workAttempts: attempts, now: func() time.Time { return now }}
+			running := Running{Issue: issue, WorkAttemptID: 23, Generation: 5, Mode: runner.RunModeImplement}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			orch.connector = &checkpointLaneConnector{read: func() ([]connector.Issue, error) {
+				switch scenario {
+				case "tracker unavailable":
+					return nil, errors.New("network unavailable")
+				case "lane changed":
+					issue.State = "Backlog"
+				case "ownership lost during lookup":
+					orch.latestRuntimeState.Store(&runtimeState{})
+				case "runtime lost during lookup":
+					orch.latestRuntimeState.Store(nil)
+				case "lease expires during lookup":
+					now = now.Add(time.Minute)
+				}
+				return []connector.Issue{issue}, nil
+			}}
+			switch scenario {
+			case "cancelled":
+				cancel()
+			case "wrong attempt":
+				running.WorkAttemptID++
+			case "wrong generation":
+				running.Generation++
+			case "wrong mode":
+				running.Mode = runner.RunModeRoutine
+			case "no store":
+				orch.workAttempts = nil
+			case "no tracker":
+				orch.connector = nil
+			case "store unavailable":
+				attempts.err = errors.New("store unavailable")
+			case "wrong issue":
+				attempts.attempt.IssueID = "other"
+			case "terminal attempt":
+				attempts.attempt.Status = store.WorkAttemptStatusTerminal
+			case "expired lease":
+				attempts.attempt.LeaseExpiresAt = now
+			}
+			state := &runtimeState{Running: map[string]Running{issue.ID: running}}
+			if scenario == "no running" {
+				state.Running = nil
+			}
+			if scenario != "no runtime" {
+				orch.latestRuntimeState.Store(state)
+			}
+			err := orch.checkpointValidator(issue.ID, 23, 5)(ctx)
+			if (err == nil) != (scenario == "owned") {
+				t.Fatalf("checkpoint validation = %v", err)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -795,6 +795,7 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		OnActivityUpdate:    o.activityUpdateHandler(runCtx, issue),
 		OnOverrideRejected:  o.agentOverrideRejectionHandler(runCtx, issue),
 		ProgressProbe:       o.sessionProgressProbe(issue),
+		CheckpointValidate:  o.checkpointValidator(issue.ID, workAttemptID, generation),
 		MergePrecheck:       cloneMergePrecheck(queuedRetry.MergePrecheck),
 		MergeRefreshHeadSHA: reservation.RefreshHeadSHA,
 		ForgeRetry:          cloneForgeRetry(queuedRetry.ForgeRetry),

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -140,10 +140,19 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 	if err != nil {
 		t.Fatalf("ReadDir() error = %v", err)
 	}
-	if len(entries) != 1 {
-		t.Fatalf("workspace entries = %d, want 1", len(entries))
+	var workspaceKeys []string
+	for _, entry := range entries {
+		if entry.Name() != ".detent" {
+			workspaceKeys = append(workspaceKeys, entry.Name())
+		}
 	}
-	workspaceKey := entries[0].Name()
+	if len(workspaceKeys) != 1 {
+		t.Fatalf("workspace entries = %v, want one issue workspace", workspaceKeys)
+	}
+	if records, err := os.ReadDir(filepath.Join(workspacesRoot, ".detent", "cleanup-ownership")); err != nil || len(records) != 1 {
+		t.Fatalf("recovery ownership records = %v, error = %v", records, err)
+	}
+	workspaceKey := workspaceKeys[0]
 	workspacePath := filepath.Join(workspacesRoot, workspaceKey)
 	wantBranch := "detent/" + strings.ToLower(workspaceKey)
 	if got := strings.TrimSpace(e2eRunGit(t, workspacePath, "branch", "--show-current")); got != wantBranch {

--- a/internal/orchestrator/session_brake.go
+++ b/internal/orchestrator/session_brake.go
@@ -242,6 +242,7 @@ func sessionBrakeMetadata(brake *runpkg.SessionBrakeError, targetState string, r
 			"last_progress_at":    brake.LastProgressAt.UTC().Format(time.RFC3339Nano),
 			"target_state":        strings.TrimSpace(targetState),
 			"resumable":           resumable,
+			"checkpoint":          brake.Checkpoint,
 		},
 	}
 }
@@ -269,5 +270,13 @@ func sessionBrakeComment(brake *runpkg.SessionBrakeError, targetState string, re
 	body.WriteString(strconv.FormatBool(resumable))
 	body.WriteString("\n- parked_state: ")
 	body.WriteString(strings.TrimSpace(targetState))
+	if brake.Checkpoint != nil {
+		body.WriteString("\n\nCheckpoint: ")
+		body.WriteString(brake.Checkpoint.Detail)
+		body.WriteString("\n- workspace: ")
+		body.WriteString(brake.Checkpoint.WorkspacePath)
+		body.WriteString("\n- checkpoint_head: ")
+		body.WriteString(brake.Checkpoint.HeadSHA)
+	}
 	return body.String()
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1167,14 +1167,16 @@ func (r *Runner) runAgentTurn(
 		if err := r.publishRunUpdate(updateCtx, runRequest, info, workspaceIssue, progress, result, eventAt, runStartedAt, detentSessionID); err != nil {
 			return err
 		}
-		if err := r.enforceSessionTokenCeiling(agentConfig, runRequest.Issue, info.Path, update, eventAt); err != nil {
+		ceilingUpdate := update
+		ceilingUpdate.Tokens.TotalTokens += runRequest.sessionTokenOffset
+		if err := r.enforceSessionTokenCeiling(agentConfig, runRequest.Issue, info.Path, ceilingUpdate, eventAt); err != nil {
 			return err
 		}
 		observedModel := effectiveModel(result.RuntimeIdentity.ResolvedModel.Value, result.Model, sessionModel)
 		if err := r.enforceSessionBudgetProjection(budgetProjection, budgetCostOffsetUSD, observedModel, backendKind, update); err != nil {
 			return err
 		}
-		if err := runRequest.sessionBrake.observe(updateCtx, progress.turnCount(), result.Tokens.TotalTokens); err != nil {
+		if err := runRequest.sessionBrake.observe(updateCtx, progress.turnCount(), result.Tokens.TotalTokens+runRequest.sessionTokenOffset); err != nil {
 			return err
 		}
 		return nil
@@ -1706,6 +1708,7 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 			return result, fmt.Errorf("acquire model permit: %w", err)
 		}
 	}
+	checkpoint := r.prepareWorkerCheckpoint(ctx, req, runWorkspace, info, workspaceIssue)
 	sessionID, sessionStarted, err := r.startSession(ctx, req, startedAt, runtimeIdentity, resumeState, orphanRecoveryOutcome, orphanRecoveryFallbackReason)
 	if err != nil {
 		return RunResult{}, err
@@ -1797,7 +1800,14 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 			turnRequest.ToolInstructions = admissionToolInstructions
 		}
 	}
-	execution := r.runAgentTurn(sessionCtx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, targetRefObserver, runStartedAt, sessionID, runtimeIdentity, budgetProjection, 0, sessionModel, backendConfig.Kind)
+	runWithCheckpoint := func(request AgentTurnRequest, runReq RunRequest, identity agentidentity.Identity, costOffsetUSD float64) agentTurnExecution {
+		return r.runCheckpointedTurn(ctx, sessionCtx, checkpoint, workflow.Config.Agent, backend, request, runReq, func(turnCtx context.Context, request AgentTurnRequest, runReq RunRequest) agentTurnExecution {
+			execution := r.runAgentTurn(turnCtx, backend, request, runReq, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, targetRefObserver, runStartedAt, sessionID, identity, budgetProjection, costOffsetUSD, sessionModel, backendConfig.Kind)
+			costOffsetUSD += r.usageCostUSD(sessionModel, execution.result.Tokens.InputTokens, execution.result.Tokens.CachedInputTokens, execution.result.Tokens.OutputTokens, backendConfig.Kind)
+			return execution
+		})
+	}
+	execution := runWithCheckpoint(turnRequest, req, runtimeIdentity, 0)
 	execution.err = sessionBrake.wrapTurnLimit(ctx, execution.err)
 	execution.err = sessionBrake.wrapDuration(ctx, execution.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
 	execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
@@ -1826,7 +1836,7 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if targetRefObserver != nil {
 			initialDeliverableState = r.observeWorkspaceDeliverableState(runWorkspace, sessionCtx, info, workspaceIssue, "resume_fallback_initial")
 		}
-		execution = r.runAgentTurn(sessionCtx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, targetRefObserver, runStartedAt, sessionID, runtimeIdentity, budgetProjection, 0, sessionModel, backendConfig.Kind)
+		execution = runWithCheckpoint(turnRequest, req, runtimeIdentity, 0)
 		execution.err = sessionBrake.wrapTurnLimit(ctx, execution.err)
 		execution.err = sessionBrake.wrapDuration(ctx, execution.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
 		execution.err = classifyAgentCapacityError(backend, selection, backendConfig, execution.result.RuntimeIdentity, execution.err, execution.result.RateLimits, runStartedAt)
@@ -1865,7 +1875,8 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if targetRefObserver != nil {
 			initialDeliverableState = r.observeWorkspaceDeliverableState(runWorkspace, sessionCtx, info, workspaceIssue, "deliverable_recovery_initial")
 		}
-		recovery := r.runAgentTurn(sessionCtx, backend, recoveryRequest, recoveryRunRequest, info, workspaceIssue, workflow.Config.Agent, workflow.Config.Gate.CITriggerLabel, targetRefObserver, runStartedAt, sessionID, execution.result.RuntimeIdentity, budgetProjection, budgetCostOffsetUSD, sessionModel, backendConfig.Kind)
+		recoveryRunRequest.sessionTokenOffset = execution.result.Tokens.TotalTokens
+		recovery := runWithCheckpoint(recoveryRequest, recoveryRunRequest, execution.result.RuntimeIdentity, budgetCostOffsetUSD)
 		recovery.err = sessionBrake.wrapTurnLimit(ctx, recovery.err)
 		recovery.err = sessionBrake.wrapDuration(ctx, recovery.err, durationFromMillis(workflow.Config.Agent.MaxSessionDurationMS))
 		recovery.err = classifyAgentCapacityError(backend, selection, backendConfig, recovery.result.RuntimeIdentity, recovery.err, recovery.result.RateLimits, runStartedAt)
@@ -1906,6 +1917,10 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 	}
 	sessionBrake.Stop()
+	var checkpointBrake *SessionBrakeError
+	if errors.As(execution.err, &checkpointBrake) {
+		checkpointBrake.Checkpoint = execution.result.Checkpoint
+	}
 	turnResult := execution.turnResult
 	turnErr := execution.err
 	cleanupErr := execution.cleanupErr
@@ -1975,6 +1990,7 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 
 	afterRunPending = false
+	req.retainCheckpoint = result.Checkpoint != nil && turnErr != nil
 	if err := r.afterExecution(ctx, req, runWorkspace, info, workspaceIssue); err != nil {
 		return result, errors.Join(turnErr, err)
 	}

--- a/internal/runner/checkpoint.go
+++ b/internal/runner/checkpoint.go
@@ -1,0 +1,314 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+var errPeriodicCheckpoint = errors.New("periodic worker checkpoint requested")
+
+const checkpointTimeout = 2 * time.Minute
+
+type workerCheckpoint struct {
+	backend         workspace.CheckpointBackend
+	plan            workspace.CheckpointPlan
+	request         RunRequest
+	lastFingerprint string
+	prepareFailed   bool
+	fingerprint     func(context.Context) (string, error)
+	record          *workspace.CheckpointRecord
+}
+
+func (r *Runner) prepareWorkerCheckpoint(ctx context.Context, req RunRequest, backend workspace.Backend, info workspace.Info, issue workspace.Issue) *workerCheckpoint {
+	checkpointBackend, ok := backend.(workspace.CheckpointBackend)
+	if !ok || normalizeRunMode(req.Mode) != RunModeImplement {
+		return nil
+	}
+	prepareCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	plan, err := checkpointBackend.PrepareCheckpoint(prepareCtx, info, issue)
+	checkpoint := &workerCheckpoint{backend: checkpointBackend, plan: plan, request: req}
+	if reader, ok := backend.(workspace.RecoveryStateProvider); ok {
+		checkpoint.fingerprint = func(ctx context.Context) (string, error) {
+			state, err := reader.RecoveryState(ctx, info, issue)
+			return state.WorkspaceFingerprint, err
+		}
+	}
+	if err != nil {
+		r.logWorkerEvent(req.Issue, "worker_checkpoint_unavailable", "error", err)
+		if plan.Journal != "" {
+			checkpoint.prepareFailed = true
+			r.saveWorkerCheckpoint(checkpoint, workspace.CheckpointRecord{Reason: "session_started", Status: "local_only", Detail: "Checkpoint preparation failed; workspace retained and publication unavailable."})
+			return checkpoint
+		}
+		return nil
+	}
+	return checkpoint
+}
+
+func (c *workerCheckpoint) validate(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if c.request.Execution != nil {
+		return c.request.Execution.Validate(ctx)
+	}
+	if c.request.CheckpointValidate == nil {
+		return ErrExecutionAuthorityUnavailable
+	}
+	return c.request.CheckpointValidate(ctx)
+}
+
+func (r *Runner) saveWorkerCheckpoint(c *workerCheckpoint, record workspace.CheckpointRecord) {
+	record.Schema = 1
+	record.WorkspacePath = c.plan.Info.Path
+	record.Branch = c.plan.Info.Branch
+	c.record = &record
+	if err := workspace.WriteCheckpointRecord(c.plan, record); err != nil {
+		r.logWorkerEvent(c.request.Issue, "worker_checkpoint_journal_failed", "error", err)
+	}
+	r.logWorkerEvent(c.request.Issue, "worker_checkpoint", "status", record.Status, "reason", record.Reason, "head_sha", record.HeadSHA, "published", record.Published, "detail", record.Detail)
+}
+
+func (r *Runner) workerCheckpoint(ctx context.Context, c *workerCheckpoint, reason string, backend AgentBackend, turn AgentTurnRequest, run func(context.Context, AgentTurnRequest, RunRequest) agentTurnExecution) agentTurnExecution {
+	checkpointCtx, cancel := context.WithTimeout(ctx, checkpointTimeout)
+	defer cancel()
+	if c.fingerprint != nil {
+		fingerprint, err := c.fingerprint(checkpointCtx)
+		delivered := c.record != nil && (c.record.Published || c.record.Status == "unchanged")
+		if err == nil && fingerprint != "" && fingerprint == c.lastFingerprint && (reason == "periodic" || delivered) {
+			return agentTurnExecution{}
+		}
+		defer func() {
+			if fingerprint, err := c.fingerprint(checkpointCtx); err == nil {
+				c.lastFingerprint = fingerprint
+			}
+		}()
+	}
+	record := workspace.CheckpointRecord{Reason: reason, Status: "pending", Detail: "Checkpoint requested; worker handshake and publication have not completed. Retain the local workspace."}
+	r.saveWorkerCheckpoint(c, record)
+	finish := func(detail string) {
+		record.Status = "local_only"
+		record.Detail = detail
+		r.saveWorkerCheckpoint(c, record)
+	}
+	if c.prepareFailed {
+		finish("Checkpoint preparation was unavailable. No checkpoint epilogue ran; inspect retained local work and its recovery journal.")
+		return agentTurnExecution{}
+	}
+	if err := c.validate(checkpointCtx); err != nil {
+		finish("Checkpoint skipped: cancellation or ownership could not be verified. No checkpoint epilogue ran; inspect retained local work.")
+		return agentTurnExecution{}
+	}
+	if _, ok := backend.(AgentToolBackend); !ok {
+		finish("Provider does not support the checkpoint handshake. No checkpoint epilogue ran; inspect retained local work.")
+		return agentTurnExecution{}
+	}
+	turn.ReadOnly = true
+	turn.SupplementalTools = true
+	turn.MaxTurns = 2
+	turn.MaxDuration = checkpointTimeout
+	turn.ToolInstructions = "Inspect only. Submit the checkpoint selection once through detent_checkpoint_selection and return. Do not edit files, stage, commit, push, create a PR, or change tracker state."
+	turn.Prompt = fmt.Sprintf("Detent requests a bounded recovery checkpoint for %s (%s). Review the retained worktree and ALL commits after base %s. Submit the exact HEAD and a complete list of intended issue file paths safe to publish, including paths in existing local commits. Exclude credentials, unrelated changes and scratch files. Set reviewed=true only after reviewing their contents and history. This is incomplete work; do not claim validated delivery or completion. If unsafe or uncertain, return without submitting.\n\n%s", c.request.Issue.Identifier, reason, c.plan.BaseSHA, turn.ToolInstructions)
+	var selection workspace.CheckpointSelection
+	var submitted bool
+	var mu sync.Mutex
+	req := c.request
+	req.sessionBrake = nil
+	req.AgentTools = []AgentTool{{Name: "detent_checkpoint_selection", Description: "Approve exact intended issue files and commit history for an incomplete recovery checkpoint. This selection authorizes no completion or review transition.", InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false,"required":["head_sha","paths","reviewed"],"properties":{"head_sha":{"type":"string","minLength":40,"maxLength":64},"paths":{"type":"array","maxItems":1000,"items":{"type":"string"}},"reviewed":{"type":"boolean"}}}`)}}
+	req.AgentToolHandler = func(ctx context.Context, call AgentToolCall) (AgentToolResult, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if call.Name != "detent_checkpoint_selection" || submitted {
+			return AgentToolResult{Content: "checkpoint selection already submitted or unsupported tool"}, nil
+		}
+		if err := c.validate(ctx); err != nil {
+			return AgentToolResult{}, err
+		}
+		decoder := json.NewDecoder(strings.NewReader(string(call.Arguments)))
+		decoder.DisallowUnknownFields()
+		var proposed workspace.CheckpointSelection
+		if err := decoder.Decode(&proposed); err != nil {
+			return AgentToolResult{Content: "invalid checkpoint selection"}, nil
+		}
+		if err := decoder.Decode(new(any)); !errors.Is(err, io.EOF) || !proposed.Reviewed || len(proposed.Paths) > 1000 || len(proposed.HeadSHA) < 40 || len(proposed.HeadSHA) > 64 {
+			return AgentToolResult{Content: "one reviewed selection with an exact HEAD is required"}, nil
+		}
+		selection = proposed
+		submitted = true
+		return AgentToolResult{Success: true, Content: "Selection received. Return now; Detent will verify and checkpoint after the worker process exits."}, nil
+	}
+	execution := run(checkpointCtx, turn, req)
+	if execution.err != nil {
+		finish("Checkpoint worker did not finish successfully. Publication was not attempted; inspect retained local work.")
+		return execution
+	}
+	if !submitted {
+		finish("Checkpoint worker returned without an approved selection. Publication was not attempted; inspect retained local work.")
+		return execution
+	}
+	record.HeadSHA = selection.HeadSHA
+	record.Paths = selection.Paths
+	tempDir, err := workspace.PrepareWorkerScratch(checkpointCtx, c.plan.Info.Path)
+	if err != nil {
+		finish("Checkpoint credential isolation was unavailable. Publication was not attempted; inspect retained local work.")
+		return execution
+	}
+	defer func() {
+		if err := workspace.CleanupWorkerScratch(c.plan.Info.Path); err != nil {
+			r.logWorkerEvent(c.request.Issue, "worker_checkpoint_scratch_cleanup_failed", "error", err)
+		}
+	}()
+	turn.TempDir = tempDir
+	if err := configureWorkerGitHubEnvironment(&turn); err != nil {
+		finish("Checkpoint credentials were unavailable. Publication was not attempted; inspect retained local work.")
+		return execution
+	}
+	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+		turn.Environment.Variables[key] = tempDir
+	}
+	head, err := c.backend.Checkpoint(checkpointCtx, c.plan, selection, c.validate, turn.Environment)
+	if head != "" {
+		record.HeadSHA = head
+	}
+	if err != nil {
+		r.logWorkerEvent(c.request.Issue, "worker_checkpoint_publish_failed", "error", err)
+		finish("Checkpoint publication could not be verified (ownership, selected content, Git hooks, credentials, or remote state). Retain local work and inspect the remote before retrying.")
+		return execution
+	}
+	record.Published = head != c.plan.BaseSHA
+	record.Status = "unchanged"
+	record.Detail = "No issue commit to publish. Checkpoint is not validated delivery."
+	if record.Published {
+		record.Status = "published"
+		record.Detail = "Checkpoint commit verified on the owned remote branch. Work remains incomplete and subject to the normal completion, review, and CI gates."
+		r.saveWorkerCheckpoint(c, record)
+		url, err := checkpointPullRequest(checkpointCtx, c, turn, checkpointCommand)
+		if err != nil {
+			record.Detail += " Draft PR association unavailable; recover from the verified branch."
+		} else {
+			record.PullRequest = url
+		}
+	}
+	r.saveWorkerCheckpoint(c, record)
+	return execution
+}
+
+type checkpointCommander func(context.Context, AgentTurnRequest, ...string) (string, error)
+
+func checkpointCommand(ctx context.Context, turn AgentTurnRequest, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = turn.Workspace
+	cmd.WaitDelay = 5 * time.Second
+	procgroup.SetEnvironment(cmd, turn.Environment)
+	procgroup.SetTempDir(cmd, turn.TempDir)
+	output, err := cmd.Output()
+	return strings.TrimSpace(string(output)), err
+}
+
+func checkpointPullRequest(ctx context.Context, c *workerCheckpoint, turn AgentTurnRequest, command checkpointCommander) (string, error) {
+	if err := c.validate(ctx); err != nil {
+		return "", err
+	}
+	repository := strings.TrimSpace(turn.DeliverableRepository)
+	if repository == "" {
+		return "", errors.New("checkpoint PR repository is unavailable")
+	}
+	output, err := command(ctx, turn, "pr", "list", "--repo", repository, "--head", c.plan.Info.Branch, "--state", "open", "--json", "url", "--limit", "2")
+	if err != nil {
+		return "", err
+	}
+	var existing []struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(output), &existing); err != nil {
+		return "", err
+	}
+	if len(existing) == 1 {
+		return existing[0].URL, nil
+	}
+	if len(existing) > 1 {
+		return "", errors.New("multiple checkpoint pull requests require reconciliation")
+	}
+	if err := c.validate(ctx); err != nil {
+		return "", err
+	}
+	return command(ctx, turn, "pr", "create", "--repo", repository, "--head", c.plan.Info.Branch, "--draft", "--title", "Checkpoint: "+c.request.Issue.Title, "--body", "Incomplete recovery checkpoint for "+c.request.Issue.Identifier+".\n\nWork is not validated delivery. The normal completion, review, and CI gates still apply.")
+}
+
+func (r *Runner) runCheckpointedTurn(parent, session context.Context, c *workerCheckpoint, cfg config.Agent, backend AgentBackend, turn AgentTurnRequest, req RunRequest, run func(context.Context, AgentTurnRequest, RunRequest) agentTurnExecution) agentTurnExecution {
+	initialTokenOffset := req.sessionTokenOffset
+	_, supportsCheckpoint := backend.(AgentToolBackend)
+	if c != nil {
+		c.request = req
+	}
+	var combined *agentTurnExecution
+	for {
+		turnCtx := session
+		cancel := func() {}
+		if c != nil && !c.prepareFailed && supportsCheckpoint && cfg.CheckpointIntervalMS > 0 {
+			turnCtx, cancel = context.WithTimeoutCause(session, durationFromMillis(cfg.CheckpointIntervalMS), errPeriodicCheckpoint)
+		}
+		execution := run(turnCtx, turn, req)
+		periodic := errors.Is(context.Cause(turnCtx), errPeriodicCheckpoint)
+		cancel()
+		if combined != nil {
+			execution = mergeAgentTurnExecutions(*combined, execution)
+		}
+		if c == nil {
+			return execution
+		}
+		if !periodic && !durationLimitError(execution.err) && parent.Err() == nil && execution.err == nil {
+			execution.result.Checkpoint = c.record
+			return execution
+		}
+		reason := "interrupted"
+		if periodic {
+			reason = "periodic"
+		} else if errors.Is(execution.err, ErrSessionDurationExceeded) {
+			reason = SessionBrakeReasonDuration
+		} else if errors.Is(execution.err, ErrSessionNoProgress) {
+			reason = SessionBrakeReasonNoProgress
+		}
+		if !periodic && !durationLimitError(execution.err) || errors.Is(execution.err, ErrWorkerProcessReap) || parent.Err() != nil {
+			r.saveWorkerCheckpoint(c, workspace.CheckpointRecord{Reason: reason, Status: "local_only", Detail: "Worker interrupted or could not be reaped. No checkpoint epilogue ran; inspect the retained workspace and prior remote checkpoint evidence."})
+			execution.result.Checkpoint = c.record
+			return execution
+		}
+		checkpointTurn := turn
+		checkpointTurn.Resume = AgentResume{ThreadID: execution.turnResult.ThreadID, SessionID: execution.turnResult.SessionID}
+		c.request.sessionTurnOffset = execution.turnCount
+		c.request.sessionTokenOffset = initialTokenOffset + execution.result.Tokens.TotalTokens
+		recovery := r.workerCheckpoint(parent, c, reason, backend, checkpointTurn, run)
+		originalErr, originalState := execution.err, execution.result.FinalState
+		execution = mergeAgentTurnExecutions(execution, recovery)
+		execution.err, execution.result.FinalState = originalErr, originalState
+		execution.result.Checkpoint = c.record
+		if periodic && session.Err() != nil {
+			execution.err = context.Cause(session)
+			execution.result.FinalState = finalStateForTurnError(execution.err)
+		}
+		if !periodic || session.Err() != nil || recovery.err != nil {
+			return execution
+		}
+		turn.Resume = checkpointTurn.Resume
+		if recovery.turnResult.ThreadID != "" || recovery.turnResult.SessionID != "" {
+			turn.Resume = AgentResume{ThreadID: recovery.turnResult.ThreadID, SessionID: recovery.turnResult.SessionID}
+		}
+		turn.Prompt = "Continue the assigned issue work after the recovery checkpoint. Checkpoint publication is incomplete work; all original completion and review gates still apply."
+		req.sessionTurnOffset = execution.turnCount
+		req.sessionTokenOffset = initialTokenOffset + execution.result.Tokens.TotalTokens
+		combined = &execution
+	}
+}

--- a/internal/runner/checkpoint.go
+++ b/internal/runner/checkpoint.go
@@ -205,10 +205,9 @@ func (r *Runner) workerCheckpoint(ctx context.Context, c *workerCheckpoint, reas
 	return execution
 }
 
-type checkpointCommander func(context.Context, AgentTurnRequest, ...string) (string, error)
+type checkpointCommander func(AgentTurnRequest, *exec.Cmd) (string, error)
 
-func checkpointCommand(ctx context.Context, turn AgentTurnRequest, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", args...)
+func checkpointCommand(turn AgentTurnRequest, cmd *exec.Cmd) (string, error) {
 	cmd.Dir = turn.Workspace
 	cmd.WaitDelay = 5 * time.Second
 	procgroup.SetEnvironment(cmd, turn.Environment)
@@ -218,6 +217,9 @@ func checkpointCommand(ctx context.Context, turn AgentTurnRequest, args ...strin
 }
 
 func checkpointPullRequest(ctx context.Context, c *workerCheckpoint, turn AgentTurnRequest, command checkpointCommander) (string, error) {
+	if turn.DeliverableKind != config.DeliverablePullRequest {
+		return "", nil
+	}
 	if err := c.validate(ctx); err != nil {
 		return "", err
 	}
@@ -225,7 +227,9 @@ func checkpointPullRequest(ctx context.Context, c *workerCheckpoint, turn AgentT
 	if repository == "" {
 		return "", errors.New("checkpoint PR repository is unavailable")
 	}
-	output, err := command(ctx, turn, "pr", "list", "--repo", repository, "--head", c.plan.Info.Branch, "--state", "open", "--json", "url", "--limit", "2")
+	list := exec.CommandContext(ctx, "gh", "pr", "list", "--state", "open", "--json", "url", "--limit", "2")
+	list.Args = append(list.Args, "--repo="+repository, "--head="+c.plan.Info.Branch)
+	output, err := command(turn, list)
 	if err != nil {
 		return "", err
 	}
@@ -244,7 +248,14 @@ func checkpointPullRequest(ctx context.Context, c *workerCheckpoint, turn AgentT
 	if err := c.validate(ctx); err != nil {
 		return "", err
 	}
-	return command(ctx, turn, "pr", "create", "--repo", repository, "--head", c.plan.Info.Branch, "--draft", "--title", "Checkpoint: "+c.request.Issue.Title, "--body", "Incomplete recovery checkpoint for "+c.request.Issue.Identifier+".\n\nWork is not validated delivery. The normal completion, review, and CI gates still apply.")
+	create := exec.CommandContext(ctx, "gh", "pr", "create", "--draft")
+	if c.request.Issue.PullRequest != nil && c.request.Issue.PullRequest.BaseRef != "" {
+		create.Args = append(create.Args, "--base="+c.request.Issue.PullRequest.BaseRef)
+	}
+	create.Args = append(create.Args, "--repo="+repository, "--head="+c.plan.Info.Branch,
+		"--title=Checkpoint: "+c.request.Issue.Title,
+		"--body=Incomplete recovery checkpoint for "+c.request.Issue.Identifier+".\n\nWork is not validated delivery. The normal completion, review, and CI gates still apply.")
+	return command(turn, create)
 }
 
 func (r *Runner) runCheckpointedTurn(parent, session context.Context, c *workerCheckpoint, cfg config.Agent, backend AgentBackend, turn AgentTurnRequest, req RunRequest, run func(context.Context, AgentTurnRequest, RunRequest) agentTurnExecution) agentTurnExecution {

--- a/internal/runner/checkpoint_test.go
+++ b/internal/runner/checkpoint_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -163,19 +165,26 @@ func TestWorkerCheckpointHandshake(t *testing.T) {
 
 func TestCheckpointPullRequestAssociation(t *testing.T) {
 	t.Parallel()
-	for _, scenario := range []string{"existing ready PR", "new draft PR", "multiple PRs", "network failure", "invalid response", "lost lease", "unknown repository", "ownership lost before create"} {
+	for _, scenario := range []string{"existing ready PR", "new draft PR", "prior PR base", "artifact deliverable", "multiple PRs", "network failure", "invalid response", "lost lease", "unknown repository", "ownership lost before create"} {
 		t.Run(scenario, func(t *testing.T) {
 			t.Parallel()
 			_, checkpoint, _ := checkpointRunnerFixture(t)
 			calls := 0
-			turn := AgentTurnRequest{DeliverableRepository: "example/repo"}
+			turn := AgentTurnRequest{DeliverableKind: config.DeliverablePullRequest, DeliverableRepository: "example/repo"}
+			if scenario == "artifact deliverable" {
+				turn.DeliverableKind = config.DeliverableArtifact
+			}
+			if scenario == "prior PR base" {
+				checkpoint.request.Issue.PullRequest = &connector.PullRequest{State: "closed", BaseRef: "release/stable"}
+			}
 			if scenario == "unknown repository" {
 				turn.DeliverableRepository = ""
 			}
 			if scenario == "lost lease" {
 				checkpoint.request.CheckpointValidate = func(context.Context) error { return ErrExecutionAuthorityUnavailable }
 			}
-			command := func(_ context.Context, _ AgentTurnRequest, args ...string) (string, error) {
+			command := func(_ AgentTurnRequest, cmd *exec.Cmd) (string, error) {
+				args := cmd.Args[1:]
 				calls++
 				if calls == 1 {
 					if args[1] != "list" {
@@ -198,10 +207,13 @@ func TestCheckpointPullRequestAssociation(t *testing.T) {
 				if args[1] != "create" || !strings.Contains(strings.Join(args, " "), "--draft") {
 					t.Fatalf("expected draft creation: %v", args)
 				}
+				if got := slices.Contains(args, "--base=release/stable"); got != (scenario == "prior PR base") {
+					t.Fatalf("incorrect draft base: %v", args)
+				}
 				return "https://example/pr/2", nil
 			}
 			url, err := checkpointPullRequest(t.Context(), checkpoint, turn, command)
-			wantOK := scenario == "existing ready PR" || scenario == "new draft PR"
+			wantOK := scenario == "existing ready PR" || scenario == "new draft PR" || scenario == "prior PR base" || scenario == "artifact deliverable"
 			if wantOK != (err == nil) {
 				t.Fatalf("PR = %s, %v", url, err)
 			}
@@ -210,6 +222,9 @@ func TestCheckpointPullRequestAssociation(t *testing.T) {
 			}
 			if scenario == "new draft PR" && calls != 2 {
 				t.Fatal("draft was not associated")
+			}
+			if scenario == "artifact deliverable" && (calls != 0 || url != "") {
+				t.Fatalf("artifact checkpoint associated a PR: calls=%d url=%q", calls, url)
 			}
 		})
 	}
@@ -435,7 +450,7 @@ func TestCheckpointCommandCancellation(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	_, err := checkpointCommand(ctx, AgentTurnRequest{Workspace: t.TempDir()}, "--version")
+	_, err := checkpointCommand(AgentTurnRequest{Workspace: t.TempDir()}, exec.CommandContext(ctx, "gh", "--version"))
 	if err == nil {
 		t.Fatal("cancelled command succeeded")
 	}

--- a/internal/runner/checkpoint_test.go
+++ b/internal/runner/checkpoint_test.go
@@ -1,0 +1,550 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+type checkpointBackendStub struct {
+	calls       int
+	err         error
+	published   string
+	environment procgroup.Environment
+}
+
+func (b *checkpointBackendStub) PrepareCheckpoint(context.Context, workspace.Info, workspace.Issue) (workspace.CheckpointPlan, error) {
+	return workspace.CheckpointPlan{}, nil
+}
+
+func (b *checkpointBackendStub) Checkpoint(ctx context.Context, _ workspace.CheckpointPlan, selection workspace.CheckpointSelection, guard func(context.Context) error, environment procgroup.Environment) (string, error) {
+	b.calls++
+	b.environment = environment
+	if err := guard(ctx); err != nil {
+		return "", err
+	}
+	if !selection.Reviewed || len(selection.Paths) != 1 || selection.Paths[0] != "implementation.go" {
+		return "", errors.New("wrong selection")
+	}
+	return b.published, b.err
+}
+
+type checkpointAgentStub struct{}
+
+func (checkpointAgentStub) RunTurn(context.Context, AgentTurnRequest, AgentUpdateHandler) (AgentTurnResult, error) {
+	return AgentTurnResult{}, nil
+}
+func (checkpointAgentStub) RunTurnWithTools(context.Context, AgentTurnRequest, []AgentTool, AgentToolHandler, AgentUpdateHandler) (AgentTurnResult, error) {
+	return AgentTurnResult{}, nil
+}
+
+func checkpointRunnerFixture(t *testing.T) (*Runner, *workerCheckpoint, *checkpointBackendStub) {
+	t.Helper()
+	root := t.TempDir()
+	backend := &checkpointBackendStub{published: strings.Repeat("b", 40)}
+	return &Runner{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: time.Now}, &workerCheckpoint{
+		backend: backend,
+		plan:    workspace.CheckpointPlan{Info: workspace.Info{Path: root, Branch: "owned-issue"}, BaseSHA: strings.Repeat("a", 40), Journal: filepath.Join(root, "checkpoint.json")},
+		request: RunRequest{Issue: connector.Issue{ID: "2313", Identifier: "example/repo#2313", Title: "Recover intended work"}, CheckpointValidate: func(context.Context) error { return nil }},
+	}, backend
+}
+
+func submitCheckpoint(t *testing.T, ctx context.Context, req RunRequest) {
+	t.Helper()
+	arguments, err := json.Marshal(workspace.CheckpointSelection{HeadSHA: strings.Repeat("a", 40), Paths: []string{"implementation.go"}, Reviewed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := req.AgentToolHandler(ctx, AgentToolCall{Name: "detent_checkpoint_selection", Arguments: arguments})
+	if err != nil || !result.Success {
+		t.Fatalf("selection = %+v, %v", result, err)
+	}
+}
+
+func TestWorkerCheckpointHandshake(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"published", "unchanged", "cancelled", "lost ownership", "unsupported provider", "provider unavailable", "no selection", "network unavailable", "duplicate selection", "invalid selection", "cancel during handshake"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			runner, checkpoint, publication := checkpointRunnerFixture(t)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var agent AgentBackend = checkpointAgentStub{}
+			calls := 0
+			if scenario == "cancelled" {
+				cancel()
+			}
+			if scenario == "lost ownership" {
+				checkpoint.request.CheckpointValidate = func(context.Context) error { return ErrExecutionAuthorityUnavailable }
+			}
+			if scenario == "unsupported provider" {
+				agent = nonVerifyingAgentBackend{}
+			}
+			if scenario == "network unavailable" {
+				publication.err = errors.New("network unavailable")
+			}
+			if scenario == "unchanged" {
+				publication.published = checkpoint.plan.BaseSHA
+			}
+			run := func(ctx context.Context, turn AgentTurnRequest, req RunRequest) agentTurnExecution {
+				calls++
+				if !turn.ReadOnly || !turn.SupplementalTools || req.sessionBrake != nil || turn.MaxDuration != checkpointTimeout {
+					t.Fatalf("unbounded or writable checkpoint: %+v", turn)
+				}
+				if _, ok := ctx.Deadline(); !ok {
+					t.Fatal("checkpoint lacks deadline")
+				}
+				if scenario == "provider unavailable" {
+					return agentTurnExecution{err: errors.New("provider unavailable")}
+				}
+				if scenario == "no selection" {
+					return agentTurnExecution{}
+				}
+				if scenario == "invalid selection" {
+					for _, input := range []string{`{}`, `{"reviewed":true} {}`, `{"unknown":true}`, `{"head_sha":"x","paths":[],"reviewed":true}`} {
+						result, err := req.AgentToolHandler(ctx, AgentToolCall{Name: "detent_checkpoint_selection", Arguments: json.RawMessage(input)})
+						if err != nil || result.Success {
+							t.Fatalf("invalid selection accepted: %+v %v", result, err)
+						}
+					}
+					return agentTurnExecution{}
+				}
+				submitCheckpoint(t, ctx, req)
+				if scenario == "duplicate selection" {
+					result, err := req.AgentToolHandler(ctx, AgentToolCall{Name: "detent_checkpoint_selection", Arguments: json.RawMessage(`{}`)})
+					if result.Success || err != nil {
+						t.Fatalf("duplicate accepted: %+v, %v", result, err)
+					}
+				}
+				if scenario == "cancel during handshake" {
+					cancel()
+				}
+				return agentTurnExecution{result: RunResult{FinalState: FinalStateCompleted}}
+			}
+			runner.workerCheckpoint(ctx, checkpoint, SessionBrakeReasonDuration, agent, AgentTurnRequest{}, run)
+			wantPublished := scenario == "published" || scenario == "duplicate selection"
+			if checkpoint.record == nil || checkpoint.record.Published != wantPublished {
+				t.Fatalf("record = %+v; published = %v", checkpoint.record, wantPublished)
+			}
+			if scenario == "cancelled" || scenario == "lost ownership" || scenario == "unsupported provider" {
+				if calls != 0 || publication.calls != 0 || !strings.Contains(checkpoint.record.Detail, "No checkpoint epilogue ran") {
+					t.Fatalf("unexpected epilogue: calls=%d, publication=%d, record=%+v", calls, publication.calls, checkpoint.record)
+				}
+			}
+			data, err := os.ReadFile(checkpoint.plan.Journal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var durable workspace.CheckpointRecord
+			if err := json.Unmarshal(data, &durable); err != nil {
+				t.Fatal(err)
+			}
+			if durable.Published != wantPublished || durable.Status != checkpoint.record.Status {
+				t.Fatalf("durable record mismatch: %+v", durable)
+			}
+		})
+	}
+}
+
+func TestCheckpointPullRequestAssociation(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"existing ready PR", "new draft PR", "multiple PRs", "network failure", "invalid response", "lost lease", "unknown repository", "ownership lost before create"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			_, checkpoint, _ := checkpointRunnerFixture(t)
+			calls := 0
+			turn := AgentTurnRequest{DeliverableRepository: "example/repo"}
+			if scenario == "unknown repository" {
+				turn.DeliverableRepository = ""
+			}
+			if scenario == "lost lease" {
+				checkpoint.request.CheckpointValidate = func(context.Context) error { return ErrExecutionAuthorityUnavailable }
+			}
+			command := func(_ context.Context, _ AgentTurnRequest, args ...string) (string, error) {
+				calls++
+				if calls == 1 {
+					if args[1] != "list" {
+						t.Fatalf("expected lookup: %v", args)
+					}
+					switch scenario {
+					case "existing ready PR":
+						return `[{"url":"https://example/pr/1"}]`, nil
+					case "multiple PRs":
+						return `[{},{}]`, nil
+					case "invalid response":
+						return `{`, nil
+					case "network failure":
+						return "", errors.New("network")
+					case "ownership lost before create":
+						checkpoint.request.CheckpointValidate = func(context.Context) error { return ErrExecutionAuthorityUnavailable }
+					}
+					return `[]`, nil
+				}
+				if args[1] != "create" || !strings.Contains(strings.Join(args, " "), "--draft") {
+					t.Fatalf("expected draft creation: %v", args)
+				}
+				return "https://example/pr/2", nil
+			}
+			url, err := checkpointPullRequest(t.Context(), checkpoint, turn, command)
+			wantOK := scenario == "existing ready PR" || scenario == "new draft PR"
+			if wantOK != (err == nil) {
+				t.Fatalf("PR = %s, %v", url, err)
+			}
+			if scenario == "existing ready PR" && calls != 1 {
+				t.Fatal("existing PR changed")
+			}
+			if scenario == "new draft PR" && calls != 2 {
+				t.Fatal("draft was not associated")
+			}
+		})
+	}
+}
+
+func TestCheckpointBoundedPeriodicAndTerminalTurns(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"duration", "no progress", "cancelled", "hard reap failure", "periodic", "checkpoint timeout", "duration during checkpoint"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			runner, checkpoint, publication := checkpointRunnerFixture(t)
+			synctest.Test(t, func(t *testing.T) {
+				parent, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				session := parent
+				cfg := config.Agent{}
+				if scenario == "periodic" || scenario == "duration during checkpoint" {
+					cfg.CheckpointIntervalMS = 1000
+				}
+				if scenario == "duration during checkpoint" {
+					var stop context.CancelFunc
+					session, stop = context.WithTimeoutCause(parent, 2*time.Second, ErrSessionDurationExceeded)
+					defer stop()
+				}
+				calls, handshakes := 0, 0
+				checkpoint.fingerprint = func(context.Context) (string, error) { return "identical-state", nil }
+				run := func(ctx context.Context, turn AgentTurnRequest, req RunRequest) agentTurnExecution {
+					if turn.ReadOnly {
+						handshakes++
+						if scenario == "checkpoint timeout" {
+							<-ctx.Done()
+							return agentTurnExecution{err: ctx.Err()}
+						}
+						if scenario == "duration during checkpoint" {
+							time.Sleep(2 * time.Second)
+						}
+						submitCheckpoint(t, ctx, req)
+						return agentTurnExecution{}
+					}
+					calls++
+					switch scenario {
+					case "duration", "checkpoint timeout":
+						return agentTurnExecution{err: ErrSessionDurationExceeded, result: RunResult{FinalState: FinalStateSessionDurationExceeded}}
+					case "no progress":
+						return agentTurnExecution{err: ErrSessionNoProgress}
+					case "cancelled":
+						cancel()
+						return agentTurnExecution{err: context.Canceled}
+					case "hard reap failure":
+						return agentTurnExecution{err: errors.Join(ErrSessionDurationExceeded, ErrWorkerProcessReap)}
+					case "periodic":
+						if calls == 3 {
+							return agentTurnExecution{result: RunResult{FinalState: FinalStateCompleted}}
+						}
+					}
+					<-ctx.Done()
+					return agentTurnExecution{err: context.Cause(ctx)}
+				}
+				result := runner.runCheckpointedTurn(parent, session, checkpoint, cfg, checkpointAgentStub{}, AgentTurnRequest{}, checkpoint.request, run)
+				if scenario == "periodic" {
+					if result.err != nil || calls != 3 || handshakes != 1 || publication.calls != 1 {
+						t.Fatalf("repeated checkpoint made progress: calls=%d handshake=%d publication=%d result=%+v", calls, handshakes, publication.calls, result)
+					}
+				} else if result.err == nil {
+					t.Fatal("checkpoint converted failure into completion")
+				}
+				if scenario == "cancelled" || scenario == "hard reap failure" {
+					if handshakes != 0 || publication.calls != 0 {
+						t.Fatal("unreachable epilogue ran")
+					}
+				}
+				if scenario == "checkpoint timeout" && publication.calls != 0 {
+					t.Fatal("timed out checkpoint published")
+				}
+				if scenario == "duration during checkpoint" && !errors.Is(result.err, ErrSessionDurationExceeded) {
+					t.Fatalf("session deadline extended: %v", result.err)
+				}
+			})
+		})
+	}
+}
+
+func TestCheckpointPublicationCredentialIsolation(t *testing.T) {
+	t.Parallel()
+	for _, unavailable := range []bool{false, true} {
+		t.Run(strconv.FormatBool(unavailable), func(t *testing.T) {
+			t.Parallel()
+			r, checkpoint, publication := checkpointRunnerFixture(t)
+			turn := AgentTurnRequest{workerGitHub: workerGitHubPolicy{Token: "selected-credential"}}
+			run := func(ctx context.Context, _ AgentTurnRequest, req RunRequest) agentTurnExecution {
+				submitCheckpoint(t, ctx, req)
+				if unavailable {
+					if err := os.WriteFile(filepath.Join(checkpoint.plan.Info.Path, ".detent"), []byte("unavailable scratch"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return agentTurnExecution{}
+			}
+			r.workerCheckpoint(t.Context(), checkpoint, "duration", checkpointAgentStub{}, turn, run)
+			if unavailable {
+				if publication.calls != 0 || checkpoint.record.Published {
+					t.Fatal("published without credential isolation")
+				}
+				return
+			}
+			if publication.environment.Variables["GH_TOKEN"] != "selected-credential" || publication.environment.Variables["GH_CONFIG_DIR"] == "" {
+				t.Fatal("publication did not use isolated selected credentials")
+			}
+			if _, err := os.Stat(publication.environment.Variables["GH_CONFIG_DIR"]); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("credential environment retained: %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckpointResumePreservesTokenCeiling(t *testing.T) {
+	t.Parallel()
+	for _, offset := range []int64{0, 50} {
+		t.Run(strconv.FormatInt(offset, 10), func(t *testing.T) {
+			t.Parallel()
+			r, _, _ := checkpointRunnerFixture(t)
+			backend := &toolUpdateAgentBackend{updates: []AgentUpdate{{Type: AgentUpdateTokenUsage, Tokens: AgentTokenUsage{TotalTokens: 60}}}}
+			execution := r.runAgentTurn(t.Context(), backend, AgentTurnRequest{}, RunRequest{sessionTokenOffset: offset}, workspace.Info{}, workspace.Issue{}, config.Agent{MaxSessionTokens: 100}, "", nil, time.Now(), 0, agentidentity.Identity{}, nil, 0, "", "")
+			var ceiling *SessionTokenCeilingError
+			if errors.As(execution.err, &ceiling) != (offset > 0) {
+				t.Fatalf("ceiling reset on resume: %v", execution.err)
+			}
+			if execution.result.Tokens.TotalTokens != 60 {
+				t.Fatalf("offset double-counted usage: %+v", execution.result.Tokens)
+			}
+		})
+	}
+}
+
+type preparingCheckpointBackend struct {
+	*fakeWorkspaceBackend
+	checkpointBackendStub
+	plan       workspace.CheckpointPlan
+	prepareErr error
+}
+
+func (b *preparingCheckpointBackend) PrepareCheckpoint(context.Context, workspace.Info, workspace.Issue) (workspace.CheckpointPlan, error) {
+	return b.plan, b.prepareErr
+}
+
+func TestPrepareWorkerCheckpoint(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"prepared", "unsupported", "routine", "unavailable", "journal unavailable"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			r, cp, _ := checkpointRunnerFixture(t)
+			base := &preparingCheckpointBackend{fakeWorkspaceBackend: &fakeWorkspaceBackend{recoveryStates: []workspace.RecoveryState{{WorkspaceFingerprint: "state"}}}, plan: cp.plan}
+			var backend workspace.Backend = base
+			req := cp.request
+			switch scenario {
+			case "unsupported":
+				backend = base.fakeWorkspaceBackend
+			case "routine":
+				req.Mode = RunModeRoutine
+			case "unavailable", "journal unavailable":
+				base.prepareErr = errors.New("preparation unavailable")
+			}
+			if scenario == "journal unavailable" {
+				base.plan.Journal = ""
+			}
+			got := r.prepareWorkerCheckpoint(t.Context(), req, backend, cp.plan.Info, workspace.Issue{})
+			if scenario == "prepared" {
+				if got == nil {
+					t.Fatal("checkpoint unavailable")
+				}
+				fingerprint, err := got.fingerprint(t.Context())
+				if err != nil || fingerprint != "state" {
+					t.Fatalf("fingerprint = %s, %v", fingerprint, err)
+				}
+			} else if scenario == "unavailable" {
+				if got == nil || !got.prepareFailed {
+					t.Fatal("preparation failure lost its recovery state")
+				}
+				execution := r.runCheckpointedTurn(t.Context(), t.Context(), got, config.Agent{CheckpointIntervalMS: 1}, checkpointAgentStub{}, AgentTurnRequest{}, req, func(ctx context.Context, turn AgentTurnRequest, _ RunRequest) agentTurnExecution {
+					if turn.ReadOnly {
+						t.Fatal("unavailable preparation launched a checkpoint worker")
+					}
+					if _, bounded := ctx.Deadline(); bounded {
+						t.Fatal("unavailable preparation interrupted work for a periodic checkpoint")
+					}
+					return agentTurnExecution{err: ErrSessionDurationExceeded}
+				})
+				if execution.result.Checkpoint == nil || execution.result.Checkpoint.Published || !strings.Contains(execution.result.Checkpoint.Detail, "No checkpoint epilogue ran") {
+					t.Fatalf("missing terminal recovery state: %+v", execution.result.Checkpoint)
+				}
+			} else if got != nil {
+				t.Fatal("unexpected checkpoint")
+			}
+			if scenario == "unavailable" {
+				data, err := os.ReadFile(cp.plan.Journal)
+				if err != nil || !strings.Contains(string(data), "local_only") {
+					t.Fatalf("missing preparation recovery: %s, %v", data, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckpointAuthorityAndJournalFailures(t *testing.T) {
+	t.Parallel()
+	r, cp, _ := checkpointRunnerFixture(t)
+	cp.request.CheckpointValidate = nil
+	if !errors.Is(cp.validate(t.Context()), ErrExecutionAuthorityUnavailable) {
+		t.Fatal("missing authority accepted")
+	}
+	cp.request.Execution = &testExecution{validateErr: context.Canceled}
+	if !errors.Is(cp.validate(t.Context()), context.Canceled) {
+		t.Fatal("native authority ignored")
+	}
+	cp.plan.Journal = ""
+	r.saveWorkerCheckpoint(cp, workspace.CheckpointRecord{Status: "local_only"})
+	if cp.record == nil || cp.record.Status != "local_only" {
+		t.Fatal("journal failure erased in-memory recovery")
+	}
+}
+
+func TestCheckpointCommandCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := checkpointCommand(ctx, AgentTurnRequest{Workspace: t.TempDir()}, "--version")
+	if err == nil {
+		t.Fatal("cancelled command succeeded")
+	}
+}
+
+func TestCheckpointRetentionSkipsAfterRun(t *testing.T) {
+	t.Parallel()
+	for _, native := range []bool{false, true} {
+		for _, retain := range []bool{false, true} {
+			t.Run(strconv.FormatBool(native)+"/"+strconv.FormatBool(retain), func(t *testing.T) {
+				t.Parallel()
+				r, _, _ := checkpointRunnerFixture(t)
+				r.afterRunTimeout = time.Minute
+				backend := &fakeWorkspaceBackend{}
+				req := RunRequest{retainCheckpoint: retain}
+				execution := &testExecution{}
+				if native {
+					req.Execution = execution
+				}
+				if err := r.afterExecution(t.Context(), req, backend, workspace.Info{}, workspace.Issue{}); err != nil {
+					t.Fatal(err)
+				}
+				if backend.afterRun == retain {
+					t.Fatalf("retained checkpoint cleanup = %v", backend.afterRun)
+				}
+				if native && execution.checkpoint == nil {
+					t.Fatal("native recovery evidence missing")
+				}
+			})
+		}
+	}
+}
+
+func TestPeriodicCheckpointPreservesRecoveryUsageOffset(t *testing.T) {
+	t.Parallel()
+	r, cp, _ := checkpointRunnerFixture(t)
+	synctest.Test(t, func(t *testing.T) {
+		req := cp.request
+		req.sessionTokenOffset = 40
+		calls := 0
+		run := func(ctx context.Context, turn AgentTurnRequest, req RunRequest) agentTurnExecution {
+			if turn.ReadOnly {
+				if req.sessionTokenOffset != 50 {
+					t.Fatalf("handshake offset = %d", req.sessionTokenOffset)
+				}
+				submitCheckpoint(t, ctx, req)
+				return agentTurnExecution{result: RunResult{Tokens: TokenTotals{TotalTokens: 5}}}
+			}
+			calls++
+			if calls == 1 {
+				if req.sessionTokenOffset != 40 {
+					t.Fatalf("initial offset = %d", req.sessionTokenOffset)
+				}
+				<-ctx.Done()
+				return agentTurnExecution{err: context.Cause(ctx), result: RunResult{Tokens: TokenTotals{TotalTokens: 10}}}
+			}
+			if req.sessionTokenOffset != 55 {
+				t.Fatalf("resume offset = %d", req.sessionTokenOffset)
+			}
+			return agentTurnExecution{result: RunResult{FinalState: FinalStateCompleted, Tokens: TokenTotals{TotalTokens: 10}}}
+		}
+		result := r.runCheckpointedTurn(t.Context(), t.Context(), cp, config.Agent{CheckpointIntervalMS: 1000}, checkpointAgentStub{}, AgentTurnRequest{}, req, run)
+		if result.err != nil || result.result.Tokens.TotalTokens != 25 {
+			t.Fatalf("recovery usage = %+v, %v", result.result.Tokens, result.err)
+		}
+	})
+}
+
+func TestTerminalCheckpointRetriesUnavailablePeriodicPublication(t *testing.T) {
+	t.Parallel()
+	r, cp, publication := checkpointRunnerFixture(t)
+	cp.fingerprint = func(context.Context) (string, error) { return "same-work", nil }
+	publication.err = errors.New("network unavailable")
+	handshakes := 0
+	run := func(ctx context.Context, _ AgentTurnRequest, req RunRequest) agentTurnExecution {
+		handshakes++
+		submitCheckpoint(t, ctx, req)
+		return agentTurnExecution{}
+	}
+	r.workerCheckpoint(t.Context(), cp, "periodic", checkpointAgentStub{}, AgentTurnRequest{}, run)
+	publication.err = nil
+	r.workerCheckpoint(t.Context(), cp, "periodic", checkpointAgentStub{}, AgentTurnRequest{}, run)
+	if handshakes != 1 || publication.calls != 1 {
+		t.Fatal("identical periodic work retried")
+	}
+	r.workerCheckpoint(t.Context(), cp, SessionBrakeReasonDuration, checkpointAgentStub{}, AgentTurnRequest{}, run)
+	if handshakes != 2 || publication.calls != 2 || !cp.record.Published {
+		t.Fatal("terminal checkpoint did not retry restored delivery")
+	}
+	r.workerCheckpoint(t.Context(), cp, SessionBrakeReasonDuration, checkpointAgentStub{}, AgentTurnRequest{}, run)
+	if handshakes != 2 {
+		t.Fatal("published work repeated its checkpoint")
+	}
+}
+
+func TestUnsupportedCheckpointProviderDoesNotInterruptPeriodically(t *testing.T) {
+	t.Parallel()
+	r, cp, publication := checkpointRunnerFixture(t)
+	run := func(ctx context.Context, turn AgentTurnRequest, _ RunRequest) agentTurnExecution {
+		if turn.ReadOnly {
+			t.Fatal("unsupported provider launched checkpoint turn")
+		}
+		if _, bounded := ctx.Deadline(); bounded {
+			t.Fatal("unsupported provider received a periodic interruption")
+		}
+		return agentTurnExecution{err: ErrSessionDurationExceeded}
+	}
+	execution := r.runCheckpointedTurn(t.Context(), t.Context(), cp, config.Agent{CheckpointIntervalMS: 1}, nonVerifyingAgentBackend{}, AgentTurnRequest{}, cp.request, run)
+	if execution.result.Checkpoint == nil || publication.calls != 0 || !strings.Contains(execution.result.Checkpoint.Detail, "does not support") {
+		t.Fatalf("provider recovery = %+v", execution.result.Checkpoint)
+	}
+}

--- a/internal/runner/execution.go
+++ b/internal/runner/execution.go
@@ -83,6 +83,9 @@ func (r *Runner) afterExecution(ctx context.Context, req RunRequest, backend wor
 		}
 	}
 	if req.Execution == nil {
+		if req.retainCheckpoint {
+			return nil
+		}
 		afterCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.afterRunTimeout)
 		defer cancel()
 		backend.AfterRun(afterCtx, info, issue)
@@ -107,7 +110,7 @@ func (r *Runner) afterExecution(ctx context.Context, req RunRequest, backend wor
 	if err := req.Execution.Checkpoint(ctx, checkpoint); err != nil {
 		return err
 	}
-	if checkpoint.WorktreeState != "clean" {
+	if checkpoint.WorktreeState != "clean" || req.retainCheckpoint {
 		return nil
 	}
 	afterCtx, stop := context.WithTimeout(ctx, r.afterRunTimeout)

--- a/internal/runner/session_brake.go
+++ b/internal/runner/session_brake.go
@@ -49,6 +49,7 @@ type SessionBrakeError struct {
 	FilesChanged      int
 	UnpushedCommits   int
 	Resumable         bool
+	Checkpoint        *workspace.CheckpointRecord
 	cause             error
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -19,6 +19,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
 const (
@@ -592,6 +593,7 @@ type RunRequest struct {
 	OnActivityUpdate          AgentActivityUpdateHandler
 	OnOverrideRejected        AgentOverrideRejectionHandler
 	ProgressProbe             SessionProgressProbe
+	CheckpointValidate        func(context.Context) error
 	Routine                   *RoutineRequest
 	Admission                 *AdmissionRequest
 	AgentTools                []AgentTool
@@ -604,6 +606,8 @@ type RunRequest struct {
 	workerGitHubActor         connector.IssueActor
 	deliverableRecoveryBranch string
 	sessionTurnOffset         int
+	sessionTokenOffset        int64
+	retainCheckpoint          bool
 }
 
 type ForgeRetry struct {
@@ -720,6 +724,7 @@ type SecurityAuditExecution struct {
 }
 
 type RunResult struct {
+	Checkpoint              *workspace.CheckpointRecord
 	FinalState              string
 	Output                  string
 	Model                   string

--- a/internal/workspace/checkpoint.go
+++ b/internal/workspace/checkpoint.go
@@ -1,0 +1,341 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+)
+
+var ErrCheckpointUnsafe = errors.New("checkpoint could not be safely published")
+
+var checkpointSecretPattern = regexp.MustCompile(`-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|(?:gh[pousr]_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{30,}|AKIA[A-Z0-9]{16}|sk-proj-[A-Za-z0-9_-]{30,})`)
+
+type CheckpointSelection struct {
+	HeadSHA  string   `json:"head_sha"`
+	Paths    []string `json:"paths"`
+	Reviewed bool     `json:"reviewed"`
+}
+
+type CheckpointPlan struct {
+	Info      Info   `json:"workspace"`
+	BaseSHA   string `json:"base_sha"`
+	RemoteURL string `json:"-"`
+	Journal   string `json:"-"`
+}
+
+type CheckpointRecord struct {
+	Schema        int      `json:"schema"`
+	Reason        string   `json:"reason"`
+	Status        string   `json:"status"`
+	WorkspacePath string   `json:"workspace_path"`
+	Branch        string   `json:"branch"`
+	HeadSHA       string   `json:"head_sha,omitempty"`
+	Paths         []string `json:"paths,omitempty"`
+	Published     bool     `json:"published"`
+	PullRequest   string   `json:"pull_request,omitempty"`
+	Detail        string   `json:"detail"`
+}
+
+type CheckpointBackend interface {
+	PrepareCheckpoint(context.Context, Info, Issue) (CheckpointPlan, error)
+	Checkpoint(context.Context, CheckpointPlan, CheckpointSelection, func(context.Context) error, procgroup.Environment) (string, error)
+}
+
+func (l *LocalGit) PrepareCheckpoint(ctx context.Context, info Info, issue Issue) (CheckpointPlan, error) {
+	expected, err := l.infoForIssue(issue)
+	if err != nil {
+		return CheckpointPlan{}, err
+	}
+	automatic := issue
+	automatic.BranchName = ""
+	if !l.autoBranch || expected.Branch == "" || info.Path != expected.Path || info.Branch != l.branchName(automatic, expected.Key) {
+		return CheckpointPlan{}, fmt.Errorf("%w: workspace is not an automatically owned issue branch", ErrCheckpointUnsafe)
+	}
+	if !l.isSourceWorktree(ctx, info.Path) {
+		return CheckpointPlan{}, fmt.Errorf("%w: workspace ownership is unavailable", ErrCheckpointUnsafe)
+	}
+	if err := l.recordCleanupOwnership(ctx, info, issue, true); err != nil {
+		return CheckpointPlan{}, err
+	}
+	record, err := l.readOwnershipRecord(cleanupOwnershipRecordRelativePath(info.Path))
+	if err != nil {
+		return CheckpointPlan{}, err
+	}
+	record.Preserve = true
+	if err := l.writeOwnershipRecord(record); err != nil {
+		return CheckpointPlan{}, err
+	}
+	gitDir, err := runGitAt(ctx, info.Path, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return CheckpointPlan{}, err
+	}
+	plan := CheckpointPlan{Info: info, Journal: filepath.Join(strings.TrimSpace(gitDir), "detent-checkpoint.json")}
+	if err := WriteCheckpointRecord(plan, CheckpointRecord{Reason: "session_started", Status: "active", Detail: "Worker may have local work. No checkpoint handshake or publication has been verified; inspect the retained workspace after an interrupted session."}); err != nil {
+		return plan, err
+	}
+	remote, err := runGitAt(ctx, info.Path, "remote", "get-url", "--push", defaultGitRemote)
+	if err != nil {
+		return plan, err
+	}
+	plan.RemoteURL = strings.TrimSpace(remote)
+	base := strings.TrimSpace(issue.BaseRef)
+	if base == "" {
+		_, base, err = remoteDefaultBranchHead(ctx, info.Path, defaultGitRemote)
+		if err != nil {
+			return plan, err
+		}
+	}
+	baseSHA, err := runGitAt(ctx, info.Path, "merge-base", "HEAD", base)
+	if err != nil {
+		return plan, err
+	}
+	plan.BaseSHA = strings.TrimSpace(baseSHA)
+	return plan, nil
+}
+
+func WriteCheckpointRecord(plan CheckpointPlan, record CheckpointRecord) (returnErr error) {
+	if plan.Journal == "" {
+		return errors.New("checkpoint journal is unavailable")
+	}
+	record.Schema = 1
+	record.WorkspacePath = plan.Info.Path
+	record.Branch = plan.Info.Branch
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	file, err := os.CreateTemp(filepath.Dir(plan.Journal), "detent-checkpoint-*.json")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := os.Remove(file.Name()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			returnErr = errors.Join(returnErr, err)
+		}
+	}()
+	_, writeErr := file.Write(data)
+	syncErr := file.Sync()
+	if err := errors.Join(writeErr, syncErr, file.Close()); err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), plan.Journal)
+}
+
+func (l *LocalGit) Checkpoint(ctx context.Context, plan CheckpointPlan, selection CheckpointSelection, validate func(context.Context) error, environment procgroup.Environment) (string, error) {
+	if validate == nil || !selection.Reviewed || selection.HeadSHA == "" || plan.RemoteURL == "" || plan.BaseSHA == "" {
+		return "", fmt.Errorf("%w: explicit reviewed selection and ownership validation are required", ErrCheckpointUnsafe)
+	}
+	release, err := l.acquireSourceOperation(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+	git := checkpointGit(plan.Info.Path, environment)
+	if err := checkpointGuard(ctx, git, plan, selection.HeadSHA, validate); err != nil {
+		return "", err
+	}
+	paths := slices.Clone(selection.Paths)
+	slices.Sort(paths)
+	paths = slices.Compact(paths)
+	for _, path := range paths {
+		if !checkpointPathAllowed(path) {
+			return "", fmt.Errorf("%w: excluded path %q", ErrCheckpointUnsafe, path)
+		}
+		stat, err := os.Lstat(filepath.Join(plan.Info.Path, filepath.FromSlash(path)))
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		if err == nil && !stat.Mode().IsRegular() {
+			return "", fmt.Errorf("%w: selection must name regular files", ErrCheckpointUnsafe)
+		}
+	}
+	if err := checkpointHistory(ctx, git, plan.BaseSHA, selection.HeadSHA, paths); err != nil {
+		return "", err
+	}
+	if len(paths) > 0 {
+		changed, err := git(ctx, append([]string{"diff", "--name-only", "--no-renames", "-z", "HEAD", "--"}, paths...)...)
+		if err != nil {
+			return "", err
+		}
+		untracked, err := git(ctx, append([]string{"ls-files", "--others", "--exclude-standard", "-z", "--"}, paths...)...)
+		if err != nil {
+			return "", err
+		}
+		dirty := strings.Split(strings.TrimSuffix(changed+untracked, "\x00"), "\x00")
+		if changed+untracked != "" {
+			if _, err := git(ctx, append([]string{"add", "--"}, dirty...)...); err != nil {
+				return "", err
+			}
+		}
+		diff, err := git(ctx, append([]string{"diff", "--cached", "--name-only", "-z", "HEAD", "--"}, paths...)...)
+		if err != nil {
+			return "", err
+		}
+		if diff != "" {
+			for _, path := range strings.Split(strings.TrimSuffix(diff, "\x00"), "\x00") {
+				if err := checkpointBlob(ctx, git, ":", path); err != nil {
+					return "", err
+				}
+			}
+			if err := checkpointGuard(ctx, git, plan, selection.HeadSHA, validate); err != nil {
+				return "", err
+			}
+			if _, err := git(ctx, append([]string{"commit", "--only", "-m", "chore(recovery): checkpoint intended issue work", "--"}, dirty...)...); err != nil {
+				return "", err
+			}
+		}
+	}
+	head, err := git(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	head = strings.TrimSpace(head)
+	if err := checkpointHistory(ctx, git, plan.BaseSHA, head, paths); err != nil {
+		return head, err
+	}
+	if head == plan.BaseSHA {
+		return head, nil
+	}
+	remoteHead, err := checkpointRemoteHead(ctx, git, plan)
+	if err != nil {
+		return head, err
+	}
+	if remoteHead != "" && remoteHead != head {
+		if _, err := git(ctx, "merge-base", "--is-ancestor", remoteHead, head); err != nil {
+			return head, fmt.Errorf("%w: remote branch advanced; retain local work for reconciliation", ErrCheckpointUnsafe)
+		}
+	}
+	if err := checkpointGuard(ctx, git, plan, head, validate); err != nil {
+		return head, err
+	}
+	if remoteHead != head {
+		if _, err := git(ctx, "-c", "push.followTags=false", "push", "--recurse-submodules=no", "--force-with-lease=refs/heads/"+plan.Info.Branch+":"+remoteHead, plan.RemoteURL, head+":refs/heads/"+plan.Info.Branch); err != nil {
+			return head, err
+		}
+	}
+	verified, err := checkpointRemoteHead(ctx, git, plan)
+	if err != nil || verified != head {
+		return head, errors.Join(fmt.Errorf("%w: remote checkpoint could not be verified", ErrCheckpointUnsafe), err)
+	}
+	return head, nil
+}
+
+type checkpointGitRunner func(context.Context, ...string) (string, error)
+
+func checkpointGit(path string, environment procgroup.Environment) checkpointGitRunner {
+	env := []string{"GIT_LITERAL_PATHSPECS=1", "GIT_TERMINAL_PROMPT=0"}
+	for key, value := range environment.Variables {
+		env = append(env, key+"="+value)
+	}
+	return func(ctx context.Context, args ...string) (string, error) {
+		return runGitAtWithEnv(ctx, path, env, args...)
+	}
+}
+
+func checkpointGuard(ctx context.Context, git checkpointGitRunner, plan CheckpointPlan, head string, validate func(context.Context) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := validate(ctx); err != nil {
+		return err
+	}
+	branch, err := git(ctx, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil || strings.TrimSpace(branch) != plan.Info.Branch {
+		return errors.Join(fmt.Errorf("%w: owned branch changed", ErrCheckpointUnsafe), err)
+	}
+	current, err := git(ctx, "rev-parse", "HEAD")
+	if err != nil || strings.TrimSpace(current) != head {
+		return errors.Join(fmt.Errorf("%w: reviewed head changed", ErrCheckpointUnsafe), err)
+	}
+	return nil
+}
+
+func checkpointRemoteHead(ctx context.Context, git checkpointGitRunner, plan CheckpointPlan) (string, error) {
+	output, err := git(ctx, "ls-remote", "--heads", plan.RemoteURL, "refs/heads/"+plan.Info.Branch)
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Fields(output)
+	if len(fields) == 0 {
+		return "", nil
+	}
+	if len(fields) != 2 || fields[1] != "refs/heads/"+plan.Info.Branch {
+		return "", fmt.Errorf("%w: unexpected remote ref", ErrCheckpointUnsafe)
+	}
+	return fields[0], nil
+}
+
+func checkpointHistory(ctx context.Context, git checkpointGitRunner, base, head string, paths []string) error {
+	if _, err := git(ctx, "merge-base", "--is-ancestor", base, head); err != nil {
+		return fmt.Errorf("%w: checkpoint base changed", ErrCheckpointUnsafe)
+	}
+	commits, err := git(ctx, "rev-list", base+".."+head)
+	if err != nil {
+		return err
+	}
+	for _, commit := range strings.Fields(commits) {
+		changed, err := git(ctx, "diff-tree", "--root", "--no-commit-id", "--name-only", "--no-renames", "-r", "-m", "-z", commit)
+		if err != nil {
+			return err
+		}
+		for _, path := range strings.Split(strings.TrimSuffix(changed, "\x00"), "\x00") {
+			if path == "" {
+				continue
+			}
+			if !checkpointPathAllowed(path) || !slices.Contains(paths, path) {
+				return fmt.Errorf("%w: commit contains an unapproved path %q", ErrCheckpointUnsafe, path)
+			}
+			if err := checkpointBlob(ctx, git, commit+":", path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkpointBlob(ctx context.Context, git checkpointGitRunner, prefix, path string) error {
+	args := []string{"ls-tree", "-z", strings.TrimSuffix(prefix, ":"), "--", path}
+	if prefix == ":" {
+		args = []string{"ls-files", "--stage", "-z", "--", path}
+	}
+	entry, err := git(ctx, args...)
+	if err != nil {
+		return err
+	}
+	if entry == "" {
+		return nil
+	}
+	header, name, ok := strings.Cut(strings.TrimSuffix(entry, "\x00"), "\t")
+	fields := strings.Fields(header)
+	if !ok || name != path || len(fields) != 3 || (fields[0] != "100644" && fields[0] != "100755") {
+		return fmt.Errorf("%w: selected history must contain regular files", ErrCheckpointUnsafe)
+	}
+	blob, err := git(ctx, "show", prefix+path)
+	if err != nil {
+		return err
+	}
+	if checkpointSecretPattern.MatchString(blob) {
+		return fmt.Errorf("%w: possible credential in selected content", ErrCheckpointUnsafe)
+	}
+	return nil
+}
+
+func checkpointPathAllowed(path string) bool {
+	if path == "" || !filepath.IsLocal(path) || filepath.ToSlash(filepath.Clean(path)) != path || strings.ContainsAny(path, "\\\x00\r\n") {
+		return false
+	}
+	for _, part := range strings.Split(strings.ToLower(path), "/") {
+		if part == ".git" || part == ".env" || strings.HasPrefix(part, ".env.") || part == ".ssh" || part == "node_modules" || part == "tmp" || part == "secrets" || part == "credentials.json" || strings.HasSuffix(part, ".pem") || strings.HasSuffix(part, ".key") {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/workspace/checkpoint_test.go
+++ b/internal/workspace/checkpoint_test.go
@@ -1,0 +1,348 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+)
+
+func checkpointFixture(t *testing.T) (*LocalGit, Issue, CheckpointPlan, string) {
+	t.Helper()
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+	backend, err := NewLocalGit(LocalGitOptions{Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	issue := Issue{ID: "2313", Identifier: "example/repo#2313"}
+	info, err := backend.Create(t.Context(), issue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := backend.PrepareCheckpoint(t.Context(), info, issue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return backend, issue, plan, remote
+}
+
+func checkpointWrite(t *testing.T, root, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(root, path)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, path), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckpointIntendedWork(t *testing.T) {
+	t.Parallel()
+	for _, work := range []string{"dirty", "unpushed", "already pushed", "deleted", "unchanged", "literal path"} {
+		t.Run(work, func(t *testing.T) {
+			t.Parallel()
+			backend, _, plan, remote := checkpointFixture(t)
+			path := "README.md"
+			if work == "literal path" {
+				path = "[intended].go"
+			}
+			if work != "unchanged" {
+				checkpointWrite(t, plan.Info.Path, path, "intended issue work\n")
+			}
+			if work == "deleted" {
+				if err := os.Remove(filepath.Join(plan.Info.Path, path)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if work == "unpushed" || work == "already pushed" {
+				runGit(t, plan.Info.Path, "add", path)
+				runGit(t, plan.Info.Path, "commit", "-m", "intended work")
+			}
+			if work == "already pushed" {
+				runGit(t, plan.Info.Path, "push", "origin", "HEAD")
+			}
+			checkpointWrite(t, plan.Info.Path, "unrelated.txt", "keep unrelated staged work\n")
+			runGit(t, plan.Info.Path, "add", "unrelated.txt")
+			checkpointWrite(t, plan.Info.Path, ".env", "SECRET=private\n")
+			selection := CheckpointSelection{Reviewed: true, HeadSHA: strings.TrimSpace(runGit(t, plan.Info.Path, "rev-parse", "HEAD")), Paths: []string{path}}
+			guard := func(context.Context) error { return nil }
+			head, err := backend.Checkpoint(t.Context(), plan, selection, guard, procgroup.Environment{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if work != "unchanged" {
+				if got := strings.TrimSpace(runGit(t, remote, "rev-parse", "refs/heads/"+plan.Info.Branch)); got != head {
+					t.Fatalf("remote = %s; head = %s", got, head)
+				}
+			}
+			if got := strings.TrimSpace(runGit(t, plan.Info.Path, "diff", "--cached", "--name-only")); got != "unrelated.txt" {
+				t.Fatalf("unrelated index changed: %q", got)
+			}
+			selection.HeadSHA = head
+			again, err := backend.Checkpoint(t.Context(), plan, selection, guard, procgroup.Environment{})
+			if err != nil || again != head {
+				t.Fatalf("duplicate = %q, %v; want unchanged %s", again, err, head)
+			}
+			if got := runGit(t, plan.Info.Path, "show", "--format=", "--name-only", head); strings.Contains(got, "unrelated.txt") || strings.Contains(got, ".env") {
+				t.Fatalf("unexpected published paths: %s", got)
+			}
+		})
+	}
+}
+
+func TestCheckpointRefusesUnsafePublication(t *testing.T) {
+	t.Parallel()
+	for _, failure := range []string{"unreviewed", "stale head", "different branch", "secret path", "secret content", "secret in old commit", "unapproved commit", "directory", "symlink", "path traversal", "lost lease", "lost lease before commit", "lost lease before push", "cancelled", "network unavailable", "remote advanced", "concurrent push", "hook rejected"} {
+		t.Run(failure, func(t *testing.T) {
+			t.Parallel()
+			backend, _, plan, remote := checkpointFixture(t)
+			checkpointWrite(t, plan.Info.Path, "README.md", "intended work\n")
+			selection := CheckpointSelection{Reviewed: true, HeadSHA: plan.BaseSHA, Paths: []string{"README.md"}}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			guard := func(context.Context) error { return nil }
+			switch failure {
+			case "unreviewed":
+				selection.Reviewed = false
+			case "stale head":
+				selection.HeadSHA = strings.Repeat("1", 40)
+			case "different branch":
+				runGit(t, plan.Info.Path, "switch", "-c", "human-work")
+			case "secret path":
+				selection.Paths = []string{".env"}
+				checkpointWrite(t, plan.Info.Path, ".env", "secret")
+			case "secret content":
+				checkpointWrite(t, plan.Info.Path, "README.md", "-----BEGIN PRIVATE KEY-----")
+			case "secret in old commit", "unapproved commit":
+				path, content := "README.md", "-----BEGIN PRIVATE KEY-----"
+				if failure == "unapproved commit" {
+					path, content = "unrelated.txt", "not issue work"
+				}
+				checkpointWrite(t, plan.Info.Path, path, content)
+				runGit(t, plan.Info.Path, "add", path)
+				runGit(t, plan.Info.Path, "commit", "-m", "unreviewed work")
+				checkpointWrite(t, plan.Info.Path, path, "safe now")
+				selection.HeadSHA = strings.TrimSpace(runGit(t, plan.Info.Path, "rev-parse", "HEAD"))
+			case "directory":
+				selection.Paths = []string{"."}
+			case "symlink":
+				if err := os.Symlink("README.md", filepath.Join(plan.Info.Path, "link")); err != nil {
+					t.Skip(err)
+				}
+				selection.Paths = []string{"link"}
+			case "path traversal":
+				selection.Paths = []string{"../outside"}
+			case "lost lease":
+				guard = func(context.Context) error { return errors.New("lease lost") }
+			case "lost lease before commit", "lost lease before push":
+				calls := 0
+				limit := 2
+				if failure == "lost lease before push" {
+					limit = 3
+				}
+				guard = func(context.Context) error {
+					calls++
+					if calls == limit {
+						return errors.New("lease lost during checkpoint")
+					}
+					return nil
+				}
+			case "cancelled":
+				cancel()
+			case "network unavailable":
+				plan.RemoteURL = filepath.Join(t.TempDir(), "missing.git")
+			case "remote advanced":
+				runGit(t, backend.sourceRoot, "commit", "--allow-empty", "-m", "concurrent remote work")
+				runGit(t, backend.sourceRoot, "push", "origin", "HEAD:refs/heads/"+plan.Info.Branch)
+			case "concurrent push":
+				calls := 0
+				guard = func(ctx context.Context) error {
+					calls++
+					if calls == 3 {
+						if _, err := runGitAt(ctx, backend.sourceRoot, "commit", "--allow-empty", "-m", "racing remote work"); err != nil {
+							return err
+						}
+						if _, err := runGitAt(ctx, backend.sourceRoot, "push", "origin", "HEAD:refs/heads/"+plan.Info.Branch); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+			case "hook rejected":
+				if testing.Short() {
+					t.Skip("git hook subprocess")
+				}
+				hooks := t.TempDir()
+				checkpointWrite(t, hooks, "pre-commit", "#!/bin/sh\nexit 1\n")
+				if err := os.Chmod(filepath.Join(hooks, "pre-commit"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				runGit(t, plan.Info.Path, "config", "core.hooksPath", hooks)
+			}
+			_, err := backend.Checkpoint(ctx, plan, selection, guard, procgroup.Environment{})
+			if err == nil {
+				t.Fatal("unsafe checkpoint succeeded")
+			}
+			remoteHead, _, readErr := remoteBranchHead(t.Context(), plan.Info.Path, remote, plan.Info.Branch)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if failure != "remote advanced" && failure != "concurrent push" && remoteHead != "" {
+				t.Fatalf("unexpected remote publication: %s", remoteHead)
+			}
+			if failure == "remote advanced" || failure == "concurrent push" {
+				want := strings.TrimSpace(runGit(t, backend.sourceRoot, "rev-parse", "HEAD"))
+				if remoteHead != want {
+					t.Fatalf("concurrent remote work lost: %s != %s", remoteHead, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckpointDurableEvidenceBeforeHardTermination(t *testing.T) {
+	t.Parallel()
+	backend, issue, plan, _ := checkpointFixture(t)
+	checkpointWrite(t, plan.Info.Path, "README.md", "work after journal; worker killed without epilogue")
+	data, err := os.ReadFile(plan.Journal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record CheckpointRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Status != "active" || record.Published || !strings.Contains(record.Detail, "No checkpoint handshake") {
+		t.Fatalf("false recovery claim: %+v", record)
+	}
+	reopened, err := NewLocalGit(LocalGitOptions{Root: backend.root, SourceRoot: backend.sourceRoot, AutoBranch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reopened.CleanupIssue(t.Context(), issue); !errors.Is(err, ErrWorkspacePreserved) {
+		t.Fatalf("recovery workspace removed: %v", err)
+	}
+}
+
+func TestCheckpointGitReadFailures(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"missing blob", "unreadable entry", "unreadable blob", "symlink history", "invalid entry", "empty remote", "invalid remote", "unreadable remote", "unrelated base", "unreadable history", "unreadable diff", "empty commit"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			failure := errors.New("git unavailable")
+			git := func(_ context.Context, args ...string) (string, error) {
+				switch args[0] {
+				case "ls-tree", "ls-files":
+					switch scenario {
+					case "missing blob":
+						return "", nil
+					case "unreadable entry":
+						return "", failure
+					case "symlink history":
+						return "120000 blob hash\tfile.go\x00", nil
+					case "invalid entry":
+						return "invalid", nil
+					}
+					return "100644 blob hash\tfile.go\x00", nil
+				case "show":
+					return "", failure
+				case "ls-remote":
+					if scenario == "empty remote" {
+						return "", nil
+					}
+					if scenario == "invalid remote" {
+						return "unexpected ref", nil
+					}
+					return "", failure
+				case "merge-base":
+					if scenario == "unrelated base" {
+						return "", failure
+					}
+					return "", nil
+				case "rev-list":
+					if scenario == "unreadable history" {
+						return "", failure
+					}
+					return "commit", nil
+				case "diff-tree":
+					if scenario == "unreadable diff" {
+						return "", failure
+					}
+					return "", nil
+				}
+				t.Fatalf("unexpected git command %v", args)
+				return "", failure
+			}
+			var err error
+			switch scenario {
+			case "empty remote", "invalid remote", "unreadable remote":
+				_, err = checkpointRemoteHead(t.Context(), git, CheckpointPlan{Info: Info{Branch: "owned"}, RemoteURL: "remote"})
+			case "unrelated base", "unreadable history", "unreadable diff", "empty commit":
+				err = checkpointHistory(t.Context(), git, "base", "head", []string{"file.go"})
+			default:
+				err = checkpointBlob(t.Context(), git, "commit:", "file.go")
+			}
+			wantOK := scenario == "missing blob" || scenario == "empty remote" || scenario == "empty commit"
+			if (err == nil) != wantOK {
+				t.Fatalf("Git failure handling = %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckpointPreparationRefusesUnownedWork(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"human branch", "other workspace", "not a worktree", "missing remote", "missing base", "invalid root"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			backend, issue, plan, _ := checkpointFixture(t)
+			switch scenario {
+			case "human branch":
+				plan.Info.Branch = "human"
+			case "other workspace":
+				plan.Info.Path = t.TempDir()
+			case "not a worktree":
+				backend.sourceRoot = t.TempDir()
+			case "missing remote":
+				runGit(t, plan.Info.Path, "remote", "remove", "origin")
+			case "missing base":
+				issue.BaseRef = "missing-base"
+			case "invalid root":
+				backend.root = ""
+			}
+			if _, err := backend.PrepareCheckpoint(t.Context(), plan.Info, issue); err == nil {
+				t.Fatal("unsafe preparation succeeded")
+			}
+		})
+	}
+}
+
+func TestCheckpointJournalUnavailable(t *testing.T) {
+	t.Parallel()
+	for _, journal := range []string{"", filepath.Join(t.TempDir(), "missing", "journal.json")} {
+		t.Run(journal, func(t *testing.T) {
+			t.Parallel()
+			if err := WriteCheckpointRecord(CheckpointPlan{Journal: journal}, CheckpointRecord{}); err == nil {
+				t.Fatal("unavailable journal accepted")
+			}
+		})
+	}
+}
+
+func TestCheckpointGuardCancelledBeforeGit(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	git := func(context.Context, ...string) (string, error) { t.Fatal("cancelled guard ran Git"); return "", nil }
+	if err := checkpointGuard(ctx, git, CheckpointPlan{}, "head", func(context.Context) error { return nil }); !errors.Is(err, context.Canceled) {
+		t.Fatalf("guard = %v", err)
+	}
+}

--- a/scripts/coverage-exceptions.txt
+++ b/scripts/coverage-exceptions.txt
@@ -7,6 +7,9 @@ github.com/digitaldrywood/detent/internal/orchestrator/backend_capacity.go 90 # 
 github.com/digitaldrywood/detent/internal/connector/human.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/dependency_autounblock.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/dispatch.go 90
+github.com/digitaldrywood/detent/internal/orchestrator/checkpoint.go 90
+github.com/digitaldrywood/detent/internal/runner/checkpoint.go 90
+github.com/digitaldrywood/detent/internal/workspace/checkpoint.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/dispatch_planner.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/human_prerequisite.go 90
 github.com/digitaldrywood/detent/internal/orchestrator/implement_dependency_deferral.go 90


### PR DESCRIPTION
## Summary

When an implementation worker reaches a duration, turn, or no-progress limit, request a bounded read-only checkpoint selection and publish only reviewed issue files and commit history on its owned branch. Verify the active lease and remote ref, preserve existing PR state and base branches, and associate a draft PR for pull-request deliverables when needed. Artifact deliverables retain branch/workspace recovery without creating a PR.

Write durable local recovery evidence before worker execution and retain it when interruption, unavailable delivery, or lost ownership prevents publication. Optional periodic checkpoints reuse the same mechanism without resetting session limits; checkpoint publication never satisfies completion or review gates.

Includes merged prerequisite #2322 through df58cce6, fixing the shared checklock deadline failure that affected the previous PR head. Both checkpoint patches are unchanged by the rebase.

Fixes #2313

## UI Surface Contract

- [x] N/A: no layout or responsive changes.
- [x] No persistent top-of-screen messaging added.
- [x] No primary operator-screen visual changes.

## Test Plan

- [x] Deterministic stdlib checkpoint tests: dirty and unpushed work, repeated deletions, existing/draft PRs, artifact deliverables, prior PR base, remote advancement, lease loss, cancellation, credentials/network failures, and hard-termination evidence.
- [x] Focused checkpoint and checklock race tests and `FuzzSafetyCriticalOrchestratorBoundaries` seeds on a95850dc.
- [x] Exact-file coverage on a95850dc: orchestrator checkpoint 100%, runner checkpoint 97.2%, workspace checkpoint 90.5%, dispatch 93.9%.
- [x] `make check CHECK_LOCK_WAIT=60m` on a95850dc: build, lint, vet, nilaway, race tests, 80.3% overall coverage, and all package/exact-file floors passed.
- [x] All 11 current-head CI checks passed on a95850dc ([run 34279132833](https://github.com/digitaldrywood/detent/actions/runs/34279132833)), including GoReleaser Snapshot, Security, Browser Visual, and Linux/macOS/Windows verification.
