### PR TITLE
test(project): stabilize Windows overlay removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,10 @@ jobs:
         if: runner.os == 'Windows'
         run: go run ./tools/testgate -output tmp/windows-test-evidence -parallel 4 -timeout 10m ./...
 
+      - name: Repeat Windows workflow overlay lifecycle
+        if: runner.os == 'Windows'
+        run: go test ./internal/project -run '^TestGitRefWorkflowWatcherReloadsLocalOverlayLifecycle$' -count=50 -timeout=5m
+
       - name: Upload Windows test evidence
         if: always() && runner.os == 'Windows'
         uses: actions/upload-artifact@v7

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -520,8 +521,24 @@ func TestGitRefWorkflowWatcherReloadsLocalOverlayLifecycle(t *testing.T) {
 		t.Fatalf("create Prompt = %q, want shared and local", created.Workflow.Prompt)
 	}
 
-	if err := os.Remove(localPath); err != nil {
-		t.Fatalf("Remove() error = %v", err)
+	removeDeadline := time.NewTimer(5 * time.Second)
+	defer removeDeadline.Stop()
+	removeRetry := time.NewTicker(10 * time.Millisecond)
+	defer removeRetry.Stop()
+	for {
+		err := os.Remove(localPath)
+		if err == nil {
+			break
+		}
+		const windowsSharingViolation syscall.Errno = 32
+		if runtime.GOOS != "windows" || !errors.Is(err, windowsSharingViolation) {
+			t.Fatalf("Remove() error = %v", err)
+		}
+		select {
+		case <-removeDeadline.C:
+			t.Fatalf("Remove() still failing after retry deadline: %v", err)
+		case <-removeRetry.C:
+		}
 	}
 	deleted := readWorkflowSourceUpdate(t, updates)
 	if deleted.Err != nil {


### PR DESCRIPTION
## Summary

- Stabilize live workflow overlay deletion on Windows by retrying only sharing violations for at most five seconds. Other removal errors still fail immediately.
- Preserve assertions that deleting the overlay while the watcher runs restores the shared workflow and clears overlay metadata.
- Repeat the lifecycle 50 times in Windows portability CI. Both production read paths close their handles; the fixture can overlap a valid short read.

Fixes #2345

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes.

## Test Plan

- [x] Focused project and config watcher race tests, repeated 10 times.
- [x] Windows amd64 test cross-compilation.
- [x] `make check CHECK_LOCK_WAIT=60m` (all checks passed; 80.3% overall coverage).
- [ ] Windows lifecycle test repeated 50 times in CI.
