### PR TITLE
perf(dashboard): cache workflow history

### DIFF
--- a/.detent/skills/revisioned-history-cache.md
+++ b/.detent/skills/revisioned-history-cache.md
@@ -1,0 +1,34 @@
+---
+name: revisioned-history-cache
+description: Separate expensive historical analytics from live operational snapshots using durable revisions and bounded window freshness.
+when_to_use: Use when heartbeat-driven dashboard enrichment repeatedly scans unchanged history and history also has correction or transactional write paths.
+---
+
+Trace every writer before choosing invalidation. A counter in the primary insert
+method misses direct updates, deletes, and other transactions. A singleton
+revision maintained by database triggers covers committed mutations, including
+corrections that preserve row count and timestamp extrema; rollback must restore
+the revision too.
+
+Cache immutable historical results by scope and revision. Bound freshness by
+both wall time and the report window endpoint, and retain the actual computed
+window timestamps. Recompute operational blockers, running status, and lane ages
+from the current snapshot. Check outer snapshot caches as well: an unchanged
+snapshot must not mask a changed history revision indefinitely.
+
+Coalesce concurrent loads, allow waiting requests to cancel, and do not retain
+failed or canceled results. Compare revisions before and after a multi-query
+load so a mutation during reporting forces another refresh. Bound scope entries
+and keep superseded queued snapshots from triggering historical work.
+
+For identity correlation, preserve direct matching semantics. Union candidate
+positions from project-scoped identity indexes and deduplicate positions; do not
+use transitive connected components when the original predicate is pairwise.
+Keep the old implementation as a test oracle for alias collisions, overlapping
+intervals, and stable representative ordering.
+
+Benchmark cold history and heartbeat cadence separately, with six or more runs.
+Advance an injected clock on every simulated heartbeat: a frozen clock or a
+repeating window can accidentally measure permanent cache hits. Include periodic
+refreshes in the cadence comparison. Profile fixture setup separately or identify
+its frames explicitly; database seeding can dominate whole-test CPU profiles.

--- a/docs/workflow-history-performance.md
+++ b/docs/workflow-history-performance.md
@@ -1,0 +1,179 @@
+# Workflow history performance — issue 2326
+
+Measured on 2026-09-08, Go 1.26.6, Darwin arm64, Apple M4 Max.
+Baseline: `6d3a5eabbe0c46d6cf65fce91c223b8ea68626ad` plus the benchmark fixtures in this change.
+Each comparison uses six repetitions and `benchstat`; all reported time
+improvements have p=0.002. These are local production-like fixtures, not a
+measurement of the live Linux daemon, which was left running unchanged.
+
+## Workload and results
+
+The report fixture contains 500 or 2,000 issues across four projects and 55 days,
+with two lane visits and six overlapping active intervals per issue. The SQLite
+fixture uses the same 16,000 events. The dashboard fixture uses 8,000 events for
+2,000 issues, querying all six current/previous windows. It advances an injected
+wall clock by one second per heartbeat and repeats a 30-second observation range
+to keep the history population stable while including periodic refreshes.
+The baseline ignores the injected clock; the snapshot endpoints are identical.
+
+| Benchmark | Before median | After median | Reduction |
+| --- | ---: | ---: | ---: |
+| Report, 500 issues | 65.373 ms | 3.480 ms | 94.68% |
+| Report, 2,000 issues | 1,003.08 ms | 16.78 ms | 98.33% |
+| SQLite report, 2,000 issues | 1,129.1 ms | 112.5 ms | 90.04% |
+| Dashboard heartbeat including cadence | 201.717 ms | 2.585 ms | 98.72% |
+
+The SQLite after timings varied substantially (78% interval); every after sample
+remained below every before sample. Heartbeat before timings varied by 37%; after
+by 7%. The index slightly reduces total allocated bytes (4.32% for 2,000 issues)
+but increases small allocation counts (85.3% for in-memory reports, 4.4% for
+SQLite reports). Across heartbeat cadence, allocated bytes fall 96.73% and
+allocation counts fall 96.54%.
+
+The query-count regressions verify one six-report batch shared by three real SSE
+clients, no new batch on a heartbeat, and a new batch on a history revision or
+30-second window expiry. With unchanged history at one heartbeat per second,
+historical row scans and runtime table-count batches fall from 30 to one per
+30 ticks (96.7%). Tiny revision-row reads remain. This is query-work evidence;
+Linux read-syscall or logical-byte counters were not measured on this Mac.
+
+## CPU profiles
+
+Before/after CPU profiles and their test binaries were captured with
+`go test -cpuprofile` in the Detent-provided temporary directory, under `perf/`.
+Fixtures are populated before `b.Loop`, so allocation/timing measurements exclude
+setup. Whole-test CPU profiles include fixture population: inspect the
+`snapshotWorkflowMetrics` subtree to distinguish reporting from SQLite seeding.
+Adaptive benchmark iteration counts differ, so total sample percentages are not
+a per-operation performance comparison.
+
+In the baseline dashboard subtree, workflow reports accumulated 3.75 CPU seconds:
+`workflowLaneFlows` accounted for 3.02 seconds cumulatively, identity comparison
+0.99 seconds, and `strings.TrimSpace` 0.61 seconds flat. In the cadence profile,
+the dashboard subtree accumulated 2.48 CPU seconds across many more operations;
+SQLite stepping accounts for 1.81 seconds and the broad pairwise identity scan is
+absent. The before in-memory profile similarly identifies lane flows as its
+largest application hotspot (45.98% cumulative). The six-run timings above
+quantify the per-operation reduction.
+
+## Freshness and correctness contract
+
+History windows and runtime table counts are cached for at most 30 seconds,
+measured against both wall time and the observation endpoint. Returned window
+bounds retain the actual report timestamp. SQLite insert/update/delete triggers
+advance a durable revision even when corrections preserve counts and timestamps.
+The revision is checked before and after loading. Failed/canceled loads and loads
+that span a revision change are not retained. Backends without the optional
+revision reader use bounded freshness. Cache scope is the normalized project ID;
+the empty ID represents fleet scope, with at most 16 retained entries.
+
+Running status, blockers, gates, lane ages, and active bottlenecks are still
+enriched from each current snapshot. The outer enrichment cache also observes
+history revision/freshness and coalesces superseded queued snapshots. Identity
+correlation preserves direct, project-isolated ID/identifier/URL/PR matches,
+interval unions, ordering ties, and representative fallback behavior. Randomized
+regressions compare both changed correlation outputs to the original functions.
+
+## Reproduction
+
+Run the benchmark files against the baseline production code and the changed
+code, retaining separate output files and binaries. Use an isolated checkout in
+`TMPDIR` for the baseline. Do not modify or restart a live daemon.
+
+```sh
+go test ./internal/store -run '^$' -bench 'Benchmark(WorkflowHistory|SQLiteWorkflowHistory)$' -benchmem -count=6 -cpuprofile="$TMPDIR/store.cpu" -o "$TMPDIR/store.test"
+go test ./internal/web -run '^$' -bench '^BenchmarkWorkflowSnapshotHeartbeat$' -benchmem -count=6 -cpuprofile="$TMPDIR/web.cpu" -o "$TMPDIR/web.test"
+go tool pprof -top -cum -focus=snapshotWorkflowMetrics "$TMPDIR/web.test" "$TMPDIR/web.cpu"
+```
+
+Goose migration logs can appear between a benchmark name and its result. Remove
+those setup log lines and join the benchmark name to its result before running
+`benchstat`. Preserve the six individual samples; do not compare only averages.
+
+## Recorded samples
+
+Times below are ns/op, with bytes and allocations per operation from Go.
+
+### before
+
+```text
+goos: darwin
+goarch: arm64
+pkg: github.com/digitaldrywood/detent/internal/store
+cpu: Apple M4 Max
+BenchmarkWorkflowHistory/issues_500-16         	      16	  65155133 ns/op	 5159081 B/op	   14288 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	      18	  65599442 ns/op	 5157988 B/op	   14287 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	      16	  65541685 ns/op	 5157897 B/op	   14287 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	      18	  65112139 ns/op	 5157563 B/op	   14287 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	      18	  65203863 ns/op	 5157836 B/op	   14287 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	      18	  65611516 ns/op	 5158476 B/op	   14287 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	       1	1001681708 ns/op	21141632 B/op	   56327 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	       1	1003134417 ns/op	21141632 B/op	   56327 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	       1	1009071709 ns/op	21146984 B/op	   56334 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	       1	1001626125 ns/op	21141632 B/op	   56327 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	       1	1006637458 ns/op	21141632 B/op	   56327 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	       1	1003032041 ns/op	21146952 B/op	   56333 allocs/op
+BenchmarkSQLiteWorkflowHistory-16              	       1	1127621333 ns/op	133269224 B/op	 1092060 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 1	1104399583 ns/op	133254464 B/op	 1092052 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 1	1118588125 ns/op	133254448 B/op	 1092052 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 1	1130671917 ns/op	133246288 B/op	 1092050 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 1	1133305417 ns/op	133246288 B/op	 1092050 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 1	1136438333 ns/op	133246336 B/op	 1092050 allocs/op
+```
+
+### final
+
+```text
+goos: darwin
+goarch: arm64
+pkg: github.com/digitaldrywood/detent/internal/store
+cpu: Apple M4 Max
+BenchmarkWorkflowHistory/issues_500-16         	     348	   3459779 ns/op	 4932656 B/op	   26308 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	     351	   3415017 ns/op	 4932650 B/op	   26308 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	     343	   3728013 ns/op	 4932659 B/op	   26308 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	     345	   3499843 ns/op	 4932644 B/op	   26308 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	     346	   3460983 ns/op	 4932662 B/op	   26308 allocs/op
+BenchmarkWorkflowHistory/issues_500-16         	     331	   3542378 ns/op	 4932614 B/op	   26308 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	      67	  16932214 ns/op	20229332 B/op	  104374 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	      66	  16596540 ns/op	20229462 B/op	  104374 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	      72	  16712961 ns/op	20229510 B/op	  104374 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	      69	  17267289 ns/op	20229253 B/op	  104374 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	      68	  16850848 ns/op	20229258 B/op	  104374 allocs/op
+BenchmarkWorkflowHistory/issues_2000-16        	      73	  16551247 ns/op	20229355 B/op	  104374 allocs/op
+BenchmarkSQLiteWorkflowHistory-16              	       5	 200445775 ns/op	132333684 B/op	 1140096 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 10	 107345183 ns/op	132334540 B/op	 1140096 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 10	 110051000 ns/op	132334560 B/op	 1140096 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 9	 127775824 ns/op	132334296 B/op	 1140096 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 10	 107465517 ns/op	132333731 B/op	 1140096 allocs/op
+BenchmarkSQLiteWorkflowHistory-16 9	 114957926 ns/op	132333730 B/op	 1140096 allocs/op
+```
+
+### heartbeat-before
+
+```text
+goos: darwin
+goarch: arm64
+pkg: github.com/digitaldrywood/detent/internal/web
+cpu: Apple M4 Max
+BenchmarkWorkflowSnapshotHeartbeat-16    	       5	 200109008 ns/op	72527491 B/op	  528939 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 5	 201197125 ns/op	72525665 B/op	  528937 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 5	 200718058 ns/op	72530796 B/op	  528937 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 5	 202237533 ns/op	72525595 B/op	  528936 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 4	 275541166 ns/op	72525410 B/op	  528935 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 5	 202690025 ns/op	72525499 B/op	  528935 allocs/op
+```
+
+### heartbeat-cadence
+
+```text
+goos: darwin
+goarch: arm64
+pkg: github.com/digitaldrywood/detent/internal/web
+cpu: Apple M4 Max
+BenchmarkWorkflowSnapshotHeartbeat-16    	     448	   2555447 ns/op	 2324564 B/op	   17929 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 504	   2430393 ns/op	 2341426 B/op	   18060 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 422	   2596131 ns/op	 2467601 B/op	   19032 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 394	   2712838 ns/op	 2466797 B/op	   19027 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 411	   2573157 ns/op	 2364795 B/op	   18241 allocs/op
+BenchmarkWorkflowSnapshotHeartbeat-16 379	   2770613 ns/op	 2381367 B/op	   18369 allocs/op
+```

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -310,8 +310,9 @@ func workflowMetricsReport(rows []workflowMetricRow, flowRows []workflowMetricRo
 		bucket.turns += event.Turns
 	}
 
