### PR TITLE
fix(web): reuse concurrent snapshot enrichment

### DIFF
--- a/.detent/skills/cache-request-time-ordering.md
+++ b/.detent/skills/cache-request-time-ordering.md
@@ -1,0 +1,19 @@
+---
+name: cache-request-time-ordering
+description: Diagnose duplicate cache loads caused by request timestamps arriving out of order.
+when_to_use: Concurrent callers unexpectedly reload a fresh cache whose freshness predicate rejects negative ages.
+---
+
+Trace where the request timestamp is sampled relative to lock acquisition and
+single-flight waiting. A caller sampled earlier can acquire the lock after a
+later caller has populated the cache; this does not establish clock rollback.
+
+Reproduce with an injected clock and channels: suspend the first sample, let a
+second caller start loading, then return the earlier sample. Keep the original
+load-count assertion and run both normal and forced ordering cases. Avoid sleeps.
+
+For request-relative expiry, compare the sample to the cached expiry deadline;
+a result populated after the request began can satisfy that request. Preserve
+revision and identity checks. Do not globally relax negative-age checks: report
+window endpoints and actual clock rollback may require invalidation independently.
+Test revision changes and the exact expiry boundary alongside reversed samples.

--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -121,7 +121,7 @@ func (c *snapshotEnrichmentCache) enrichVersion(ctx context.Context, snapshot te
 			snapshot = c.pending
 		}
 
-		if c.cached && c.revision == revision && workflowHistoryFresh(c.loadedAt, now) && (sameSnapshotForEnrichment(c.raw, snapshot) || newerEnrichmentSnapshot(c.raw, snapshot)) {
+		if c.cached && c.revision == revision && now.Before(c.loadedAt.Add(workflowHistoryFreshness)) && (sameSnapshotForEnrichment(c.raw, snapshot) || newerEnrichmentSnapshot(c.raw, snapshot)) {
 			enriched := c.enriched
 			c.mu.Unlock()
 			return enriched

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -9669,57 +9669,81 @@ func TestServerEventsPreserveProjectContextForStaticSidebarNavigation(t *testing
 func TestServerEventsEnrichesSnapshotOncePerPublish(t *testing.T) {
 	t.Parallel()
 
-	generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
-	year, month, day := generatedAt.UTC().Date()
-	budgetPeriodStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	budgetQueryFrom := budgetPeriodStart.AddDate(0, 0, -6)
+	for _, tt := range []struct {
+		name              string
+		reverseClockOrder bool
+	}{
+		{name: "concurrent subscribers"},
+		{name: "earlier clock sample arrives after enrichment starts", reverseClockOrder: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+			year, month, day := generatedAt.UTC().Date()
+			budgetPeriodStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			budgetQueryFrom := budgetPeriodStart.AddDate(0, 0, -6)
 
-	var cycleTimeCalls atomic.Int64
-	var budgetCalls atomic.Int64
+			enrichmentStarted := make(chan struct{})
+			var enrichmentStartedOnce sync.Once
+			var clockCalls atomic.Int64
+			var cycleTimeCalls atomic.Int64
+			var budgetCalls atomic.Int64
 
-	registry := project.NewRegistry()
-	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10, workflowconfig.BillingModeSubscription)); err != nil {
-		t.Fatalf("Registry.Set() error = %v", err)
-	}
-
-	deps := testDeps(t)
-	deps.Registry = registry
-	deps.Store = storeProbe{
-		cycleTimeReport: func(context.Context) (store.CycleTimeReport, error) {
-			cycleTimeCalls.Add(1)
-			return store.CycleTimeReport{}, nil
-		},
-		budgetCostEvents: func(_ context.Context, query store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
-			if query.From.Equal(budgetQueryFrom) {
-				budgetCalls.Add(1)
+			registry := project.NewRegistry()
+			if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10, workflowconfig.BillingModeSubscription)); err != nil {
+				t.Fatalf("Registry.Set() error = %v", err)
 			}
-			return nil, nil
-		},
-	}
-	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
-	if err != nil {
-		t.Fatalf("NewServer() error = %v", err)
-	}
 
-	first := openEventStream(t, server)
-	second := openEventStream(t, server)
+			deps := testDeps(t)
+			deps.Registry = registry
+			deps.Store = storeProbe{
+				cycleTimeReport: func(context.Context) (store.CycleTimeReport, error) {
+					cycleTimeCalls.Add(1)
+					enrichmentStartedOnce.Do(func() { close(enrichmentStarted) })
+					return store.CycleTimeReport{}, nil
+				},
+				budgetCostEvents: func(_ context.Context, query store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+					if query.From.Equal(budgetQueryFrom) {
+						budgetCalls.Add(1)
+					}
+					return nil, nil
+				},
+			}
+			server, err := web.NewServer(web.Config{SSETickInterval: time.Hour, Now: func() time.Time {
+				if !tt.reverseClockOrder {
+					return time.Now()
+				}
+				if clockCalls.Add(1) == 1 {
+					<-enrichmentStarted
+					return generatedAt
+				}
+				return generatedAt.Add(time.Nanosecond)
+			}}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
 
-	if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
-		t.Fatalf("Publish() error = %v", err)
-	}
+			first := openEventStream(t, server)
+			second := openEventStream(t, server)
+			t.Cleanup(func() { enrichmentStartedOnce.Do(func() { close(enrichmentStarted) }) })
 
-	for _, body := range []io.Reader{first, second} {
-		event := readSSEEvent(t, body)
-		if event.name != "snapshot" {
-			t.Fatalf("event name = %q, want snapshot", event.name)
-		}
-	}
+			if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
 
-	if got := cycleTimeCalls.Load(); got != 1 {
-		t.Fatalf("CycleTimeReport calls = %d, want 1", got)
-	}
-	if got := budgetCalls.Load(); got != 1 {
-		t.Fatalf("BudgetCostEvents calls = %d, want 1", got)
+			for _, body := range []io.Reader{first, second} {
+				event := readSSEEvent(t, body)
+				if event.name != "snapshot" {
+					t.Fatalf("event name = %q, want snapshot", event.name)
+				}
+			}
+
+			if got := cycleTimeCalls.Load(); got != 1 {
+				t.Fatalf("CycleTimeReport calls = %d, want 1", got)
+			}
+			if got := budgetCalls.Load(); got != 1 {
+				t.Fatalf("BudgetCostEvents calls = %d, want 1", got)
+			}
+		})
 	}
 }
 

