### PR TITLE
fix(hub): support bound-tenant credential maintenance

### DIFF
--- a/docs/cloud-onboarding.md
+++ b/docs/cloud-onboarding.md
@@ -106,12 +106,35 @@ Enrolled runners retain their existing `collaborate` operation for expected
 `customer` checks. They cannot satisfy an `independent` check or change the
 source pinned by the immutable version.
 
-Provision through the existing instance-administrator token APIs before enabling
-hosted serving, or during an explicitly authorized private maintenance window.
-For maintenance, the hosted process must be stopped and the sole database-owning
-Hub process must expose its non-hosted administration API only on private
-loopback. Never run a second process against the live database. Hosted serving
-intentionally does not expose these generic administration APIs.
+Provision and maintain credentials for an already initialized hosted tenant during
+an explicitly authorized private maintenance window. Stop the hosted process,
+then start the sole database owner with the **same hosted configuration**, database
+path, organization/provider/bootstrap identity and public URL. Set
+`workos_organization_id` explicitly to the allocated provider organization
+if the original bootstrap configuration omitted it:
+
+```sh
+detent hub serve --database /var/lib/detent/hub.db \
+  --hosted-config /etc/detent/hosted.yaml \
+  --credential-maintenance --listen 127.0.0.1:7778
+```
+
+Keep this listener private, outside all reverse-proxy routes and port forwarding.
+Maintenance rejects non-loopback listeners and `--trusted-proxy`. Each request
+below goes to `http://127.0.0.1:7778` with
+`Authorization: Bearer <existing-instance-administrator-secret>`. Loopback
+alone provides no authority. Use the existing unscoped instance administrator
+credential retained at initial setup; the default `DETENT_HUB_ADMIN_TOKEN`
+environment variable is still required by the serve command, but maintenance
+never creates or resets a bootstrap credential. Browser cookies, staff sessions,
+scoped administrators, CI reporters and runners cannot authorize maintenance.
+
+Only the four token creation, rotation, revocation and project-grant routes are
+served. Requests record the administrator principal in hosted audit history.
+The normal database ownership lock prevents a second writer. Tenant binding
+checks remain enabled; ordinary non-hosted reopen still fails. Shut down
+maintenance before restoring the original hosted command. Public hosted serving
+continues to deny instance token administration.
 
 1. Create a dedicated token with `POST /api/v1/tokens`, using
    `{"name":"project-independent-ci","scope":"operator"}`. Deliver the returned

--- a/internal/cli/hub.go
+++ b/internal/cli/hub.go
@@ -63,6 +63,7 @@ func newHubCommandWithRun(version string, lookupEnv func(string) string, run hub
 
 func newHubServeCommand(version string, lookupEnv func(string) string, run hubRunFunc) *cobra.Command {
 	var hostedConfigPath string
+	var credentialMaintenance bool
 	var githubDisabled bool
 	var databasePath string
 	var listenAddress string
@@ -112,6 +113,7 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 			}
 			return run(cmd.Context(), hubserver.Config{
 				Hosted:                     hosted,
+				CredentialMaintenance:      credentialMaintenance,
 				GitHubDisabled:             githubDisabled || hosted != nil,
 				DatabasePath:               databasePath,
 				ListenAddress:              listenAddress,
@@ -131,6 +133,7 @@ func newHubServeCommand(version string, lookupEnv func(string) string, run hubRu
 			})
 		},
 	}
+	cmd.Flags().BoolVar(&credentialMaintenance, "credential-maintenance", false, "serve only authenticated credential administration for the bound hosted tenant on private loopback")
 	cmd.Flags().StringVar(&databasePath, "database", "", "local filesystem path to the Hub SQLite database")
 	cmd.Flags().StringVar(&hostedConfigPath, "hosted-config", "", "hosted organization and WorkOS configuration file")
 	cmd.Flags().BoolVar(&githubDisabled, "github-disabled", false, "serve native collaboration without GitHub credentials or transport")

