### PR TITLE
fix(codex): preserve effective turn identity

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -510,7 +510,7 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		AuthenticationMode: authenticationMode,
 	}
 	if !turn.StartedEmitted {
-		startedIdentity := runtimeIdentity
+		startedIdentity := runtimeIdentity.Merge(turn.RuntimeIdentity)
 		if turn.Model != "" {
 			startedIdentity = startedIdentity.Merge(agentidentity.RuntimeUpdate(
 				turn.Model,
@@ -526,7 +526,7 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 			ThreadID:        threadID,
 			TurnID:          turnID,
 			Status:          "started",
-			Model:           firstNonBlank(turn.Model, model),
+			Model:           startedIdentity.Model(),
 			RuntimeIdentity: startedIdentity,
 		}, onUpdate); err != nil {
 			return RunTurnResult{}, err
@@ -940,9 +940,10 @@ func (s *AppServer) resumeThread(
 }
 
 type startTurnResult struct {
-	ID             string
-	Model          string
-	StartedEmitted bool
+	ID              string
+	Model           string
+	RuntimeIdentity agentidentity.Identity
+	StartedEmitted  bool
 }
 
 func (s *AppServer) startTurn(
@@ -985,6 +986,7 @@ func (s *AppServer) startTurn(
 	}
 
 	trackTurnStarted := func(update Update) error {
+		turn.RuntimeIdentity = turn.RuntimeIdentity.Merge(update.RuntimeIdentity)
 		if update.Type == UpdateTurnStarted {
 			turn.StartedEmitted = true
 			if update.Model != "" {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -996,6 +996,105 @@ func TestAppServerRunTurnPreservesTurnStartedRuntimeModel(t *testing.T) {
 	}
 }
 
+func TestAppServerRunTurnPreservesLatestSettingsIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		effort        string
+		settings      string
+		settingsModel string
+		started       bool
+		threadEffort  string
+		wantEffort    agentidentity.Value
+		wantProvider  string
+		wantTier      agentidentity.Value
+	}{
+		{name: "low override", effort: "low", settings: `"effort":"low","serviceTier":"priority"`, threadEffort: "medium", wantEffort: agentidentity.NewValue("low", agentidentity.ProvenanceRuntime), wantProvider: "azure", wantTier: agentidentity.NewValue("priority", agentidentity.ProvenanceRuntime)},
+		{name: "high override", effort: "high", settings: `"effort":"high","serviceTier":"priority"`, threadEffort: "medium", wantEffort: agentidentity.NewValue("high", agentidentity.ProvenanceRuntime), wantProvider: "azure", wantTier: agentidentity.NewValue("priority", agentidentity.ProvenanceRuntime)},
+		{name: "xhigh override", effort: "xhigh", settings: `"effort":"xhigh","serviceTier":"priority"`, threadEffort: "medium", wantEffort: agentidentity.NewValue("xhigh", agentidentity.ProvenanceRuntime), wantProvider: "azure", wantTier: agentidentity.NewValue("priority", agentidentity.ProvenanceRuntime)},
+		{name: "real turn started", effort: "xhigh", settings: `"effort":"xhigh","serviceTier":"priority"`, started: true, threadEffort: "medium", wantEffort: agentidentity.NewValue("xhigh", agentidentity.ProvenanceRuntime), wantProvider: "azure", wantTier: agentidentity.NewValue("priority", agentidentity.ProvenanceRuntime)},
+		{name: "settings unavailable", effort: "xhigh", settings: `"effort":null,"serviceTier":null`, threadEffort: "medium", wantEffort: agentidentity.UnknownValue(), wantProvider: "azure", wantTier: agentidentity.UnknownValue()},
+		{name: "no runtime effort evidence", effort: "xhigh", wantProvider: "openai", wantTier: agentidentity.NewValue("default", agentidentity.ProvenanceRuntime)},
+		{name: "thread evidence only", effort: "medium", threadEffort: "medium", wantEffort: agentidentity.NewValue("medium", agentidentity.ProvenanceRuntime), wantProvider: "openai", wantTier: agentidentity.NewValue("default", agentidentity.ProvenanceRuntime)},
+		{name: "runtime model update", effort: "high", settings: `"effort":"high","serviceTier":"priority"`, settingsModel: "gpt-5.6-sol", threadEffort: "medium", wantEffort: agentidentity.NewValue("high", agentidentity.ProvenanceRuntime), wantProvider: "azure", wantTier: agentidentity.NewValue("priority", agentidentity.ProvenanceRuntime)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			messages := []Message{
+				responseMessage(t, 1, `{"userAgent":"codex-cli/0.143.0"}`),
+				responseMessage(t, threadResumeRequestID, `{"thread":{"id":"thread-1"},"model":"gpt-6-astra","modelProvider":"openai","reasoningEffort":"`+tt.threadEffort+`","serviceTier":"default"}`),
+			}
+			wantModel := "gpt-6-astra"
+			if tt.settingsModel != "" {
+				wantModel = tt.settingsModel
+			}
+			if tt.settings != "" {
+				messages = append(messages, notificationMessage(t, "thread/settings/updated", `{"threadId":"thread-1","threadSettings":{"model":"`+wantModel+`","modelProvider":"azure",`+tt.settings+`}}`))
+			}
+			if tt.started {
+				messages = append(messages, notificationMessage(t, "turn/started", `{"threadId":"thread-1","turn":{"id":"turn-1","model":"gpt-6-astra"}}`))
+			}
+			messages = append(messages,
+				responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+				notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+			)
+			transport := newFakeAppServerTransport(messages)
+			server, err := NewAppServer(staticTransportFactory{transport: transport})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var identity agentidentity.Identity
+			var started []Update
+			_, err = server.RunTurn(t.Context(), RunTurnRequest{
+				Workspace: t.TempDir(), ResumeThreadID: "thread-1", Model: "gpt-6-astra", ReasoningEffort: tt.effort,
+			}, func(update Update) error {
+				identity = identity.Merge(update.RuntimeIdentity)
+				if update.Type == UpdateTurnStarted {
+					started = append(started, update)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("RunTurn() error = %v", err)
+			}
+			if len(started) != 1 {
+				t.Fatalf("turn started updates = %d, want 1", len(started))
+			}
+			wantMethod := "turn/start"
+			if tt.started {
+				wantMethod = "turn/started"
+			}
+			if started[0].Method != wantMethod {
+				t.Fatalf("turn started method = %q, want %q", started[0].Method, wantMethod)
+			}
+			if identity.Model() != wantModel || started[0].Model != wantModel {
+				t.Fatalf("final model = %q, turn started model = %q, want %q", identity.Model(), started[0].Model, wantModel)
+			}
+			if identity.ReasoningEffort != tt.wantEffort || identity.Provider != agentidentity.NewValue(tt.wantProvider, agentidentity.ProvenanceRuntime) || identity.ServiceTier != tt.wantTier {
+				t.Fatalf("final identity = %+v, want effort=%+v provider=%s tier=%+v", identity, tt.wantEffort, tt.wantProvider, tt.wantTier)
+			}
+			for _, message := range transport.sent {
+				if message.Method != "turn/start" {
+					continue
+				}
+				var params struct {
+					Effort string `json:"effort"`
+				}
+				if err := json.Unmarshal(message.Params, &params); err != nil {
+					t.Fatal(err)
+				}
+				if params.Effort != tt.effort {
+					t.Fatalf("requested effort = %q, want %q", params.Effort, tt.effort)
+				}
+			}
+		})
+	}
+}
+
 func TestUpdateFromMessageCapturesModelReroute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1876,6 +1876,66 @@ func TestRunnerRunRecordsRuntimeModelUpdate(t *testing.T) {
 	}
 }
 
+func TestRunnerRunRetainsEffectiveTurnIdentity(t *testing.T) {
+	t.Parallel()
+
+	for _, effort := range []string{"low", "high", "xhigh"} {
+		t.Run(effort, func(t *testing.T) {
+			t.Parallel()
+
+			threadIdentity := agentidentity.RuntimeUpdate("gpt-6-astra", "openai", "medium", "default", time.Time{})
+			turnIdentity := agentidentity.RuntimeUpdate("gpt-6-astra", "azure", effort, "priority", time.Time{})
+			agentBackend := &fakeCodexClient{
+				models: []AgentModel{{ID: "gpt-6-astra", Model: "gpt-6-astra", SupportedReasoningEfforts: []string{"low", "medium", "high", "xhigh"}}},
+				updates: []AgentUpdate{
+					{Type: AgentUpdateRuntimeIdentity, Method: "thread/resume", ThreadID: "thread-2332", RuntimeIdentity: threadIdentity},
+					{Type: AgentUpdateRuntimeIdentity, Method: "thread/settings/updated", ThreadID: "thread-2332", RuntimeIdentity: turnIdentity},
+					{Type: AgentUpdateTurnStarted, Method: "turn/start", ThreadID: "thread-2332", TurnID: "turn-1", Model: "gpt-6-astra", RuntimeIdentity: turnIdentity},
+				},
+				result: AgentTurnResult{ThreadID: "thread-2332", TurnID: "turn-1", SessionID: "thread-2332-turn-1"},
+			}
+			sessionStore := &fakeSessionStore{sessionID: 2332}
+			r, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{Prompt: "Work"},
+				Workspace: &fakeWorkspaceBackend{
+					info:      workspace.Info{Path: t.TempDir(), Key: "issue-2332"},
+					diffStats: []workspace.DiffStat{{Files: 1, Added: 1}},
+				},
+				AgentBackend: agentBackend,
+				Store:        sessionStore,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var telemetryIdentity agentidentity.Identity
+			result, err := r.Run(t.Context(), RunRequest{
+				Issue: connector.Issue{
+					ID: "issue-2332", Identifier: "digitaldrywood/detent#2332", Title: "Preserve effective turn effort",
+					Description: "```detent-agent\nschema: 1\nmodel: gpt-6-astra\neffort: " + effort + "\n```",
+				},
+				StartedAt: time.Now(),
+				OnUsageUpdate: func(update UsageUpdate) error {
+					telemetryIdentity = update.RuntimeIdentity
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if agentBackend.request.ReasoningEffort != effort {
+				t.Fatalf("requested effort = %q, want %q", agentBackend.request.ReasoningEffort, effort)
+			}
+			for name, identity := range map[string]agentidentity.Identity{
+				"result": result.RuntimeIdentity, "session": sessionStore.finished.RuntimeIdentity, "telemetry": telemetryIdentity,
+			} {
+				if identity.ReasoningEffort != turnIdentity.ReasoningEffort || identity.Provider != turnIdentity.Provider || identity.ServiceTier != turnIdentity.ServiceTier {
+					t.Errorf("%s identity = %+v, want effective turn settings %+v", name, identity, turnIdentity)
+				}
+			}
+		})
+	}
+}
+
 func TestRunnerRunLogsBudgetRefusalWithDerivedRole(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Preserve the latest provider-confirmed Codex model, effort, provider, and service tier when synthesizing turn-start telemetry after settings arrive during startup. A thread default of medium can no longer overwrite a newer low/high/xhigh turn setting.
- Keep explicit issue effort overrides and unknown-value provenance intact; cover real turn-start notifications and final runner/session/telemetry identity.

Fixes #2332

## UI Surface Contract

- [x] N/A: this corrects telemetry consumed by existing board components without changing layout or visibility.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual layout changes; existing board badge and identity rendering tests pass.

## Test Plan

- [x] Focused app-server transcript, runner, store persistence, identity, and issue override tests.
- [x] Board runtime badge, identity detail, provenance, and unavailable-value rendering tests.
- [x] `make check` (build, lint, vet, NilAway, race tests, 80.2% coverage, package/file floors).