-	laneFlows := workflowLaneFlows(flowRows)
-	laneRepresentatives := workflowLaneRepresentativeRuns(rows, flowRows)
+	index := newWorkflowEventIndex(flowRows)
+	laneFlows := workflowLaneFlowsIndexed(flowRows, index)
+	laneRepresentatives := workflowLaneRepresentativeRunsIndexed(rows, index)
 	metrics := make([]WorkflowPhaseMetric, 0, len(buckets))
 	for _, bucket := range buckets {
 		metric := workflowPhaseMetricFromBucket(bucket)
@@ -373,15 +374,7 @@ func workflowMetricKeyFromParts(projectID string, phaseType string, phaseName st
 	return strings.Join(parts, "\x00")
 }
 
-func workflowLaneFlows(rows []workflowMetricRow) map[string]workflowLaneFlow {
-	activeEvents := make([]WorkflowPhaseEvent, 0, len(rows))
-	for _, row := range rows {
-		event := row.event
-		if workflowPhaseTypeIsActive(event.PhaseType) && workflowEventHasInterval(event) {
-			activeEvents = append(activeEvents, event)
-		}
-	}
-
+func workflowLaneFlowsIndexed(rows []workflowMetricRow, index workflowEventIndex) map[string]workflowLaneFlow {
 	flows := map[string]*workflowLaneFlow{}
 	for _, row := range rows {
 		lane := row.event
@@ -397,10 +390,8 @@ func workflowLaneFlows(rows []workflowMetricRow) map[string]workflowLaneFlow {
 
 		activeIntervals := []workflowInterval{}
 		if workflowEventHasInterval(lane) {
-			for _, activeEvent := range activeEvents {
-				if !workflowEventsShareIssue(lane, activeEvent) {
-					continue
-				}
+			for _, candidate := range index.matching(lane) {
+				activeEvent := index.events[candidate]
 				if overlap, ok := workflowEventOverlap(lane, activeEvent); ok {
 					activeIntervals = append(activeIntervals, overlap)
 				}
@@ -424,21 +415,7 @@ func workflowLaneFlows(rows []workflowMetricRow) map[string]workflowLaneFlow {
 	return out
 }
 
-func workflowLaneRepresentativeRuns(rows []workflowMetricRow, flowRows []workflowMetricRow) map[string][]WorkflowRepresentativeRun {
-	activeEvents := make([]WorkflowPhaseEvent, 0, len(flowRows))
-	for _, row := range flowRows {
-		event := row.event
-		if workflowPhaseTypeIsActive(event.PhaseType) && workflowEventHasInterval(event) {
-			activeEvents = append(activeEvents, event)
-		}
-	}
-	sort.SliceStable(activeEvents, func(i int, j int) bool {
-		if activeEvents[i].FinishedAt.Equal(activeEvents[j].FinishedAt) {
-			return activeEvents[i].ID > activeEvents[j].ID
-		}
-		return activeEvents[i].FinishedAt.After(activeEvents[j].FinishedAt)
-	})
-
+func workflowLaneRepresentativeRunsIndexed(rows []workflowMetricRow, index workflowEventIndex) map[string][]WorkflowRepresentativeRun {
 	laneEvents := make([]WorkflowPhaseEvent, 0, len(rows))
 	for _, row := range rows {
 		event := row.event
@@ -458,12 +435,10 @@ func workflowLaneRepresentativeRuns(rows []workflowMetricRow, flowRows []workflo
 	fallbacks := map[string][]WorkflowRepresentativeRun{}
 	for _, lane := range laneEvents {
 		key := workflowMetricKey(lane)
-		for _, activeEvent := range activeEvents {
+		for _, candidate := range index.matching(lane) {
+			activeEvent := index.events[candidate]
 			if len(out[key]) >= maxWorkflowRepresentativeRuns {
 				break
-			}
-			if !workflowEventsShareIssue(lane, activeEvent) {
-				continue
 			}
 			if _, ok := workflowEventOverlap(lane, activeEvent); !ok {
 				continue
@@ -675,31 +650,6 @@ func workflowEventHasInterval(event WorkflowPhaseEvent) bool {
 	return !event.StartedAt.IsZero() && !event.FinishedAt.IsZero() && event.StartedAt.Before(event.FinishedAt)
 }
 
-func workflowEventsShareIssue(lane WorkflowPhaseEvent, event WorkflowPhaseEvent) bool {
-	if strings.TrimSpace(lane.ProjectID) != strings.TrimSpace(event.ProjectID) {
-		return false
-	}
-	if workflowNonEmptyEqual(lane.IssueID, event.IssueID) {
-		return true
-	}
-	if workflowNonEmptyEqual(lane.Identifier, event.Identifier) {
-		return true
-	}
-	if workflowNonEmptyEqual(lane.IssueURL, event.IssueURL) {
-		return true
-	}
-	if lane.PRNumber != nil && event.PRNumber != nil && *lane.PRNumber == *event.PRNumber {
-		return true
-	}
-	return false
-}
-
-func workflowNonEmptyEqual(a string, b string) bool {
-	a = strings.TrimSpace(a)
-	b = strings.TrimSpace(b)
-	return a != "" && b != "" && a == b
-}
-
 func workflowEventOverlap(lane WorkflowPhaseEvent, event WorkflowPhaseEvent) (workflowInterval, bool) {
 	startedAt := lane.StartedAt
 	if event.StartedAt.After(startedAt) {
@@ -881,4 +831,12 @@ func workflowPhaseEventFromRow(row sqlc.WorkflowPhaseEvent) (WorkflowPhaseEvent,
 		event.ModelContextWindow = &value
 	}
 	return event, nil
+}
+
+func (s *sqliteStore) WorkflowHistoryRevision(ctx context.Context) (int64, error) {
+	var revision int64
+	if err := s.db.QueryRowContext(ctx, "SELECT revision FROM workflow_history_revision WHERE id = 1").Scan(&revision); err != nil {
+		return 0, fmt.Errorf("reading workflow history revision: %w", err)
+	}
+	return revision, nil
 }

--- a/internal/store/metrics_benchmark_test.go
+++ b/internal/store/metrics_benchmark_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func benchmarkWorkflowRows(issues int) []workflowMetricRow {
+	rows := make([]workflowMetricRow, 0, issues*8)
+	for i := range issues {
+		project := fmt.Sprintf("project-%d", i%4)
+		issue := fmt.Sprintf("issue-%d", i)
+		offset := -time.Duration(i%55) * 24 * time.Hour
+		for j := range 2 {
+			lane := workflowMetricTestEvent(project, issue, WorkflowPhaseTypeLane, "In Progress", offset+time.Duration(j)*time.Hour, time.Hour)
+			lane.ID = int64(len(rows) + 1)
+			rows = append(rows, workflowMetricRow{event: lane})
+			for k := range 3 {
+				active := workflowMetricTestEvent(project, issue, WorkflowPhaseTypeAgentSession, "implement", offset+time.Duration(j)*time.Hour+time.Duration(k)*10*time.Minute, 20*time.Minute)
+				active.ID = int64(len(rows) + 1)
+				rows = append(rows, workflowMetricRow{event: active})
+			}
+		}
+	}
+	return rows
+}
+
+func BenchmarkWorkflowHistory(b *testing.B) {
+	for _, issues := range []int{500, 2000} {
+		b.Run(fmt.Sprintf("issues_%d", issues), func(b *testing.B) {
+			rows := benchmarkWorkflowRows(issues)
+			b.ReportAllocs()
+			for b.Loop() {
+				workflowMetricsReport(rows, rows, workflowMetricTestBase.Add(-60*24*time.Hour), workflowMetricTestBase.Add(24*time.Hour))
+			}
+		})
+	}
+}
+
+func BenchmarkSQLiteWorkflowHistory(b *testing.B) {
+	backend, err := openSQLite(b.Context(), Config{Path: filepath.Join(b.TempDir(), "history.db")})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			b.Error(err)
+		}
+	})
+	for _, row := range benchmarkWorkflowRows(2000) {
+		if _, err := backend.RecordWorkflowPhaseEvent(b.Context(), row.event); err != nil {
+			b.Fatal(err)
+		}
+	}
+	query := WorkflowMetricsQuery{From: workflowMetricTestBase.Add(-60 * 24 * time.Hour), To: workflowMetricTestBase.Add(24 * time.Hour)}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := backend.WorkflowMetricsReport(b.Context(), query); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/store/metrics_index.go
+++ b/internal/store/metrics_index.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type workflowEventKey struct {
+	project string
+	kind    int
+	value   string
+}
+
+type workflowEventIndex struct {
+	events     []WorkflowPhaseEvent
+	identities map[workflowEventKey][]int
+}
+
+func workflowEventKeys(event WorkflowPhaseEvent) [4]workflowEventKey {
+	project := strings.TrimSpace(event.ProjectID)
+	keys := [4]workflowEventKey{
+		{project, 0, strings.TrimSpace(event.IssueID)},
+		{project, 1, strings.TrimSpace(event.Identifier)},
+		{project, 2, strings.TrimSpace(event.IssueURL)},
+		{project, 3, ""},
+	}
+	if event.PRNumber != nil {
+		keys[3].value = strconv.FormatInt(*event.PRNumber, 10)
+	}
+	return keys
+}
+
+func newWorkflowEventIndex(rows []workflowMetricRow) workflowEventIndex {
+	index := workflowEventIndex{identities: make(map[workflowEventKey][]int), events: make([]WorkflowPhaseEvent, 0, len(rows))}
+	for _, row := range rows {
+		if workflowPhaseTypeIsActive(row.event.PhaseType) && workflowEventHasInterval(row.event) {
+			index.events = append(index.events, row.event)
+		}
+	}
+	sort.SliceStable(index.events, func(i, j int) bool {
+		if index.events[i].FinishedAt.Equal(index.events[j].FinishedAt) {
+			return index.events[i].ID > index.events[j].ID
+		}
+		return index.events[i].FinishedAt.After(index.events[j].FinishedAt)
+	})
+	for i, event := range index.events {
+		for _, key := range workflowEventKeys(event) {
+			if key.value != "" {
+				index.identities[key] = append(index.identities[key], i)
+			}
+		}
+	}
+	return index
+}
+
+func (index workflowEventIndex) matching(event WorkflowPhaseEvent) []int {
+	var candidates []int
+	for _, key := range workflowEventKeys(event) {
+		if key.value != "" {
+			candidates = append(candidates, index.identities[key]...)
+		}
+	}
+	sort.Ints(candidates)
+	return slices.Compact(candidates)
+}

--- a/internal/store/metrics_index_test.go
+++ b/internal/store/metrics_index_test.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"math/rand/v2"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestWorkflowIndexedCorrelationEquivalence(t *testing.T) {
+	t.Parallel()
+	for _, seed := range []uint64{1, 7, 42, 2326} {
+		t.Run(strconv.FormatUint(seed, 10), func(t *testing.T) {
+			random := rand.New(rand.NewPCG(seed, seed+1))
+			values := []string{"", " ", "a", " a ", "b", "c"}
+			rows := make([]workflowMetricRow, 0, 400)
+			for i := range 400 {
+				phase := []WorkflowPhaseType{WorkflowPhaseTypeLane, WorkflowPhaseTypeAgentSession, WorkflowPhaseTypeCI, WorkflowPhaseTypeLocalCheck, WorkflowPhaseTypeReview}[random.IntN(5)]
+				event := WorkflowPhaseEvent{
+					ID: int64(i % 11), ProjectID: values[random.IntN(len(values))],
+					IssueID: values[random.IntN(len(values))], Identifier: values[random.IntN(len(values))], IssueURL: values[random.IntN(len(values))],
+					PhaseType: phase, PhaseName: []string{"In Progress", "Merging", "Rework"}[random.IntN(3)],
+					StartedAt:       workflowMetricTestBase.Add(time.Duration(random.IntN(10)) * time.Minute),
+					FinishedAt:      workflowMetricTestBase.Add(time.Duration(random.IntN(15)) * time.Minute),
+					DurationSeconds: int64(random.IntN(1000) - 1), RunID: int64(random.IntN(15)), SessionID: int64(random.IntN(15)),
+				}
+				if random.IntN(2) == 0 {
+					event.PRNumber = new(int64(random.IntN(3)))
+				}
+				rows = append(rows, workflowMetricRow{event: event})
+			}
+			if got, want := workflowLaneFlowsIndexed(rows, newWorkflowEventIndex(rows)), referenceWorkflowLaneFlows(rows); !reflect.DeepEqual(got, want) {
+				t.Fatalf("flows differ: got %#v want %#v", got, want)
+			}
+			for _, selected := range [][]workflowMetricRow{rows, rows[:100], nil} {
+				if got, want := workflowLaneRepresentativeRunsIndexed(selected, newWorkflowEventIndex(rows)), referenceWorkflowLaneRepresentativeRuns(selected, rows); !reflect.DeepEqual(got, want) {
+					t.Fatalf("representatives differ: got %#v want %#v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWorkflowHistoryRevision(t *testing.T) {
+	t.Parallel()
+	backend, err := openSQLite(t.Context(), Config{Path: filepath.Join(t.TempDir(), "history.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	event := workflowMetricTestEvent("project", "issue", WorkflowPhaseTypeLane, "In Progress", 0, time.Hour)
+	var id int64
+	tests := []struct {
+		name   string
+		mutate func() error
+		want   int64
+	}{
+		{"initial", func() error { return nil }, 0},
+		{"insert", func() error {
+			var err error
+			id, err = backend.RecordWorkflowPhaseEvent(t.Context(), event)
+			return err
+		}, 1},
+		{"metadata correction", func() error { return backend.UpdateWorkflowPhaseEventMetadata(t.Context(), id, `{"corrected":true}`) }, 2},
+		{"same count and timestamps correction", func() error {
+			_, err := backend.db.ExecContext(t.Context(), "UPDATE workflow_phase_events SET duration_seconds = 42 WHERE id = ?", id)
+			return err
+		}, 3},
+		{"rollback", func() error {
+			tx, err := backend.db.BeginTx(t.Context(), nil)
+			if err != nil {
+				return err
+			}
+			if _, err = tx.ExecContext(t.Context(), "DELETE FROM workflow_phase_events"); err != nil {
+				t.Error(err)
+			}
+			return tx.Rollback()
+		}, 3},
+		{"delete", func() error {
+			_, err := backend.db.ExecContext(t.Context(), "DELETE FROM workflow_phase_events WHERE id = ?", id)
+			return err
+		}, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.mutate(); err != nil {
+				t.Fatal(err)
+			}
+			got, err := backend.WorkflowHistoryRevision(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("revision = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/store/metrics_reference_test.go
+++ b/internal/store/metrics_reference_test.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"sort"
+	"strings"
+)
+
+func referenceWorkflowLaneFlows(rows []workflowMetricRow) map[string]workflowLaneFlow {
+	activeEvents := make([]WorkflowPhaseEvent, 0, len(rows))
+	for _, row := range rows {
+		event := row.event
+		if workflowPhaseTypeIsActive(event.PhaseType) && workflowEventHasInterval(event) {
+			activeEvents = append(activeEvents, event)
+		}
+	}
+
+	flows := map[string]*workflowLaneFlow{}
+	for _, row := range rows {
+		lane := row.event
+		if lane.PhaseType != WorkflowPhaseTypeLane || lane.DurationSeconds < 0 {
+			continue
+		}
+		key := workflowMetricKey(lane)
+		flow, ok := flows[key]
+		if !ok {
+			flow = &workflowLaneFlow{}
+			flows[key] = flow
+		}
+
+		activeIntervals := []workflowInterval{}
+		if workflowEventHasInterval(lane) {
+			for _, activeEvent := range activeEvents {
+				if !workflowEventsShareIssue(lane, activeEvent) {
+					continue
+				}
+				if overlap, ok := workflowEventOverlap(lane, activeEvent); ok {
+					activeIntervals = append(activeIntervals, overlap)
+				}
+			}
+		}
+		activeSeconds := workflowMergedIntervalSeconds(activeIntervals)
+		if activeSeconds > lane.DurationSeconds {
+			activeSeconds = lane.DurationSeconds
+		}
+		if activeSeconds < 0 {
+			activeSeconds = 0
+		}
+		flow.activeSeconds += activeSeconds
+		flow.waitSeconds += lane.DurationSeconds - activeSeconds
+	}
+
+	out := make(map[string]workflowLaneFlow, len(flows))
+	for key, flow := range flows {
+		out[key] = *flow
+	}
+	return out
+}
+
+func referenceWorkflowLaneRepresentativeRuns(rows []workflowMetricRow, flowRows []workflowMetricRow) map[string][]WorkflowRepresentativeRun {
+	activeEvents := make([]WorkflowPhaseEvent, 0, len(flowRows))
+	for _, row := range flowRows {
+		event := row.event
+		if workflowPhaseTypeIsActive(event.PhaseType) && workflowEventHasInterval(event) {
+			activeEvents = append(activeEvents, event)
+		}
+	}
+	sort.SliceStable(activeEvents, func(i int, j int) bool {
+		if activeEvents[i].FinishedAt.Equal(activeEvents[j].FinishedAt) {
+			return activeEvents[i].ID > activeEvents[j].ID
+		}
+		return activeEvents[i].FinishedAt.After(activeEvents[j].FinishedAt)
+	})
+
+	laneEvents := make([]WorkflowPhaseEvent, 0, len(rows))
+	for _, row := range rows {
+		event := row.event
+		if event.PhaseType == WorkflowPhaseTypeLane && event.DurationSeconds >= 0 {
+			laneEvents = append(laneEvents, event)
+		}
+	}
+	sort.SliceStable(laneEvents, func(i int, j int) bool {
+		if laneEvents[i].FinishedAt.Equal(laneEvents[j].FinishedAt) {
+			return laneEvents[i].ID > laneEvents[j].ID
+		}
+		return laneEvents[i].FinishedAt.After(laneEvents[j].FinishedAt)
+	})
+
+	out := map[string][]WorkflowRepresentativeRun{}
+	seen := map[string]map[string]struct{}{}
+	fallbacks := map[string][]WorkflowRepresentativeRun{}
+	for _, lane := range laneEvents {
+		key := workflowMetricKey(lane)
+		for _, activeEvent := range activeEvents {
+			if len(out[key]) >= maxWorkflowRepresentativeRuns {
+				break
+			}
+			if !workflowEventsShareIssue(lane, activeEvent) {
+				continue
+			}
+			if _, ok := workflowEventOverlap(lane, activeEvent); !ok {
+				continue
+			}
+			representative := workflowRepresentativeRunFromEvents(lane, activeEvent)
+			workflowAppendRepresentative(out, seen, key, representative)
+		}
+		fallbacks[key] = append(fallbacks[key], workflowRepresentativeRunFromEvents(lane, lane))
+	}
+	for key, representatives := range fallbacks {
+		for _, representative := range representatives {
+			if len(out[key]) >= maxWorkflowRepresentativeRuns {
+				break
+			}
+			workflowAppendRepresentative(out, seen, key, representative)
+		}
+	}
+	return out
+}
+
+func workflowEventsShareIssue(lane WorkflowPhaseEvent, event WorkflowPhaseEvent) bool {
+	if strings.TrimSpace(lane.ProjectID) != strings.TrimSpace(event.ProjectID) {
+		return false
+	}
+	if workflowNonEmptyEqual(lane.IssueID, event.IssueID) {
+		return true
+	}
+	if workflowNonEmptyEqual(lane.Identifier, event.Identifier) {
+		return true
+	}
+	if workflowNonEmptyEqual(lane.IssueURL, event.IssueURL) {
+		return true
+	}
+	if lane.PRNumber != nil && event.PRNumber != nil && *lane.PRNumber == *event.PRNumber {
+		return true
+	}
+	return false
+}
+
+func workflowNonEmptyEqual(a string, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	return a != "" && b != "" && a == b
+}

--- a/internal/store/migrations/00057_add_workflow_history_revision.sql
+++ b/internal/store/migrations/00057_add_workflow_history_revision.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+CREATE TABLE workflow_history_revision (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  revision INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO workflow_history_revision (id) VALUES (1);
+
+-- +goose StatementBegin
+CREATE TRIGGER workflow_history_insert AFTER INSERT ON workflow_phase_events
+BEGIN
+  UPDATE workflow_history_revision SET revision = revision + 1 WHERE id = 1;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER workflow_history_update AFTER UPDATE ON workflow_phase_events
+BEGIN
+  UPDATE workflow_history_revision SET revision = revision + 1 WHERE id = 1;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER workflow_history_delete AFTER DELETE ON workflow_phase_events
+BEGIN
+  UPDATE workflow_history_revision SET revision = revision + 1 WHERE id = 1;
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TRIGGER workflow_history_delete;
+DROP TRIGGER workflow_history_update;
+DROP TRIGGER workflow_history_insert;
+DROP TABLE workflow_history_revision;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -543,6 +543,11 @@ type WorkAttempt struct {
 	RuntimeIdentityJson    string         `json:"runtime_identity_json"`
 }
 
+type WorkflowHistoryRevision struct {
+	ID       int64 `json:"id"`
+	Revision int64 `json:"revision"`
+}
+
 type WorkflowPhaseEvent struct {
 	ID                    int64          `json:"id"`
 	ProjectID             string         `json:"project_id"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -144,6 +144,10 @@ type ProgressCreditStore interface {
 	IssueProgressCredit(context.Context, IssueIdentity) (IssueProgressCredit, error)
 }
 
+type WorkflowHistoryRevisionReader interface {
+	WorkflowHistoryRevision(context.Context) (int64, error)
+}
+
 type WorkflowMetricsStore interface {
 	RecordWorkflowPhaseEvent(context.Context, WorkflowPhaseEvent) (int64, error)
 	WorkflowMetricsReport(context.Context, WorkflowMetricsQuery) (WorkflowMetricsReport, error)

--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -35,6 +35,9 @@ type snapshotEnrichmentCache struct {
 	raw      telemetry.Snapshot
 	enriched telemetry.Snapshot
 	loading  bool
+	pending  telemetry.Snapshot
+	revision int64
+	loadedAt time.Time
 }
 
 type spendRegressionMonitor struct {
@@ -53,7 +56,11 @@ func newSnapshotEnrichmentCache() *snapshotEnrichmentCache {
 }
 
 func (s *Server) cachedEnrichedSnapshot(ctx context.Context, snapshot telemetry.Snapshot) telemetry.Snapshot {
-	return s.snapshots.enrich(ctx, snapshot, s.enrichSnapshot)
+	revision, err := workflowHistoryRevision(ctx, s.store)
+	if err != nil {
+		return s.enrichSnapshot(ctx, snapshot)
+	}
+	return s.snapshots.enrichVersion(ctx, snapshot, revision, s.now(), s.enrichSnapshot)
 }
 
 func (c *snapshotEnrichmentCache) get(snapshot telemetry.Snapshot) (telemetry.Snapshot, bool) {
@@ -88,14 +95,33 @@ func sameSnapshotForEnrichment(left telemetry.Snapshot, right telemetry.Snapshot
 	return reflect.DeepEqual(left, right)
 }
 
+func newerEnrichmentSnapshot(left, right telemetry.Snapshot) bool {
+	return left.Seq > right.Seq && left.Project.ID == right.Project.ID && !left.GeneratedAt.Before(right.GeneratedAt)
+}
+
 func (c *snapshotEnrichmentCache) enrich(ctx context.Context, snapshot telemetry.Snapshot, enrich func(context.Context, telemetry.Snapshot) telemetry.Snapshot) telemetry.Snapshot {
+	return c.enrichVersion(ctx, snapshot, 0, time.Now(), enrich)
+}
+
+func (c *snapshotEnrichmentCache) enrichVersion(ctx context.Context, snapshot telemetry.Snapshot, revision int64, now time.Time, enrich func(context.Context, telemetry.Snapshot) telemetry.Snapshot) telemetry.Snapshot {
 	if c == nil {
 		return enrich(ctx, snapshot)
 	}
 
 	c.mu.Lock()
+	if !c.loading || newerEnrichmentSnapshot(snapshot, c.pending) {
+		c.pending = snapshot
+	}
 	for {
-		if c.cached && sameSnapshotForEnrichment(c.raw, snapshot) {
+		if ctx != nil && ctx.Err() != nil {
+			c.mu.Unlock()
+			return snapshot
+		}
+		if newerEnrichmentSnapshot(c.pending, snapshot) {
+			snapshot = c.pending
+		}
+
+		if c.cached && c.revision == revision && workflowHistoryFresh(c.loadedAt, now) && (sameSnapshotForEnrichment(c.raw, snapshot) || newerEnrichmentSnapshot(c.raw, snapshot)) {
 			enriched := c.enriched
 			c.mu.Unlock()
 			return enriched
@@ -119,6 +145,8 @@ func (c *snapshotEnrichmentCache) enrich(ctx context.Context, snapshot telemetry
 	}
 
 	c.mu.Lock()
+	c.revision = revision
+	c.loadedAt = now
 	c.raw = snapshot
 	c.enriched = enriched
 	c.cached = true

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -209,6 +209,7 @@ type Server struct {
 	assets              staticAssets
 	projects            *projectSmallMultipleRecorder
 	snapshots           *snapshotEnrichmentCache
+	workflowHistory     workflowHistoryCache
 	stateEndpoints      *stateEndpointRecorder
 	spendRegressions    *spendRegressionMonitor
 	kanbanMutations     *kanbanstate.MutationTracker

--- a/internal/web/workflow_history_cache.go
+++ b/internal/web/workflow_history_cache.go
@@ -1,0 +1,92 @@
+package web
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const workflowHistoryFreshness = 30 * time.Second
+const maxWorkflowHistoryScopes = 16
+
+type workflowHistoryEntry struct {
+	metrics    telemetry.WorkflowMetrics
+	revision   int64
+	observedAt time.Time
+	loadedAt   time.Time
+}
+
+type workflowHistoryCache struct {
+	mu      sync.Mutex
+	entries map[string]workflowHistoryEntry
+	loading chan struct{}
+}
+
+func (c *workflowHistoryCache) get(ctx context.Context, backend store.Store, projectID string, observedAt time.Time, clock func() time.Time, load func(context.Context, string, time.Time) telemetry.WorkflowMetrics) telemetry.WorkflowMetrics {
+	if clock == nil {
+		clock = time.Now
+	}
+	for {
+		revision, err := workflowHistoryRevision(ctx, backend)
+		if err != nil {
+			return telemetry.WorkflowMetrics{DegradedReason: "workflow history revision query failed"}
+		}
+		now := clock()
+		c.mu.Lock()
+		entry, ok := c.entries[projectID]
+		if ok && entry.revision == revision && workflowHistoryFresh(entry.loadedAt, now) && workflowHistoryFresh(entry.observedAt, observedAt) {
+			c.mu.Unlock()
+			return entry.metrics
+		}
+		if loading := c.loading; loading != nil {
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return telemetry.WorkflowMetrics{DegradedReason: "workflow history query canceled"}
+			case <-loading:
+				continue
+			}
+		}
+		c.loading = make(chan struct{})
+		c.mu.Unlock()
+
+		metrics := load(ctx, projectID, observedAt)
+		finalRevision, revisionErr := workflowHistoryRevision(ctx, backend)
+		c.mu.Lock()
+		if metrics.Available && ctx.Err() == nil && revisionErr == nil && revision == finalRevision {
+			if c.entries == nil {
+				c.entries = make(map[string]workflowHistoryEntry)
+			}
+			if len(c.entries) >= maxWorkflowHistoryScopes {
+				var oldestProject string
+				var oldest time.Time
+				for project, candidate := range c.entries {
+					if oldest.IsZero() || candidate.loadedAt.Before(oldest) {
+						oldestProject, oldest = project, candidate.loadedAt
+					}
+				}
+				delete(c.entries, oldestProject)
+			}
+			c.entries[projectID] = workflowHistoryEntry{metrics: metrics, revision: revision, observedAt: observedAt, loadedAt: now}
+		}
+		close(c.loading)
+		c.loading = nil
+		c.mu.Unlock()
+		return metrics
+	}
+}
+
+func workflowHistoryFresh(loadedAt, now time.Time) bool {
+	elapsed := now.Sub(loadedAt)
+	return elapsed >= 0 && elapsed < workflowHistoryFreshness
+}
+
+func workflowHistoryRevision(ctx context.Context, backend store.Store) (int64, error) {
+	if reader, ok := backend.(store.WorkflowHistoryRevisionReader); ok {
+		return reader.WorkflowHistoryRevision(ctx)
+	}
+	return 0, nil
+}

--- a/internal/web/workflow_history_cache_test.go
+++ b/internal/web/workflow_history_cache_test.go
@@ -1,0 +1,265 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type workflowHistoryTestStore struct {
+	store.Store
+	revision      atomic.Int64
+	reports       atomic.Int64
+	evidence      atomic.Int64
+	revisionError bool
+	reportError   bool
+	onReport      func()
+}
+
+func (s *workflowHistoryTestStore) WorkflowHistoryRevision(context.Context) (int64, error) {
+	if s.revisionError {
+		return 0, errors.New("revision unavailable")
+	}
+	return s.revision.Load(), nil
+}
+func (s *workflowHistoryTestStore) RuntimeEvidence(context.Context, store.RuntimeEvidenceQuery) (store.RuntimeEvidence, error) {
+	s.evidence.Add(1)
+	return store.RuntimeEvidence{Healthy: true}, nil
+}
+func (s *workflowHistoryTestStore) WorkflowMetricsReport(_ context.Context, q store.WorkflowMetricsQuery) (store.WorkflowMetricsReport, error) {
+	s.reports.Add(1)
+	if s.onReport != nil {
+		s.onReport()
+	}
+	if s.reportError {
+		return store.WorkflowMetricsReport{}, errors.New("report unavailable")
+	}
+	return store.WorkflowMetricsReport{Lanes: []store.WorkflowPhaseMetric{{ProjectID: q.ProjectID, PhaseName: "In Progress", Count: 1, AverageSeconds: s.revision.Load()}}}, nil
+}
+
+func TestWorkflowHistoryCacheCadence(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name               string
+		elapsed, timeShift time.Duration
+		project            string
+		changed            bool
+		want               int64
+	}{
+		{name: "heartbeat", elapsed: time.Second, timeShift: time.Second, want: 6},
+		{name: "bounded wall freshness", elapsed: 30 * time.Second, want: 12},
+		{name: "moving window", timeShift: 30 * time.Second, want: 12},
+		{name: "clock moves backward", elapsed: -time.Second, want: 12},
+		{name: "window moves backward", timeShift: -time.Second, want: 12},
+		{name: "correction", changed: true, want: 12},
+		{name: "project scope", project: "other", want: 12},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &workflowHistoryTestStore{}
+			now := base
+			server := &Server{store: backend, logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return now }}
+			snapshot := telemetry.Snapshot{Seq: 1, GeneratedAt: base}
+			first := server.snapshotWorkflowMetrics(t.Context(), snapshot)
+			if !first.Available {
+				t.Fatal("history unavailable")
+			}
+			now = base.Add(tt.elapsed)
+			snapshot.GeneratedAt = base.Add(tt.timeShift)
+			snapshot.Seq++
+			snapshot.Project.ID = tt.project
+			snapshot.Running = []telemetry.Running{{Issue: telemetry.Issue{ID: "live"}, RuntimeSeconds: 42}}
+			if tt.changed {
+				backend.revision.Add(1)
+			}
+			got := server.snapshotWorkflowMetrics(t.Context(), snapshot)
+			if backend.reports.Load() != tt.want {
+				t.Fatalf("reports = %d, want %d", backend.reports.Load(), tt.want)
+			}
+			if backend.evidence.Load() != tt.want/6 {
+				t.Fatalf("evidence queries = %d", backend.evidence.Load())
+			}
+			if got.ActiveBottleneck.IssueID != "live" || got.ActiveBottleneck.Seconds != 42 {
+				t.Fatalf("stale operational evidence: %#v", got.ActiveBottleneck)
+			}
+			if got.Windows[0].Lanes[0].ProjectID != tt.project {
+				t.Fatal("project scope leaked")
+			}
+			wantTo := base
+			if tt.want == 12 {
+				wantTo = snapshot.GeneratedAt
+			}
+			if !got.Windows[0].To.Equal(wantTo) {
+				t.Fatalf("window timestamp = %s, want %s", got.Windows[0].To, wantTo)
+			}
+		})
+	}
+}
+
+func TestWorkflowHistoryConcurrentClients(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		backend := &workflowHistoryTestStore{}
+		started, release := make(chan struct{}), make(chan struct{})
+		var once sync.Once
+		backend.onReport = func() { once.Do(func() { close(started); <-release }) }
+		server := &Server{store: backend, logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: time.Now}
+		snapshot := telemetry.Snapshot{GeneratedAt: time.Now()}
+		var wg sync.WaitGroup
+		for range 12 {
+			wg.Go(func() {
+				if !server.snapshotWorkflowMetrics(t.Context(), snapshot).Available {
+					t.Error("history unavailable")
+				}
+			})
+		}
+		<-started
+		synctest.Wait()
+		close(release)
+		wg.Wait()
+		if backend.reports.Load() != 6 || backend.evidence.Load() != 1 {
+			t.Fatalf("queries: reports=%d evidence=%d", backend.reports.Load(), backend.evidence.Load())
+		}
+	})
+}
+
+func TestWorkflowHistoryCacheFailureAndConcurrentMutation(t *testing.T) {
+	for _, mode := range []string{"report failure", "revision failure", "mutation during load", "canceled load"} {
+		t.Run(mode, func(t *testing.T) {
+			backend := &workflowHistoryTestStore{}
+			server := &Server{store: backend, logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: time.Now}
+			snapshot := telemetry.Snapshot{GeneratedAt: time.Now()}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			switch mode {
+			case "report failure":
+				backend.reportError = true
+			case "revision failure":
+				backend.revisionError = true
+			case "mutation during load":
+				backend.onReport = func() { backend.revision.Add(1) }
+			case "canceled load":
+				backend.onReport = cancel
+			}
+			server.snapshotWorkflowMetrics(ctx, snapshot)
+			before := backend.reports.Load()
+			backend.reportError = false
+			backend.revisionError = false
+			backend.onReport = nil
+			if !server.snapshotWorkflowMetrics(t.Context(), snapshot).Available {
+				t.Fatal("retry did not recover")
+			}
+			if backend.reports.Load() != before+6 {
+				t.Fatal("invalid load was cached")
+			}
+		})
+	}
+}
+
+func TestWorkflowHistoryWaitCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		backend := &workflowHistoryTestStore{}
+		release := make(chan struct{})
+		backend.onReport = func() { <-release }
+		server := &Server{store: backend, logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: time.Now}
+		snapshot := telemetry.Snapshot{GeneratedAt: time.Now()}
+		var wg sync.WaitGroup
+		wg.Go(func() { server.snapshotWorkflowMetrics(t.Context(), snapshot) })
+		synctest.Wait()
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan telemetry.WorkflowMetrics, 1)
+		go func() { done <- server.snapshotWorkflowMetrics(ctx, snapshot) }()
+		synctest.Wait()
+		cancel()
+		if got := <-done; got.Available || got.DegradedReason == "" {
+			t.Fatal("canceled waiter returned history")
+		}
+		close(release)
+		wg.Wait()
+	})
+}
+
+func TestSnapshotEnrichmentSkipsSupersededClients(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cache := newSnapshotEnrichmentCache()
+		release := make(chan struct{})
+		var calls atomic.Int64
+		enrich := func(_ context.Context, snapshot telemetry.Snapshot) telemetry.Snapshot {
+			if calls.Add(1) == 1 {
+				<-release
+			}
+			return snapshot
+		}
+		base := telemetry.Snapshot{Seq: 1, GeneratedAt: time.Now()}
+		var wg sync.WaitGroup
+		wg.Go(func() { cache.enrich(t.Context(), base, enrich) })
+		synctest.Wait()
+		for seq := uint64(2); seq <= 10; seq++ {
+			snapshot := base
+			snapshot.Seq = seq
+			wg.Go(func() { cache.enrich(t.Context(), snapshot, enrich) })
+		}
+		synctest.Wait()
+		close(release)
+		wg.Wait()
+		if calls.Load() != 2 {
+			t.Fatalf("enrich calls = %d, want 2", calls.Load())
+		}
+		if got := cache.enrich(t.Context(), base, enrich); got.Seq != 10 {
+			t.Fatalf("stale client regressed cache to %d", got.Seq)
+		}
+	})
+}
+
+func TestSnapshotEnrichmentHistoryInvalidation(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		revision int64
+		elapsed  time.Duration
+		want     int
+	}{
+		{name: "identical snapshot", want: 1},
+		{name: "corrected history", revision: 1, want: 2},
+		{name: "bounded freshness", elapsed: workflowHistoryFreshness, want: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSnapshotEnrichmentCache()
+			now := time.Now()
+			calls := 0
+			enrich := func(_ context.Context, snapshot telemetry.Snapshot) telemetry.Snapshot { calls++; return snapshot }
+			snapshot := telemetry.Snapshot{Seq: 1, GeneratedAt: now}
+			cache.enrichVersion(t.Context(), snapshot, 0, now, enrich)
+			cache.enrichVersion(t.Context(), snapshot, tt.revision, now.Add(tt.elapsed), enrich)
+			if calls != tt.want {
+				t.Fatalf("calls = %d, want %d", calls, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowHistoryScopeEviction(t *testing.T) {
+	backend := &workflowHistoryTestStore{}
+	now := time.Now()
+	server := &Server{store: backend, logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return now }}
+	for i := range maxWorkflowHistoryScopes + 1 {
+		snapshot := telemetry.Snapshot{GeneratedAt: now}
+		snapshot.Project.ID = string(rune('a' + i))
+		server.snapshotWorkflowMetrics(t.Context(), snapshot)
+		now = now.Add(time.Millisecond)
+	}
+	if len(server.workflowHistory.entries) != maxWorkflowHistoryScopes {
+		t.Fatalf("cached scopes = %d", len(server.workflowHistory.entries))
+	}
+	if _, ok := server.workflowHistory.entries["a"]; ok {
+		t.Fatal("oldest scope was retained")
+	}
+}

--- a/internal/web/workflow_history_sse_test.go
+++ b/internal/web/workflow_history_sse_test.go
@@ -1,0 +1,75 @@
+package web_test
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+type workflowSSECountingStore struct {
+	enrichmentQueryCountingStore
+	revision atomic.Int64
+}
+
+func (s *workflowSSECountingStore) WorkflowHistoryRevision(context.Context) (int64, error) {
+	return s.revision.Load(), nil
+}
+
+func TestWorkflowHistorySharedAcrossSSEClients(t *testing.T) {
+	t.Parallel()
+	backend := &workflowSSECountingStore{}
+	deps := testDeps(t)
+	deps.Store = backend
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour, SSEFragmentInterval: -1, Now: func() time.Time { return now }}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := startWebServer(t, server)
+	type client struct {
+		conn   net.Conn
+		reader *bufio.Reader
+	}
+	clients := make([]client, 3)
+	for i := range clients {
+		clients[i].conn, clients[i].reader = openRawEventStream(t, addr)
+	}
+	for _, tt := range []struct {
+		name, title string
+		seq         uint64
+		elapsed     time.Duration
+		correct     bool
+		want        int64
+	}{
+		{name: "initial", title: "Initial operational row", seq: 1, want: 6},
+		{name: "heartbeat", title: "Updated operational row", seq: 2, elapsed: time.Second, want: 6},
+		{name: "correction", title: "Corrected history row", seq: 3, elapsed: 2 * time.Second, correct: true, want: 12},
+		{name: "moving window", title: "Window refreshed row", seq: 4, elapsed: 32 * time.Second, want: 18},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.correct {
+				backend.revision.Add(1)
+			}
+			snapshot := telemetry.Snapshot{Seq: tt.seq, GeneratedAt: now.Add(tt.elapsed), Running: []telemetry.Running{{Issue: telemetry.Issue{ID: "live", Identifier: "LIVE-1", Title: tt.title, State: "In Progress"}}}}
+			if err := deps.Hub.Publish(snapshot); err != nil {
+				t.Fatal(err)
+			}
+			for _, client := range clients {
+				event := readRawSSEEventNamed(t, client.conn, client.reader, "snapshot")
+				if !strings.Contains(event.data, tt.title) {
+					t.Fatalf("operational row missing %q", tt.title)
+				}
+			}
+			if got := backend.workflowMetricsCalls.Load(); got != tt.want {
+				t.Fatalf("history queries = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/web/workflow_metrics.go
+++ b/internal/web/workflow_metrics.go
@@ -28,7 +28,13 @@ func (s *Server) snapshotWorkflowMetrics(ctx context.Context, snapshot telemetry
 		now = time.Now()
 	}
 
-	projectID := strings.TrimSpace(snapshot.Project.ID)
+	out := s.workflowHistory.get(ctx, s.store, strings.TrimSpace(snapshot.Project.ID), now, s.now, s.loadWorkflowHistory)
+	out.OldestCards = workflowOldestCards(snapshot)
+	out.ActiveBottleneck = workflowActiveBottleneck(snapshot, now)
+	return out
+}
+
+func (s *Server) loadWorkflowHistory(ctx context.Context, projectID string, now time.Time) telemetry.WorkflowMetrics {
 	runtimeEvidence, err := s.store.RuntimeEvidence(ctx, store.RuntimeEvidenceQuery{ProjectID: projectID})
 	if err != nil {
 		s.logger.Warn("runtime store evidence query failed", slog.Any("error", err))
@@ -49,10 +55,8 @@ func (s *Server) snapshotWorkflowMetrics(ctx context.Context, snapshot telemetry
 	}
 
 	out := telemetry.WorkflowMetrics{
-		Available:        true,
-		RuntimeStore:     runtimeStoreEvidenceFromStore(runtimeEvidence),
-		OldestCards:      workflowOldestCards(snapshot),
-		ActiveBottleneck: workflowActiveBottleneck(snapshot, now),
+		Available:    true,
+		RuntimeStore: runtimeStoreEvidenceFromStore(runtimeEvidence),
 	}
 	for _, window := range windows {
 		from := now.Add(-window.duration)

--- a/internal/web/workflow_metrics_benchmark_test.go
+++ b/internal/web/workflow_metrics_benchmark_test.go
@@ -1,0 +1,52 @@
+package web
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func BenchmarkWorkflowSnapshotHeartbeat(b *testing.B) {
+	backend, err := store.Open(b.Context(), store.Config{Backend: store.BackendSQLite, Path: filepath.Join(b.TempDir(), "history.db")})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			b.Error(err)
+		}
+	})
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	for i := range 2000 {
+		for j := range 4 {
+			phaseType, phaseName := store.WorkflowPhaseTypeAgentSession, "implement"
+			if j == 0 {
+				phaseType, phaseName = store.WorkflowPhaseTypeLane, "In Progress"
+			}
+			started := now.Add(-time.Duration(i%55)*24*time.Hour - time.Hour)
+			_, err := backend.RecordWorkflowPhaseEvent(b.Context(), store.WorkflowPhaseEvent{
+				ProjectID: fmt.Sprintf("project-%d", i%4), IssueID: fmt.Sprintf("issue-%d", i), PhaseType: phaseType, PhaseName: phaseName,
+				StartedAt: started, FinishedAt: started.Add(time.Hour),
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	clock := now
+	server := &Server{store: backend, logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: func() time.Time { return clock }}
+	snapshot := telemetry.Snapshot{GeneratedAt: now}
+	b.ReportAllocs()
+	for b.Loop() {
+		snapshot.Seq++
+		clock = clock.Add(time.Second)
+		snapshot.GeneratedAt = now.Add(time.Duration(snapshot.Seq%30) * time.Second)
+		server.snapshotWorkflowMetrics(b.Context(), snapshot)
+	}
+}


### PR DESCRIPTION
## Summary

- Stop rebuilding six historical workflow reports on every dashboard heartbeat. Share history across clients for up to 30 seconds, invalidate committed inserts/corrections/deletes through a durable revision, and keep operational evidence current on each snapshot. Bound project scopes and skip superseded queued snapshots.
- Correlate lane activity through project-scoped identity indexes while preserving direct ID/identifier/URL/PR matching, interval unions, and representative ordering/fallbacks.
- Six-run benchmarks show 98.33% lower large-history computation time, 90.04% lower SQLite report time, and 98.72% lower heartbeat enrichment time including periodic refreshes (all p=.002). Historical query batches fall 96.7% at one unchanged heartbeat per second. Cold-report allocation counts increase, while heartbeat allocation counts fall 96.54%. [Recorded samples, profiles, and limitations](https://github.com/digitaldrywood/detent/blob/6a2ea7185187c396fc2dbfe4d18c0fae4076d2b2/docs/workflow-history-performance.md).

Fixes #2326

## UI Surface Contract

- [x] N/A: this changes enrichment performance and freshness; no layout, density, first-viewport, or responsive visibility changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens. Three real SSE clients verify that operational rows update while sharing historical reports.

## Test Plan

- [x] `make check` (80.2% overall coverage; all package/file floors passed)
- [x] Complete store and web race suites.
- [x] Randomized equivalence against the original correlation functions; correction, deletion, and rollback revision tests; cache cadence, scope eviction, cancellation, mutation-during-load, and superseded-snapshot regressions.
- [x] Three simultaneous SSE clients: initial shared history, heartbeat operational update, corrected history, and moving-window expiry.
- [x] Six repetitions for large-history, SQLite, and heartbeat-cadence benchmarks, with before/after CPU profiles. Fixtures cover four projects, 2,000 issues, overlapping activity, retries, and 55 days. Live daemon unchanged.
- [x] All 11 current-head CI jobs passed, including Linux race tests, Windows/macOS portability, Security, Browser Visual, and release packaging. Codex review completed with no findings.