--- a/internal/cli/hub_hosted_test.go
+++ b/internal/cli/hub_hosted_test.go
@@ -105,14 +105,16 @@ func TestReadHostedEntitlementConfig(t *testing.T) {
 func TestHubServeIdentityModes(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
-		name     string
-		hosted   bool
-		native   bool
-		wantMode bool
+		maintenance bool
+		name        string
+		hosted      bool
+		native      bool
+		wantMode    bool
 	}{
 		{name: "local compatibility"},
 		{name: "local native", native: true, wantMode: true},
 		{name: "hosted without GitHub flag", hosted: true, wantMode: true},
+		{name: "hosted credential maintenance", hosted: true, maintenance: true, wantMode: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -129,6 +131,9 @@ func TestHubServeIdentityModes(t *testing.T) {
 			if test.native {
 				args = append(args, "--github-disabled")
 			}
+			if test.maintenance {
+				args = append(args, "--credential-maintenance")
+			}
 			called := false
 			cmd := newHubCommandWithRun("test", func(name string) string {
 				switch name {
@@ -144,7 +149,7 @@ func TestHubServeIdentityModes(t *testing.T) {
 				}
 			}, func(_ context.Context, cfg hubserver.Config) error {
 				called = true
-				if cfg.GitHubDisabled != test.wantMode || (cfg.Hosted != nil) != test.hosted {
+				if cfg.CredentialMaintenance != test.maintenance || cfg.GitHubDisabled != test.wantMode || (cfg.Hosted != nil) != test.hosted {
 					t.Errorf("mode = native %t, hosted %t", cfg.GitHubDisabled, cfg.Hosted != nil)
 				}
 				return nil

--- a/internal/hubserver/api_http.go
+++ b/internal/hubserver/api_http.go
@@ -18,6 +18,10 @@ import (
 const maxAPIRequestBodyBytes = 1 << 20
 
 func (s *Service) registerRoutes(e *echo.Echo) {
+	if s.config.CredentialMaintenance {
+		s.registerCredentialMaintenanceRoutes(e)
+		return
+	}
 	if s.config.Hosted != nil {
 		e.Use(s.hostedBoundary)
 		s.registerHostedRoutes(e)

--- a/internal/hubserver/config.go
+++ b/internal/hubserver/config.go
@@ -40,6 +40,7 @@ var (
 )
 
 type Config struct {
+	CredentialMaintenance      bool
 	Hosted                     *HostedConfig
 	GitHubRequestCounts        func() []GitHubRequestCount
 	GitHubDisabled             bool
@@ -77,6 +78,9 @@ type Config struct {
 }
 
 func (c Config) normalized() Config {
+	if c.CredentialMaintenance {
+		c.GitHubDisabled = true
+	}
 	if c.GitHubDisabled {
 		c.ImportBackend, c.OutboxBackend, c.ReconcileBackend = nil, nil, nil
 		c.GitHubWebhookSecret, c.GitHubRequestCounts = nil, nil

--- a/internal/hubserver/credential_maintenance.go
+++ b/internal/hubserver/credential_maintenance.go
@@ -1,0 +1,54 @@
+package hubserver
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/auth"
+)
+
+func validateCredentialMaintenance(cfg Config) error {
+	if !cfg.CredentialMaintenance {
+		return nil
+	}
+	if cfg.Hosted == nil || cfg.Hosted.WorkOSOrganizationID == "" || !listenerAddressLoopback(cfg.ListenAddress) || cfg.TrustedProxy {
+		return errors.New("credential maintenance requires hosted configuration with an explicit provider organization and private loopback without a trusted proxy")
+	}
+	return nil
+}
+
+func (s *Service) registerCredentialMaintenanceRoutes(e *echo.Echo) {
+	admin := s.requireCredentialMaintenance
+	e.POST("/api/v1/tokens", s.createAPIToken, admin)
+	e.POST("/api/v1/tokens/:id/rotate", s.rotateAPIToken, admin)
+	e.DELETE("/api/v1/tokens/:id", s.revokeAPIToken, admin)
+	e.POST("/api/v2/tokens/:id/grants", s.grantNativeToken, admin)
+}
+
+func (s *Service) requireCredentialMaintenance(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set("Cache-Control", "no-store")
+		if _, err := apiBearerToken(c); err != nil || c.Request().Header.Get("Origin") != "" {
+			return c.NoContent(http.StatusUnauthorized)
+		}
+		credential, status, err := s.authenticateAPIRequest(c)
+		if err != nil {
+			return c.NoContent(status)
+		}
+		if credential.Scope != apiScopeAdmin || credential.NativeOnly || credential.Hosted != nil || credential.Runner.RunnerID != "" {
+			return c.NoContent(http.StatusForbidden)
+		}
+		var members int
+		if err := s.database.db.QueryRowContext(c.Request().Context(), "SELECT count(*) FROM hosted_members WHERE principal_id = ?", credential.ID).Scan(&members); err != nil || members != 0 {
+			return c.NoContent(http.StatusForbidden)
+		}
+		identity := &auth.HostedIdentity{Subject: credential.ID, CreatedAt: s.config.now()}
+		if err := s.hostedAudit(c.Request().Context(), identity, "credential_maintenance", c.Request().Method+" "+c.Request().URL.Path, "", 0); err != nil {
+			return s.nativeAPIError(c, err)
+		}
+		c.Set("hub_api_credential", credential)
+		return next(c)
+	}
+}

--- a/internal/hubserver/credential_maintenance.go
+++ b/internal/hubserver/credential_maintenance.go
@@ -45,10 +45,14 @@ func (s *Service) requireCredentialMaintenance(next echo.HandlerFunc) echo.Handl
 			return c.NoContent(http.StatusForbidden)
 		}
 		identity := &auth.HostedIdentity{Subject: credential.ID, CreatedAt: s.config.now()}
-		if err := s.hostedAudit(c.Request().Context(), identity, "credential_maintenance", c.Request().Method+" "+c.Request().URL.Path, "", 0); err != nil {
+		route := c.Request().Method + " " + c.Request().URL.Path
+		if err := s.hostedAudit(c.Request().Context(), identity, "credential_maintenance_attempt", route, "", 0); err != nil {
 			return s.nativeAPIError(c, err)
 		}
 		c.Set("hub_api_credential", credential)
-		return next(c)
+		if err := next(c); err != nil {
+			c.Error(err)
+		}
+		return s.hostedAudit(c.Request().Context(), identity, "credential_maintenance", route, "", c.Response().Status)
 	}
 }

--- a/internal/hubserver/credential_maintenance_test.go
+++ b/internal/hubserver/credential_maintenance_test.go
@@ -1,0 +1,194 @@
+package hubserver
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/apikey"
+	"github.com/digitaldrywood/detent/internal/runnerauth"
+	"github.com/digitaldrywood/detent/internal/tracker"
+)
+
+func reopenCredentialFixture(t *testing.T, f *browserHostedFixture, maintenance bool) {
+	t.Helper()
+	cfg := f.service.config
+	if err := f.service.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cfg.CredentialMaintenance = maintenance
+	cfg.ListenAddress = "127.0.0.1:0"
+	service, err := Open(t.Context(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.service = service
+}
+
+func testMaintenanceCheckLifecycle(t *testing.T, f *browserHostedFixture, path string, created tokenResponse, version tracker.ChangeVersion) {
+	t.Helper()
+	request := changeTestResult(version)
+	for _, test := range []struct {
+		name, method, suffix string
+		status               int
+	}{
+		{"rotation", http.MethodPost, "/rotate", http.StatusOK},
+		{"revocation", http.MethodDelete, "", http.StatusNoContent},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reopenCredentialFixture(t, f, true)
+			response := performHubAPIRequest(t, f.service, test.method, "/api/v1/tokens/"+created.ID+test.suffix, testHubAdminToken, nil)
+			requireNativeStatus(t, response, test.status)
+			oldToken := created.Token
+			if test.name == "rotation" {
+				var rotated tokenResponse
+				decodeHubResponse(t, response, &rotated)
+				if rotated.ID != created.ID || rotated.Token == oldToken {
+					t.Fatal("rotation changed principal or retained the old secret")
+				}
+				created = rotated
+			}
+			reopenCredentialFixture(t, f, false)
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, oldToken, request), http.StatusUnauthorized)
+			if test.name == "rotation" {
+				requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path, created.Token, request), http.StatusOK)
+			}
+		})
+	}
+}
+
+func TestCredentialMaintenanceAccess(t *testing.T) {
+	t.Parallel()
+	f := newBrowserHostedFixture(t, true)
+	for _, project := range []string{f.project, f.privateProject} {
+		requireNativeStatus(t, f.form(t, "owner", "/organization/grants", url.Values{"user": {"user_browser_owner"}, "project": {project}, "write": {"true"}, "runner": {"true"}}), http.StatusSeeOther)
+	}
+	binding := runnerauth.NewBinding()
+	path := "/api/v2/organizations/org_browser_preview/runner-enrollments"
+	response := f.setupRequest(t, "owner", http.MethodPost, path, runnerauth.EnrollmentRequest{Binding: binding, ProjectIDs: []tracker.ProjectID{tracker.ProjectID(f.project)}, Operations: []string{runnerauth.Read, runnerauth.Heartbeat}, TTLSeconds: 60})
+	requireNativeStatus(t, response, http.StatusCreated)
+	var enrollment runnerauth.Enrollment
+	decodeHubResponse(t, response, &enrollment)
+	runnerToken, err := apikey.GenerateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, path+"/redeem", enrollment.Token, runnerauth.Redemption{Binding: binding, Credential: runnerToken, Hostname: "maintenance-test", DisplayName: "Maintenance test", Capacity: 1, Version: "test"}), http.StatusCreated)
+	f.service.config.InitialAdminToken = []byte("replacement-bootstrap-secret")
+	reopenCredentialFixture(t, f, true)
+	if second, err := Open(t.Context(), f.service.config); err == nil {
+		second.Close()
+		t.Fatal("second database owner was admitted")
+	}
+	var scopedAdmin, reporter, worker string
+	for _, scope := range []apiScope{apiScopeAdmin, apiScopeOperator, apiScopeWorker} {
+		response := performHubAPIRequest(t, f.service, http.MethodPost, "/api/v1/tokens", testHubAdminToken, tokenRequest{Name: string(scope), Scope: scope})
+		requireNativeStatus(t, response, http.StatusCreated)
+		var token tokenResponse
+		decodeHubResponse(t, response, &token)
+		requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, "/api/v2/tokens/"+token.ID+"/grants", testHubAdminToken, map[string]string{"organization_id": "org_browser_preview", "project_id": f.project}), http.StatusNoContent)
+		switch scope {
+		case apiScopeAdmin:
+			scopedAdmin = token.Token
+		case apiScopeOperator:
+			reporter = token.Token
+		case apiScopeWorker:
+			worker = token.Token
+		}
+	}
+	for _, test := range []struct {
+		name, bearer, cookie, origin string
+	}{
+		{name: "anonymous loopback"},
+		{name: "invalid", bearer: "invalid"},
+		{name: "reporter", bearer: reporter},
+		{name: "worker", bearer: worker},
+		{name: "enrolled runner", bearer: runnerToken},
+		{name: "replacement bootstrap", bearer: "replacement-bootstrap-secret"},
+		{name: "project administrator", bearer: scopedAdmin},
+		{name: "owner cookie", cookie: "owner"},
+		{name: "staff cookie", cookie: "staff"},
+		{name: "support cookie", cookie: "support-viewer"},
+		{name: "browser origin", bearer: testHubAdminToken, origin: f.server.URL},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, route := range []struct{ method, path string }{
+				{http.MethodPost, "/api/v1/tokens"},
+				{http.MethodPost, "/api/v1/tokens/example/rotate"},
+				{http.MethodDelete, "/api/v1/tokens/example"},
+				{http.MethodPost, "/api/v2/tokens/example/grants"},
+			} {
+				request := httptest.NewRequest(route.method, route.path, strings.NewReader("{}"))
+				request.RemoteAddr = "127.0.0.1:12345"
+				request.Header.Set("Content-Type", "application/json")
+				if test.bearer != "" {
+					request.Header.Set("Authorization", "Bearer "+test.bearer)
+				}
+				if test.cookie != "" {
+					request.AddCookie(f.cookies[test.cookie])
+				}
+				if test.origin != "" {
+					request.Header.Set("Origin", test.origin)
+				}
+				response := httptest.NewRecorder()
+				f.service.Handler().ServeHTTP(response, request)
+				if response.Code != http.StatusUnauthorized && response.Code != http.StatusForbidden {
+					t.Fatalf("%s %s: status %d", route.method, route.path, response.Code)
+				}
+			}
+		})
+	}
+	for _, path := range []string{"/", "/health", "/api/v1/work-items", "/api/v2/organizations/org_browser_preview/projects"} {
+		requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodGet, path, testHubAdminToken, nil), http.StatusNotFound)
+	}
+	var events int
+	if err := f.service.database.db.QueryRowContext(t.Context(), "SELECT count(*) FROM hosted_audit WHERE event = 'credential_maintenance' AND actual_actor = ? AND effective_user = ? AND organization_id = ?", bootstrapTokenID, bootstrapTokenID, "org_browser_preview").Scan(&events); err != nil || events != 6 {
+		t.Fatalf("attributed maintenance events = %d, error = %v", events, err)
+	}
+	reopenCredentialFixture(t, f, false)
+	requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, "/api/v1/tokens", testHubAdminToken, tokenRequest{Name: "public-denied", Scope: apiScopeOperator}), http.StatusNotFound)
+}
+
+func TestCredentialMaintenanceConfiguration(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name string
+		edit func(*Config)
+	}{
+		{"non-hosted", func(c *Config) { c.Hosted = nil }},
+		{"public listener", func(c *Config) { c.ListenAddress = "0.0.0.0:7778" }},
+		{"public TLS listener", func(c *Config) { c.ListenAddress = "0.0.0.0:7778"; c.TLSCertFile = "cert"; c.TLSKeyFile = "key" }},
+		{"proxy", func(c *Config) { c.TrustedProxy = true }},
+		{"unspecified provider", func(c *Config) { c.Hosted.WorkOSOrganizationID = "" }},
+		{"wrong organization", func(c *Config) { c.Hosted.OrganizationID = "org_other" }},
+		{"wrong provider", func(c *Config) { c.Hosted.WorkOSOrganizationID = "org_other" }},
+		{"wrong origin", func(c *Config) { c.Hosted.PublicURL = "https://other.example.test" }},
+		{"wrong bootstrap", func(c *Config) { c.Hosted.BootstrapSubject = "other-owner" }},
+		{"unbound", func(c *Config) { c.DatabasePath = filepath.Join(t.TempDir(), "unbound.db") }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			f := newBrowserHostedFixture(t, true)
+			cfg := f.service.config
+			if err := f.service.Close(); err != nil {
+				t.Fatal(err)
+			}
+			cfg.CredentialMaintenance = true
+			test.edit(&cfg)
+			service, err := Open(t.Context(), cfg)
+			if err == nil {
+				service.Close()
+				t.Fatal("invalid maintenance configuration was accepted")
+			}
+			if strings.HasPrefix(test.name, "wrong ") || test.name == "unbound" {
+				if !errors.Is(err, ErrHostedDatabaseBinding) {
+					t.Fatalf("binding error = %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/hubserver/credential_maintenance_test.go
+++ b/internal/hubserver/credential_maintenance_test.go
@@ -192,3 +192,37 @@ func TestCredentialMaintenanceConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestCredentialMaintenanceAuditOutcomes(t *testing.T) {
+	t.Parallel()
+	f := newBrowserHostedFixture(t, true)
+	reopenCredentialFixture(t, f, true)
+	response := performHubAPIRequest(t, f.service, http.MethodPost, "/api/v1/tokens", testHubAdminToken, tokenRequest{Name: "audit-token", Scope: apiScopeOperator})
+	requireNativeStatus(t, response, http.StatusCreated)
+	var created tokenResponse
+	decodeHubResponse(t, response, &created)
+	for _, test := range []struct {
+		name, method, path string
+		body               any
+		status             int
+	}{
+		{"create", http.MethodPost, "/api/v1/tokens", tokenRequest{Name: "second-token", Scope: apiScopeOperator}, http.StatusCreated},
+		{"rotate", http.MethodPost, "/api/v1/tokens/" + created.ID + "/rotate", nil, http.StatusOK},
+		{"revoke", http.MethodDelete, "/api/v1/tokens/" + created.ID, nil, http.StatusNoContent},
+		{"duplicate", http.MethodPost, "/api/v1/tokens", tokenRequest{Name: "audit-token", Scope: apiScopeOperator}, http.StatusConflict},
+		{"invalid body", http.MethodPost, "/api/v1/tokens", map[string]string{"unknown": "field"}, http.StatusUnprocessableEntity},
+		{"unknown token", http.MethodPost, "/api/v1/tokens/unknown/rotate", nil, http.StatusNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, test.method, test.path, testHubAdminToken, test.body), test.status)
+			var status int
+			var actor, route string
+			if err := f.service.database.db.QueryRowContext(t.Context(), "SELECT status, actual_actor, route FROM hosted_audit WHERE event = 'credential_maintenance' ORDER BY id DESC LIMIT 1").Scan(&status, &actor, &route); err != nil {
+				t.Fatal(err)
+			}
+			if status != test.status || actor != bootstrapTokenID || route != test.method+" "+test.path {
+				t.Fatalf("audit status=%d actor=%s route=%s", status, actor, route)
+			}
+		})
+	}
+}

--- a/internal/hubserver/database.go
+++ b/internal/hubserver/database.go
@@ -71,8 +71,17 @@ func openDatabase(ctx context.Context, cfg Config) (*database, error) {
 		return nil, errors.Join(err, store.Close())
 	}
 	store.schemaVersion = version
+	if cfg.CredentialMaintenance {
+		var bound int
+		if err := db.QueryRowContext(ctx, "SELECT count(*) FROM hosted_tenant").Scan(&bound); err != nil || bound != 1 {
+			return nil, errors.Join(ErrHostedDatabaseBinding, store.Close())
+		}
+	}
 	if err := store.bindHostedDatabase(ctx, cfg.Hosted); err != nil {
 		return nil, errors.Join(err, store.Close())
+	}
+	if cfg.CredentialMaintenance {
+		return store, nil
 	}
 	if err := store.configureHostedPlans(ctx, cfg.Hosted); err != nil {
 		return nil, errors.Join(err, store.Close())

--- a/internal/hubserver/hosted_browser_test.go
+++ b/internal/hubserver/hosted_browser_test.go
@@ -192,7 +192,7 @@ func newBrowserHostedFixture(t *testing.T, allocated bool) *browserHostedFixture
 		base: base, organization: auth.Organization{ID: "org_browser_provider", ExternalID: "org_browser_preview", Name: "Browser organization"},
 		members: make(map[string]auth.Membership), sessions: make(map[string]auth.HostedIdentity), invitations: make(map[string]auth.Invitation), inviteRoles: make(map[string]string), authorizations: make(map[string]string), codes: make(map[string]auth.Identity),
 	}
-	cfg := Config{DatabasePath: filepath.Join(t.TempDir(), "hosted-browser.db"), GitHubDisabled: true, Logger: slog.New(slog.NewTextHandler(io.Discard, nil)), Hosted: &HostedConfig{
+	cfg := Config{InitialAdminToken: []byte(testHubAdminToken), DatabasePath: filepath.Join(t.TempDir(), "hosted-browser.db"), GitHubDisabled: true, Logger: slog.New(slog.NewTextHandler(io.Discard, nil)), Hosted: &HostedConfig{
 		OrganizationID: "org_browser_preview", BootstrapSubject: "user_browser_owner", PublicURL: base, Provider: provider,
 		StaffEmails: []string{"staff@example.test", "support@example.test"}, SupportActors: []string{"support@example.test"},
 		Directory: []HostedDestination{{OrganizationID: "org_browser_preview", WorkOSOrganizationID: "org_browser_provider", PublicURL: base}},
@@ -208,7 +208,7 @@ func newBrowserHostedFixture(t *testing.T, allocated bool) *browserHostedFixture
 	fixture := &browserHostedFixture{service: service, server: server, provider: provider, cookies: make(map[string]*http.Cookie), stop: make(chan struct{})}
 	t.Cleanup(func() {
 		server.Close()
-		if err := service.Close(); err != nil {
+		if err := fixture.service.Close(); err != nil {
 			t.Error(err)
 		}
 	})

--- a/internal/hubserver/hosted_change_checks_test.go
+++ b/internal/hubserver/hosted_change_checks_test.go
@@ -40,14 +40,17 @@ func TestHostedIndependentChangeChecks(t *testing.T) {
 			}
 			descriptor = descriptor.WithID()
 			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/onboarding/policy", policy.Change{Policy: descriptor}), http.StatusOK)
-			principal, token := "ci-"+test.project, "credential-"+test.project
-			seedHubAPIToken(t, f.service, principal, token, apiScopeOperator)
-			if _, err := f.service.database.db.ExecContext(t.Context(), "INSERT INTO token_grants VALUES (?, 'org_browser_preview', ?)", principal, test.project); err != nil {
-				t.Fatal(err)
-			}
+			reopenCredentialFixture(t, f, true)
+			response := performHubAPIRequest(t, f.service, http.MethodPost, "/api/v1/tokens", testHubAdminToken, tokenRequest{Name: "ci-" + test.project, Scope: apiScopeOperator})
+			requireNativeStatus(t, response, http.StatusCreated)
+			var created tokenResponse
+			decodeHubResponse(t, response, &created)
+			principal, token := created.ID, created.Token
+			requireNativeStatus(t, performHubAPIRequest(t, f.service, http.MethodPost, "/api/v2/tokens/"+principal+"/grants", testHubAdminToken, map[string]string{"organization_id": "org_browser_preview", "project_id": test.project}), http.StatusNoContent)
+			reopenCredentialFixture(t, f, false)
 			rules := tracker.ChangeReviewPolicy{PolicyID: descriptor.ID, RequireReview: test.review, RequiredChecks: []tracker.ChangeCheckSpec{{Name: "test", PrincipalID: principal, WorkflowID: "ci.yml", WorkflowSHA256: policy.Digest([]byte("trusted CI")), Source: "independent", MaxAgeSeconds: 3600}}}
 			requireNativeStatus(t, f.setupRequest(t, "owner", http.MethodPut, base+"/change-review-policy", tracker.ApproveChangeReviewPolicy{Mutation: tracker.Mutation{IdempotencyKey: "rules"}, Policy: rules}), http.StatusOK)
-			response := f.setupRequest(t, "owner", http.MethodPost, base+"/work-items", tracker.CreateIssue{Mutation: tracker.Mutation{IdempotencyKey: "work"}, Title: "Independent CI", State: "Todo"})
+			response = f.setupRequest(t, "owner", http.MethodPost, base+"/work-items", tracker.CreateIssue{Mutation: tracker.Mutation{IdempotencyKey: "work"}, Title: "Independent CI", State: "Todo"})
 			requireNativeStatus(t, response, http.StatusOK)
 			var issue tracker.NativeIssue
 			decodeHubResponse(t, response, &issue)
@@ -129,6 +132,7 @@ func TestHostedIndependentChangeChecks(t *testing.T) {
 				t.Fatalf("freshness bypassed: %+v", summary)
 			}
 			f.service.config.now = now
+			testMaintenanceCheckLifecycle(t, f, checkPath, created, version)
 		})
 	}
 }

--- a/internal/hubserver/service.go
+++ b/internal/hubserver/service.go
@@ -56,6 +56,9 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 		ctx = context.Background()
 	}
 	cfg = cfg.normalized()
+	if err := validateCredentialMaintenance(cfg); err != nil {
+		return nil, err
+	}
 	if err := cfg.Hosted.validate(); err != nil {
 		return nil, err
 	}
@@ -66,8 +69,10 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := database.ensureInitialAdminToken(ctx, cfg.InitialAdminToken); err != nil {
-		return nil, errors.Join(err, database.Close())
+	if !cfg.CredentialMaintenance {
+		if err := database.ensureInitialAdminToken(ctx, cfg.InitialAdminToken); err != nil {
+			return nil, errors.Join(err, database.Close())
+		}
 	}
 	cfg.InitialAdminToken = nil
 	workTracker, err := tracker.NewStore(database)
@@ -104,6 +109,14 @@ func Open(ctx context.Context, cfg Config) (*Service, error) {
 		}
 	}
 	service.registerRoutes(e)
+	if cfg.CredentialMaintenance {
+		workerCancel()
+		reconcileCancel()
+		close(service.workerDone)
+		close(service.reconcileDone)
+		service.ready.Store(true)
+		return service, nil
+	}
 	service.maintainGitHubWebhooks(ctx)
 	go service.runGitHubWebhookMaintenance(workerContext)
 	go service.runGitHubReconciliation(reconcileContext)
@@ -194,6 +207,9 @@ func (s *Service) Handler() http.Handler {
 }
 
 func (s *Service) Serve(listener net.Listener) error {
+	if s.config.CredentialMaintenance && listener != nil && !listenerAddressLoopback(listener.Addr().String()) {
+		return ErrInsecureListener
+	}
 	if listener == nil {
 		return errors.New("hub listener is required")
 	}
@@ -208,6 +224,9 @@ func (s *Service) Serve(listener net.Listener) error {
 }
 
 func (s *Service) ServeTLS(listener net.Listener, certificateFile string, keyFile string) error {
+	if s.config.CredentialMaintenance && listener != nil && !listenerAddressLoopback(listener.Addr().String()) {
+		return ErrInsecureListener
+	}
 	if listener == nil {
 		return errors.New("hub listener is required")
 	}


### PR DESCRIPTION
## Summary

- Add `hub serve --credential-maintenance` for provisioning, rotating and revoking credentials on an already bound hosted tenant. Preserve exact tenant binding, exclusive SQLite ownership and existing instance-administrator authentication; expose only credential administration on private loopback.
- Reuse token/grant handlers and record maintenance attempts and actual response outcomes with administrator attribution in hosted audit history. Preserve public hosted administration denial and reject browser, staff, scoped administrator, reporter and runner credentials.
- Replace the unsupported non-hosted reopen runbook with an executable maintenance sequence. Exercise realistic hosted initialization, maintenance provisioning and independent-check submission after rotation/revocation.

Fixes #2350

## UI Surface Contract

- [x] N/A: no UI surface or layout changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Focused Hub and CLI tests for maintenance access/configuration, independent-check lifecycle, hosted binding restart and CLI mode selection.
- [x] Table-driven audit outcome tests for successful mutations and rejected requests.
- [x] `make check` (80.3% overall coverage; all package/file floors passed)
