### PR TITLE
test(cli): isolate scoped doctor path validation

### DIFF
--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3645,7 +3645,7 @@ func TestRunDoctorWithProjectScopeSkipsUnrelatedProjectFailures(t *testing.T) {
 	}
 }
 
-func TestRunDoctorWithProjectScopeSkipsUnrelatedProjectPathValidation(t *testing.T) {
+func TestCheckDoctorConfigWithProjectScopeValidatesOnlySelectedPaths(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -3681,39 +3681,71 @@ func TestRunDoctorWithProjectScopeSkipsUnrelatedProjectPathValidation(t *testing
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	deps := successfulDoctorDeps()
-	deps.loadWorkflow = func(path string) (workflowconfig.Workflow, error) {
-		if strings.Contains(path, "missing-beta") {
-			t.Fatalf("loadWorkflow(%q) called for skipped project", path)
-		}
-		return workflowconfig.Workflow{Config: validDoctorWorkflow(alphaWorkdir)}, nil
-	}
-
-	report := runDoctor(context.Background(), doctorConfig{
-		ConfigPath:   configPath,
-		Output:       io.Discard,
-		CheckTimeout: time.Second,
-		ProjectID:    "alpha",
-		Flags: runtimeFlags{
-			Port: runtimeIntFlag{Value: 0, Set: true},
-		},
-	}, options{
+	opts := doctorOptions(options{
 		resolvePath: func(string) (globalconfig.PathResolution, error) {
 			return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
 		},
-		stdoutTTY: func() bool { return true },
-	}, deps)
+	})
+	tests := []struct {
+		name        string
+		projectID   string
+		wantStatus  doctorStatus
+		wantSkipped []string
+	}{
+		{
+			name:        "skip unrelated missing paths",
+			projectID:   "alpha",
+			wantStatus:  doctorOK,
+			wantSkipped: []string{"beta"},
+		},
+		{
+			name:        "reject selected missing paths",
+			projectID:   "beta",
+			wantStatus:  doctorFail,
+			wantSkipped: []string{"alpha"},
+		},
+		{
+			name:       "reject unscoped missing paths",
+			wantStatus: doctorFail,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if report.HasFailures() {
-		t.Fatalf("HasFailures() = true, want scoped doctor to ignore beta path validation: %#v", report.Checks)
+			resolution, global, scope, scopeCheck, check := checkDoctorConfig(configPath, tt.projectID, opts)
+			if resolution.Path != configPath || resolution.Rule != globalconfig.PathRuleFlag {
+				t.Fatalf("resolution = %#v, want explicit config path %q", resolution, configPath)
+			}
+			if check.Status != tt.wantStatus {
+				t.Fatalf("config check = %#v, want status %s", check, tt.wantStatus)
+			}
+			if scope.SelectedProject != tt.projectID || !slices.Equal(scope.SkippedProjects, tt.wantSkipped) {
+				t.Fatalf("scope = %#v, want selected %q and skipped %v", scope, tt.projectID, tt.wantSkipped)
+			}
+			if scopeCheck != nil {
+				t.Fatalf("scope check = %#v, want nil", scopeCheck)
+			}
+			if tt.wantStatus == doctorFail {
+				if global != nil {
+					t.Fatalf("global = %#v, want nil for invalid paths", global)
+				}
+				for _, want := range []string{"workflow: path does not exist", "workdir: path does not exist"} {
+					if !strings.Contains(check.Detail, want) {
+						t.Errorf("Detail = %q, want containing %q", check.Detail, want)
+					}
+				}
+				return
+			}
+			if global == nil || len(global.Projects) != 1 {
+				t.Fatalf("global = %#v, want only the selected project", global)
+			}
+			project := global.Projects[0]
+			if project.ID != "alpha" || project.Workflow != alphaWorkflow || project.Workdir != alphaWorkdir {
+				t.Fatalf("project = %#v, want alpha with its validated workflow and workdir", project)
+			}
+		})
 	}
-	if report.Scope.SelectedProject != "alpha" {
-		t.Fatalf("SelectedProject = %q, want alpha", report.Scope.SelectedProject)
-	}
-	if !slices.Equal(report.Scope.SkippedProjects, []string{"beta"}) {
-		t.Fatalf("SkippedProjects = %#v, want beta", report.Scope.SkippedProjects)
-	}
-	assertDoctorMissingCheck(t, report, "Project beta workflow")
 }
 
 func TestRunDoctorWithMissingProjectScopeFails(t *testing.T) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3681,11 +3681,10 @@ func TestCheckDoctorConfigWithProjectScopeValidatesOnlySelectedPaths(t *testing.
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	opts := doctorOptions(options{
-		resolvePath: func(string) (globalconfig.PathResolution, error) {
-			return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
-		},
-	})
+	opts := defaultOptions()
+	opts.resolvePath = func(string) (globalconfig.PathResolution, error) {
+		return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
+	}
 	tests := []struct {
 		name        string
 		projectID   string
@@ -3730,10 +3729,11 @@ func TestCheckDoctorConfigWithProjectScopeValidatesOnlySelectedPaths(t *testing.
 				if global != nil {
 					t.Fatalf("global = %#v, want nil for invalid paths", global)
 				}
-				for _, want := range []string{"workflow: path does not exist", "workdir: path does not exist"} {
-					if !strings.Contains(check.Detail, want) {
-						t.Errorf("Detail = %q, want containing %q", check.Detail, want)
-					}
+				if !strings.Contains(check.Detail, "workdir: path does not exist") {
+					t.Errorf("Detail = %q, want missing workdir error", check.Detail)
+				}
+				if strings.Contains(check.Detail, "workflow: path does not exist") {
+					t.Errorf("Detail = %q, want missing workflow preserved for diagnosis", check.Detail)
 				}
 				return
 			}


### PR DESCRIPTION
## Summary

- Test scoped doctor path validation directly through config checking so unrelated workspace inspection cannot expire its deadline.
- Use production doctor readers and cover scoped success plus selected-project and unscoped rejection of missing workdirs. Verify missing workflow diagnosis remains deferred, matching production behavior.
- Preserve separate end-to-end scoping and production timeout/cancellation coverage.

Fixes #2328

## UI Surface Contract

- [x] N/A: test-only change with no UI surface, layout, density, viewport, or responsive visibility tradeoff.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] `make check CHECK_LOCK_WAIT=60m`: build, lint, vet, NilAway, all race tests, and coverage floors passed; overall coverage 80.2%, CLI 77.5%. Only the shared lock queue wait was extended.
- [x] Scoped validation, missing-workflow diagnosis, end-to-end scoping, and timeout/cancellation tests: 50 race repetitions.
- [x] Mutation check: forcing unscoped production reading fails the scoped alpha case on beta's missing workdir.
- [x] Mutation check: forcing strict scoped reading fails the deferred missing-workflow assertion.
- [x] `git diff --check`

The original workspace-inspection delay remains unconfirmed; this isolates the scope assertion from timed inspection without extending a doctor deadline.
