### PR TITLE
fix(merge): release failed-head CI reservations

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2747,8 +2747,8 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
 	}
 	pr := got[0].PullRequest
-	if pr == nil || pr.Number != 190 || pr.CIStatus != "pending" || pr.CodexReviewState != "P1" {
-		t.Fatalf("PullRequest = %#v, want PR 190 with pending CI and P1 review", pr)
+	if pr == nil || pr.Number != 190 || pr.CIStatus != "fail" || pr.CodexReviewState != "P1" {
+		t.Fatalf("PullRequest = %#v, want PR 190 with failed CI and P1 review", pr)
 	}
 	if pr.CodexReviewSource != connector.PullRequestReviewSourceFormal {
 		t.Fatalf("CodexReviewSource = %q, want formal review", pr.CodexReviewSource)
@@ -2977,12 +2977,12 @@ func TestCheckRunsStateUsesSettledContextResults(t *testing.T) {
 			want: "failure",
 		},
 		{
-			name: "pending context keeps a different failure unsettled",
+			name: "settled failure wins over a different pending context",
 			checkRuns: []restCheckRun{
 				{Name: "Checks", Status: "completed", Conclusion: "failure"},
 				{Name: "Test", Status: "queued"},
 			},
-			want: "pending",
+			want: "failure",
 		},
 		{
 			name: "cancelled artifact does not shadow success",
@@ -3072,18 +3072,91 @@ func TestCompletedFailedCheckRunIgnoresNonFailureArtifacts(t *testing.T) {
 	}
 }
 
-func TestCIStateWaitsForAllContextsToSettle(t *testing.T) {
+func TestCIStateReportsFailureWhileOtherContextsWait(t *testing.T) {
 	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		checks       string
+		statuses     []restCommitStatus
+		wantStatuses string
+		want         string
+	}{
+		{name: "mixed statuses", statuses: []restCommitStatus{{Context: "Checks", State: "failure"}, {Context: "Test", State: "pending"}}, wantStatuses: "failure", want: "failure"},
+		{name: "failed check pending status", checks: "failure", statuses: []restCommitStatus{{Context: "Test", State: "pending"}}, wantStatuses: "pending", want: "failure"},
+		{name: "pending check failed status", checks: "pending", statuses: []restCommitStatus{{Context: "Test", State: "error"}}, wantStatuses: "failure", want: "failure"},
+		{name: "pending only", checks: "success", statuses: []restCommitStatus{{Context: "Test", State: "pending"}}, wantStatuses: "pending", want: "pending"},
+		{name: "superseded failure", checks: "pending", statuses: []restCommitStatus{{Context: "Test", State: "pending", CreatedAt: new(time.Date(2026, 9, 8, 15, 0, 0, 0, time.UTC))}, {Context: "Test", State: "failure"}}, wantStatuses: "pending", want: "pending"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			statuses := commitStatusesState(tt.statuses)
+			if statuses != tt.wantStatuses {
+				t.Fatalf("commitStatusesState() = %q, want %q", statuses, tt.wantStatuses)
+			}
+			if got := combinedCIState(tt.checks, statuses); got != tt.want {
+				t.Fatalf("combinedCIState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
-	statuses := []restCommitStatus{
-		{Context: "Checks", State: "failure"},
-		{Context: "Test", State: "pending"},
-	}
-	if got := commitStatusesState(statuses); got != "pending" {
-		t.Fatalf("commitStatusesState() = %q, want pending", got)
-	}
-	if got := combinedCIState("failure", "pending"); got != "pending" {
-		t.Fatalf("combinedCIState() = %q, want pending", got)
+func TestConnectorHydratePullRequestMixedCurrentHeadChecks(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		conclusion string
+		required   []string
+		statuses   string
+		want       string
+	}{
+		{name: "failed check and running checks", conclusion: "failure", want: "fail"},
+		{name: "failed check and missing required check", conclusion: "failure", required: []string{"Missing"}, want: "fail"},
+		{name: "required failure and running required check", conclusion: "failure", required: []string{"GoReleaser Snapshot", "Windows Core"}, want: "fail"},
+		{name: "failed legacy status and running check", conclusion: "success", statuses: `[{"context":"external","state":"failure"},{"context":"another","state":"pending"}]`, want: "fail"},
+		{name: "old head failure replaced by pending head", conclusion: "success", want: "pending"},
+		{name: "optional neutral check", conclusion: "neutral", want: "pending"},
+		{name: "optional skipped check", conclusion: "skipped", want: "pending"},
+		{name: "optional cancelled check", conclusion: "cancelled", want: "pending"},
+		{name: "missing required check needs startup", conclusion: "success", required: []string{"Missing"}, want: "pending"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			statuses := tt.statuses
+			if statuses == "" {
+				statuses = `[]`
+			}
+			server := newGraphQLTestServer(t, []graphqlTestResponse{
+				{method: http.MethodGet, path: "/repos/example/repo/pulls/42", body: `{"number":42,"state":"open","mergeable_state":"blocked","head":{"sha":"current-head"},"base":{"sha":"base"}}`},
+				{method: http.MethodGet, path: "/repos/example/repo/commits/current-head/check-runs?per_page=100", body: fmt.Sprintf(`{"check_runs":[{"name":"GoReleaser Snapshot","status":"completed","conclusion":%q,"started_at":"2026-09-08T15:40:00Z","completed_at":"2026-09-08T15:42:36Z"},{"name":"Windows Core","status":"in_progress","started_at":"2026-09-08T15:40:00Z"},{"name":"Linux","status":"queued","created_at":"2026-09-08T15:40:00Z"}]}`, tt.conclusion)},
+				{method: http.MethodGet, path: "/repos/example/repo/commits/current-head/statuses?per_page=100", body: statuses},
+				{method: http.MethodGet, path: "/repos/example/repo/pulls/42/reviews?per_page=100", body: `[]`},
+				emptyPullRequestCommentsResponse("example/repo", 42),
+			})
+			c := newGitHubTestConnector(t, server, Config{RequiredStatusChecks: tt.required})
+			c.now = func() time.Time { return time.Date(2026, 9, 8, 15, 54, 0, 0, time.UTC) }
+			c.unstartedThreshold = time.Minute
+			issue := connector.Issue{ID: "issue-1", Identifier: "example/repo#1", PRNumber: new(42), PRRepository: "example/repo", PullRequest: &connector.PullRequest{Number: 42, HeadSHA: "old-head", CIStatus: "failure", RequiredCheckFailures: []connector.PullRequestCheck{{Name: "Old", Status: "completed", Conclusion: "failure"}}}}
+			got, err := c.HydratePullRequest(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pr := got.PullRequest
+			if pr == nil {
+				t.Fatal("missing pull request")
+			}
+			if pr.HeadSHA != "current-head" || pr.CIStatus != tt.want {
+				t.Fatalf("head=%q CI=%q, want current-head CI=%q", pr.HeadSHA, pr.CIStatus, tt.want)
+			}
+			if !reflect.DeepEqual(pr.RunningChecks, []string{"Windows Core"}) || pr.UnstartedCheckCount != 1 || len(pr.UnstartedChecks) != 1 || pr.UnstartedChecks[0].Name != "Linux" {
+				t.Fatalf("pending telemetry lost: running=%v unstarted=%v", pr.RunningChecks, pr.UnstartedChecks)
+			}
+			if pr.CIDurationSeconds != 0 || len(pr.Checks) < 3 {
+				t.Fatalf("partial CI telemetry: duration=%d checks=%v", pr.CIDurationSeconds, pr.Checks)
+			}
+			if tt.conclusion == "failure" && (len(pr.SlowChecks) != 1 || pr.SlowChecks[0].Conclusion != "failure") {
+				t.Fatalf("failed check telemetry lost: %v", pr.SlowChecks)
+			}
+		})
 	}
 }
 
@@ -3216,13 +3289,13 @@ func TestRequiredStatusCheckFailures(t *testing.T) {
 			}},
 		},
 		{
-			name: "pending required check wins over settled failure",
+			name: "settled required failure wins over pending check",
 			checkRuns: []restCheckRun{
 				{Name: "Checks", Status: "completed", Conclusion: "failure"},
 				{Name: "Test", Status: "in_progress"},
 			},
 			required:  []string{"Checks", "Test"},
-			wantState: "pending",
+			wantState: "failure",
 			wantChecks: []connector.PullRequestCheck{
 				{Name: "Checks", Status: "completed", Conclusion: "failure"},
 				{Name: "Test", Status: "in_progress"},

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -6127,6 +6127,7 @@ func TestConnectorRerunPullRequestChecksUsesWorkflowRun(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{method: http.MethodGet, path: "/repos/example/repo/actions/runs/8001", body: `{"id":8001,"status":"completed"}`},
 		{
 			method: http.MethodPost,
 			path:   "/repos/example/repo/actions/runs/8001/rerun-failed-jobs",
@@ -6152,11 +6153,35 @@ func TestConnectorRerunPullRequestChecksUsesWorkflowRun(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 1 {
-		t.Fatalf("requests len = %d, want 1", len(requests))
+	if len(requests) != 2 {
+		t.Fatalf("requests len = %d, want 2", len(requests))
 	}
-	if requests[0]["method"] != http.MethodPost || requests[0]["path"] != "/repos/example/repo/actions/runs/8001/rerun-failed-jobs" {
-		t.Fatalf("request = %#v, want workflow rerun", requests[0])
+	if requests[1]["method"] != http.MethodPost || requests[1]["path"] != "/repos/example/repo/actions/runs/8001/rerun-failed-jobs" {
+		t.Fatalf("request = %#v, want workflow rerun", requests[1])
+	}
+}
+
+func TestConnectorRerunPullRequestChecksDefersActiveWorkflow(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"queued", "in_progress", "waiting", ""} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			server := newGraphQLTestServer(t, []graphqlTestResponse{
+				{method: http.MethodGet, path: "/repos/example/repo/actions/runs/8001", body: `{"id":8001,"status":"completed"}`},
+				{method: http.MethodGet, path: "/repos/example/repo/actions/runs/8002", body: fmt.Sprintf(`{"id":8002,"status":%q}`, status)},
+			})
+			c := newGitHubTestConnector(t, server, Config{})
+			issue := connector.Issue{Identifier: "example/repo#1", PRNumber: new(42), PRRepository: "example/repo"}
+			err := c.RerunPullRequestChecks(t.Context(), issue, []connector.PullRequestCheck{{ID: 9001, WorkflowRunID: 8001}, {ID: 9002, WorkflowRunID: 8001}, {ID: 9003, WorkflowRunID: 8002}})
+			if !connector.IsRetryable(err) {
+				t.Fatalf("RerunPullRequestChecks() = %v, want retryable deferral", err)
+			}
+			for _, request := range server.requests() {
+				if request["method"] != http.MethodGet {
+					t.Fatalf("rerun submitted before all workflows completed: %v", request)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/connector/github/pull_request_checks.go
+++ b/internal/connector/github/pull_request_checks.go
@@ -54,11 +54,7 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	c.logStaleSuccessfulCheckRuns(ctx, repo, sha, staleSuccessfulChecks)
 	requiredFailures := requiredStatusCheckFailures(checkRuns, statuses, c.requiredChecks)
 	state := combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses))
-	if requiredState := requiredStatusCheckState(requiredFailures); requiredState == "pending" {
-		state = requiredState
-	} else if requiredState != "" {
-		state = combinedCIState(requiredState, state)
-	}
+	state = combinedCIState(requiredStatusCheckState(requiredFailures), state)
 	transientFailures, err := c.transientCheckRunFailures(ctx, repo, checkRuns)
 	if err != nil {
 		return pullRequestCI{}, err
@@ -317,11 +313,11 @@ func checkRunsState(checkRuns []restCheckRun) string {
 			failed = true
 		}
 	}
-	if pending {
-		return "pending"
-	}
 	if failed {
 		return "failure"
+	}
+	if pending {
+		return "pending"
 	}
 	return "success"
 }
@@ -438,11 +434,11 @@ func requiredStatusCheckState(failures []connector.PullRequestCheck) string {
 			failed = true
 		}
 	}
-	if pending {
-		return "pending"
-	}
 	if failed {
 		return "failure"
+	}
+	if pending {
+		return "pending"
 	}
 	return ""
 }
@@ -704,11 +700,11 @@ func commitStatusesState(statuses []restCommitStatus) string {
 			failed = true
 		}
 	}
-	if pending {
-		return "pending"
-	}
 	if failed {
 		return "failure"
+	}
+	if pending {
+		return "pending"
 	}
 	return "success"
 }
@@ -770,11 +766,11 @@ func combinedCIState(checkRuns string, statuses string) string {
 			hasSuccess = true
 		}
 	}
-	if hasPending {
-		return "pending"
-	}
 	if hasFailure {
 		return "failure"
+	}
+	if hasPending {
+		return "pending"
 	}
 	if hasSuccess {
 		return "success"

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -558,6 +558,9 @@ func (c *Connector) RerunPullRequestChecks(ctx context.Context, issue connector.
 	if !ok {
 		return errors.New("rerun github pull request checks: missing pull request repository")
 	}
+	if err := c.checkWorkflowRerunsReady(ctx, repo, checks); err != nil {
+		return err
+	}
 	seenRuns := map[int64]struct{}{}
 	seenChecks := map[int64]struct{}{}
 	var errs []error
@@ -585,6 +588,27 @@ func (c *Connector) RerunPullRequestChecks(ctx context.Context, issue connector.
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("rerun github pull request checks: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+func (c *Connector) checkWorkflowRerunsReady(ctx context.Context, repo pullRequestRepo, checks []connector.PullRequestCheck) error {
+	seen := map[int64]struct{}{}
+	for _, check := range checks {
+		if check.WorkflowRunID <= 0 {
+			continue
+		}
+		if _, ok := seen[check.WorkflowRunID]; ok {
+			continue
+		}
+		seen[check.WorkflowRunID] = struct{}{}
+		var run restWorkflowRun
+		if err := c.client.REST(ctx, http.MethodGet, restWorkflowRunPath(repo, check.WorkflowRunID), nil, &run); err != nil {
+			return fmt.Errorf("check workflow run %d before rerun: %w", check.WorkflowRunID, err)
+		}
+		if !strings.EqualFold(strings.TrimSpace(run.Status), "completed") {
+			return connector.NewRetryableError(fmt.Sprintf("workflow run %d is not completed; deferring failed-job rerun", check.WorkflowRunID))
+		}
 	}
 	return nil
 }

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -349,6 +349,7 @@ type restCheckRunAnnotation struct {
 
 type restWorkflowRun struct {
 	ID           int64      `json:"id"`
+	Status       string     `json:"status"`
 	CreatedAt    *time.Time `json:"created_at"`
 	RunStartedAt *time.Time `json:"run_started_at"`
 }

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1834,6 +1834,9 @@ func (o *Orchestrator) staleMergingQueueDispatchCandidates(state *State, issues 
 	for _, issue := range staleMergingQueueIssues(issues, o.cfg, state, now) {
 		issueID := strings.TrimSpace(issue.ID)
 		repository := mergeWorkerRepositoryKey(issue)
+		if mergeWorkerCIFailed(issue.PullRequest) {
+			continue
+		}
 		if staleMergingPullRequestDispatchActive(state, issueID) {
 			if reservation := state.mergeReservations[repository]; reservation.IssueID == issueID && reservation.ReleasedReason != "" {
 				continue

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1037,14 +1037,14 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 			continue
 		}
 		repository := mergeWorkerRepositoryKey(issue)
-		if mergeWorkerRepositoryConsumed(consumedRepositories, repository) {
+		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg)
+		if mergeWorkerRepositoryConsumed(consumedRepositories, repository) && decision.reason != string(AutoPromoteReasonCINotGreen) {
 			continue
 		}
 		if staleMergingPullRequestDispatchActive(state, issueID) {
 			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
 			continue
 		}
-		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg)
 		if decision.reason == string(AutoPromoteReasonOperationalCompletion) {
 			completion, _ := operationalCompletionFromIssue(issue)
 			_, completed, err := o.latestSuccessfulOperationalCompletionAttempt(ctx, issue, completion)
@@ -1136,7 +1136,7 @@ func staleMergingPullRequestDecisionForIssue(issue connector.Issue, cfg Config) 
 		if pullRequest.Draft {
 			return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: "draft_pull_request"}
 		}
-		if staleMergingCIRed(pullRequest.CIStatus) {
+		if mergeWorkerCIFailed(pullRequest) {
 			return staleMergingPullRequestDecision{targetState: autoPromoteReworkState, reason: string(AutoPromoteReasonCINotGreen)}
 		}
 		return staleMergingPullRequestDecision{}

--- a/internal/orchestrator/merge_reservation.go
+++ b/internal/orchestrator/merge_reservation.go
@@ -107,7 +107,7 @@ func reconcileMergeReservations(state *State, issues []connector.Issue, cfg Conf
 				reason = "repository_changed"
 			case strings.TrimSpace(pr.HeadSHA) != reservation.HeadSHA && !running:
 				reason = "head_changed"
-			case staleMergingCIRed(pr.CIStatus) || len(pr.RequiredCheckFailures) > 0 && !mergeWorkerProgrammaticMergeWaiting(issue):
+			case mergeWorkerCIFailed(pr):
 				reason = "required_checks_failed"
 			case strings.EqualFold(pr.MergeableState, "dirty"):
 				reason = "conflict"
@@ -125,9 +125,27 @@ func reconcileMergeReservations(state *State, issues []connector.Issue, cfg Conf
 			reservation.ReleasedReason = reason
 			state.mergeReservations[repository] = reservation
 			released = append(released, reservation)
+			if retry := state.Retry[issue.ID]; reason == "required_checks_failed" && retry.Wait.Kind == retryWaitCurrentHeadCI && !running {
+				delete(state.Retry, issue.ID)
+			}
 		}
 	}
 	return released
+}
+
+func mergeWorkerCIFailed(pr *connector.PullRequest) bool {
+	if pr == nil || pullRequestHydrationBlocksProgress(pr) {
+		return false
+	}
+	if staleMergingCIRed(pr.CIStatus) {
+		return true
+	}
+	for _, check := range pr.RequiredCheckFailures {
+		if !autoPromoteCheckPending(check) && autoPromoteCheckFailed(check) {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Orchestrator) reconcileMergeReservations(state *State, issues []connector.Issue, now time.Time) {

--- a/internal/orchestrator/merge_reservation_test.go
+++ b/internal/orchestrator/merge_reservation_test.go
@@ -14,6 +14,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/workspace"
@@ -262,6 +263,62 @@ func TestMergeReservationTracksWorkerPushWithoutRenewal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMergeReservationTransientFailureDefersRerun(t *testing.T) {
+	t.Parallel()
+	for _, restart := range []bool{false, true} {
+		t.Run(fmt.Sprintf("restart=%t", restart), func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 8, 15, 54, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{ActiveStates: []string{"Merging", "Rework"}, TerminalStates: []string{"Done"}, MergeFastPathEnabled: true, AutoPromote: AutoPromoteConfig{Gate: gate.Config{TransientCIRetryLimit: new(1)}}})
+			issue := nativeMergeQueueTestIssue(2320, "failure")
+			issue.StageUpdatedAt = timePointer(now.Add(-2 * time.Hour))
+			issue.PullRequest.MergeableState = "blocked"
+			issue.PullRequest.RunningChecks = []string{"Windows"}
+			issue.PullRequest.TransientFailedChecks = []connector.PullRequestCheck{{Name: "Snapshot", ID: 9001, WorkflowRunID: 8001, Status: "completed", Conclusion: "timed_out"}}
+			other := nativeMergeQueueTestIssue(2318, "success")
+			other.StageUpdatedAt = timePointer(now.Add(-time.Hour))
+			other.PullRequest.MergeableState = "behind"
+			tracker := &deferredMergeCIRetryConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue, other}}, err: connector.NewRetryableError("workflow is still running")}
+			orch := Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			if !restart {
+				reserveMergeCandidate(&state, issue, now.Add(-time.Minute))
+				state.Retry[issue.ID] = Retry{Issue: issue, Wait: RetryWait{Kind: retryWaitCurrentHeadCI}}
+			}
+			orch.reconcileMergeReservations(&state, tracker.stateIssues, now)
+			orch.reconcileStaleMergingPullRequestIssues(t.Context(), &state, tracker.stateIssues, now)
+			if len(tracker.updates) != 0 || len(state.TransientCheckRetries) != 0 || len(tracker.comments) != 0 {
+				t.Fatalf("active workflow caused rework or charged retry: updates=%v retries=%v comments=%v", tracker.updates, state.TransientCheckRetries, tracker.comments)
+			}
+			candidates := orch.mergeWorkerDispatchCandidates(&state, tracker.stateIssues, now)
+			if len(candidates) != 1 || candidates[0].ID != other.ID {
+				t.Fatalf("candidates=%v, want next candidate while transient rerun waits", candidates)
+			}
+			tracker.err = nil
+			orch.reconcileStaleMergingPullRequestIssues(t.Context(), &state, tracker.stateIssues, now.Add(time.Minute))
+			if len(tracker.reruns) != 1 || len(state.TransientCheckRetries) != 1 || len(tracker.updates) != 0 {
+				t.Fatalf("settled workflow did not retry: reruns=%v retries=%v updates=%v", tracker.reruns, state.TransientCheckRetries, tracker.updates)
+			}
+			orch.reconcileStaleMergingPullRequestIssues(t.Context(), &state, tracker.stateIssues, now.Add(2*time.Minute))
+			if !reflect.DeepEqual(tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}) {
+				t.Fatalf("exhausted retry updates=%v, want Rework", tracker.updates)
+			}
+		})
+	}
+}
+
+type deferredMergeCIRetryConnector struct {
+	*autoPromoteTickConnector
+	err error
+}
+
+func (c *deferredMergeCIRetryConnector) RerunPullRequestChecks(ctx context.Context, issue connector.Issue, checks []connector.PullRequestCheck) error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.autoPromoteTickConnector.RerunPullRequestChecks(ctx, issue, checks)
 }
 
 func TestMergeReservationRecoversCurrentWaitingHead(t *testing.T) {

--- a/internal/orchestrator/merge_reservation_test.go
+++ b/internal/orchestrator/merge_reservation_test.go
@@ -77,6 +77,30 @@ func TestMergeReservationLifecycle(t *testing.T) {
 		}},
 		{name: "external head change", mutate: func(i *connector.Issue) { i.PullRequest.HeadSHA = "external-head" }, reason: "head_changed"},
 		{name: "failed checks", mutate: func(i *connector.Issue) { i.PullRequest.CIStatus = "failure" }, reason: "required_checks_failed"},
+		{name: "failed required check with pending aggregate", mutate: func(i *connector.Issue) {
+			i.PullRequest.MergeableState = "blocked"
+			i.PullRequest.RunningChecks = []string{"Windows Core"}
+			i.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "GoReleaser Snapshot", Status: "completed", Conclusion: "failure"}, {Name: "Windows Core", Status: "in_progress"}}
+		}, reason: "required_checks_failed"},
+		{name: "missing required check needs startup", mutate: func(i *connector.Issue) {
+			i.PullRequest.MergeableState = "blocked"
+			i.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Windows Core", Status: "missing", Conclusion: "missing"}}
+		}},
+		{name: "running required check", mutate: func(i *connector.Issue) {
+			i.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Windows Core", Status: "in_progress"}}
+		}},
+		{name: "ignored check telemetry", mutate: func(i *connector.Issue) {
+			i.PullRequest.SlowChecks = []connector.PullRequestCheck{{Name: "Optional", Status: "completed", Conclusion: "neutral"}, {Name: "Cancelled", Status: "completed", Conclusion: "cancelled"}}
+		}},
+		{name: "degraded failure is not authoritative", mutate: func(i *connector.Issue) {
+			i.PullRequest.CIStatus = "failure"
+			i.PullRequest.HydrationDegradedReason = "rate_limited"
+			i.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "completed", Conclusion: "failure"}}
+		}},
+		{name: "unavailable failure is not authoritative", mutate: func(i *connector.Issue) {
+			i.PullRequest.CIStatus = "failure"
+			i.PullRequest.HydrationUnavailableReason = "checks_unavailable"
+		}},
 		{name: "conflict", mutate: func(i *connector.Issue) { i.PullRequest.MergeableState = "dirty" }, reason: "conflict"},
 		{name: "withdrawal", mutate: func(i *connector.Issue) { i.State = "Rework" }, reason: "withdrawn"},
 		{name: "closed", mutate: func(i *connector.Issue) { i.PullRequest.State = "closed" }, reason: "withdrawn"},
@@ -141,6 +165,73 @@ func TestMergeReservationAllowsIndependentWork(t *testing.T) {
 	}
 }
 
+func TestMergeReservationFailedHeadAdmitsNextCandidate(t *testing.T) {
+	t.Parallel()
+	for _, restart := range []string{"none", "before failure", "after failure"} {
+		t.Run(restart, func(t *testing.T) {
+			t.Parallel()
+			for _, ci := range []string{"failure", "pending"} {
+				t.Run(ci, func(t *testing.T) {
+					t.Parallel()
+					now := time.Date(2026, 9, 8, 15, 40, 0, 0, time.UTC)
+					cfg := normalizeConfig(Config{MaxConcurrentAgents: 3, MaxConcurrentAgentsByState: map[string]int{"Merging": 1}, ActiveStates: []string{"Merging", "Rework"}, TerminalStates: []string{"Done"}, MergeFastPathEnabled: true})
+					issue := nativeMergeQueueTestIssue(2320, "pending")
+					issue.StageUpdatedAt = timePointer(now.Add(-time.Hour))
+					other := nativeMergeQueueTestIssue(2318, "success")
+					attempts := &recordingWorkAttemptStore{}
+					tracker := &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue, other}}}
+					orch := Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts}
+					state := newState(cfg)
+					orch.waitForMergeWorkerCurrentHeadCI(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: now}, Running{Issue: issue, Attempt: 1, WorkAttemptID: 1}, issue)
+					if len(attempts.completions) != 1 {
+						t.Fatalf("completions = %d, want 1", len(attempts.completions))
+					}
+					completion := attempts.completions[0]
+					attempts.history = []store.WorkAttempt{{ID: 1, IssueID: issue.ID, Phase: completion.Phase, Status: completion.Status, TerminalState: completion.TerminalState, AttemptNumber: 1, CompletedAt: now, WorkerMetadataJSON: completion.WorkerMetadataJSON}}
+					if restart == "before failure" {
+						state = newState(cfg)
+						orch.restoreDurableMergeReservations(t.Context(), &state, []connector.Issue{issue}, now.Add(time.Minute))
+					}
+					if _, blocked := mergeReservationBlocks(&state, other, now.Add(time.Minute)); !blocked {
+						t.Fatal("pending head did not reserve repository")
+					}
+					issue.PullRequest.CIStatus = ci
+					issue.PullRequest.MergeableState = "blocked"
+					issue.PullRequest.RunningChecks = []string{"Verify (ubuntu-latest)", "Windows Core"}
+					issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "GoReleaser Snapshot", Status: "completed", Conclusion: "failure"}, {Name: "Windows Core", Status: "in_progress"}}
+					tracker.stateIssues = []connector.Issue{issue, other}
+					if restart == "after failure" {
+						state = newState(cfg)
+						orch.restoreDurableMergeReservations(t.Context(), &state, []connector.Issue{issue}, now.Add(3*time.Minute))
+					}
+					orch.reconcileMergeReservations(&state, tracker.stateIssues, now.Add(3*time.Minute))
+					if _, blocked := mergeReservationBlocks(&state, other, now.Add(3*time.Minute)); blocked {
+						t.Fatal("failed head still reserves repository")
+					}
+					transitioned := orch.reconcileStaleMergingPullRequestIssues(t.Context(), &state, tracker.stateIssues, now.Add(3*time.Minute))
+					if _, ok := transitioned[issue.ID]; !ok {
+						t.Fatalf("failed head was not reconciled to Rework: updates=%#v wait=%q", tracker.updates, state.Retry[issue.ID].Wait.Kind)
+					}
+					if !reflect.DeepEqual(tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}) {
+						t.Fatalf("updates = %#v, want failed issue in Rework", tracker.updates)
+					}
+					if _, retry := state.Retry[issue.ID]; retry {
+						t.Fatal("failed head retained CI wait retry")
+					}
+					candidates := orch.mergeWorkerDispatchCandidates(&state, issuesInStates(tracker.stateIssues, []string{"Merging"}), now.Add(3*time.Minute))
+					plan := newDispatchPlanner(cfg).plan(&state, candidates, now.Add(3*time.Minute), dispatchPlanHooks{})
+					if len(plan.Dispatches) != 1 || plan.Dispatches[0].IssueID != other.ID {
+						t.Fatalf("dispatches = %#v, want next green candidate", plan.Dispatches)
+					}
+					if len(tracker.merges) != 0 {
+						t.Fatal("failed head reached merge API")
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestMergeReservationTracksWorkerPushWithoutRenewal(t *testing.T) {
 	t.Parallel()
 	for _, expired := range []bool{false, true} {
@@ -187,6 +278,12 @@ func TestMergeReservationRecoversCurrentWaitingHead(t *testing.T) {
 		{name: "head changed", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.PullRequest.HeadSHA = "changed" }},
 		{name: "withdrawn", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.State = "Rework" }},
 		{name: "failed", mutate: func(i *connector.Issue, _ *store.WorkAttempt) { i.PullRequest.CIStatus = "failure" }},
+		{name: "failed required check while pending", mutate: func(i *connector.Issue, _ *store.WorkAttempt) {
+			i.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Snapshot", Status: "completed", Conclusion: "failure"}, {Name: "Test", Status: "queued"}}
+		}},
+		{name: "missing check needs startup", mutate: func(i *connector.Issue, _ *store.WorkAttempt) {
+			i.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{Name: "Test", Status: "missing", Conclusion: "missing"}}
+		}, want: true},
 		{name: "newer completed attempt", mutate: func(_ *connector.Issue, a *store.WorkAttempt) { a.Phase = "completed" }},
 		{name: "malformed metadata", mutate: func(_ *connector.Issue, a *store.WorkAttempt) { a.WorkerMetadataJSON = "{" }},
 	} {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -2116,7 +2116,7 @@ func mergeWorkerProgrammaticMergeWaiting(issue connector.Issue) bool {
 		return false
 	}
 	pullRequest := issue.PullRequest
-	if pullRequestHydrationBlocksProgress(pullRequest) {
+	if pullRequestHydrationBlocksProgress(pullRequest) || mergeWorkerCIFailed(pullRequest) {
 		return false
 	}
 	if normalizePullRequestState(pullRequest.State) != "open" || pullRequest.Draft {

--- a/internal/orchestrator/transient_ci_retry.go
+++ b/internal/orchestrator/transient_ci_retry.go
@@ -48,6 +48,12 @@ func (o *Orchestrator) retryTransientPullRequestChecks(
 		return false
 	}
 	if err := rerunner.RerunPullRequestChecks(ctx, issue, retryable); err != nil {
+		if connector.IsRetryable(err) {
+			if o.logger != nil {
+				o.logger.Info("transient ci retry deferred", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+			}
+			return true
+		}
 		if o.logger != nil {
 			o.logger.Warn("transient ci retry failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 		}


### PR DESCRIPTION
## Summary

A completed CI failure on the current PR head now releases its merge reservation even while other checks remain queued or running. The failed issue is reconciled to Rework or transient-retry handling, allowing the next eligible same-repository candidate to proceed. Pending-check telemetry, exact-head filtering, missing-check startup waits, degraded-hydration safeguards, and the one-hour reservation bound are preserved.

Transient workflow reruns wait until the workflow completes, without consuming a retry attempt or retaining repository ownership.

Fixes #2323

## UI Surface Contract

- [x] N/A: no UI layout or visibility changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens; browser verification is not applicable.

## Test Plan

- [x] Deterministic mixed failed/pending aggregation and hydration tests.
- [x] Live and restored reservation release, next-candidate dispatch, pending-only safeguards, and transient-rerun tests.
- [x] `make check CHECK_LOCK_WAIT=60m` on `a564680a`: all checks passed; 80.3% overall coverage and configured package/file floors met.
- [x] Full race suites, including GitHub connector and orchestrator.
- [x] All 11 current-head CI jobs passed in [run 34294443357](https://github.com/digitaldrywood/detent/actions/runs/34294443357), including repeated Windows overlay lifecycle verification.

Dependencies #2345 and #2364 are resolved. The Windows portability fix is included in the branch base. The actionable review thread is resolved.
