### PR TITLE
fix(agents): enforce configured effort ceilings

### DIFF
--- a/.detent/skills/cache-request-time-ordering.md
+++ b/.detent/skills/cache-request-time-ordering.md
@@ -1,0 +1,19 @@
+---
+name: cache-request-time-ordering
+description: Diagnose duplicate cache loads caused by request timestamps arriving out of order.
+when_to_use: Concurrent callers unexpectedly reload a fresh cache whose freshness predicate rejects negative ages.
+---
+
+Trace where the request timestamp is sampled relative to lock acquisition and
+single-flight waiting. A caller sampled earlier can acquire the lock after a
+later caller has populated the cache; this does not establish clock rollback.
+
+Reproduce with an injected clock and channels: suspend the first sample, let a
+second caller start loading, then return the earlier sample. Keep the original
+load-count assertion and run both normal and forced ordering cases. Avoid sleeps.
+
+For request-relative expiry, compare the sample to the cached expiry deadline;
+a result populated after the request began can satisfy that request. Preserve
+revision and identity checks. Do not globally relax negative-age checks: report
+window endpoints and actual clock rollback may require invalidation independently.
+Test revision changes and the exact expiry boundary alongside reversed samples.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -516,7 +516,9 @@ requests rather than free `304` checks.
 To make existing and newly onboarded projects use Sol for ordinary work and
 Astra for explicitly complex work, configure `global.agents.model_selection.preset:
 sol_first` in the instance configuration. This defaults omitted effort to medium
-(or high for very complex work) and preserves explicit issue model/effort fields.
+(or high for very complex work). Explicit models and supported effort overrides
+within the configured policy ceiling are preserved; legacy xhigh/max requests
+use the selected level effort, including after resume.
 Create `complexity:complex` and `complexity:very-complex` repository labels for
 operators who want those signals, plus `design` if using an inherited Claude
 selector. Generic `enhancement` does not select Astra. Projects inherit each

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -616,7 +616,9 @@ global:
 This is opt-in. Existing pinned models remain pinned. The preset sets normal
 work to `gpt-5.6-sol` at medium effort; complex work to `gpt-6-astra` at medium;
 and very complex work to Astra at high. It never automatically assigns max.
-Explicit issue effort, including low, xhigh, and max, is retained when supported.
+Explicit issue effort is retained when supported and within the configured
+effort ceiling. Legacy xhigh/max requests select complex work but use medium
+effort under this preset; very complex work uses high.
 A provider default changing to Astra does not affect enabled automatic selection.
 
 Host backend and route defaults use the same schema as project `agents`. For
@@ -737,7 +739,7 @@ make a classification-model call:
 | Missing metadata, simple/basic work, or generic `enhancement` alone | Sol | medium |
 | `complexity:complex` for substantive feature/implementation work | Astra | medium |
 | `complexity:very-complex` for subsystems, difficult architecture, state, concurrency, or recovery | Astra | high |
-| Explicit applicable issue xhigh/max, with model omitted | Astra | explicit effort retained |
+| Explicit applicable issue xhigh/max, with model omitted | Astra | medium, bounded by the policy |
 
 Priority, entering Rework, waiting for CI, provider errors, and host/backend
 effort defaults are not complexity signals in the preset. Label substantive work
@@ -773,7 +775,19 @@ The independent security auditor retains its trusted gate model and does not
 consume issue-body model or effort overrides; its unpinned defaults use the
 configured `security_audit` policy stage.
 A model-only override still receives an effort default; an effort-only override
-still receives an automatic model. Explicit values are never clamped by defaults.
+still receives an automatic model.
+
+The highest effort among configured levels and the applicable stage is the
+policy ceiling. Issue, role, project, and backend effort overrides above that
+ceiling use the selected level/stage effort, with `:ceiling` recorded in the
+effort source. Lower supported overrides remain unchanged. To deliberately
+permit xhigh, configure an applicable policy level or stage at xhigh. Disabled
+policies and excluded backends retain their existing override behavior.
+
+For an Astra fleet, set both model aliases to `gpt-6-astra` and configure normal,
+complex, and very_complex effort as low, medium, and high. Existing xhigh/max
+complexity signals then request medium instead of passing the legacy effort to
+the provider. No issue-body migration is required for this protection.
 
 With the policy enabled on an eligible backend, invalid explicit model/effort
 values are reported and dispatch fails; they are never replaced by automatic