--- a/internal/web/workflow_history_cache_test.go
+++ b/internal/web/workflow_history_cache_test.go
@@ -228,7 +228,10 @@ func TestSnapshotEnrichmentHistoryInvalidation(t *testing.T) {
 		want     int
 	}{
 		{name: "identical snapshot", want: 1},
+		{name: "earlier request clock sample", elapsed: -time.Nanosecond, want: 1},
+		{name: "earlier request with corrected history", elapsed: -time.Nanosecond, revision: 1, want: 2},
 		{name: "corrected history", revision: 1, want: 2},
+		{name: "before freshness deadline", elapsed: workflowHistoryFreshness - time.Nanosecond, want: 1},
 		{name: "bounded freshness", elapsed: workflowHistoryFreshness, want: 2},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Concurrent SSE subscribers could enrich the same publication twice when a request sampled its clock before a later caller populated the cache. Comparing a negative cache age treated that fresh result as invalid.
- Compare the request time against the cache expiry deadline while preserving snapshot identity, revision, and expiry checks. Keep workflow report-window invalidation unchanged.
- Add a channel-controlled reproduction of reversed request ordering, alongside the original one-load assertion and revision/expiry boundary cases.

Fixes #2344

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: cache behavior only.

## Test Plan

- [x] Worker reproduced the original failure and a deterministic two-subscriber ordering failure before applying the fix.
- [x] Independent focused race validation of subscriber ordering and invalidation boundaries passed ten repetitions.
- [ ] `make check` is running through the shared validation gate; do not merge until the full gate and CI pass.

The PR is submitted while local validation runs so CI can proceed concurrently; it is a prerequisite for the urgent effort-correction release.

The prerequisite commit is included in #2335. Remaining full validation and merge are coordinated on that combined release branch to avoid duplicate queued gates.


Combined validation passed on PR #2335 head `b91f41b0`: full `make check`, 80.3% coverage and all eleven CI checks. This PR also passed all eleven of its own CI checks.
