### PR TITLE
fix(runtime): attribute worker cancellations

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -163,6 +163,9 @@ func writeIssueExplanationPretty(writer io.Writer, result explain.IssueExplanati
 	}
 	if result.Attempt != nil {
 		lines = append(lines, fmt.Sprintf("Attempt: %d (%s)", result.Attempt.ID, result.Attempt.Status))
+		if detail := strings.TrimSpace(result.Attempt.StatusMessage); detail != "" {
+			lines = append(lines, "Attempt detail: "+detail)
+		}
 	}
 	lines = append(lines,
 		fmt.Sprintf("Lifetime attempts: %d", result.ParkSummary.AttemptCount),

--- a/internal/cli/issue_cancellation_test.go
+++ b/internal/cli/issue_cancellation_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/explain"
+)
+
+func TestIssueExplanationIncludesAttemptDetail(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		attempt *explain.Attempt
+		want    string
+	}{
+		{name: "no attempt"},
+		{name: "no detail", attempt: &explain.Attempt{ID: 4885}},
+		{name: "cancellation", attempt: &explain.Attempt{ID: 4885, StatusMessage: "worker cancellation: context_cancelled (source: orchestrator.release_claim)"}, want: "Attempt detail: worker cancellation: context_cancelled (source: orchestrator.release_claim)"},
+		{name: "active attempt", attempt: &explain.Attempt{ID: 4894, StatusMessage: "waiting for validation"}, want: "Attempt detail: waiting for validation"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var output bytes.Buffer
+			if err := writeIssueExplanationPretty(&output, explain.IssueExplanation{Attempt: tt.attempt}); err != nil {
+				t.Fatal(err)
+			}
+			if tt.want == "" {
+				if strings.Contains(output.String(), "Attempt detail:") {
+					t.Fatalf("unexpected attempt detail: %s", output.String())
+				}
+			} else if !strings.Contains(output.String(), tt.want) {
+				t.Fatalf("output = %s, want %s", output.String(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/cancellation_test.go
+++ b/internal/orchestrator/cancellation_test.go
@@ -17,13 +17,23 @@ import (
 
 func TestDispatchCancellationLogsFirstCause(t *testing.T) {
 	t.Parallel()
-	for _, cleanup := range []bool{false, true} {
-		t.Run(map[bool]string{false: "requested stop", true: "completion cleanup"}[cleanup], func(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		source  string
+		cleanup bool
+		preempt bool
+	}{
+		{name: "requested stop", source: "test.first"},
+		{name: "completion cleanup", source: "orchestrator.completion_cleanup", cleanup: true},
+		{name: "global preemption", source: "scheduler.global_dispatch_preemption", preempt: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := normalizeConfig(Config{MaxConcurrentAgents: 1, ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}, Project: scheduler.ProjectCandidate{ID: "detent"}})
 			backend := newWorkerHostRunner()
+			dispatchGate := &cancellationDispatchGate{}
 			var logs bytes.Buffer
-			orch := Orchestrator{cfg: cfg, supervisor: newTestSupervisor(t, backend, cfg), runResults: make(chan runpkg.Completion, 1), logger: slog.New(slog.NewTextHandler(&logs, nil))}
+			orch := Orchestrator{cfg: cfg, globalDispatchGate: dispatchGate, supervisor: newTestSupervisor(t, backend, cfg), runResults: make(chan runpkg.Completion, 1), logger: slog.New(slog.NewTextHandler(&logs, nil))}
 			state := newState(cfg)
 			issue := dispatchTestIssue("queued-worker", "Todo")
 			if !orch.dispatchIssue(t.Context(), &state, issue, 0, time.Now(), "") {
@@ -31,7 +41,13 @@ func TestDispatchCancellationLogsFirstCause(t *testing.T) {
 			}
 			receiveWorkerHostRunRequest(t, backend.started)
 			running := state.Running[issue.ID]
-			if cleanup {
+			if tt.preempt {
+				if dispatchGate.preempt == nil {
+					t.Fatal("preemption callback missing")
+				}
+				dispatchGate.preempt()
+				running.cancel()
+			} else if tt.cleanup {
 				running.cancel()
 			} else {
 				running.stop(runpkg.NewCancellationCause(context.Canceled, "test.first"))
@@ -40,15 +56,12 @@ func TestDispatchCancellationLogsFirstCause(t *testing.T) {
 			<-running.done
 			completion := <-orch.runResults
 			var cause *runpkg.CancellationCause
-			wantSource := "test.first"
-			if cleanup {
-				wantSource = "orchestrator.completion_cleanup"
-			}
+			wantSource := tt.source
 			if !errors.As(completion.Err, &cause) || cause.Source != wantSource {
 				t.Fatalf("completion cause = %v, want source %s", completion.Err, wantSource)
 			}
 			count := strings.Count(logs.String(), "worker_cancellation_requested")
-			if cleanup && count != 0 || !cleanup && (count != 1 || !strings.Contains(logs.String(), "test.first") || strings.Contains(logs.String(), "test.second")) {
+			if tt.cleanup && count != 0 || !tt.cleanup && (count != 1 || !strings.Contains(logs.String(), wantSource) || strings.Contains(logs.String(), "test.second")) {
 				t.Fatalf("cancellation log = %s", logs.String())
 			}
 		})
@@ -57,7 +70,7 @@ func TestDispatchCancellationLogsFirstCause(t *testing.T) {
 
 func TestCancellationCompletionPreservesAttributionAndRetry(t *testing.T) {
 	t.Parallel()
-	for _, source := range []string{"orchestrator.cancel_running", "orchestrator.parent_context", "runner.agent_backend"} {
+	for _, source := range []string{"orchestrator.cancel_running", "orchestrator.parent_context", "runner.agent_backend", "runner.dispatch_pacer", "scheduler.global_dispatch_preemption"} {
 		t.Run(source, func(t *testing.T) {
 			t.Parallel()
 			cfg := normalizeConfig(Config{MaxConcurrentAgents: 1, ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}, Project: scheduler.ProjectCandidate{ID: "detent"}})
@@ -120,4 +133,17 @@ func TestCancelRunningPreservesFirstInitiator(t *testing.T) {
 			}
 		})
 	}
+}
+
+type cancellationDispatchGate struct {
+	countingProjectDispatchGate
+	preempt func()
+}
+
+func (*cancellationDispatchGate) TryAcquire(context.Context, scheduler.ProjectCandidate, scheduler.SlotRequest, time.Time) (scheduler.Slot, bool, error) {
+	return scheduler.Slot{Weight: 1}, true, nil
+}
+
+func (g *cancellationDispatchGate) SetPreempt(_ scheduler.Slot, preempt func()) {
+	g.preempt = preempt
 }

--- a/internal/orchestrator/cancellation_test.go
+++ b/internal/orchestrator/cancellation_test.go
@@ -1,0 +1,123 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestDispatchCancellationLogsFirstCause(t *testing.T) {
+	t.Parallel()
+	for _, cleanup := range []bool{false, true} {
+		t.Run(map[bool]string{false: "requested stop", true: "completion cleanup"}[cleanup], func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 1, ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}, Project: scheduler.ProjectCandidate{ID: "detent"}})
+			backend := newWorkerHostRunner()
+			var logs bytes.Buffer
+			orch := Orchestrator{cfg: cfg, supervisor: newTestSupervisor(t, backend, cfg), runResults: make(chan runpkg.Completion, 1), logger: slog.New(slog.NewTextHandler(&logs, nil))}
+			state := newState(cfg)
+			issue := dispatchTestIssue("queued-worker", "Todo")
+			if !orch.dispatchIssue(t.Context(), &state, issue, 0, time.Now(), "") {
+				t.Fatal("dispatch failed")
+			}
+			receiveWorkerHostRunRequest(t, backend.started)
+			running := state.Running[issue.ID]
+			if cleanup {
+				running.cancel()
+			} else {
+				running.stop(runpkg.NewCancellationCause(context.Canceled, "test.first"))
+				running.stop(runpkg.NewCancellationCause(context.Canceled, "test.second"))
+			}
+			<-running.done
+			completion := <-orch.runResults
+			var cause *runpkg.CancellationCause
+			wantSource := "test.first"
+			if cleanup {
+				wantSource = "orchestrator.completion_cleanup"
+			}
+			if !errors.As(completion.Err, &cause) || cause.Source != wantSource {
+				t.Fatalf("completion cause = %v, want source %s", completion.Err, wantSource)
+			}
+			count := strings.Count(logs.String(), "worker_cancellation_requested")
+			if cleanup && count != 0 || !cleanup && (count != 1 || !strings.Contains(logs.String(), "test.first") || strings.Contains(logs.String(), "test.second")) {
+				t.Fatalf("cancellation log = %s", logs.String())
+			}
+		})
+	}
+}
+
+func TestCancellationCompletionPreservesAttributionAndRetry(t *testing.T) {
+	t.Parallel()
+	for _, source := range []string{"orchestrator.cancel_running", "orchestrator.parent_context", "runner.agent_backend"} {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 1, ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}, Project: scheduler.ProjectCandidate{ID: "detent"}})
+			attempts := &recordingWorkAttemptStore{}
+			orch := Orchestrator{cfg: cfg, workAttempts: attempts}
+			state := newState(cfg)
+			issue := dispatchTestIssue("cancelled-worker", "Todo")
+			state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: 4885, StartedAt: time.Now().Add(-time.Minute)}
+			cause := runpkg.NewCancellationCause(context.Canceled, source)
+			event := runpkg.Completion{IssueID: issue.ID, Request: RunRequest{Issue: issue, WorkAttemptID: 4885}, Err: cause, CompletedAt: time.Now(), Retryable: true, RetryAttempt: 1, RetryDelay: 10 * time.Second}
+			orch.handleRunResult(t.Context(), &state, event)
+			if len(attempts.completions) != 1 {
+				t.Fatalf("completions = %d", len(attempts.completions))
+			}
+			completed := attempts.completions[0]
+			var metadata struct {
+				Cancellation *runpkg.CancellationCause `json:"cancellation"`
+			}
+			if err := json.Unmarshal([]byte(completed.WorkerMetadataJSON), &metadata); err != nil {
+				t.Fatal(err)
+			}
+			if metadata.Cancellation == nil || metadata.Cancellation.Source != source || metadata.Cancellation.Reason != cause.Reason {
+				t.Fatalf("durable cancellation = %+v", metadata.Cancellation)
+			}
+			if completed.TerminalState != store.WorkAttemptTerminalCancelled || !strings.Contains(completed.StatusMessage, source) {
+				t.Fatalf("operator history = %+v", completed)
+			}
+			if len(state.Running) != 0 || len(state.Retry) != 1 || state.Retry[issue.ID].Attempt != 1 {
+				t.Fatalf("running=%d, retry=%+v", len(state.Running), state.Retry)
+			}
+			orch.handleRunResult(t.Context(), &state, event)
+			if len(attempts.completions) != 1 || len(state.Retry) != 1 {
+				t.Fatal("duplicate completion changed attempt or retry ownership")
+			}
+		})
+	}
+}
+
+func TestCancelRunningPreservesFirstInitiator(t *testing.T) {
+	t.Parallel()
+	for _, typed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "legacy", true: "typed"}[typed], func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancelCause(t.Context())
+			running := Running{cancel: func() { cancel(nil) }}
+			if typed {
+				running.stop = cancel
+			}
+			state := newState(Config{})
+			state.Running["issue"] = running
+			cancelRunning(&state, "missing")
+			cancelRunning(&state, "issue", "orchestrator.force_quit")
+			cancelRunning(&state, "issue", "later.cleanup")
+			if !errors.Is(context.Cause(ctx), context.Canceled) {
+				t.Fatalf("cause = %v", context.Cause(ctx))
+			}
+			var cause *runpkg.CancellationCause
+			if typed && (!errors.As(context.Cause(ctx), &cause) || cause.Source != "orchestrator.force_quit") {
+				t.Fatalf("first cause = %v", context.Cause(ctx))
+			}
+		})
+	}
+}