@@ -789,8 +803,12 @@ sources, plus backend/route provenance without commands or environment values.
 Session runtime identity and session diagnostics record the policy, matched rule
 or default reason, requested automatic model, actual requested/runtime models,
 effort, source fields, and fallback reason. Runtime updates preserve the decision.
-Policy reload affects new dispatches; active snapshots and explicit resumed
-sessions retain their established identity. Missing resume backends require
+Policy reload affects new dispatches. Active turns keep their original snapshot;
+stop and restart an active turn when an immediate cost reduction is needed.
+Resumed sessions preserve their established thread, model, backend, and route,
+but recheck the current effort ceiling and honor lower current issue overrides.
+A changed resume effort requires catalog validation before another provider turn.
+Missing resume backends require
 restoring that backend or starting fresh. Legacy sessions without stored full
 identity retain legacy recovery checks. Invalid reload retains the last valid
 agent configuration. Hub-approved execution continues to require its approved

--- a/internal/orchestrator/heartbeat_test.go
+++ b/internal/orchestrator/heartbeat_test.go
@@ -135,12 +135,19 @@ func TestHeartbeatManagerRequiresMatchingLiveProcessIdentity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			attempts := &recordingWorkAttemptStore{}
 			cfg := normalizeConfig(Config{Claiming: ClaimingConfig{LeaseTTL: time.Minute, HeartbeatInterval: 5 * time.Millisecond}})
