### PR TITLE
fix(workspace): preserve manual worktrees in cleanup

### DIFF
--- a/internal/workspace/cleanup_registry.go
+++ b/internal/workspace/cleanup_registry.go
@@ -266,6 +266,10 @@ func (l *LocalGit) ReconcileResiduals(ctx context.Context, activeIssues []Issue)
 }
 
 func (l *LocalGit) reconcileWorkspace(ctx context.Context, record cleanupOwnershipRecord, recorded bool, result *ReconcileResult) (bool, error) {
+	if !recorded && record.Branch != "detent/"+strings.ToLower(record.Key) {
+		result.UnownedSkipped++
+		return false, nil
+	}
 	exists, _, err := pathExists(record.Path)
 	if err != nil {
 		return false, err

--- a/internal/workspace/cleanup_registry_test.go
+++ b/internal/workspace/cleanup_registry_test.go
@@ -417,3 +417,55 @@ func TestLocalGitOrphanDiscoveryKeepsSourceRepository(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalGitReconcilePreservesManualWorktrees(t *testing.T) {
+	t.Parallel()
+	for _, branch := range []string{"feature/manual-hotfix", "detent/manual-hotfix", ""} {
+		t.Run(branch, func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			publishCleanupSource(t, source)
+			root := filepath.Join(t.TempDir(), "workspaces")
+			backend, err := NewLocalGit(LocalGitOptions{Root: root, SourceRoot: source, AutoBranch: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(root, "detent-astra-effort-ceiling")
+			if branch == "" {
+				runGit(t, source, "worktree", "add", "--detach", path, "main")
+			} else {
+				runGit(t, source, "worktree", "add", "-b", branch, path, "main")
+				runGit(t, path, "commit", "--allow-empty", "-m", "manual hotfix")
+				runGit(t, path, "push", "-u", "origin", branch)
+			}
+			if got := strings.TrimSpace(runGit(t, path, "status", "--porcelain")); got != "" {
+				t.Fatalf("manual worktree is dirty: %s", got)
+			}
+			if recorded, err := backend.cleanupOwnershipRecorded(t.Context(), path); err != nil || recorded {
+				t.Fatalf("ownership = %t, %v; want no record", recorded, err)
+			}
+			backend.scanWorkspacePaths = func(context.Context, string) ([]int, error) {
+				return nil, nil
+			}
+			result, err := backend.ReconcileResiduals(t.Context(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("manual worktree removed: %v; result = %+v", err, result)
+			}
+			if registered, err := backend.sourceWorktreeRegistered(t.Context(), path); err != nil || !registered {
+				t.Fatalf("manual worktree registration = %t, %v", registered, err)
+			}
+			if branch != "" && !branchExists(t, source, branch) {
+				t.Fatal("manual branch removed")
+			}
+			if result.UnownedSkipped != 1 || result.Removed != 0 || len(result.CompletedPaths) != 0 || len(result.Failures) != 0 || result.PreservedSkipped != 0 || result.RegisteredSkipped != 0 || result.ActiveSkipped != 0 {
+				t.Fatalf("reconcile = %+v; want one unowned skip only", result)
+			}
+			if recorded, err := backend.cleanupOwnershipRecorded(t.Context(), path); err != nil || recorded {
+				t.Fatalf("manual worktree adopted: ownership = %t, %v", recorded, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve unrecorded manual and detached worktrees during residual reconciliation. Automatic cleanup now requires a valid ownership record or the exact default managed branch identity matching the workspace key.
- Report unowned worktrees as skipped without cleanup failures or adopting ownership. Retain owned orphan cleanup and existing dirty, unpushed, and active-work protections.
- Add a deterministic regression that reproduced removal of clean pushed manual worktrees before the fix.

Fixes #2337

## UI Surface Contract

- [x] N/A: no UI surface changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Regression reproduced removal before the fix for manual feature, mismatched Detent-prefixed, and detached worktrees.
- [x] Focused workspace cleanup tests, including a race run.
- [x] `make check` (80.2% overall coverage, 71.5% workspace coverage; all package and file floors passed).
