### PR TITLE
docs(cloud): correct shared-site tenancy and launch contract

### DIFF
--- a/docs/cloud-hub-rfc.md
+++ b/docs/cloud-hub-rfc.md
@@ -1,6 +1,6 @@
 # Native Hub and Detent Cloud architecture RFC
 
-[Documentation index](../README.md#documentation) · [Implemented Hub API](hub-api.md) · [Delivery issue #2181](https://github.com/digitaldrywood/detent/issues/2181)
+[Documentation index](../README.md#documentation) · [Implemented Hub API](hub-api.md) · [Original delivery #2181](https://github.com/digitaldrywood/detent/issues/2181) · [Shared-site correction #2340](https://github.com/digitaldrywood/detent/issues/2340)
 
 Status: proposed architecture for human review. This is the authoritative design
 target for the linked Cloud work once reviewed; it does not claim those features
@@ -9,9 +9,12 @@ RFC before dependent implementation. The RFC can finish independently of every
 implementation below.
 
 Detent remains a Go agent orchestrator delivered as one binary. Local operation,
-a customer-hosted Hub, and paid hosted Cloud at `cloud.detent.build` are supported
-directions. Local and self-hosted operation require no Detent Cloud, WorkOS, or
-Stripe account. Customer machines execute work using customer provider accounts;
+a customer-hosted Hub, and the shared hosted service at `https://hub.detent.build`
+are supported directions. Hosted access has organization free/paid entitlements.
+Self-hosted Detent is free with customer-selected authentication, including WorkOS,
+custom, generic or local options; it never requires a Detent hosted account,
+subscription, or billing connection. WorkOS is optional for self-hosting. Customer
+machines execute work using customer provider accounts;
 Detent does not resell provider keys. This document authorizes no live accounts,
 DNS changes, deployment, purchases, invitations, or customer charges.
 
@@ -33,14 +36,17 @@ implementation without silently resolving the product choices in this table.
 | Billing boundary and teams | Approved September 7: organization billing; flat owner/admin/member/viewer roles with explicit project and separate runner-management grants. Nested teams and inherited permissions are deferred | Human product review; [#2193](https://github.com/digitaldrywood/detent/issues/2193), [#2195](https://github.com/digitaldrywood/detent/issues/2195) |
 | Artifact deployment | Approved September 7: optional local-only operation, customer-managed storage, and explicit opt-in hosted storage through a portable service and configurable S3 adapter. DigitalOcean Spaces is the initial hosted provider | [#2190](https://github.com/digitaldrywood/detent/issues/2190); [artifact contract](artifact-access-contract.md) |
 | Hosted tenant allocation | Approved September 7: one dedicated Hub process and SQLite file per organization, with persistent tenant binding and scoped APIs. Customer collaboration databases are not pooled; measure the per-process baseline cost | Human architecture/cost review; #2193, [#2199](https://github.com/digitaldrywood/detent/issues/2199) |
+| Shared product entry | Confirmed September 8: one public origin for sign-in, organization creation/joining/switching and organization billing; supersedes per-organization public origins without changing tenant storage | [#2340](https://github.com/digitaldrywood/detent/issues/2340), #2341, #2342, #2343 |
 | Pilot access | Recommend invitation-controlled pilot with configurable grants; eligibility and invitations remain operator decisions | #2194, #2195, #2199 |
 | Prices and free allowances | No approved prices, permanent free quantities, unlimited tier, or marginal-cost promise. Measure baseline and marginal cost before public commitments | #2195, [#2196](https://github.com/digitaldrywood/detent/issues/2196), #2199 |
 | Retention and deletion | Require explicit policies for collaboration, events, artifacts, and backups; durations, backup expiry, and revocation bounds remain unresolved | #2182, #2189, #2195, #2197 |
 
 An unresolved choice blocks only the implementation that needs it. It is not a
 dependency from this RFC back to that implementation. The first-release evidence
-gate is #2199; Stripe subscriptions (#2196), native diff rendering (#2192), and
-capacity-based routing refinements (#2198) are separate follow-ups.
+gate is #2199, including shared self-service hosting after #2342. The completed
+test billing delivery #2196 is reused by live-mode/customer provisioning #2343;
+paid activation is independent of the free pilot. Native diff rendering (#2192)
+and capacity-based routing refinements (#2198) remain separate work.
 
 ## Existing implementation and superseded assumptions
 
@@ -135,14 +141,18 @@ flowchart TB
 
 Each Hub process alone opens its database. Remote clients use authenticated HTTP;
 no SQLite file is shared over NFS/SMB, and no replicated writers are added. Hosted
-placement assigns one organization to one dedicated Hub process and SQLite file.
-The organization binding persists across restart; a different tenant, host origin,
-or local-mode reopen is rejected. A reserved empty Hub can create its WorkOS
-organization for its configured bootstrap user. The deployment directory routes
-organization switching to a fresh protected login on the owning Hub. Automatic
-placement and recovery remain deployment work in #2199. Tenant filters remain
-mandatory even with dedicated processes; customer collaboration databases are
-not pooled.
+placement retains one organization per dedicated Hub process and SQLite file.
+The September 8 correction separates that storage boundary from the public site:
+all customer application navigation uses `https://hub.detent.build`
+(external identity/payment screens return to this same origin). A shared entry service
+owns authentication, organization selection, provisioning and trusted routing.
+It does not open tenant databases. Tenant filters remain mandatory.
+
+The previously delivered reserved bootstrap user, immutable public-origin binding
+and cross-origin directory are migration inputs, not the self-service launch
+contract. Stable organization/provider bindings remain enforced; removing their
+checks globally is prohibited. See [identity migration](hosted-identity.md#existing-origin-migration)
+and [deployment examples](examples/hub/README.md).
 
 Preserve startup ownership locks, schema identity checks, WAL, foreign keys,
 busy-timeout handling, and fail-closed migration/version checks. Health becomes
@@ -151,6 +161,146 @@ backup path; do not copy live database/WAL files. Recovery starts a replacement
 only after the previous owner is fenced off. A reverse proxy may terminate TLS
 under the existing trusted-proxy contract. Self-hosted endpoints and identity
 adapters are configurable; no compiled-in Cloud login or billing requirement.
+
+## Shared-site control and tenant storage
+
+This September 8 design is proposed for review in #2340. #2341 implements shared
+routing, #2342 provisioning/lifecycle and #2343 customer billing. It does not
+claim those implementations or any live deployment are complete.
+
+```mermaid
+flowchart LR
+    Browser[Browser and customer runners] --> Edge[hub.detent.build TLS ingress]
+    Edge --> Entry[Shared entry and authenticated routing]
+    Entry --> Registry[(Metadata registry: one SQLite owner)]
+    Entry -->|Private authenticated requests for A| A[Tenant A Hub]
+    Entry -->|Private authenticated requests for B| B[Tenant B Hub]
+    A --> ADB[(A collaboration SQLite)]
+    B --> BDB[(B collaboration SQLite)]
+    Entry --> Identity[WorkOS identity]
+    Entry --> Billing[Optional Stripe billing]
+```
+
+The registry is a separate, single-owner local SQLite service at the baseline.
+Other processes access it through authenticated bounded APIs, never a shared
+mount. Registry records allow only stable Detent/provider user and organization
+IDs, verified identity fields needed for account administration, organization
+names for the chooser, membership status/revision mappings, provisioning intents
+and checkpoints, allocation IDs/private endpoints/generations, non-secret
+runner/service principal-to-organization routing references, tombstones,
+versioned plan references and Stripe account/environment/customer references.
+Authentication state and encrypted provider credentials needed for login live in
+a private auth store with explicit retention, not in operator reports. Minimal
+hashed invitation/operation references permit recovery; raw invitation tokens,
+session capabilities and secrets never enter the reporting registry schema.
+The entry service exclusively owns the auth store; other services use its private
+validated-session API for continuing authorization, not a second SQLite handle
+or copies of the operator WorkOS key. Restoring auth storage invalidates sessions.
+
+Project grants and all issues, comments, run history, policies, source/artifact
+references and artifact bytes remain in their owning tenant/service. The registry
+must not replicate collaboration content, arbitrary metadata maps, project
+search indexes, credential material or provider payloads. Counts/health use the
+existing bounded tenant metadata API. A membership mapping is a routing candidate,
+not authorization: current provider membership, local revocation and tenant
+project grants must still agree. Unknown, stale or conflicting bindings fail
+closed. Registry unavailability denies new routing/provisioning; already admitted
+work follows its existing lease and safe checkpoint rules, never another tenant.
+
+Only the entry service resolves an immutable organization ID to an allowlisted
+allocation endpoint. It validates the route and caller before routing, including
+current membership for browser authority and independent credential binding for
+machines/services. The tenant checks its persisted organization/allocation generation
+and project/operation authority. Neither client headers, Host, return URLs, JSON
+IDs nor provider metadata may supply an upstream address or filesystem path.
+Use private authenticated transport (mTLS between services, or an equivalently
+reviewed local Unix-socket identity) plus a short-lived signed request assertion.
+Bind the assertion to issuer, exact tenant audience, organization, allocation
+generation, actual/effective principal, session/credential ID, method, canonical
+path, body digest, issued/expiry times and replay identity. Expiry is at most
+30 seconds and never extends underlying authority. Tenants validate all fields;
+mutation retries use their existing idempotency journal after fresh authorization.
+Key rotation permits bounded overlap, and replayed transport assertions are denied.
+For SSE the assertion admits the connection only; ongoing session/membership and
+revocation checks authorize every frame and idle heartbeat independently.
+
+Ingress strips all inbound internal identity/forwarding headers and sets only
+trusted transport metadata. Backend listeners are private, firewall-restricted
+or socket-permission restricted, and reject missing/invalid assertions even on
+loopback. A public proxy-header-only bypass is never supported. Separate principals
+limit allocator, registry, reporter and tenant access; a reporter cannot mint
+browser or runner assertions. TLS termination alone is not proxy authentication.
+
+Browser sessions, CSRF, invitations, scoped routes, SSE and artifact grants are
+specified in [hosted identity](hosted-identity.md#shared-origin-route-and-session-contract).
+Runner and integration credentials remain independently authenticated and
+organization-bound; a browser session cannot confer machine authority.
+
+## Provisioning, recovery and capacity
+
+The durable lifecycle is `requested -> allocating -> ready`, with `failed` for a
+recoverable or terminal failure and `deleting -> deleted` for retirement. Record
+step, attempt count, next retry, bounded error code and allocation generation.
+The verified creator sees the same operation after refresh/login; failure never
+requires another organization ID. [Onboarding](cloud-onboarding.md#organization-provisioning-and-recovery)
+defines the checkpoints and user-visible outcomes.
+
+Before creating external resources, atomically reserve a finite organization
+slot, allocation concurrency, measured memory headroom and local disk/backup
+budget. Apply per-identity signup limits and operator eligibility policy; invitation
+control can bound a pilot without manually assigning each tenant's YAML. Reject
+new admission with a retryable capacity result before disrupting ready tenants.
+A durable reservation is tied to the intent and fenced allocator lease. After a
+crash, reconcile actual process/disk/provider state before releasing it or starting
+a replacement; an expired timer alone cannot prove a live owner is gone.
+
+Dedicated processes and separate databases are the baseline even when idle.
+Measure shared entry/registry overhead separately from each tenant's startup peak,
+idle and active RSS/CPU, file descriptors, connections/SSE, database/WAL growth,
+backup staging/retention, network and optional artifact relay. Capacity is bounded
+by the tightest measured memory, CPU, disk, descriptors and service limits with
+explicit reserve. Record workload, hardware, binary revision, concurrency,
+measurement window and calculation inputs in #2199/#2308. Publish the maximum
+admitted tenants and allocation refusal result, not an unmeasured cost promise.
+No existing snapshot of free RAM is an admission measurement.
+
+Process pooling or on-demand activation is a separate reviewed lifecycle design.
+It needs evidence for activation latency and stampedes, exclusive database
+ownership, idle eviction with SSE/leases/jobs, drain/fencing, crash/restart,
+webhook delivery, backup/restore, quota fairness and secret isolation. Do not
+silently pool collaboration databases or promise pennies to reduce memory cost.
+
+Backups pair a registry checkpoint and per-tenant owner-produced snapshots in a
+manifest with organization, allocation generation, schema, restore epoch and
+checksums. Quiesce provisioning/membership changes and relevant tenant writes for
+a consistent capture; do not claim cross-database atomic snapshots. Keep deletion
+and revocation ledgers outside rollbackable snapshots. Restore fenced/isolated,
+verify registry-to-tenant bindings, reconcile provider and billing references,
+reapply tombstones/revocations, rotate restored authority and runner credentials
+under the existing recovery contract, then publish a new allocation generation.
+Missing or conflicting records leave only the affected tenant unavailable;
+never guess ownership or serve a restored deleted organization.
+
+Organization deletion requires a current, non-impersonating owner, fresh identity
+verification and explicit confirmation. Mark `deleting`, deny new allocations,
+invitations and writes, revoke sessions/grants/enrollment, and drain or safely
+stop active work. Reconcile/cancel paid service before retiring its billing
+mapping. Fence the Hub and disable routing before the storage owner erases tenant
+content, artifacts under the selected custody contract, exports and backups under
+the approved retention policy. Keep minimal deletion/billing references needed
+to reject delayed events and restoration; IDs are never reused. Failed erasure
+stays visible as pending, not deleted. Customer-managed artifacts and external
+GitHub projections require their own authorized owner actions. Policy durations,
+retained billing records and recovery objectives must be published before launch;
+this RFC invents none and performs no erasure.
+
+Account deletion is distinct: revoke all that account's sessions and memberships
+across organizations and remove its grants without deleting other members' work.
+A last owner must transfer ownership to another verified member or complete
+organization deletion first. Preserve opaque authorship attribution as required
+by the tenant retention contract; remove account profile/provider identity only
+after membership cleanup and documented retention checks. Cross-service failures
+remain a resumable deletion operation. Re-creation never restores old grants.
 
 ## Stable identities and protocol compatibility
 
@@ -454,8 +604,10 @@ not reveal another organization's existence/content. Revalidate membership and
 runner authority on protected operations; define session/capability revocation
 bounds in the identity and artifact designs. Billing administration alone does
 not grant code credentials or privileged execution. Local/self-hosted auth stays
-pluggable and independent of WorkOS availability. Legacy Hub tokens need explicit
-overlap/rotation guidance, not silent invalidation.
+pluggable and independent of Detent Cloud. A customer-selected WorkOS adapter
+may depend on WorkOS; custom/local authentication requires no WorkOS connection.
+Authentication provider selection never enables hosted monetization. Legacy Hub
+tokens need explicit overlap/rotation guidance, not silent invalidation.
 
 ### Approved operational reporting and support access
 
@@ -471,9 +623,10 @@ project, runner and event counts, latest activity, database/WAL bytes, health,
 versioned plan assignment, scoped grant expiry, allowance/consumption and bounded
 request/artifact telemetry. Hosted mode initializes an operator-configurable pilot
 free plan; missing allowances inside a plan mean zero. See [hosted allowances](hosted-allowances.md)
-for enforcement, downgrade and reporting policy. Owner-only `GET /api/cloud/billing` exposes the same bounded usage
-for that Hub's organization. Organization administration cannot read project
-content without an explicit project grant.
+for enforcement, downgrade and reporting policy. The delivered owner-only
+`GET /api/cloud/billing` exposes bounded tenant usage; the shared site scopes it
+as `GET /api/cloud/organizations/ORG/billing`. Organization administration cannot
+read project content without an explicit project grant.
 
 Reports exclude issue/comment bodies and titles, repository names and paths,
 prompts, source, diffs, logs, artifact references and contents, credentials, and
@@ -730,7 +883,10 @@ services; the RFC author does not configure live customer accounts.
 
 | Scenario | Evidence required |
 | --- | --- |
-| Local and self-hosted portability | Run with Cloud, WorkOS and Stripe networking denied; local workflow and self-hosted auth/claims/recovery work without hosted entitlements |
+| Local and self-hosted portability | Run custom/local auth with Detent Cloud, WorkOS and Stripe networking denied; auth/claims/recovery work without hosted entitlements. Separately use a WorkOS fixture with Cloud/Stripe blocked and verify auth choice does not enable billing |
+| Shared-site journey | Execute the two-organization, concurrent-tab trace in [onboarding](cloud-onboarding.md#shared-site-acceptance-trace); all customer routes use hub.detent.build |
+| Shared ingress isolation | Spoof headers/paths, replay assertions, bypass the entry service, change allocation generation and reuse cross-tenant cursors/grants; deny before content or mutation |
+| Self-service recovery | Crash between each provider/registry/tenant commit, repeat creation concurrently, exhaust capacity, restore mismatched snapshots and replay deletion; no duplicate owner, tenant, customer or live SQLite writer |
 | Cloud native work | Hosted fixture login, scoped organization/project, full native issue/comment/dependency edits, customer runner execution and Change creation; no external issue identity required |
 | Compatibility coexistence | Native and GitHub-compatible projects run together; existing split/legacy/local/external-root configurations and GitHub-owned field semantics survive |
 | Tagged and pinned runners | A targets one stable Mac machine; B requires Linux tags. Competing incompatible runners cannot claim either; rename preserves pin; offline/no-match waits with no widened selector |
@@ -756,15 +912,15 @@ issues, especially #2191/#2192/#2194; no UI change is made by this RFC.
 
 ## Implementation order and dependency contract
 
-The following table is the current native blocked-by graph, verified against issue
-bodies on September 4, 2026: 19 issues including this RFC, 32 edges, acyclic.
+The following table and diagram preserve the original September 4 delivery graph
+(19 issues, 32 edges). They are historical ordering, not current open blockers.
 Dependencies are prerequisites, not a request to implement this whole table in
 the RFC. The two design reviews precede their consumers. Current tracker state
 and merged deliverables must be checked again before each implementation.
 
 | Issue and deliverable | Direct prerequisites |
 | --- | --- |
-| [#2181 — this architecture RFC](https://github.com/digitaldrywood/detent/issues/2181) | None |
+| [#2181 — original architecture RFC](https://github.com/digitaldrywood/detent/issues/2181) | None |
 | [#2182 — native issues, comments and history](https://github.com/digitaldrywood/detent/issues/2182) | #2181 |
 | [#2183 — repository workflow/policy compatibility](https://github.com/digitaldrywood/detent/issues/2183) | #2182 |
 | [#2184 — scoped enrollment and runner identity](https://github.com/digitaldrywood/detent/issues/2184) | #2182 |
@@ -820,14 +976,23 @@ flowchart TD
     Self --> Pilot
 ```
 
-Planning for this issue uses its requested Astra model. Configurable Sol/Astra
-selection belongs to [#2175](https://github.com/digitaldrywood/detent/issues/2175);
-this document neither duplicates that work nor changes live fleet defaults.
+The September 8 correction extends that completed work without reopening its
+completion records. #2181/#2193/#2194/#2196/#2197 are merged into `origin/main`.
+
+| Follow-up | Current scope and prerequisite |
+| --- | --- |
+| [#2340](https://github.com/digitaldrywood/detent/issues/2340) | This reviewed shared-site correction; no implementation prerequisite |
+| [#2341](https://github.com/digitaldrywood/detent/issues/2341) | Shared sessions, routing and origin migration after #2340 |
+| [#2342](https://github.com/digitaldrywood/detent/issues/2342) | Self-service provisioning, allocation and lifecycle after #2341 |
+| [#2343](https://github.com/digitaldrywood/detent/issues/2343) | Idempotent billing customers and explicit test/live separation after #2342; independent of free pilot |
+| [#2199](https://github.com/digitaldrywood/detent/issues/2199) | Retain prior pilot evidence and add shared-site journey after #2342 and its other current tracker dependencies |
+| [#2308](https://github.com/digitaldrywood/detent/issues/2308) | Human-owned capacity, costs, retention/recovery and operator evidence; not a prerequisite for this design |
 
 ## RFC validation and review checklist
 
 Validate relative links and anchors, GitHub issue links, and agreement between
-the dependency table, diagram, native dependency relations and issue-body lines.
+the historical dependency table/diagram and the current follow-up links. Check
+current native dependencies and issue-body lines before dependent implementation.
 Load the two YAML examples with `config.ParseProjectDefinition`; verify split
 local override, equivalent legacy layout and rejection of a mixed layout. Existing
 configuration compatibility tests are relevant evidence; parsing does not imply

--- a/docs/cloud-onboarding.md
+++ b/docs/cloud-onboarding.md
@@ -1,10 +1,57 @@
 # Project onboarding
 
-Sign in, create or join the reserved organization, and open a project shared with
-you. Organization administrators create projects; collaboration and runner
-management are separate explicit grants. Retrying project creation with the same
-name and creator's write grant resumes that project. Return to its page to resume
-setup. Infrastructure errors do not require another organization or host identity.
+The shared product journey starts at `https://hub.detent.build`: sign in, create
+or join an organization, then open a project explicitly shared with you. The
+organization chooser, creation/provisioning state, scoped Work/project navigation
+and billing reuse the existing Templ/HTMX shell. There is no forced tenant-domain
+navigation or persistent global billing banner. Preserve compact/cozy and narrow
+layouts, keyboard access, contextual errors and the tab's current run selection.
+
+The organization lifecycle and acceptance trace below are the reviewed-design
+target for #2341/#2342/#2343, not shipped self-service behavior. Today's hosted
+implementation starts with a reserved organization; its project/runner setup
+is reused. Organization administrators create projects; collaboration and runner
+management remain separate explicit grants. Retrying project creation with the
+same name and creator's write grant resumes that project. Return to its scoped
+page to resume setup; infrastructure errors do not require another organization
+or host identity.
+
+## Organization provisioning and recovery
+
+A verified signed-in identity submits `POST /organizations` with a session-bound
+CSRF token and stable creation idempotency key. Persist a fingerprint of the
+validated creation input and an opaque organization ID before external effects.
+Same user/key/payload returns the same operation; a changed payload conflicts.
+Separate tabs retrying the same intent cannot acquire duplicate owners or slots.
+An organization display name is never identity or proof of ownership.
+
+| Durable checkpoint | Required action and recovery invariant |
+| --- | --- |
+| `requested` | Bind creator to verified provider issuer/subject and creation intent, enforce eligibility and per-identity quotas. Unverified email, client-submitted owner IDs and support impersonation cannot bootstrap ownership |
+| `allocating`: reservation | Atomically reserve bounded process/memory/disk capacity with an allocation generation and fenced worker lease before creating resources |
+| `allocating`: provider | Create/recover the WorkOS organization and owner membership for that exact subject; persist provider IDs and step result. Query/reconcile an uncertain response before another create |
+| `allocating`: tenant | Allocate a private path and service identity from trusted IDs, initialize a fresh tenant database through its sole owner, persist immutable organization/provider/generation binding and that creator's owner membership |
+| `allocating`: free access | Assign the configured versioned free plan idempotently. No Stripe customer, card or paid subscription is required |
+| `ready` | Publish the registry route only after database health, tenant/provider membership, allocation and plan references agree. Link to `/organizations/ORG/work` and existing project/runner setup |
+| `failed` | Preserve intent, reservation/resource inventory, completed checkpoints, bounded error and retry eligibility. Offer Resume for recoverable failures, without generating a new identity. No capacity shows a retryable state; existing tenants stay healthy |
+| `deleting` / `deleted` | Apply the RFC owner-confirmed retirement contract, fence routing/writers and track erasure/retention results. Tombstones prevent reuse and resurrection |
+
+A provider create without a usable idempotency/reconciliation mechanism cannot
+be blindly retried after an uncertain response. Record it as unresolved and
+reconcile through the provider's supported lookup or operator repair of that
+same intent. Likewise reconcile live process ownership before replacement.
+Retry workers have finite attempt/deadline/backoff limits; exhaustion exposes a
+sanitized resumable failure and retains evidence/resources safely. Cleanup uses
+an explicit allocation inventory and ownership checks, never recursive deletion
+of an inferred user path. Do not erase customer data after a failed signup.
+
+The verified subject can recover a pending intent after login or process restart.
+Provider email changes do not transfer ownership. An existing organization must
+be joined through current membership or a provider-validated exact-recipient
+invitation, never claimed by matching its name/domain or replaying a bootstrap
+subject. Membership removal, re-invitation and last-owner protections remain in
+[hosted identity](hosted-identity.md#permissions-and-revocation). Account and
+organization deletion follow the [RFC lifecycle contract](cloud-hub-rfc.md#provisioning-recovery-and-capacity).
 
 ## Repository configuration and policy
 
@@ -14,7 +61,8 @@ host. Inspect existing files before using `detent onboarding draft-answers`,
 output options. Review generated files before applying them. Cloud neither stores
 workflow source nor writes repository files.
 
-Configure the local client URL, `client.organization_id`, and
+For the shared-site target, use `client.hub_url: https://hub.detent.build`
+and the selected immutable organization ID. Configure `client.organization_id` and
 `client.native_projects` mapping in the instance configuration. The project's
 page shows its native ID. Run `detent doctor` against that configuration; resolve
 reported problems locally. Sign in to the selected agent provider on that host.
@@ -31,7 +79,10 @@ requirements in the repository, then inspect and approve the new descriptor.
 
 ## Customer host enrollment
 
-On the selected host, run `detent hub runner init --hub-url HUB_URL`. Keep its
+On the selected host, run `detent hub runner init --hub-url HUB_URL`.
+For shared hosting, `HUB_URL` is `https://hub.detent.build`; self-hosting uses the
+customer endpoint. The selected organization is explicit in enrollment and client
+configuration, not inferred from hostname. Keep its
 private identity file outside repositories. Use the IDs printed on that host in
 the enrollment form, which grants only the selected project. The existing Hub
 runner administration contract requires runner-management grants for every
@@ -52,6 +103,9 @@ projects' grants, leases and provider account records are omitted from readiness
 
 ## Artifact history and GitHub
 
+Preserve the September 7 choices: local-only history, customer-managed durable
+storage, and explicit opt-in hosted storage through the portable S3 adapter
+(DigitalOcean Spaces initially). No setup default silently uploads artifacts.
 Local history is supported without a bucket or Cloud services. For history with
 execution runners offline, follow [artifact deployment](artifacts-deployment.md):
 private S3-compatible bucket, durable catalog, separate TLS gateway, dedicated
@@ -70,7 +124,9 @@ remain separate actions through the existing native API.
 
 ## Shared protocol and recovery
 
-Self-hosted Hub uses the same scoped API without WorkOS, Stripe or Cloud:
+Self-hosted Hub uses the same scoped API with customer-selected authentication,
+without a Detent Cloud account, subscription or Stripe connection. These are
+currently supported project setup endpoints:
 
 - `GET /api/v2/organizations/ORG/projects/PROJECT/onboarding` reads persisted
   progress, current approved policy, eligible runners, bindings and latest run.
@@ -80,7 +136,8 @@ Self-hosted Hub uses the same scoped API without WorkOS, Stripe or Cloud:
 - Writes compare revisions and reuse the native idempotency journal. Restarting
   the service retains progress. Browser retries retain a command key and payload
   fingerprint in session storage; no issue body or provider credential is stored
-  there.
+  there. In the shared-site target, browser retry keys also bind organization,
+  project and user so concurrent tabs cannot replay into another scope.
 - The `/onboarding/policy`, `/onboarding/artifact-services/SERVICE`,
   `/onboarding/integration` and `/onboarding/repository` adapters require scoped
   administration and call the existing validated implementations.
@@ -91,7 +148,54 @@ require retrying the existing operation. The first native issue uses the ordinar
 idempotent work-item API. Its state determines whether it queues; policy and runner
 checks remain authoritative for execution.
 
+The current `artifacts` progress field accepts only `local`/`customer`; the
+approved opt-in hosted mode is a target storage choice, not a new value accepted
+by this API today. Future setup must save explicit custody consent and use the
+configured portable artifact service rather than overloading local/customer.
+
+## Shared-site acceptance trace
+
+This is a test specification for #2341/#2342/#2343 and the expanded #2199 evidence,
+not a claim that current reserved-tenant fixtures pass it. Use synthetic providers,
+ephemeral services and one test hostname representing `hub.detent.build`.
+
+Alice and Bob are unrelated verified identities. Alice creates A, Bob creates B,
+and Casey receives separate invitations to both. A has project PA and B has PB.
+Each tenant owns a separate database and process. Every application URL below is
+on **https://hub.detent.build**; WorkOS/Stripe hosted screens may temporarily leave
+the site only for their authenticated provider flow and return to that same host.
+
+| Step | Action and expected evidence |
+| --- | --- |
+| Signup | Alice and Bob create A/B from `/organizations/new` without operator YAML, bootstrap user, DNS or public port allocation. Crash/retry after every checkpoint returns the original A/B IDs with exactly one verified owner each |
+| Capacity | Concurrent creates at the admitted limit leave a resumable capacity failure; already-ready A/B remain routable, no extra process or unsafe disk allocation appears |
+| Invitations | A/B admins invite Casey through the common `/invite` entry. Exact recipient and provider organization must match; wrong-account, alias, expired/replayed and guessed-organization attempts fail. Casey sees both memberships, never an unrelated organization |
+| Grants | Grant Casey read-only PA and write PB, separately from runner management. Ownership/admin status alone never reveals project content. Bob cannot read PA by guessing its ID; cross-tenant searches/cursors return no A content |
+| Concurrent tabs | Casey opens `/organizations/A/projects/PA/...` in one tab and `/organizations/B/projects/PB/...` in another. Selecting a B run, submitting a B form, reauthenticating B or opening billing leaves A's URL, CSRF context, stream and run/attempt selection intact |
+| Mutations and streams | A write remains denied and B write commits only to B. Swap route/body/header IDs, reuse a CSRF token in the other scope, spoof proxy authority, and bypass the entry service: all fail. Frames/cursors from A never appear in B |
+| Billing | Free signup creates zero Stripe customers. Alice's first paid action creates/reuses A's test customer; Bob's creates/reuses B's. Casey cannot purchase as member. Swapped customer IDs, A return URLs in B and cross-account/mode webhooks cannot grant or expose another organization's plan/invoices |
+| Runners | Enroll named/tagged RA for A/PA and RB for B/PB against the same base URL. Each renews/posts events/claims only its own scope; cookie changes and forged IDs cannot move credentials. Exact-host no-match waits without fallback |
+| Artifacts | Test local-only without uploads, customer-managed durable service, and explicit opt-in hosted Spaces-compatible fixtures. An A grant fails for B, expired/revoked grants fail, and retained uploaded artifacts remain readable with execution runners stopped. Local-only makes no offline-availability promise |
+| Review policy | PA requires human review; PB permits automatic merge after checks. Repo-local policy remains authoritative for both, with external branch protections and independent-check principals preserved |
+| Revocation | Remove Casey from A while both streams are idle: A protected requests/download authorization fail immediately on recheck and its stream closes within 30 seconds. B stays usable. Shared logout/expiry closes both scopes |
+| Restore/deletion | Restore paired registry/tenant fixtures with current tombstones and a new generation; stale authority fails. A owner deletion remains resumable until erasure completes, does not affect B, and is never reversed by old snapshots/webhooks. Casey account deletion removes both memberships without deleting Alice/Bob's work |
+| Free self-hosting | With custom/local auth, block all Detent Cloud, WorkOS and Stripe networking. Create native work, enroll a runner, execute/checkpoint, export and recover with no subscription or hosted entitlement requirement. Repeat using a local WorkOS fixture with Cloud/Stripe blocked: auth selection still performs no billing call |
+
+Record browser evidence for the existing shell in compact/cozy and narrow layouts,
+no-access/expired-session states, provisioning interruption and the two-tab trace.
+Record tenant database IDs and bounded routing/provider call counts without
+content or credentials. #2199's free pilot checks free/complimentary billing UI;
+paid customer/webhook cases are #2343 fixtures and do not block that free pilot.
+The retained single-tenant evidence is a baseline, not shared-site launch evidence.
+
 ## Independent Change checks
+
+Known setup limitation: the private non-hosted maintenance recipe below is not
+executable for an already bound hosted database, which rejects local-mode reopen.
+[#2350](https://github.com/digitaldrywood/detent/issues/2350) tracks a supported
+credential-maintenance path and correction of that recipe. Keep the binding
+checks intact. The existing scoped independent-check submission protocol remains
+valid; this RFC does not add token provisioning/rotation/revocation authority.
 
 Hosted admission permits a dedicated `operator` bearer to submit only
 `POST /api/v2/organizations/ORG/projects/PROJECT/work-items/ITEM/changes/CHANGE/versions/VERSION/checks`.

--- a/docs/examples/hub/README.md
+++ b/docs/examples/hub/README.md
@@ -1,0 +1,152 @@
+# Hub deployment examples and shared-site target
+
+[Caddyfile](Caddyfile) and [detent-hub.service](detent-hub.service) are currently
+supported **customer-operated, free self-hosting** examples. They serve a single
+Hub at the customer's chosen origin with scoped bearer auth. Follow the
+[self-hosting runbook](../../hub-self-hosting.md) for installation, credentials,
+backup and recovery. They require no Detent subscription or billing connectivity.
+Changing their hostname to hub.detent.build does not create the shared product.
+
+The operator-hosted product has one public site at `https://hub.detent.build`,
+a shared identity/provisioning entry and metadata registry, and dedicated private
+tenant Hub processes with separate databases. All use the Detent binary; the
+entry role is additional work in #2341/#2342. The public reverse proxy forwards
+to that entry service, never chooses a tenant with a URL rewrite. The entry uses
+[authenticated private routing](../../cloud-hub-rfc.md#shared-site-control-and-tenant-storage)
+and each tenant verifies its own immutable binding. This directory installs no
+shared-site service and authorizes no deployment, DNS/account change or purchase.
+
+## Configuration availability
+
+| Surface | Supported today | Shared-site target, not yet implemented |
+| --- | --- | --- |
+| Customer Hub | `detent hub serve --database PATH --listen ADDRESS --github-disabled`; private `DETENT_HUB_ADMIN_TOKEN`, optional TLS/trusted-proxy flags | Remains free; deployment mode independent of customer-selected auth |
+| Reserved WorkOS tenant | `--hosted-config PATH`; root `organization_id`, `workos_organization_id`, `bootstrap_subject`, `public_url`, `workos`, `directory`, `staff_emails`, `support_actors`, entitlement/billing fields | Compatibility importer preserves IDs; no manual tenant YAML/bootstrap user/public origin at signup |
+| WorkOS fields | `client_id`, `api_key_env` (default `WORKOS_API_KEY`), optional `api_url`, `issuer_url` | Same explicit provider wiring under independent `auth`; one shared callback and invitation entry |
+| Pilot entitlements | Existing `entitlements` plans/assignments and separate administrator environment reference; see [allowances](../../hosted-allowances.md) | Allocator assigns a configured versioned free plan; no auth-provider inference |
+| Stripe | Optional `billing.account_id`, `customer_id`, `portal_configuration_id`, `api_key_env`, `webhook_secret_env`, `grace_seconds`, `reconcile_seconds`, `prices`; test keys only | Optional `billing.mode: test/live`; registry owns customer mappings; no root per-customer configuration |
+| Shared entry/registry/allocator | No supported YAML fields or CLI entry role yet | Versioned site configuration below; private entry/registry ownership and finite admission required |
+
+The current hosted YAML parser rejects unknown fields. Do not pass the following
+proposed configuration to `--hosted-config`. #2341/#2342 must deliver a versioned
+parser and documented CLI wiring for the entry role; #2343 adds billing mode.
+Until then there is no command in this document that launches shared self-service.
+
+## Proposed site YAML contract
+
+This is a reviewable schema proposal, not supported runtime configuration. Paths
+and the two-tenant admission limit illustrate an isolated fixture only; production
+limits require #2308 measurements and operator settings. Memory/disk byte values
+must be measured positive integers before the configuration is deployable; the
+placeholder strings deliberately prevent treating this as a working deployment.
+
+```yaml
+schema: 1
+deployment:
+  mode: operator_hosted
+public_url: https://hub.detent.build
+auth:
+  provider: workos
+  workos:
+    client_id: client_example
+    api_key_env: WORKOS_API_KEY
+    issuer_url: https://api.workos.com
+registry:
+  database: /var/lib/detent-site/registry.db
+allocation:
+  tenant_root: /var/lib/detent-tenants
+  max_tenants: 2
+  max_concurrent_provisions: 1
+  max_organizations_per_identity: 1
+  memory_reserve_bytes: REPLACE_WITH_MEASURED_INTEGER
+  tenant_memory_budget_bytes: REPLACE_WITH_MEASURED_INTEGER
+  disk_reserve_bytes: REPLACE_WITH_MEASURED_INTEGER
+  tenant_disk_budget_bytes: REPLACE_WITH_MEASURED_INTEGER
+  retry_limit: 5
+  retry_deadline_seconds: 900
+proxy_auth:
+  issuer: detent-site-example
+  signing_key_env: DETENT_SITE_SIGNING_KEY
+  mtls_certificate_file: /etc/detent-site/entry.crt
+  mtls_private_key_file: /etc/detent-site/entry.key
+  tenant_ca_file: /etc/detent-site/tenant-ca.crt
+free_plan:
+  id: pilot_free
+  version: 1
+```
+
+The named free plan must exist in the configured versioned entitlement catalog;
+example IDs/quantities are not approved commercial allowances. Generated tenant
+configuration includes immutable organization/provider IDs, private endpoint,
+database path and allocation generation, with scoped verification keys and service
+identity. It contains no browser bootstrap subject or per-tenant public origin.
+The allocator owns path/endpoint selection; request data cannot override them.
+No wildcard DNS, certificates or public tenant ports are required. Co-located
+services can use separately permissioned Unix sockets after equivalent peer
+identity verification; remote services require authenticated private transport.
+
+Proposed configuration validation must reject unknown fields, conflicting legacy
+and site settings, a missing/non-HTTPS public origin outside loopback fixtures,
+non-positive/unmeasured limits, untrusted paths/endpoints and mode/key mismatches.
+`deployment.mode` defaults to `self_hosted` when omitted in the new schema;
+`auth.provider` never changes it. `operator_hosted` explicitly enables hosted
+resource policy; billing remains opt-in. Self-hosted mode rejects allocation,
+registry and billing blocks before any Cloud/Stripe adapter starts. Authentication
+adapters use their own validated issuer/client/secret configuration. WorkOS uses
+the fields above; custom adapters must implement the supported auth interface,
+not trust arbitrary proxy identity headers. Generic/local configuration remains
+in its existing deployment surface; this proposal does not invent a custom-auth
+protocol or imply that `--hosted-config` already separates those modes.
+
+There is no automatic environment-to-YAML interpolation or implicit `.envrc`
+loading. Environment references resolve only in the process that consumes them.
+Missing named secrets fail startup without logging their values. In systemd use
+a reviewed private `EnvironmentFile` or credential facility for the entry/billing
+service; a developer's Mac shell does not populate a Linux service environment.
+Tenant services receive only their scoped credentials, not the operator's WorkOS
+or Stripe key. Never place secrets in the registry, command arguments or reports.
+
+## WorkOS and Stripe wiring
+
+The common WorkOS callback is exactly
+`https://hub.detent.build/auth/oidc/callback`, with User invitation URL
+`https://hub.detent.build/invite`. Every organization uses these values. Configure
+client ID, API key and issuer from the same provider environment. See
+[identity setup](../../hosted-identity.md#workos-application-setup) for invitation
+verification and staging separation. Existing-origin migration must use the
+[controlled procedure](../../hosted-identity.md#existing-origin-migration).
+
+The target optional billing block keeps the pilot account/portal/price/plan fields
+but replaces static `customer_id` with durable organization mappings and adds
+`mode`. For example, append this **proposed** test block only with a matching paid
+plan catalog and independently configured test account/portal/price objects:
+
+```yaml
+billing:
+  mode: test
+  account_id: acct_example
+  portal_configuration_id: bpc_example
+  api_key_env: DETENT_STRIPE_TEST_KEY
+  webhook_secret_env: DETENT_STRIPE_TEST_WEBHOOK_SECRET
+  grace_seconds: 86400
+  reconcile_seconds: 120
+  prices:
+    - price_id: price_example
+      label: Extended pilot
+      plan: {id: pilot_extended, version: 1}
+```
+
+`test` is the billing default, never inferred from auth. Its exact webhook is
+`https://hub.detent.build/webhooks/stripe/test`. Explicit separately authorized
+`live` activation instead uses `DETENT_STRIPE_LIVE_KEY`,
+`DETENT_STRIPE_LIVE_WEBHOOK_SECRET`, matching live account/price/customer/portal
+bindings and `https://hub.detent.build/webhooks/stripe/live`. Each environment's
+webhook secret, event livemode and account must agree; there is no fallback
+between environments. Staging substitutes its separately configured origin.
+See [billing lifecycle and rollback](../../hosted-billing.md#environment-separation-and-shared-webhooks).
+Free signup omits billing and creates no Stripe customer or card requirement.
+
+Before any deployment, the implementation must publish its actual CLI/schema
+reference and validate this contract with synthetic two-tenant/provider fixtures,
+capacity refusal and restore evidence. The design review does not install units,
+change DNS/TLS, register WorkOS/Stripe endpoints, or activate live charging.

--- a/docs/hosted-billing.md
+++ b/docs/hosted-billing.md
@@ -1,12 +1,20 @@
 # Hosted subscription billing
 
-Stripe billing is an optional, operator-configured **test-mode pilot** for an
-existing Detent Cloud organization. The subscription pays for Detent's hosted
-service. Customer model accounts, keys, usage, and provider charges stay separate.
-Free organizations need neither a card nor a Stripe customer. Local and
-self-hosted Hubs do not initialize billing or contact Stripe.
+The shared product at `https://hub.detent.build` bills organizations only for use
+of the operator's hosted service. Self-hosted Detent is free with any supported
+authentication provider, including WorkOS/custom; auth selection never enables
+Detent billing, a subscription check or Cloud networking.
 
-## Configuration
+The delivered Stripe implementation is an optional, operator-configured
+**test-mode pilot** for an existing reserved Detent Cloud organization. The
+subscription pays for Detent's hosted service. Customer model accounts, keys,
+usage, and provider charges stay separate.
+Free organizations need neither a card nor a Stripe customer. The shared-site
+design requires local and self-hosted Hubs to reject hosted billing configuration and never initialize billing or contact Stripe. Current
+self-hosting without `--hosted-config` already runs independently; separating that
+flag's WorkOS/policy coupling is follow-up work, not a shipped auth-mode switch.
+
+## Supported test-pilot configuration
 
 Add the following to the hosted identity YAML, alongside explicit
 [versioned entitlement plans](hosted-allowances.md). The referenced paid plan
@@ -62,7 +70,7 @@ shapes do not grant access. Responses requiring more than 100 subscriptions or
 100 payments/disputes fail reconciliation without applying a partial result;
 operators must resolve that unsupported account history before resuming billing.
 
-## Purchase and administration
+## Delivered tenant purchase and administration
 
 `GET /organization/billing` shows the effective plan, subscription status,
 complimentary access, reconciliation time, and the 50 most recent subscription
@@ -101,7 +109,7 @@ payloads, provider error bodies, and invoice/dispute evidence are not stored.
 Stripe session URLs remain private to the owning database/browser and are
 excluded from audit records and logs.
 
-## Signed webhooks and recovery
+## Delivered tenant webhooks and recovery
 
 Configure an organization-specific test webhook destination at
 `<public_url>/webhooks/stripe` using its own signing secret. Subscribe to
@@ -168,10 +176,108 @@ runner, provider-budget, or permission controls. Omitting billing configuration
 stops billing activity; previously verified local access still expires at its
 stored deadline rather than being extended indefinitely.
 
+## Shared-site customer and billing contract
+
+The following design is for [#2343](https://github.com/digitaldrywood/detent/issues/2343),
+after shared routing/provisioning #2341/#2342. Reuse current entitlement, grant,
+owner authorization, journal, grace and reconciliation behavior. Static
+`billing.customer_id` becomes a legacy import input, not per-customer operator
+configuration. [Deployment examples](examples/hub/README.md) distinguish currently
+supported fields from the proposed mode configuration.
+
+On a verified, non-impersonating owner's first paid action, atomically persist a
+customer-creation intent keyed by deployment, Stripe account, mode and immutable
+organization ID. Serialize competing purchases. Send a stable provider idempotency
+key and the expected organization metadata, then persist the returned customer ID
+in a unique account/mode/customer-to-organization mapping. Recover uncertain
+responses using that same operation and provider lookup; after a provider
+idempotency window expires, reconcile before issuing another creation. Never
+adopt a customer solely because user-supplied/provider metadata names an org.
+Conflicting/missing bindings leave the operation pending repair and grant no paid
+access. Free signup never creates a customer or needs a Stripe connection.
+
+The registry retains only these billing references and operation status; the
+tenant retains subscription/entitlement audit state. Use durable outbox/checkpoint
+reconciliation across the two stores; no distributed transaction is assumed.
+Checkout is enabled only after both agree on the binding. Customer creation does
+not grant a paid plan. Store operation parameters before Checkout, reuse existing
+preflight/retry rules and reconcile the authoritative subscription/invoice before
+changing entitlements. Registry unavailability cannot route a purchase to another
+customer; tenant dispatch keeps using bounded local entitlement state.
+
+Owner actions live at `/organizations/ORG/billing/checkout` and `/portal` (POST).
+All returns are server-generated from the configured shared origin and that ORG,
+with only allowlisted result parameters on `/organizations/ORG/billing`. A return
+never selects a customer or grants access. The UI shows pending verification,
+free/complimentary/subscribed state, usage and contextual grace/limit messages in
+the existing shell. Billing reads/portal/export remain available when over quota;
+no global banner or project access is conferred by billing ownership.
+
+### Environment separation and shared webhooks
+
+The target operator setting is `deployment.mode: operator_hosted`, independent of
+`auth.provider`. Billing is separately optional; when enabled `billing.mode`
+defaults to `test`. An explicit `live` value requires matching live credentials,
+objects and a separately authorized activation. A self-hosted deployment rejects
+any billing block before provider initialization. Missing/invalid config fails
+startup; neither auth choice nor a key prefix silently chooses a deployment mode.
+
+| Binding | Test | Live target |
+| --- | --- | --- |
+| API key environment reference | `DETENT_STRIPE_TEST_KEY` (`sk_test_` / `rk_test_`) | `DETENT_STRIPE_LIVE_KEY` (`sk_live_` / `rk_live_`) |
+| Webhook secret environment reference | `DETENT_STRIPE_TEST_WEBHOOK_SECRET` | `DETENT_STRIPE_LIVE_WEBHOOK_SECRET` |
+| Shared endpoint | `https://hub.detent.build/webhooks/stripe/test` | `https://hub.detent.build/webhooks/stripe/live` |
+| Object/event requirement | Verified account, mapped customer/price, `livemode=false` | Verified account, separate mapped customer/price, `livemode=true` |
+
+Both secrets use `whsec_`; the prefix cannot establish mode. Verify the signature
+with the endpoint's configured secret over raw bounded bytes before routing, then
+validate mode and account against the durable mapping. Only the configured mode's
+endpoint is active for that deployment; a separate test deployment remains
+isolated when production activates live mode. Staging uses its own exact public
+origin and account/environment configuration, not production session authority.
+Stripe documents separate test/live keys and objects in [API keys](https://docs.stripe.com/keys).
+
+The shared inbox stores only verified event ID/type, account/mode/customer
+reference and delivery status before acknowledgment. Dispatch to the mapped tenant
+with authenticated backend authority; duplicate/out-of-order delivery reuses the
+existing idempotent reconciliation worker. A tenant outage leaves a durable pending
+event. Unknown or deleted customers never cause tenant creation; record bounded
+quarantine/tombstone disposition without content and never grant access. Forged
+metadata, mismatched accounts/modes and invalid signatures fail before tenant
+mutation. Limit body size, timestamp tolerance, queues and retries as in the pilot.
+No provider payload is copied into the metadata registry or customer logs.
+
+Customer, subscription, price, portal, operation and event IDs are namespaced by
+operator deployment/account/mode. Mode changes cannot reinterpret persisted test
+records as live. Activation requires a new validated live binding/configuration
+revision and explicitly mapped live prices/plans; old test records remain isolated.
+On rollback, disable new Checkout while preserving live audit/reconciliation
+and cancellation access through the authorized live binding until obligations are
+resolved. Resume testing only in the separate test deployment; changing the
+production mode is not a billing rollback. Never delete paid records or reset grace to simulate rollback. Test and
+live credentials must not coexist as automatic fallbacks.
+
+Before live activation the operator must supply approved product/price mappings,
+portal settings, business/tax/payment policy, retention and cancellation/refund
+handling, secret distribution and webhook verification evidence. This issue
+specifies the contract; it creates no Stripe accounts/prices/webhooks, enables no
+live endpoint and authorizes no charge. Fixture tests cover live-shaped objects
+and mismatch rejection without a live transaction. Paid activation is independent
+of #2199's free pilot evidence gate.
+
+Organization deletion blocks new purchases and reconciles/cancels the existing
+subscription before retiring its routing reference; cancellation/erasure failures
+remain resumable. Account deletion does not silently cancel other owners'
+organizations. Retain minimal audited account/mode/customer tombstones under the
+operator retention policy so delayed events cannot revive deleted access.
+
 ## Validation
 
-All integration tests use test-mode HTTP fixtures, never live Stripe keys or
-charges. Focused tests cover signatures and replay tolerance, customer/account
+Delivered integration tests use test-mode HTTP fixtures, never live Stripe keys
+or charges. #2343 adds fixture-only live-mode shapes, customer-create crash/retry,
+mode/account mismatch and two-organization routing cases from the
+[shared-site trace](cloud-onboarding.md#shared-site-acceptance-trace).
+Focused tests cover signatures and replay tolerance, customer/account
 authorization, Checkout/portal requests, duplicate/reordered/concurrent event
 delivery, transaction rollback, restart recovery, grace boundaries, renewals,
 refunds/disputes, grant preservation, safe lease completion, local-only dispatch,

--- a/docs/hosted-identity.md
+++ b/docs/hosted-identity.md
@@ -1,27 +1,40 @@
 # Hosted identity and organization authorization
 
-Hosted identity is optional. `detent hub serve --hosted-config /path/to/hosted.yaml`
-selects the WorkOS adapter and tenant Hub UI. Local dashboards, generic OIDC,
-magic links and customer-hosted Hub bearer authentication remain independent of
-WorkOS. Hosted mode starts native collaboration without GitHub credentials.
+The operator-hosted product is one shared authenticated site at
+`https://hub.detent.build`. Organization creation, invitations, selection, Work,
+runner setup and organization billing stay on that public origin. Separate tenant
+processes/databases remain the storage baseline; a separate public origin per
+organization is superseded by [#2340](https://github.com/digitaldrywood/detent/issues/2340).
+
+The shared-site sections below are the design contract for #2341/#2342/#2343,
+pending implementation and review. The existing reserved-tenant configuration is
+shown explicitly as current behavior. This document enables no live account,
+invitation, DNS, deployment or charge.
+
+Self-hosting is free with operator-selected auth: WorkOS, custom, generic or local.
+Selecting an auth adapter must never select a billable deployment mode or require
+a Detent Cloud account. The current `--hosted-config` couples WorkOS and hosted
+policy; it is not yet a general self-hosted WorkOS switch. Generic scoped Hub
+bearer auth and local dashboard auth remain supported without it. The proposed
+configuration separation is in [deployment examples](examples/hub/README.md).
 
 ## Allocation and configuration
 
-Allocate one process, filesystem database and HTTPS origin per organization.
-Retain the existing exclusive database owner and backup procedures. Do not point
-two processes at one file, share SQLite over a network filesystem, or combine
-customer databases. Hosted binding rejects an existing populated/local database,
-a different organization/origin, or reopening a hosted database in local mode.
-Origin moves require an explicit controlled migration while the Hub is offline.
+Allocate one dedicated Hub process and local filesystem database per organization,
+behind the shared entry service's authenticated private routing. Retain exclusive
+ownership and backup procedures. Do not share SQLite over network filesystems,
+combine collaboration databases, or expose tenant listeners publicly.
 
-Reserve a fresh Hub for a verified WorkOS user ID before enabling signup there.
-Generate its stable Detent organization ID independently of the provider. The
-bootstrap user creates the WorkOS organization and owner membership; the Hub
-persists the provider mapping. The bootstrap subject cannot reclaim ownership
-after members exist. For an already-created WorkOS organization, supply its ID
-and an existing owner's bootstrap subject for initial local membership. Subsequent
-users require invitations issued by this Hub. Changing provider account identity
-does not silently change the Detent organization identity.
+### Supported reserved-tenant configuration
+
+Today `detent hub serve --hosted-config /path/to/hosted.yaml` selects the WorkOS
+adapter and tenant Hub UI, with native collaboration independent of GitHub.
+It requires a fresh reserved database and stable organization ID, plus a verified
+bootstrap subject when creating the WorkOS organization. That subject cannot
+reclaim ownership after members exist. Binding rejects a populated/local database,
+a different organization/origin, or reopening a hosted database in local mode.
+The following YAML is supported today for an isolated reserved-tenant deployment;
+it does **not** implement shared signup by replacing its URL with hub.detent.build.
 
 ```yaml
 organization_id: org_example_opaque_id
@@ -57,35 +70,144 @@ customer projects, create general tokens or use instance-admin routes. Treat it
 as a reporter secret. Existing runner credentials retain their separate scoped
 identity, renewal, revocation, project and operation permissions.
 
-The directory is trusted deployment configuration containing only IDs and Hub
-origins. Switching checks active provider membership, redirects to the selected
-Hub's protected login and creates an organization-bound cookie there. Cookies
-are host-only, HttpOnly and SameSite=Lax, with Secure on HTTPS. No session or
-capability is transferred in a redirect. Automatic provisioning of another Hub
-belongs to deployment orchestration (#2199); this delivery supports one reserved
-organization per allocated Hub and switching among configured allocations.
+The current `directory` maps IDs to trusted public origins and switches via a
+fresh protected login on the owning Hub. That behavior is retained only as a
+legacy deployment/migration input; the shared product uses registry allocations
+and scoped navigation, not cross-origin redirects. See [the RFC routing trust
+boundary](cloud-hub-rfc.md#shared-site-control-and-tenant-storage).
+
+## Shared-origin route and session contract
+
+These are target routes for #2341, not aliases already accepted by the binary.
+`ORG` and `PROJECT` stand for immutable opaque IDs, never organization names.
+
+| Surface | Public route/behavior |
+| --- | --- |
+| Sign-in and callback | `/auth/oidc/start`, `/auth/oidc/callback`; one shared login transaction authority |
+| Entry and chooser | `/` sends an authenticated user to `/organizations`; `/organizations/new` offers creation; `POST /organizations` starts an idempotent intent |
+| Provisioning status | `/organizations/ORG/provisioning`; visible only to the verified creator/current authorized member |
+| Organization shell | `/organizations/ORG/work`, `/organizations/ORG/projects`, `/organizations/ORG/settings` |
+| Project work and run selection | `/organizations/ORG/projects/PROJECT/...`; issue, Change, run and attempt IDs remain in that tab's URL |
+| Deletion | Owner-confirmed `POST /organizations/ORG/delete`; account-confirmed `POST /account/delete` and private `/account/deletion` status; resumable lifecycle, never a GET side effect |
+| Organization billing | `/organizations/ORG/billing`, with CSRF-protected `/checkout` and `/portal` POST actions |
+| Native content/runner API | `/api/v2/organizations/ORG/...`; preserve current project, machine, runner, lease and operation scope |
+| Hosted usage/subscription APIs | `/api/cloud/organizations/ORG/billing` and `/billing/subscription` |
+| Project SSE | `/organizations/ORG/projects/PROJECT/events` |
+| Invitations | `/invite?invitation_token=...`; resolve provider-verified organization through the registry |
+| Shared billing ingress | `/webhooks/stripe/test` and separately `/webhooks/stripe/live`; signature/account/environment validation before customer routing |
+| Capabilities and static assets | `/api/v2/capabilities` exposes only shared protocol metadata; static shell assets contain no tenant state |
+
+A shared opaque session cookie identifies a signed-in account, not a mutable
+current organization. Use a `__Host-` cookie with `Secure`, `HttpOnly`,
+`SameSite=Lax`, `Path=/` and no Domain attribute on HTTPS. No cookie is shared
+with other detent.build hosts. Loopback HTTP fixtures use an explicitly separate
+non-production cookie convention. Rotate authority on authentication changes;
+logout invalidates the shared session and all its tenant authorizations.
+
+Each request derives its organization from the canonical route and revalidates
+membership plus project grants. Body/header IDs must agree with the route. Reject
+ambiguous encoded separators, dot segments, duplicate scope parameters and
+conflicting authorities before proxying. An unscoped legacy customer route must
+lead to the chooser or fail, never infer a tenant from last selection. No cookie,
+localStorage setting or server-global selection may control another tab's action.
+HTMX links, forms, history URLs, redirects, polling, dialog actions and browser
+retry keys all preserve explicit organization/project/run/attempt context.
+
+Retain provider-validated organization sessions server-side per shared session
+and organization. Selecting B may obtain a new B authorization through the common
+callback, but cannot replace A's authorization. State/PKCE transactions are one-use,
+short-lived and bound to the initiating browser, requested organization and a
+validated return route; concurrent tab logins cannot overwrite each other's
+transaction. Provider identity, active session and current membership are verified
+on every protected request, and tenant mutations recheck local grants/revocation
+inside the transaction before replay. Provider failure fails closed. Removed
+membership invalidates only that organization's authority; account logout/expiry
+invalidates every organization. Support sessions remain separately scoped and
+cannot change organization or replace another tab's ordinary session. A tab
+selects an opaque support context bound server-side to that shared session, actor
+and organization; an unverified header or query value cannot enable impersonation.
+
+All cookie-authenticated mutations require a session-bound CSRF token, exact
+configured Origin verification and intended organization binding (including HTMX
+requests). Account-level creation/deletion instead binds the account and operation
+intent before an organization exists. Login/callback uses state and PKCE instead; signed provider webhooks
+and explicit bearer-only machine routes do not accept cookie authority. GETs do
+not mutate membership or billing; the invitation GET stores an intent and begins
+authentication, with acceptance only after the verified transaction. Reject cross-
+origin form submissions even when browser SameSite rules would send the cookie.
+
+Return destinations are server-generated or canonical relative application paths
+validated against allowed route templates and the initiating organization. Reject
+client-supplied absolute/scheme-relative URLs, backslashes, encoded traversal, userinfo and any
+unapproved query fields. Reauthorize on return; invalid/removed access returns to
+the chooser with no tenant content. Never put provider, session, invitation or
+artifact capabilities into redirect destinations, logs, referrers or analytics.
+Use `Referrer-Policy: no-referrer` on auth/invitation and sensitive pages.
+
+SSE authenticates both connection and each emitted frame, closes on revocation
+and session expiry, and sends bounded heartbeats that recheck authority even
+without content events. Target revocation/idle-close bound is 30 seconds; no
+positive authorization cache may extend it. Reconnect/cursors bind organization,
+project, session and allocation generation; switching a tab closes that tab's
+old stream. Search, caches and idempotency namespaces carry the same scope.
+Tenant responses are `no-store`; shared caches store only public static assets.
+Escape customer text and sanitize rendered Markdown/links, enforce a restrictive
+CSP, and never serve arbitrary active artifact HTML on the authenticated origin.
+Separate databases do not protect two organizations from same-origin XSS.
+
+Runner enrollment, renewal, events and claims go to the common hostname using
+explicit organization routes and independently verified enrolled credentials.
+For existing machine/service APIs without a scoped path, the entry service may
+resolve only a durable credential-to-organization binding, never a browser cookie
+or unverified token field; ambiguous/missing bindings fail. The tenant repeats
+credential, organization, project, machine, operation and fencing checks. Artifact
+publisher and independent-check tokens retain their narrow exceptions. Hostname
+routing never widens token authority or exposes generic instance-admin APIs.
+
+Artifact grant issuance uses the scoped native API, binds organization/project,
+artifact/service, originating session, actual/effective identity and operation,
+and expires within one minute or the earlier session/retention deadline. The
+artifact authorizer rechecks current session, membership, grant and service
+binding at redemption through the shared trusted route. Grants from A cannot be
+redeemed for B; path/header substitutions and revoked authority fail. Downloads
+continue through the selected customer-managed or opt-in hosted artifact service;
+local-only mode never silently uploads. Storage credentials remain at that service.
 
 ## WorkOS application setup
 
-Configure AuthKit and exact callback URLs ending in `/auth/oidc/callback` for
-each permitted Hub origin. Enable the intended email/password, Magic Auth or SSO
-methods; a GitHub login is unnecessary. Define flat role slugs `owner`, `admin`,
-`member`, `viewer`. Detent accepts only active memberships with these roles.
+For the operator-hosted production application, the exact registered values are:
 
-Configure the application's **User invitation URL** to the owning Hub's `/invite`
-entry, or an authenticated deployment router that sends the invitation to that
-owning Hub. WorkOS appends `invitation_token`. A deployment serving several Hubs
-must route that provider-validated organization to its configured destination;
-do not accept an arbitrary redirect URL. Separate WorkOS applications/origins are
-another supported deployment arrangement. Do not leave the invitation URL on the
-default AuthKit entry: that path can accept corporate-domain aliases before the
-application's exact-recipient check. See [custom invitation redirects](https://workos.com/docs/authkit/custom-emails)
+| WorkOS setting | Value |
+| --- | --- |
+| Sign-in initiation in Detent | `https://hub.detent.build/auth/oidc/start` |
+| Redirect/callback URL | `https://hub.detent.build/auth/oidc/callback` |
+| User invitation URL | `https://hub.detent.build/invite` |
+
+These are the common URLs for every organization, with no wildcard callback,
+tenant-specific subdomain or public tenant port. The callback matches the
+`public_url` used by the shared auth adapter, never a private tenant endpoint.
+Configure separate provider environments/applications for fixtures/staging with
+explicit callback and invitation URLs on their own origins; do not mix client IDs,
+issuer, keys or sessions across environments. Enable intended email/password,
+Magic Auth or SSO methods and flat role slugs `owner`, `admin`, `member`, `viewer`.
+No GitHub login is required. Account setup still needs separate operator action.
+
+WorkOS appends `invitation_token` to the configured User invitation URL. The
+shared entry looks up the invitation with WorkOS and maps its verified provider
+organization to the registry; client organization/return parameters cannot select
+the destination. The issuing owner/admin and grant authority are checked before
+provider dispatch, and a durable invitation intent tracks retries without duplicate
+mail. Use the application's `/invite` entry rather than default AuthKit acceptance
+so Detent's exact-recipient checks run. See [custom invitation redirects](https://workos.com/docs/authkit/custom-emails)
 and [WorkOS invitation behavior](https://workos.com/docs/authkit/invitations).
 
 Detent records the invitation in a one-use browser transaction, starts ordinary
 state/PKCE login without forwarding the invitation token to AuthKit, and verifies
-the exact recipient and organization before accepting membership. It then starts
-a fresh organization login. The manual **Join with invitation** flow also lets a
+the exact recipient and organization before accepting membership. It then
+establishes the selected organization authorization under the shared
+account session, preserving other tabs. Exact-recipient matching uses the verified
+provider email and existing normalization rules, never corporate-domain/alias
+equivalence to grant access. The manual **Join with invitation** flow also lets a
 signed-in user enter a token. Pending, expired, reused, wrong-account and
 wrong-organization invitations fail closed. Provider success followed by a lost
 local response is recoverable only for the same verified user and local invitation
@@ -126,7 +248,8 @@ explicit promotion followed by demotion; nested teams and inherited permissions
 are deferred.
 
 Hosted pages reuse the shell without mounting process-wide dashboards, caches,
-search, operator tools or streams. `/projects/:project/events` checks membership,
+search, operator tools or streams. The delivered `/projects/:project/events` (scoped under `/organizations/ORG`
+in the shared-site target) checks membership,
 session and project permission for each counter frame and closes on revocation.
 Content API reads, run events, attempt artifact references and changes use native
 organization/project scope. Artifact read grants use the existing artifact
@@ -184,7 +307,10 @@ validation do not enable impersonation or modify a live WorkOS account.
 verified staff session. Its closed schema contains organization/provider IDs,
 active member/project/runner/event counts, latest activity, database/WAL size,
 health and configured plan/quota fields. Only the owning Hub queries SQLite.
-`GET /api/cloud/billing` exposes this organization's usage only to its owner.
+`GET /api/cloud/billing` is the delivered tenant-local usage route; the shared
+public route is `/api/cloud/organizations/ORG/billing`, owner-only. Metadata
+reporting stays private to authenticated staff/reporters and is never a public
+route for inspecting an arbitrary organization.
 
 Reports have no content cache. Hosted process logging drops arbitrary messages
 and attributes, retaining a fixed message, timestamp and severity. Customer
@@ -198,3 +324,40 @@ infrastructure operator remains technically capable of reading hosted data.
 Customer-managed artifacts and optional hosted artifacts have distinct custody
 boundaries; hosted artifacts do not imply operator-inaccessible encryption.
 No zero-knowledge guarantee is made.
+
+## Existing-origin migration
+
+#2341 must deliver an explicit versioned offline migration, not manual SQL edits
+or a startup bypass. The current immutable origin check remains until that tool
+and its fixture tests ship; no migration command is available in this RFC.
+
+1. Inventory each old organization/provider mapping, bootstrap state, database,
+   origin, runner/service bindings, plan and Stripe account/environment/customer
+   reference. Verify no duplicate or conflicting IDs. Create owner-produced
+   backups and a registry import manifest; preserve all content/history/grants.
+2. Drain/fence the old tenant, block old writes and revoke old browser sessions,
+   login/invitation transactions and outstanding artifact grants. Keep a separate
+   revocation/deletion ledger. Never copy cookies or trust old-origin headers.
+3. With exclusive ownership, migrate the public-origin binding into a versioned
+   shared-deployment binding carrying the same organization/provider IDs and a
+   new allocation generation. Import allocation/membership/billing references
+   into the registry idempotently. Validate tenant and registry agreement before
+   readiness; preserve the prohibition on an ordinary local-mode reopen.
+4. Rebind runner URLs and artifact authorizer endpoints through authenticated
+   administration; preserve identity/history during an origin-only move. A restore
+   still follows the existing epoch/credential rotation rules. Test renewal,
+   callbacks, invitations, grants and reconciliation on the isolated destination.
+5. Register the common callback/invitation URLs through separately authorized
+   operator configuration, then enable shared routing only after verification.
+   Old read-only bookmarks may redirect through a fixed allowlisted mapping to
+   shared sign-in; old mutation/webhook/API endpoints fail closed until explicitly
+   migrated. Never forward old cookies, invitation tokens or capabilities in a
+   redirect. Reissue unconsumed invitations when their intent cannot safely migrate.
+6. For rollback, fence the shared allocation first. Restore only a compatible
+   pre-migration backup with the recovery procedure and reconciled external effects;
+   do not downgrade a live database or activate both owners. Reapply revocations
+   and tombstones and issue fresh sessions. Record the migration result per tenant.
+
+Tests must interrupt each step, repeat it, reject mismatched bindings and prove
+that migration preserves IDs, membership, history and billing references without
+weakening the tenant identity lock. See [recovery baseline](hub-self-hosting.md#restoreimport-and-move-between-hubs).

--- a/docs/hub-self-hosting.md
+++ b/docs/hub-self-hosting.md
@@ -7,8 +7,15 @@ with explicit downtime for maintenance; there is no active-active replication,
 automatic failover, or high availability guarantee. Never share a live SQLite
 file over NFS/SMB, mount it into runners, or run a second owner against it.
 
-No WorkOS, Stripe, Detent Cloud account, `cloud.detent.build` callback, or paid
-infrastructure is required. The native-only example disables GitHub transport.
+Self-hosted Detent is free. No WorkOS, Stripe, Detent Cloud account,
+`hub.detent.build` callback, Detent subscription or purchased infrastructure is
+required. Operators choose authentication, including WorkOS/custom/generic/local
+options; selecting WorkOS must never enable Detent billing. An external auth
+provider may have its own connectivity/account requirements. The currently
+supported Hub bearer deployment below has no such dependency. Shared-site mode
+and self-hosted WorkOS configuration separation are design targets documented in
+[the deployment examples](examples/hub/README.md), not new flags in this runbook.
+The native-only example disables GitHub transport.
 Ordinary local Detent remains supported separately: omit `client.hub_url` and
 run `detent` using local configuration and the selected local/tracker backend.
 Durable artifacts are optional in both modes; local-only artifact availability
@@ -23,7 +30,9 @@ recovery. Linux packages install `/usr/bin/detent`; archive installations must
 install the executable at that path or adjust the example unit. Do not use an
 unversioned download URL for an upgrade. The release includes this runbook and
 the [Hub unit](examples/hub/detent-hub.service) and
-[Caddy example](examples/hub/Caddyfile); equivalent files are in the same tagged
+[Caddy example](examples/hub/Caddyfile). These examples deploy a customer-operated
+Hub, not the shared hub.detent.build entry/registry. See the
+[deployment boundary](examples/hub/README.md); equivalent files are in the same tagged
 source checkout. Native package documentation lives under `/usr/share/doc/detent/docs`.
 
 On a clean Linux host with systemd, install the selected Detent package and a


### PR DESCRIPTION
## Summary

The hosted design previously required an allocated public origin and bootstrap user per organization. Define the shared self-service product at hub.detent.build while retaining dedicated tenant processes, separate databases and exclusive SQLite ownership.

Specify authenticated tenant routing, independent tab/session scope, provisioning and deletion recovery, controlled origin migration, and a two-organization acceptance trace. Separate free self-hosting and authentication choice from optional hosted billing, with explicit test/live customer bindings. Distinguish currently supported deployment configuration from proposed shared-site YAML, and preserve September 7 artifact, role/grant, runner and repository-policy decisions.

This is a design correction for human RFC review and follow-up implementation in #2341/#2342/#2343. It does not deploy services, mutate provider accounts, authorize charges, or reopen historical completion records.

Known independent-check credential-maintenance inconsistency is labeled in the runbook and tracked separately in Backlog #2350; no maintenance implementation is included here.

Fixes #2340

## UI Surface Contract

- [x] N/A for runtime changes; the issue authorizes design only for the existing Templ/HTMX shared sign-in, organization chooser/creation, scoped navigation and billing shell.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes; shared-site browser acceptance is specified for dependent implementations.

## Test Plan

- [x] Verify the five referenced deliverables are merged into origin/main and check native issue dependencies.
- [x] Review the two-organization/shared-member trace against route, membership, tab, billing, runner and artifact boundaries.
- [x] Validate all 52 relative documentation links/anchors and parse six YAML blocks (syntax only; proposed schema remains unimplemented).
- [x] `git diff --check`
- [x] `make check CHECK_LOCK_WAIT=90m` — all checks passed; 80.2% coverage, package/file floors passed. The override only extended the shared-lock queue wait after the default wait expired.