-			manager := newHeartbeatManager(cfg, nil, attempts, time.Now, nil)
-			result := runHeartbeatManagerOnce(t, manager, heartbeatTarget{
+			now := time.Now()
+			manager := newHeartbeatManager(cfg, nil, attempts, func() time.Time { return now }, nil)
+			manager.upsert(heartbeatTarget{
 				issueID:              tt.name,
 				workAttemptHeartbeat: store.WorkAttemptHeartbeat{AttemptID: 1433},
 				workerProcess:        tt.identity,
 			})
+			due := manager.due(now.Add(cfg.Claiming.HeartbeatInterval))
+			if len(due) != 1 {
+				t.Fatalf("due heartbeat count = %d, want 1", len(due))
+			}
+			manager.execute(t.Context(), due[0])
+			result := <-manager.results
 
 			if result.workAttemptRenewed != tt.wantRenewed || result.workerChecked != tt.wantChecked || result.workerAlive != tt.wantAlive {
 				t.Fatalf("heartbeat result = %#v, want renewed=%v checked=%v alive=%v", result, tt.wantRenewed, tt.wantChecked, tt.wantAlive)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1609,7 +1609,10 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	if hasResumeIdentity(req) {
 		runtimeIdentity = req.ResumeState.RuntimeIdentity.ObserveAt(startedAt)
-		effort = runtimeIdentity.ReasoningEffort.Value
+		runtimeIdentity.Selection = resolvedOverride.Selection
+		if effort != runtimeIdentity.ReasoningEffort.Value {
+			runtimeIdentity.ReasoningEffort = agentidentity.NewValue(effort, agentidentity.ProvenanceConfigured)
+		}
 		modelProvider = runtimeIdentity.Provider.Value
 		serviceTier = runtimeIdentity.ServiceTier.Value
 	}

--- a/internal/runner/model_selection.go
+++ b/internal/runner/model_selection.go
@@ -216,7 +216,11 @@ func boundSelectionEffort(result agentSelection, policy config.ModelSelection, l
 }
 
 func selectionEffortRank(effort string) int {
-	return slices.Index([]string{"none", "minimal", "low", "medium", "high", "xhigh", "max"}, strings.ToLower(strings.TrimSpace(effort)))
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	if effort == "ultracode" {
+		effort = "max"
+	}
+	return slices.Index([]string{"none", "minimal", "low", "medium", "high", "xhigh", "max"}, effort)
 }
 
 func selectionValue(value *string) string {

--- a/internal/runner/model_selection.go
+++ b/internal/runner/model_selection.go
@@ -42,7 +42,48 @@ func resolveRequestAgentSelection(ctx context.Context, req RunRequest, workspace
 	if hasResumeIdentity(req) {
 		identity := req.ResumeState.RuntimeIdentity
 		model := effectiveModel("", identity.RequestedModel.Value, identity.ResolvedModel.Value)
-		return agentSelection{resolvedAgentOverride: resolvedAgentOverride{Model: model, Effort: identity.ReasoningEffort.Value}, Selection: identity.Selection}
+		result := agentSelection{resolvedAgentOverride: resolvedAgentOverride{Model: model, Effort: identity.ReasoningEffort.Value}, Selection: identity.Selection}
+		policy := cfg.EffectiveModelSelection()
+		if !policy.Active() || policy.BackendKinds == nil || !slices.Contains(*policy.BackendKinds, backendConfig.Kind) {
+			return result
+		}
+		override, _, err := agentoverride.FromIssueBody(req.Issue.Description)
+		if err != nil {
+			return result.reject("block", "", err.Error())
+		}
+		effort, field := override.EffortForRole(role)
+		roleEffort := effort != ""
+		if effort == "" {
+			effort, field = override.Effort, "effort"
+		}
+		if effort != "" && selectionEffortRank(effort) < selectionEffortRank(result.Effort) {
+			result.Effort = effort
+			result.Selection.EffortSource = "issue." + field
+		}
+		explicitModel, _ := override.ModelForRole(role)
+		level, _ := selectionComplexity(policy, req.Issue, role, result.Effort, roleEffort, explicitModel == "")
+		result = boundSelectionEffort(result, policy, level, role)
+		if result.Effort == identity.ReasoningEffort.Value {
+			return result
+		}
+		provider, ok := backend.(AgentModelCatalogProvider)
+		if !ok {
+			return result.reject("effort", result.Effort, "changed resume effort requires a backend model catalog")
+		}
+		models, err := provider.ListModels(ctx)
+		if err != nil {
+			return result.reject("effort", result.Effort, "model catalog unavailable while validating changed resume effort")
+		}
+		selected, ok := findAgentModel(models, model)
+		if !ok {
+			return result.reject("model", model, "resumed model is unavailable while validating changed effort")
+		}
+		if effort, ok := supportedAgentEffort(selected, result.Effort); ok {
+			result.Effort = effort
+		} else {
+			return result.reject("effort", result.Effort, "changed resume effort is unsupported by the resumed model")
+		}
+		return result
 	}
 	return resolveAgentSelection(ctx, req.Issue, workspace, baseModel, role, cfg, backendConfig, backend)
 }
@@ -107,6 +148,7 @@ func resolveAgentSelection(ctx context.Context, issue connector.Issue, workspace
 			result.Selection.EffortSource = selectionSource(policy, "stages."+role+".effort", "")
 		}
 	}
+	result = boundSelectionEffort(result, policy, level, role)
 	result.Selection.RequestedModel = result.Model
 	provider, ok := backend.(AgentModelCatalogProvider)
 	if !ok {
@@ -151,6 +193,30 @@ func (s agentSelection) reject(field, value, reason string) agentSelection {
 	s.Rejections = append(s.Rejections, AgentOverrideRejection{Field: field, Value: value, Reason: reason})
 	s.Err = fmt.Errorf("agent override rejected: %s: %s", field, reason)
 	return s
+}
+
+func boundSelectionEffort(result agentSelection, policy config.ModelSelection, level, role string) agentSelection {
+	ceiling := -1
+	for _, defaults := range policy.Levels {
+		ceiling = max(ceiling, selectionEffortRank(selectionValue(defaults.Effort)))
+	}
+	stage := policy.Stages[role]
+	ceiling = max(ceiling, selectionEffortRank(selectionValue(stage.Effort)))
+	if ceiling < 0 || selectionEffortRank(result.Effort) <= ceiling {
+		return result
+	}
+	result.Effort = selectionValue(policy.Levels[level].Effort)
+	field := "levels." + level + ".effort"
+	if stage.Effort != nil && *stage.Effort != "" {
+		result.Effort = *stage.Effort
+		field = "stages." + role + ".effort"
+	}
+	result.Selection.EffortSource = selectionSource(policy, field, "") + ":ceiling"
+	return result
+}
+
+func selectionEffortRank(effort string) int {
+	return slices.Index([]string{"none", "minimal", "low", "medium", "high", "xhigh", "max"}, strings.ToLower(strings.TrimSpace(effort)))
 }
 
 func selectionValue(value *string) string {

--- a/internal/runner/model_selection_test.go
+++ b/internal/runner/model_selection_test.go
@@ -283,6 +283,26 @@ func TestRunnerResumeUsesBoundedEffort(t *testing.T) {
 	}
 }
 
+func TestUltracodeEffortCeiling(t *testing.T) {
+	t.Parallel()
+	for _, resume := range []bool{false, true} {
+		cfg := config.Default()
+		cfg.Agents.ModelSelection = config.ModelSelection{Preset: new("sol_first")}
+		cfg.Agent.Effort.Code = "ultracode"
+		req := RunRequest{}
+		if resume {
+			req.RetryMode = RetryModeResume
+			req.ResumeState = store.AgentResumeState{ProviderThreadID: "thread-1", RuntimeIdentity: agentidentity.Configured("codex", "codex", "default", RoleCode, "gpt-5.6-sol", "", "ultracode", "", time.Now())}
+		}
+		catalog := selectionCatalog()
+		catalog[0].SupportedReasoningEfforts = append(catalog[0].SupportedReasoningEfforts, "ultracode")
+		got := resolveRequestAgentSelection(t.Context(), req, "", "", RoleCode, cfg, config.AgentBackend{Kind: config.AgentBackendCodex}, &catalogAgentBackend{models: catalog})
+		if got.Err != nil || got.Effort != "medium" {
+			t.Fatalf("resume=%t selection=%+v, want medium effort", resume, got)
+		}
+	}
+}
+
 func TestEffortCeilingPolicyBoundaries(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/runner/model_selection_test.go
+++ b/internal/runner/model_selection_test.go
@@ -126,21 +126,21 @@ func TestAutomaticModelSelection(t *testing.T) {
 		{name: "very complex", label: "complexity:very-complex", model: "gpt-6-astra", effort: "high"},
 		{name: "model only", body: "model: gpt-6-astra", model: "gpt-6-astra", effort: "medium"},
 		{name: "explicit low", body: "effort: low", label: "complexity:very-complex", model: "gpt-6-astra", effort: "low"},
-		{name: "xhigh signal", body: "effort: xhigh", model: "gpt-6-astra", effort: "xhigh"},
-		{name: "max signal", body: "effort: max", model: "gpt-6-astra", effort: "max"},
-		{name: "both explicit", body: "model: gpt-5.6-sol\neffort: max", label: "complexity:very-complex", model: "gpt-5.6-sol", effort: "max"},
+		{name: "xhigh signal", body: "effort: xhigh", model: "gpt-6-astra", effort: "medium"},
+		{name: "max signal", body: "effort: max", model: "gpt-6-astra", effort: "medium"},
+		{name: "both explicit", body: "model: gpt-5.6-sol\neffort: max", label: "complexity:very-complex", model: "gpt-5.6-sol", effort: "high"},
 		{name: "role fields", body: "model: gpt-6-astra\neffort: high\ncode:\n  model: gpt-5.6-sol\n  effort: low", model: "gpt-5.6-sol", effort: "low"},
-		{name: "role model issue effort", body: "effort: xhigh\ncode:\n  model: gpt-5.6-sol", model: "gpt-5.6-sol", effort: "xhigh"},
-		{name: "role effort issue model", body: "model: gpt-5.6-sol\ncode:\n  effort: xhigh", model: "gpt-5.6-sol", effort: "xhigh"},
+		{name: "role model issue effort", body: "effort: xhigh\ncode:\n  model: gpt-5.6-sol", model: "gpt-5.6-sol", effort: "medium"},
+		{name: "role effort issue model", body: "model: gpt-5.6-sol\ncode:\n  effort: xhigh", model: "gpt-5.6-sol", effort: "medium"},
 		{name: "code inherited in rework", role: RoleRework, body: "code:\n  model: gpt-6-astra\n  effort: low", model: "gpt-6-astra", effort: "low"},
 		{name: "entering rework", role: RoleRework, model: "gpt-5.6-sol", effort: "medium"},
-		{name: "routine stays normal", role: RoleRoutine, label: "complexity:very-complex", body: "effort: xhigh", model: "gpt-5.6-sol", effort: "xhigh"},
+		{name: "routine stays normal", role: RoleRoutine, label: "complexity:very-complex", body: "effort: xhigh", model: "gpt-5.6-sol", effort: "medium"},
 		{name: "merge stays normal", role: RoleMerge, label: "complexity:very-complex", model: "gpt-5.6-sol", effort: "medium"},
 		{name: "validator stays normal", role: RoleValidator, label: "complexity:complex", model: "gpt-5.6-sol", effort: "medium"},
-		{name: "role specific merge signal", role: RoleMerge, body: "merge:\n  effort: xhigh", model: "gpt-6-astra", effort: "xhigh"},
+		{name: "role specific merge signal", role: RoleMerge, body: "merge:\n  effort: xhigh", model: "gpt-6-astra", effort: "medium"},
 		{name: "route pin", base: "gpt-5.6-sol", label: "complexity:very-complex", model: "gpt-5.6-sol", effort: "high"},
 		{name: "issue wins route", base: "gpt-6-astra", body: "model: gpt-5.6-sol", model: "gpt-5.6-sol", effort: "medium"},
-		{name: "project effort not complexity", projectEffort: "xhigh", model: "gpt-5.6-sol", effort: "xhigh"},
+		{name: "project effort not complexity", projectEffort: "xhigh", model: "gpt-5.6-sol", effort: "medium"},
 		{name: "issue effort wins project", projectEffort: "high", body: "effort: low", model: "gpt-5.6-sol", effort: "low"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -213,6 +213,138 @@ func TestAutomaticModelSelectionFailures(t *testing.T) {
 			}
 			if got.Err != nil && strings.Contains(got.Err.Error(), "secret") {
 				t.Fatal("catalog details leaked")
+			}
+		})
+	}
+}
+
+func TestConfiguredEffortCeiling(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		effort string
+		resume bool
+		want   string
+	}{
+		{name: "legacy xhigh", effort: "xhigh", want: "medium"},
+		{name: "legacy max", effort: "max", want: "medium"},
+		{name: "supported high", effort: "high", want: "high"},
+		{name: "resumed legacy xhigh", effort: "xhigh", resume: true, want: "medium"},
+		{name: "resumed operator reduction", effort: "medium", resume: true, want: "medium"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Default()
+			cfg.Agents.ModelSelection = config.ModelSelection{Preset: new("sol_first"), NormalModel: new("gpt-6-astra"), Levels: map[string]config.ModelSelectionDefaults{"normal": {Effort: new("low")}}}
+			req := RunRequest{Issue: connector.Issue{Description: "```detent-agent\nschema: 1\neffort: " + test.effort + "\n```"}}
+			if test.resume {
+				identity := agentidentity.Configured("codex", "codex", "default", RoleCode, "gpt-6-astra", "", "xhigh", "", time.Now())
+				req.RetryMode = RetryModeResume
+				req.ResumeState = store.AgentResumeState{ProviderThreadID: "thread-1", RuntimeIdentity: identity}
+			}
+			backend := &catalogAgentBackend{models: selectionCatalog()}
+			got := resolveRequestAgentSelection(t.Context(), req, "", "", RoleCode, cfg, config.AgentBackend{Kind: config.AgentBackendCodex}, backend)
+			if got.Err != nil || got.Model != "gpt-6-astra" || got.Effort != test.want {
+				t.Fatalf("selection = %+v, want Astra effort %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRunnerResumeUsesBoundedEffort(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agents.ModelSelection = config.ModelSelection{Preset: new("sol_first")}
+	backend := &fakeCodexClient{models: selectionCatalog(), result: AgentTurnResult{ThreadID: "thread-1", TurnID: "turn-2", SessionID: "thread-1-turn-2"}}
+	sessionStore := &fakeSessionStore{sessionID: 1}
+	runner, err := NewRunner(Dependencies{
+		ProjectID:    "detent",
+		Workflow:     config.Workflow{Config: cfg, Prompt: "Work"},
+		Workspace:    &fakeWorkspaceBackend{info: workspace.Info{Path: t.TempDir()}},
+		AgentBackend: backend,
+		Store:        sessionStore,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := agentidentity.Configured("codex", "codex", "default", RoleCode, "gpt-6-astra", "", "xhigh", "", time.Now())
+	_, err = runner.Run(t.Context(), RunRequest{
+		Issue:       connector.Issue{ID: "issue-1", Identifier: "repo#1", Description: "```detent-agent\nschema: 1\neffort: medium\n```"},
+		RetryMode:   RetryModeResume,
+		ResumeState: store.AgentResumeState{ProviderThreadID: "thread-1", RuntimeIdentity: identity},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if backend.request.Model != "gpt-6-astra" || backend.request.ReasoningEffort != "medium" || backend.request.Resume.ThreadID != "thread-1" {
+		t.Fatalf("resumed request model=%s effort=%s thread=%s", backend.request.Model, backend.request.ReasoningEffort, backend.request.Resume.ThreadID)
+	}
+	if sessionStore.started.RuntimeIdentity.ReasoningEffort.Value != "medium" {
+		t.Fatalf("persisted start effort=%+v", sessionStore.started.RuntimeIdentity.ReasoningEffort)
+	}
+}
+
+func TestEffortCeilingPolicyBoundaries(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name       string
+		mutate     func(*config.ModelSelection)
+		body       string
+		role       string
+		kind       string
+		catalog    []AgentModel
+		resume     bool
+		catalogErr error
+		want       string
+		wantError  bool
+	}{
+		{name: "policy permits xhigh", mutate: func(p *config.ModelSelection) {
+			p.Levels = map[string]config.ModelSelectionDefaults{"complex": {Effort: new("xhigh")}}
+		}, body: "effort: xhigh", want: "xhigh"},
+		{name: "stage permits xhigh", mutate: func(p *config.ModelSelection) {
+			p.Stages = map[string]config.ModelSelectionStage{RoleMerge: {Effort: new("xhigh")}}
+		}, role: RoleMerge, body: "effort: xhigh", want: "xhigh"},
+		{name: "other stage does not raise ceiling", mutate: func(p *config.ModelSelection) {
+			p.Stages = map[string]config.ModelSelectionStage{RoleMerge: {Effort: new("xhigh")}}
+		}, body: "effort: xhigh", want: "medium"},
+		{name: "disabled", mutate: func(p *config.ModelSelection) { p.Enabled = new(false) }, body: "model: gpt-6-astra\neffort: max", want: "max"},
+		{name: "excluded backend", kind: config.AgentBackendClaudeCode, body: "model: gpt-6-astra\neffort: xhigh", want: "xhigh"},
+		{name: "fallback stays bounded", catalog: selectionCatalog()[:1], body: "effort: xhigh", want: "medium"},
+		{name: "resume no issue override", resume: true, want: "medium"},
+		{name: "resume role override", resume: true, body: "code:\n  effort: low", want: "low"},
+		{name: "resume malformed override", resume: true, body: "effort: unknown", wantError: true},
+		{name: "resume changed effort catalog unavailable", resume: true, catalogErr: errors.New("unavailable"), wantError: true},
+		{name: "resume changed effort unsupported", resume: true, catalog: []AgentModel{{ID: "gpt-6-astra", Model: "gpt-6-astra", SupportedReasoningEfforts: []string{"xhigh"}}}, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Default()
+			cfg.Agents.ModelSelection = config.ModelSelection{Preset: new("sol_first")}
+			if test.mutate != nil {
+				test.mutate(&cfg.Agents.ModelSelection)
+			}
+			req := RunRequest{}
+			if test.body != "" {
+				req.Issue.Description = "```detent-agent\nschema: 1\n" + test.body + "\n```"
+			}
+			if test.resume {
+				req.RetryMode = RetryModeResume
+				req.ResumeState = store.AgentResumeState{ProviderThreadID: "thread-1", RuntimeIdentity: agentidentity.Configured("codex", "codex", "default", RoleCode, "gpt-6-astra", "", "xhigh", "", time.Now())}
+			}
+			catalog := test.catalog
+			if catalog == nil {
+				catalog = selectionCatalog()
+			}
+			role, kind := test.role, test.kind
+			if role == "" {
+				role = RoleCode
+			}
+			if kind == "" {
+				kind = config.AgentBackendCodex
+			}
+			backend := &catalogAgentBackend{models: catalog, err: test.catalogErr}
+			got := resolveRequestAgentSelection(t.Context(), req, "", "", role, cfg, config.AgentBackend{Kind: kind}, backend)
+			if (got.Err != nil) != test.wantError || !test.wantError && got.Effort != test.want {
+				t.Fatalf("selection=%+v want effort=%s error=%v", got, test.want, test.wantError)
 			}
 		})
 	}

--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -121,7 +121,7 @@ func (c *snapshotEnrichmentCache) enrichVersion(ctx context.Context, snapshot te
 			snapshot = c.pending
 		}
 
-		if c.cached && c.revision == revision && workflowHistoryFresh(c.loadedAt, now) && (sameSnapshotForEnrichment(c.raw, snapshot) || newerEnrichmentSnapshot(c.raw, snapshot)) {
+		if c.cached && c.revision == revision && now.Before(c.loadedAt.Add(workflowHistoryFreshness)) && (sameSnapshotForEnrichment(c.raw, snapshot) || newerEnrichmentSnapshot(c.raw, snapshot)) {
 			enriched := c.enriched
 			c.mu.Unlock()
 			return enriched

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -9669,57 +9669,81 @@ func TestServerEventsPreserveProjectContextForStaticSidebarNavigation(t *testing
 func TestServerEventsEnrichesSnapshotOncePerPublish(t *testing.T) {
 	t.Parallel()
 
-	generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
-	year, month, day := generatedAt.UTC().Date()
-	budgetPeriodStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	budgetQueryFrom := budgetPeriodStart.AddDate(0, 0, -6)
+	for _, tt := range []struct {
+		name              string
+		reverseClockOrder bool
+	}{
+		{name: "concurrent subscribers"},
+		{name: "earlier clock sample arrives after enrichment starts", reverseClockOrder: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+			year, month, day := generatedAt.UTC().Date()
+			budgetPeriodStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			budgetQueryFrom := budgetPeriodStart.AddDate(0, 0, -6)
 
-	var cycleTimeCalls atomic.Int64
-	var budgetCalls atomic.Int64
+			enrichmentStarted := make(chan struct{})
+			var enrichmentStartedOnce sync.Once
+			var clockCalls atomic.Int64
+			var cycleTimeCalls atomic.Int64
+			var budgetCalls atomic.Int64
 
-	registry := project.NewRegistry()
-	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10, workflowconfig.BillingModeSubscription)); err != nil {
-		t.Fatalf("Registry.Set() error = %v", err)
-	}
-
-	deps := testDeps(t)
-	deps.Registry = registry
-	deps.Store = storeProbe{
-		cycleTimeReport: func(context.Context) (store.CycleTimeReport, error) {
-			cycleTimeCalls.Add(1)
-			return store.CycleTimeReport{}, nil
-		},
-		budgetCostEvents: func(_ context.Context, query store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
-			if query.From.Equal(budgetQueryFrom) {
-				budgetCalls.Add(1)
+			registry := project.NewRegistry()
+			if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10, workflowconfig.BillingModeSubscription)); err != nil {
+				t.Fatalf("Registry.Set() error = %v", err)
 			}
-			return nil, nil
-		},
-	}
-	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
-	if err != nil {
-		t.Fatalf("NewServer() error = %v", err)
-	}
 
-	first := openEventStream(t, server)
-	second := openEventStream(t, server)
+			deps := testDeps(t)
+			deps.Registry = registry
+			deps.Store = storeProbe{
+				cycleTimeReport: func(context.Context) (store.CycleTimeReport, error) {
+					cycleTimeCalls.Add(1)
+					enrichmentStartedOnce.Do(func() { close(enrichmentStarted) })
+					return store.CycleTimeReport{}, nil
+				},
+				budgetCostEvents: func(_ context.Context, query store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+					if query.From.Equal(budgetQueryFrom) {
+						budgetCalls.Add(1)
+					}
+					return nil, nil
+				},
+			}
+			server, err := web.NewServer(web.Config{SSETickInterval: time.Hour, Now: func() time.Time {
+				if !tt.reverseClockOrder {
+					return time.Now()
+				}
+				if clockCalls.Add(1) == 1 {
+					<-enrichmentStarted
+					return generatedAt
+				}
+				return generatedAt.Add(time.Nanosecond)
+			}}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
 
-	if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
-		t.Fatalf("Publish() error = %v", err)
-	}
+			first := openEventStream(t, server)
+			second := openEventStream(t, server)
+			t.Cleanup(func() { enrichmentStartedOnce.Do(func() { close(enrichmentStarted) }) })
 
-	for _, body := range []io.Reader{first, second} {
-		event := readSSEEvent(t, body)
-		if event.name != "snapshot" {
-			t.Fatalf("event name = %q, want snapshot", event.name)
-		}
-	}
+			if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
 
-	if got := cycleTimeCalls.Load(); got != 1 {
-		t.Fatalf("CycleTimeReport calls = %d, want 1", got)
-	}
-	if got := budgetCalls.Load(); got != 1 {
-		t.Fatalf("BudgetCostEvents calls = %d, want 1", got)
+			for _, body := range []io.Reader{first, second} {
+				event := readSSEEvent(t, body)
+				if event.name != "snapshot" {
+					t.Fatalf("event name = %q, want snapshot", event.name)
+				}
+			}
+
+			if got := cycleTimeCalls.Load(); got != 1 {
+				t.Fatalf("CycleTimeReport calls = %d, want 1", got)
+			}
+			if got := budgetCalls.Load(); got != 1 {
+				t.Fatalf("BudgetCostEvents calls = %d, want 1", got)
+			}
+		})
 	}
 }
 

--- a/internal/web/workflow_history_cache_test.go
+++ b/internal/web/workflow_history_cache_test.go
@@ -228,7 +228,10 @@ func TestSnapshotEnrichmentHistoryInvalidation(t *testing.T) {
 		want     int
 	}{
 		{name: "identical snapshot", want: 1},
+		{name: "earlier request clock sample", elapsed: -time.Nanosecond, want: 1},
+		{name: "earlier request with corrected history", elapsed: -time.Nanosecond, revision: 1, want: 2},
 		{name: "corrected history", revision: 1, want: 2},
+		{name: "before freshness deadline", elapsed: workflowHistoryFreshness - time.Nanosecond, want: 1},
 		{name: "bounded freshness", elapsed: workflowHistoryFreshness, want: 2},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Enforce configured automatic-selection effort ceilings for new and resumed work. With an Astra low/medium/high policy, stale xhigh/max overrides use the selected level effort; ultracode has the same cost rank as max. Preserve lower supported overrides and existing thread/model identity.
- Prevent concurrent SSE subscribers from enriching the same publication twice when request clock samples arrive out of order. Preserve cache revision, snapshot identity and expiry checks. This includes the prerequisite fix from #2349.
- Make the heartbeat identity fixture execute one scheduled renewal deterministically, fixing its unrelated release-blocking CI failure without changing production heartbeat behavior.

Fixes #2333
Fixes #2338
Fixes #2344

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual changes.

## Test Plan

- [x] Focused effort selection, actual resumed provider request, catalog failure and policy-boundary race tests passed.
- [x] Heartbeat identity test passed 100 race repetitions; broader heartbeat tests passed five repetitions.
- [x] Independent SSE subscriber ordering and cache invalidation tests passed ten race repetitions; the deterministic ordering regression failed before the fix.
- [x] Combined `make check CHECK_LOCK_WAIT=2h` passed on `b91f41b0`: build, lint, vet, NilAway, full Hub and repository race suites, 80.3% coverage, package/file floors.
- [x] All eleven CI checks passed on combined release head `b91f41b0348304f7702345278c6312540e90bb7c`.

Component validation and CI passed before integration. The combined full gate and all eleven CI checks passed; the prerequisite cache commit is included in this branch so it can land with the effort fix in one validated merge.