--- a/internal/orchestrator/ci_availability.go
+++ b/internal/orchestrator/ci_availability.go
@@ -163,7 +163,7 @@ func (o *Orchestrator) parkCIUnavailableWaiters(state *State, issues []connector
 		}
 		running.CIStopRequested = true
 		state.Running[issueID] = running
-		running.stop(runpkg.ErrCIUnavailable)
+		running.stop(runpkg.NewCancellationCause(runpkg.ErrCIUnavailable, "orchestrator.ci_availability"))
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      now.UTC(),
 			Event:   "ci_unavailable_attempt_parking",

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -781,7 +781,9 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 		cancel:                 cancel,
 		stop:                   cancelCause,
 	}
-	o.setGlobalDispatchPreempt(globalSlot, cancel)
+	o.setGlobalDispatchPreempt(globalSlot, func() {
+		cancelCause(runpkg.NewCancellationCause(context.Canceled, "scheduler.global_dispatch_preemption"))
+	})
 	state.Claimed[issue.ID] = claim
 	delete(state.Retry, issue.ID)
 	delete(state.Blocked, issue.ID)

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -2,7 +2,9 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/activity"
@@ -684,9 +686,25 @@ func (o *Orchestrator) dispatchIssueWithAdmission(
 	claim.Issue = issue
 	runCtx, stop := context.WithCancelCause(runCtx)
 	var startupTimer mergeWorkerStartupTimer
+	var cancelOnce sync.Once
 	cancelRun := func(cause error) {
-		stop(cause)
-		cancelDurationLimit()
+		cancelOnce.Do(func() {
+			requested := cause != nil
+			source := "orchestrator.stop"
+			if !requested {
+				source = "orchestrator.completion_cleanup"
+			}
+			first := runpkg.NewCancellationCause(cause, source)
+			cause = first
+			stop(cause)
+			cancelDurationLimit()
+			if requested && errors.Is(context.Cause(runCtx), cause) && o.logger != nil {
+				o.logger.Info("worker_cancellation_requested", "project_id", o.cfg.Project.ID,
+					"issue_id", issue.ID, "issue_identifier", issue.Identifier,
+					"work_attempt_id", workAttemptID, "cancellation_reason", first.Reason,
+					"cancellation_source", first.Source)
+			}
+		})
 	}
 	if runMode == runpkg.RunModeMerge {
 		timerFactory := o.mergeWorkerStartupTimer

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -1222,7 +1222,7 @@ func (p dispatchPlanner) retryDelay(attempt int, continuation bool) time.Duratio
 }
 
 func (p dispatchPlanner) releaseIssue(state *State, issueID string) {
-	cancelRunning(state, issueID)
+	cancelRunning(state, issueID, "dispatch_planner.release_issue")
 	delete(state.Running, issueID)
 	delete(state.Claimed, issueID)
 	delete(state.Blocked, issueID)
@@ -1231,14 +1231,14 @@ func (p dispatchPlanner) releaseIssue(state *State, issueID string) {
 }
 
 func (p dispatchPlanner) parkBudgetHardHold(state *State, issueID string) {
-	cancelRunning(state, issueID)
+	cancelRunning(state, issueID, "dispatch_planner.budget_hard_hold")
 	delete(state.Running, issueID)
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 }
 
 func (p dispatchPlanner) releaseClaim(state *State, issueID string) {
-	cancelRunning(state, issueID)
+	cancelRunning(state, issueID, "dispatch_planner.release_claim")
 	delete(state.Running, issueID)
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)

--- a/internal/orchestrator/lane_revocation.go
+++ b/internal/orchestrator/lane_revocation.go
@@ -172,7 +172,7 @@ func (o *Orchestrator) beginLaneRevocationWithMutation(
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
 	if running.stop != nil {
-		running.stop(runpkg.ErrLaneRevoked)
+		running.stop(runpkg.NewCancellationCause(runpkg.ErrLaneRevoked, "orchestrator.lane_revocation"))
 	} else if running.cancel != nil {
 		running.cancel()
 	}

--- a/internal/orchestrator/merge_revocation.go
+++ b/internal/orchestrator/merge_revocation.go
@@ -210,7 +210,7 @@ func (o *Orchestrator) beginMergeRevocation(state *State, running Running, revoc
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
 	if running.stop != nil {
-		running.stop(runpkg.ErrMergeRevoked)
+		running.stop(runpkg.NewCancellationCause(runpkg.ErrMergeRevoked, "orchestrator.merge_revocation"))
 	} else if running.cancel != nil {
 		running.cancel()
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1420,7 +1420,7 @@ func (o *Orchestrator) forceQuit(ctx context.Context, state *State, now time.Tim
 
 	var err error
 	for _, issueID := range sortedKeys(state.Running) {
-		o.cancelRunning(state, issueID)
+		o.cancelRunning(state, issueID, "orchestrator.force_quit")
 		o.heartbeats.remove(issueID)
 		err = errors.Join(err, o.abandonClaim(ctx, issueID))
 		delete(state.Running, issueID)

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -89,6 +89,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.rejectWorkerCompletion(ctx, state, event, running, "worker generation or work-attempt lease no longer owns the item", nil)
 		return
 	}
+	if errors.As(event.Err, &running.Cancellation) {
+		state.Running[event.IssueID] = running
+	}
 	if o.handleLaneRevocationCompletion(ctx, state, event, running) {
 		return
 	}
@@ -364,6 +367,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		errorMessage := event.Err.Error()
 		phase := "failed"
 		statusMessage := "worker failed"
+		if running.Cancellation != nil {
+			statusMessage = running.Cancellation.Error()
+		}
 		deliverableRecoveryErr = nil
 		credentialFailure := runpkg.IsDeliverableConfigurationError(event.Err)
 		var projectionErr *runpkg.SessionBudgetProjectionError
@@ -2791,7 +2797,7 @@ func (o *Orchestrator) retryDelay(attempt int, continuation bool) time.Duration 
 }
 
 func (o *Orchestrator) releaseClaim(state *State, issueID string) {
-	o.cancelRunning(state, issueID)
+	o.cancelRunning(state, issueID, "orchestrator.release_claim")
 	o.heartbeats.remove(issueID)
 	delete(state.Running, issueID)
 	delete(state.Claimed, issueID)
@@ -2943,7 +2949,7 @@ func terminalCompletedAt(issue connector.Issue, terminalStates []string, fallbac
 	return time.Now().UTC()
 }
 
-func (o *Orchestrator) cancelRunning(state *State, issueID string) {
+func (o *Orchestrator) cancelRunning(state *State, issueID string, source ...string) {
 	running, ok := state.Running[issueID]
 	if !ok {
 		return
@@ -2951,16 +2957,25 @@ func (o *Orchestrator) cancelRunning(state *State, issueID string) {
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	running.globalSlot = scheduler.Slot{}
 	state.Running[issueID] = running
-	cancelRunning(state, issueID)
+	cancelRunning(state, issueID, source...)
 }
 
-func cancelRunning(state *State, issueID string) {
+func cancelRunning(state *State, issueID string, source ...string) {
 	running, ok := state.Running[issueID]
-	if !ok || running.cancel == nil {
+	if !ok || running.cancel == nil && running.stop == nil {
 		return
 	}
-	running.cancel()
+	initiator := "orchestrator.cancel_running"
+	if len(source) > 0 {
+		initiator = source[0]
+	}
+	if running.stop != nil {
+		running.stop(runpkg.NewCancellationCause(context.Canceled, initiator))
+	} else {
+		running.cancel()
+	}
 	running.cancel = nil
+	running.stop = nil
 	state.Running[issueID] = running
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -141,6 +141,7 @@ type Running struct {
 	Issue                       connector.Issue
 	Attempt                     int
 	WorkAttemptID               int64
+	Cancellation                *runpkg.CancellationCause
 	Generation                  uint64
 	Mode                        string
 	DispatchSourceState         string

--- a/internal/orchestrator/stop_run.go
+++ b/internal/orchestrator/stop_run.go
@@ -213,7 +213,7 @@ func (o *Orchestrator) handleStopRunRequest(ctx context.Context, state *State, e
 	recordStateEvent(state, telemetry.ActivityEvent{At: event.at, Event: "operator_stop_requested", Message: "operator requested stop for " + issueLabel(running.Issue)})
 	event.reply <- stopRunReply{result: result}
 	if running.stop != nil {
-		running.stop(runpkg.ErrOperatorStopped)
+		running.stop(runpkg.NewCancellationCause(runpkg.ErrOperatorStopped, "operator.stop_run"))
 	} else if running.cancel != nil {
 		running.cancel()
 	}

--- a/internal/orchestrator/work_attempt_recovery.go
+++ b/internal/orchestrator/work_attempt_recovery.go
@@ -461,7 +461,7 @@ func (o *Orchestrator) clearLiveWorkAttemptState(state *State, attempt telemetry
 		return
 	}
 	if running, ok := state.Running[issueID]; ok && running.WorkAttemptID == attempt.AttemptID {
-		cancelRunning(state, issueID)
+		cancelRunning(state, issueID, "operator.work_attempt_recovery")
 		o.releaseGlobalDispatchSlot(running.globalSlot)
 		o.heartbeats.remove(issueID)
 		delete(state.Running, issueID)

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -1071,6 +1071,9 @@ func runningWorkAttemptMetadataJSON(running Running, metadata map[string]any) st
 		"issue_title":         strings.TrimSpace(running.Issue.Title),
 		"work_product_pushed": running.WorkProductPushed,
 	}
+	if running.Cancellation != nil {
+		out["cancellation"] = running.Cancellation
+	}
 	if strings.TrimSpace(running.Mode) == runpkg.RunModeImplement {
 		out[dispatchLoopStartMetadataKey] = running.DispatchLoopStart
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -967,6 +967,7 @@ func runAgentBackendTurnWithToolsUsingLimitPreservingScratch(
 		} else {
 			result, runErr = backend.RunTurn(governedCtx, request, boundedUpdateHandler)
 		}
+		runErr = preserveCancellation(governedCtx, runErr, "runner.agent_backend")
 		cancelTurn(nil)
 		memoryGovernorWG.Wait()
 		runErr = errors.Join(runErr, stopGovernor())
@@ -1202,6 +1203,7 @@ func (r *Runner) runAgentTurn(
 		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 	}
 	if cause := context.Cause(ctx); cooperativeStopError(cause) || durationLimitError(cause) {
+		cause = errors.Join(firstCancellationCause(turnErr, cause, "runner.session"), cause)
 		if workerReapErr != nil {
 			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 		} else {
@@ -1972,6 +1974,7 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	commandFinishedAttrs = append(commandFinishedAttrs, runtimeIdentityLogAttrs(result.RuntimeIdentity)...)
 	commandFinishedAttrs = append(commandFinishedAttrs, backendErrorAttrs(turnErr)...)
+	commandFinishedAttrs = append(commandFinishedAttrs, cancellationAttrs(turnErr)...)
 	if cleanupErr != nil {
 		commandFinishedAttrs = append(commandFinishedAttrs,
 			"cleanup_error", errorString(cleanupErr),
@@ -3054,6 +3057,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		turnErr = errors.Join(turnErr, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 	}
 	if cause := context.Cause(sessionCtx); cooperativeStopError(cause) || durationLimitError(cause) {
+		cause = errors.Join(firstCancellationCause(turnErr, cause, "runner.session"), cause)
 		if workerReapErr != nil {
 			turnErr = errors.Join(cause, fmt.Errorf("%w: %w", ErrWorkerProcessReap, workerReapErr))
 		} else {
@@ -3567,6 +3571,10 @@ func (r *Runner) cleanupSessionWorkerArtifacts(ctx context.Context, root string,
 func workerProcessReapReason(ctx context.Context, turnErr error) string {
 	cause := context.Cause(ctx)
 	combined := errors.Join(cause, turnErr)
+	var cancellation *CancellationCause
+	if errors.As(turnErr, &cancellation) {
+		combined = cancellation
+	}
 	switch {
 	case errors.Is(combined, ErrSessionDurationExceeded), errors.Is(combined, ErrMergeFallbackBudgetExceeded):
 		return "maximum_session_lifetime_exceeded"
@@ -3574,6 +3582,8 @@ func workerProcessReapReason(ctx context.Context, turnErr error) string {
 		return SessionBrakeReasonNoProgress
 	case errors.Is(combined, ErrTurnDurationExceeded):
 		return "maximum_turn_lifetime_exceeded"
+	case errors.As(combined, &cancellation):
+		return cancellation.Reason + ":" + cancellation.Source
 	case errors.Is(combined, context.Canceled):
 		return "session_cancelled"
 	case turnErr != nil:
@@ -3630,6 +3640,8 @@ func (r *Runner) finishSession(
 	if !started {
 		return nil
 	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
 	if result.FinalState == "" {
 		result.FinalState = FinalStateCompleted
 	}

--- a/internal/runner/cancellation.go
+++ b/internal/runner/cancellation.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+type CancellationCause struct {
+	Reason string `json:"reason"`
+	Source string `json:"source"`
+	err    error
+}
+
+func (c *CancellationCause) Error() string {
+	return fmt.Sprintf("worker cancellation: %s (source: %s)", c.Reason, c.Source)
+}
+
+func (c *CancellationCause) Unwrap() error {
+	return c.err
+}
+
+func NewCancellationCause(cause error, source string) *CancellationCause {
+	var first *CancellationCause
+	if errors.As(cause, &first) {
+		return first
+	}
+	reason := "unclassified_cancellation"
+	if cause == nil || errors.Is(cause, context.Canceled) {
+		reason = "context_cancelled"
+	}
+	for _, candidate := range []struct {
+		err    error
+		reason string
+	}{
+		{ErrOperatorStopped, "operator_stopped"},
+		{ErrLaneRevoked, "lane_revoked"},
+		{ErrMergeRevoked, "merge_revoked"},
+		{ErrCIUnavailable, "ci_unavailable"},
+		{ErrMergeWorkerStartupTimeout, "merge_worker_startup_timeout"},
+		{ErrMergeWorkerDurationExceeded, "merge_worker_duration_exceeded"},
+		{ErrMergeFallbackBudgetExceeded, "merge_fallback_budget_exceeded"},
+		{ErrSessionDurationExceeded, "session_duration_exceeded"},
+		{ErrTurnDurationExceeded, "turn_duration_exceeded"},
+		{ErrSessionMemoryCeilingExceeded, "session_memory_ceiling_exceeded"},
+		{ErrSessionNoProgress, "session_no_progress"},
+		{context.DeadlineExceeded, "deadline_exceeded"},
+	} {
+		if errors.Is(cause, candidate.err) {
+			reason = candidate.reason
+			break
+		}
+	}
+	if cause == nil {
+		cause = context.Canceled
+	}
+	return &CancellationCause{Reason: reason, Source: source, err: cause}
+}
+
+func preserveCancellation(ctx context.Context, err error, source string) error {
+	if err == nil {
+		return nil
+	}
+	var first *CancellationCause
+	if errors.As(err, &first) {
+		return err
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return errors.Join(NewCancellationCause(cause, source), err)
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return errors.Join(NewCancellationCause(err, source), err)
+	}
+	return err
+}
+
+func cancellationAttrs(err error) []any {
+	var cause *CancellationCause
+	if !errors.As(err, &cause) {
+		return nil
+	}
+	return []any{"cancellation_reason", cause.Reason, "cancellation_source", cause.Source}
+}
+
+func firstCancellationCause(err error, cause error, source string) *CancellationCause {
+	var first *CancellationCause
+	if errors.As(err, &first) {
+		return first
+	}
+	return NewCancellationCause(cause, source)
+}

--- a/internal/runner/cancellation_test.go
+++ b/internal/runner/cancellation_test.go
@@ -1,0 +1,155 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestCancellationFirstCause(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		cause  error
+		reason string
+	}{
+		{"operator", ErrOperatorStopped, "operator_stopped"},
+		{"lane", ErrLaneRevoked, "lane_revoked"},
+		{"merge", ErrMergeRevoked, "merge_revoked"},
+		{"CI", ErrCIUnavailable, "ci_unavailable"},
+		{"startup", ErrMergeWorkerStartupTimeout, "merge_worker_startup_timeout"},
+		{"merge duration", ErrMergeWorkerDurationExceeded, "merge_worker_duration_exceeded"},
+		{"fallback", ErrMergeFallbackBudgetExceeded, "merge_fallback_budget_exceeded"},
+		{"session duration", ErrSessionDurationExceeded, "session_duration_exceeded"},
+		{"turn duration", ErrTurnDurationExceeded, "turn_duration_exceeded"},
+		{"memory", ErrSessionMemoryCeilingExceeded, "session_memory_ceiling_exceeded"},
+		{"no progress", ErrSessionNoProgress, "session_no_progress"},
+		{"deadline", context.DeadlineExceeded, "deadline_exceeded"},
+		{"shutdown", context.Canceled, "context_cancelled"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancelCause(t.Context())
+			first := NewCancellationCause(tt.cause, "test.initiator")
+			cancel(first)
+			cancel(NewCancellationCause(context.Canceled, "test.cleanup"))
+			err := preserveCancellation(ctx, fmt.Errorf("stream turn: %w", context.Canceled), "test.backend")
+			err = preserveCancellation(ctx, err, "test.completion")
+			if got := firstCancellationCause(err, ErrOperatorStopped, "later.stop"); got != first {
+				t.Fatalf("session finalization replaced first cause with %v", got)
+			}
+			var got *CancellationCause
+			if !errors.As(err, &got) || got != first || got.Reason != tt.reason || !errors.Is(err, tt.cause) {
+				t.Fatalf("cancellation = %v, want first cause %v", err, first)
+			}
+			if len(cancellationAttrs(err)) != 4 {
+				t.Fatalf("missing cancellation log attributes: %v", cancellationAttrs(err))
+			}
+		})
+	}
+}
+
+func TestCancellationDoesNotInventFailureOrExposeCause(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"success", nil, false},
+		{"ordinary error", errors.New("failure"), false},
+		{"backend cancellation", context.Canceled, true},
+		{"backend deadline", context.DeadlineExceeded, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := preserveCancellation(t.Context(), tt.err, "runner.agent_backend")
+			var cause *CancellationCause
+			if errors.As(err, &cause) != tt.want || !errors.Is(err, tt.err) {
+				t.Fatalf("preserveCancellation() = %v", err)
+			}
+		})
+	}
+	cause := NewCancellationCause(fmt.Errorf("private token: %w", context.Canceled), "test.source")
+	data, err := json.Marshal(cause)
+	if err != nil || strings.Contains(string(data)+cause.Error(), "private token") {
+		t.Fatalf("cancellation serialization exposed underlying details: %s, %v", data, err)
+	}
+	if !errors.Is(NewCancellationCause(nil, "test.source"), context.Canceled) {
+		t.Fatal("nil cancellation must retain context.Canceled semantics")
+	}
+	if got := firstCancellationCause(nil, ErrOperatorStopped, "test.source"); got.Reason != "operator_stopped" {
+		t.Fatalf("unattributed session cause = %v", got)
+	}
+}
+
+func TestFinishSessionAfterCancellation(t *testing.T) {
+	t.Parallel()
+	for _, cause := range []error{context.Canceled, context.DeadlineExceeded, ErrOperatorStopped, ErrLaneRevoked} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancelCause(t.Context())
+			cancel(cause)
+			sessions := &cancellationSessionStore{}
+			r := &Runner{store: sessions, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			err := r.finishSession(ctx, 5782, true, 4885, connector.Issue{ID: "issue"}, time.Now(), time.Now(), RunResult{FinalState: FinalStateFailed}, "model", "codex", 1, AgentTurnResult{ThreadID: "thread", SessionID: "session"}, 0)
+			if err != nil {
+				t.Fatalf("finishSession() = %v", err)
+			}
+			if !sessions.bounded || sessions.finishCalls != 1 {
+				t.Fatalf("session finalization: bounded=%v, writes=%d", sessions.bounded, sessions.finishCalls)
+			}
+		})
+	}
+}
+
+func TestCancellationProcessReapAttribution(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		cause error
+		want  string
+	}{
+		{context.Canceled, "context_cancelled:test.source"},
+		{context.DeadlineExceeded, "deadline_exceeded:test.source"},
+		{ErrOperatorStopped, "operator_stopped:test.source"},
+		{ErrLaneRevoked, "lane_revoked:test.source"},
+		{ErrSessionDurationExceeded, "maximum_session_lifetime_exceeded"},
+		{ErrTurnDurationExceeded, "maximum_turn_lifetime_exceeded"},
+		{ErrSessionNoProgress, SessionBrakeReasonNoProgress},
+	} {
+		t.Run(tt.cause.Error(), func(t *testing.T) {
+			t.Parallel()
+			cause := NewCancellationCause(tt.cause, "test.source")
+			if got := workerProcessReapReason(t.Context(), cause); got != tt.want {
+				t.Fatalf("workerProcessReapReason() = %q, want %q", got, tt.want)
+			}
+			ctx, cancel := context.WithCancelCause(t.Context())
+			cancel(NewCancellationCause(ErrOperatorStopped, "later.stop"))
+			if got := workerProcessReapReason(ctx, cause); got != tt.want {
+				t.Fatalf("later parent cancellation replaced first reap reason with %q", got)
+			}
+		})
+	}
+}
+
+type cancellationSessionStore struct {
+	fakeSessionStore
+	bounded bool
+}
+
+func (s *cancellationSessionStore) FinishSession(ctx context.Context, id int64, attrs store.SessionFinish) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, s.bounded = ctx.Deadline()
+	return s.fakeSessionStore.FinishSession(ctx, id, attrs)
+}

--- a/internal/runner/cancellation_test.go
+++ b/internal/runner/cancellation_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -152,4 +153,56 @@ func (s *cancellationSessionStore) FinishSession(ctx context.Context, id int64, 
 	}
 	_, s.bounded = ctx.Deadline()
 	return s.fakeSessionStore.FinishSession(ctx, id, attrs)
+}
+
+func TestCancellationDuringDispatchPacing(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		cause     error
+		source    string
+		retryable bool
+	}{
+		{name: "parent cancellation", cause: context.Canceled, source: "runner.dispatch_pacer", retryable: true},
+		{name: "deadline", cause: context.DeadlineExceeded, source: "runner.dispatch_pacer", retryable: true},
+		{name: "operator", cause: NewCancellationCause(ErrOperatorStopped, "operator.stop_run"), source: "operator.stop_run"},
+		{name: "lane", cause: NewCancellationCause(ErrLaneRevoked, "orchestrator.lane_revocation"), source: "orchestrator.lane_revocation"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			pacer := NewStartupDispatchPacer(StartupDispatchPacerConfig{
+				MaxStartsPerSecond: 1,
+				RampStarts:         2,
+				Sleep: func(ctx context.Context, _ time.Duration) error {
+					cancel(tt.cause)
+					return ctx.Err()
+				},
+			})
+			if err := pacer.Wait(ctx); err != nil {
+				t.Fatal(err)
+			}
+			var calls []string
+			var logs bytes.Buffer
+			supervisor, err := NewSupervisor(orderRecordingBackend{order: &calls}, SupervisorConfig{
+				DispatchPacer: pacer,
+				Logger:        slog.New(slog.NewTextHandler(&logs, nil)),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			completion := supervisor.Run(ctx, RunRequest{Issue: connector.Issue{ID: "queued-worker"}})
+			var cause *CancellationCause
+			if !errors.As(completion.Err, &cause) || cause.Source != tt.source || !errors.Is(completion.Err, tt.cause) {
+				t.Fatalf("pacing cancellation = %v, want source %s", completion.Err, tt.source)
+			}
+			if len(calls) != 0 || completion.Retryable != tt.retryable {
+				t.Fatalf("backend calls = %v, retryable = %v", calls, completion.Retryable)
+			}
+			if !strings.Contains(logs.String(), "cancellation_source="+tt.source) {
+				t.Fatalf("completion log lacks pacing attribution: %s", logs.String())
+			}
+		})
+	}
 }

--- a/internal/runner/duration_limit_test.go
+++ b/internal/runner/duration_limit_test.go
@@ -225,7 +225,7 @@ func TestRunnerReapsWorkerAfterTerminalTurn(t *testing.T) {
 	}{
 		{name: "completed", wantReason: "turn_completed"},
 		{name: "failed", turnErr: errors.New("provider failed"), wantReason: "turn_failed"},
-		{name: "cancelled", turnErr: context.Canceled, wantReason: "session_cancelled"},
+		{name: "cancelled", turnErr: context.Canceled, wantReason: "context_cancelled:runner.agent_backend"},
 		{name: "no progress", turnErr: ErrSessionNoProgress, wantReason: SessionBrakeReasonNoProgress},
 	}
 	for _, tt := range tests {

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -203,7 +203,7 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 				err = cause
 			}
 			completion.CompletedAt = s.now()
-			completion.Err = err
+			completion.Err = preserveCancellation(ctx, err, "runner.dispatch_pacer")
 			return completion
 		}
 	}

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -179,6 +179,7 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 			"error", completion.Err,
 		}
 		attrs = append(attrs, backendErrorAttrs(completion.Err)...)
+		attrs = append(attrs, cancellationAttrs(completion.Err)...)
 		level := slog.LevelDebug
 		if IsTransientOverload(completion.Err) {
 			attrs = append(attrs, "reason", "transient_overload")
@@ -222,11 +223,9 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 	}
 
 	result, err := s.backend.Run(ctx, request)
-	if cause := context.Cause(ctx); errors.Is(cause, ErrMergeWorkerStartupTimeout) ||
-		errors.Is(cause, ErrMergeWorkerDurationExceeded) ||
-		errors.Is(cause, ErrCIUnavailable) ||
-		errors.Is(cause, ErrLaneRevoked) {
-		err = errors.Join(cause, err)
+	err = preserveCancellation(ctx, err, "orchestrator.parent_context")
+	if cause := context.Cause(ctx); cooperativeStopError(cause) {
+		err = errors.Join(err, cause)
 		if errors.Is(cause, ErrMergeWorkerDurationExceeded) {
 			result.FinalState = FinalStateMergeDurationExceeded
 		}

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -271,6 +271,8 @@ func TestSupervisorPropagatesCancellationCause(t *testing.T) {
 		wantRetryable bool
 	}{
 		{name: "CI unavailable remains cooperative", cause: ErrCIUnavailable, wantCI: true},
+		{name: "operator stop remains cooperative", cause: ErrOperatorStopped},
+		{name: "merge revocation remains cooperative", cause: ErrMergeRevoked},
 		{name: "lane revocation remains cooperative", cause: ErrLaneRevoked, wantLane: true, wantFinal: FinalStateLaneRevoked},
 		{name: "ordinary cancellation remains retryable", cause: context.Canceled, wantRetryable: true},
 	}


### PR DESCRIPTION
## Summary

Canceled workers could lose their initiating cause and leave session records marked running when finalization reused the canceled context. Preserve the first typed cancellation reason and known source through dispatch, backend completion, process-reap logs, durable attempt metadata, and CLI attempt detail. Use a bounded uncanceled context for session finalization.

Scheduler preemption now records `scheduler.global_dispatch_preemption` instead of completion cleanup, and cancellation during startup pacing retains its cause before returning. Tests cover both review findings.

Full logs, durable records, and provider events correlate the interruptions reported for #2344, #2347, and #2350. Their historical initiating caller was not recorded and remains unknown. This change fixes attribution and finalization gaps; it does not establish a shared trigger or claim the recurring throughput interruption is resolved. Existing child cleanup, retry ownership, dirty-worktree reuse, provider resume policy, and process-owned validation queue semantics remain intact.

Fixes #2351

## UI Surface Contract

- [x] N/A: no layout, density, first-viewport, or responsive visibility changes.
- [x] No persistent top-of-screen messaging added.
- [x] N/A: no visual changes to primary operator screens; existing status data gains cancellation detail, and plain CLI output displays attempt detail.

## Test Plan

- [x] Reproduced canceled-context session finalization failure before the fix.
- [x] Focused stdlib tests cover first-cause preservation, operator stop, lane revocation, deadlines, shutdown attribution, bounded session persistence, CLI output, and duplicate completion/retry ownership.
- [x] Focused cancellation regressions pass on d86e57f4 in runner, orchestrator, and CLI, including scheduler-preemption logging and startup-pacer cancellation.
- [x] Full `make check CHECK_LOCK_WAIT=2h` passed on d86e57f4 after #2364 disk-capacity recovery: 80.3% overall coverage and all configured package/file floors satisfied.
- [x] All current-head CI jobs passed in [run 34296562646](https://github.com/digitaldrywood/detent/actions/runs/34296562646), including Linux race, macOS/Windows portability, browser visual, security, coverage, and release snapshot.
