### PR TITLE
fix(cli): resolve shorthand issue references

### DIFF
--- a/internal/cli/dashboard_client_test.go
+++ b/internal/cli/dashboard_client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/explain"
 	"github.com/digitaldrywood/detent/internal/operatortool"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestDashboardReadClientExecutesSharedOperatorTool(t *testing.T) {
@@ -659,5 +660,70 @@ func TestIssueCommandHelpCoversScopingAndJSON(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("help missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+type issueCommandSnapshot struct {
+	observation explain.SnapshotObservation
+}
+
+func (s issueCommandSnapshot) Snapshot(context.Context) (explain.SnapshotObservation, error) {
+	return s.observation, nil
+}
+
+func TestIssueCommandMissingNumberReferences(t *testing.T) {
+	t.Parallel()
+	issue := telemetry.Issue{ID: "I_example", Identifier: "digitaldrywood/detent#2337", ProjectID: "detent", State: "Merging"}
+	service := explain.New(explain.Dependencies{Snapshots: issueCommandSnapshot{observation: explain.SnapshotObservation{
+		State:    explain.SourceLive,
+		Snapshot: telemetry.Snapshot{GeneratedAt: time.Now(), Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusDegraded}, Queue: []telemetry.Queued{{Issue: issue}}},
+	}}})
+	for _, reference := range []string{"#2337", "2337", issue.Identifier} {
+		t.Run(reference, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.Method != http.MethodGet {
+					t.Errorf("method = %s, want GET", request.Method)
+				}
+				result, err := service.Explain(request.Context(), explain.Query{ProjectID: strings.TrimSuffix(strings.TrimPrefix(request.URL.Path, "/api/v1/projects/"), "/issues/explanation"), Reference: request.URL.Query().Get("reference")})
+				if err != nil {
+					http.Error(writer, err.Error(), http.StatusNotFound)
+					return
+				}
+				if err := json.NewEncoder(writer).Encode(result); err != nil {
+					t.Error(err)
+				}
+			}))
+			t.Cleanup(server.Close)
+			parsed, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			port, err := strconv.Atoi(parsed.Port())
+			if err != nil {
+				t.Fatal(err)
+			}
+			opts := dashboardClientOptions(server.Client().Do, "", "")
+			opts.read = func(string) (globalconfig.Config, error) { return globalconfig.Config{Port: &port}, nil }
+			configPath, host := "/config/global.yaml", parsed.Hostname()
+			cmd := newIssueCommand(&configPath, &host, &port, opts)
+			var format string
+			AddFormatFlag(cmd, &format)
+			cmd.SetContext(withCommandOutputOptions(t.Context(), commandOutputOptions{lookupEnv: opts.lookupEnv, stdoutTTY: func() bool { return false }}))
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{reference, "--explain", "--project", "detent", "--format", "json"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			var got explain.IssueExplanation
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.Schema != explain.SchemaVersion || !got.Found || got.Identity.IssueID != issue.ID || got.Identity.Identifier != issue.Identifier || got.CurrentLane.Name != "Merging" || !got.CurrentLane.Degraded {
+				t.Fatalf("explanation = %#v", got)
+			}
+		})
 	}
 }

--- a/internal/explain/select.go
+++ b/internal/explain/select.go
@@ -2,6 +2,7 @@ package explain
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -184,7 +185,15 @@ func compareSnapshotIssues(left snapshotIssue, right snapshotIssue) int {
 	return strings.Compare(issueIdentityKey(left.issue), issueIdentityKey(right.issue))
 }
 
+var canonicalIssueNumberPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#([1-9][0-9]*)$`)
+
 func queryMatchesIssue(query Query, issue telemetry.Issue) bool {
+	number := ""
+	if issue.Number > 0 {
+		number = strconv.Itoa(issue.Number)
+	} else if matches := canonicalIssueNumberPattern.FindStringSubmatch(strings.TrimSpace(issue.Identifier)); len(matches) == 2 {
+		number = matches[1]
+	}
 	values := []string{strings.TrimSpace(issue.ID), strings.TrimSpace(issue.Identifier), strings.TrimSpace(issue.URL)}
 	for _, queryValue := range []string{query.IssueID, query.Identifier, query.IssueURL, query.Reference} {
 		queryValue = strings.TrimSpace(queryValue)
@@ -196,8 +205,7 @@ func queryMatchesIssue(query Query, issue telemetry.Issue) bool {
 				return true
 			}
 		}
-		if issue.Number > 0 {
-			number := strconv.Itoa(issue.Number)
+		if number != "" {
 			if queryValue == number || queryValue == "#"+number {
 				return true
 			}

--- a/internal/explain/select_test.go
+++ b/internal/explain/select_test.go
@@ -13,7 +13,6 @@ func TestResolveSnapshotIssueReferenceForms(t *testing.T) {
 	issue := telemetry.Issue{
 		ID:         "issue-1640",
 		Identifier: "digitaldrywood/detent#1640",
-		Number:     1640,
 		ProjectID:  "detent",
 		URL:        "https://github.com/digitaldrywood/detent/issues/1640",
 		State:      "Rework",
@@ -130,5 +129,81 @@ func TestResolveSnapshotIssueRejectsProjectCollision(t *testing.T) {
 	var ambiguous *AmbiguousIdentityError
 	if !errors.As(err, &ambiguous) || ambiguous.Field != "project_id" {
 		t.Fatalf("ResolveSnapshotIssue() error = %#v, want project ambiguity", err)
+	}
+}
+
+func TestResolveSnapshotIssueMissingNumberScope(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		issues  []telemetry.Issue
+		project string
+		wantID  string
+		wantErr error
+	}{
+		{name: "selected project", project: "detent", issues: []telemetry.Issue{
+			{ID: "a", Identifier: "owner/a#2337", ProjectID: "detent"},
+			{ID: "b", Identifier: "owner/b#2337", ProjectID: "other"},
+		}, wantID: "a"},
+		{name: "other project only", project: "detent", issues: []telemetry.Issue{
+			{ID: "b", Identifier: "owner/b#2337", ProjectID: "other"},
+		}, wantErr: ErrNotFound},
+		{name: "same project ambiguity", project: "detent", issues: []telemetry.Issue{
+			{ID: "a", Identifier: "owner/a#2337", ProjectID: "detent"},
+			{ID: "b", Identifier: "owner/b#2337", ProjectID: "detent"},
+		}, wantErr: &AmbiguousIdentityError{}},
+		{name: "unscoped project ambiguity", issues: []telemetry.Issue{
+			{ID: "a", Identifier: "owner/a#2337", ProjectID: "detent"},
+			{ID: "b", Identifier: "owner/b#2337", ProjectID: "other"},
+		}, wantErr: &AmbiguousIdentityError{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveSnapshotIssue(telemetry.Snapshot{BoardIssues: tt.issues}, Query{ProjectID: tt.project, Reference: "#2337"}, SnapshotIssueScope{})
+			var ambiguous *AmbiguousIdentityError
+			if errors.As(tt.wantErr, &ambiguous) {
+				var target *AmbiguousIdentityError
+				if !errors.As(err, &target) {
+					t.Fatalf("error = %v, want ambiguity", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if got.Identity.IssueID != tt.wantID {
+				t.Fatalf("identity = %#v, want %q", got.Identity, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestQueryMatchesIssueNumberFallback(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		issue     telemetry.Issue
+		reference string
+		want      bool
+	}{
+		{name: "canonical fallback", issue: telemetry.Issue{Identifier: "owner/repo#2337"}, reference: "#2337", want: true},
+		{name: "explicit number preserved", issue: telemetry.Issue{Identifier: "local/item", Number: 2337}, reference: "2337", want: true},
+		{name: "explicit number takes precedence", issue: telemetry.Issue{Identifier: "owner/repo#2337", Number: 7}, reference: "#2337"},
+		{name: "PR number ignored", issue: telemetry.Issue{Identifier: "owner/repo#7", PullRequest: &telemetry.PullRequest{Number: 2337}}, reference: "#2337"},
+		{name: "PR URL ignored", issue: telemetry.Issue{URL: "https://github.com/owner/repo/pull/2337"}, reference: "2337"},
+		{name: "URL fragment ignored", issue: telemetry.Issue{Identifier: "https://example.com/item#2337"}, reference: "#2337"},
+		{name: "node suffix ignored", issue: telemetry.Issue{ID: "node#2337"}, reference: "#2337"},
+		{name: "noncanonical suffix ignored", issue: telemetry.Issue{Identifier: "item#2337"}, reference: "#2337"},
+		{name: "invalid suffix ignored", issue: telemetry.Issue{Identifier: "owner/repo#2337extra"}, reference: "#2337"},
+		{name: "partial number ignored", issue: telemetry.Issue{Identifier: "owner/repo#23370"}, reference: "#2337"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := queryMatchesIssue(Query{Reference: tt.reference}, tt.issue); got != tt.want {
+				t.Fatalf("match = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/explain/service_test.go
+++ b/internal/explain/service_test.go
@@ -643,3 +643,33 @@ func findSourceStatus(statuses []SourceStatus, name string) SourceStatus {
 	}
 	return SourceStatus{}
 }
+
+func TestServiceExplainsRetryWithoutNumberDuringDegradedRefresh(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	issue := telemetry.Issue{ID: "I_example", Identifier: "digitaldrywood/detent#2337", ProjectID: "detent", URL: "https://github.com/digitaldrywood/detent/issues/2337", State: "Merging", PullRequest: &telemetry.PullRequest{Number: 2400}}
+	reader := &evidenceReader{observation: SnapshotObservation{
+		State:    SourceLive,
+		Snapshot: telemetry.Snapshot{GeneratedAt: now, Refresh: telemetry.Refresh{Status: telemetry.RefreshStatusDegraded}, Queue: []telemetry.Queued{{Issue: issue}}},
+	}}
+	service := New(Dependencies{Snapshots: reader, Now: func() time.Time { return now }})
+	want, err := service.Explain(t.Context(), Query{ProjectID: "detent", Reference: issue.Identifier})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !want.Found || want.CurrentLane.Name != "Merging" || !want.CurrentLane.Degraded {
+		t.Fatalf("canonical explanation = %#v", want)
+	}
+	for _, reference := range []string{"#2337", "2337", issue.ID, issue.URL} {
+		t.Run(reference, func(t *testing.T) {
+			t.Parallel()
+			got, err := service.Explain(t.Context(), Query{ProjectID: "detent", Reference: reference})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("explanation = %#v, want canonical result %#v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Resolve bare and hash-prefixed issue numbers from canonical issue identifiers when local snapshots omit the optional numeric field, so degraded tracker refresh does not break shorthand inspection.
- Preserve explicit numbers, project isolation, ambiguity handling, canonical identifiers, node IDs, issue URLs, and separation from linked PR numbers. Resolution stays read-only and uses local evidence.
- Add selector, explanation-service, and CLI JSON regression coverage, including the documented commands.

Fixes #2358

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: CLI issue resolution only.

## Test Plan

- [x] `make check` — build, lint, vet, NilAway, full race suites, 80.3% aggregate coverage, and configured package/file coverage floors passed.
- [x] Both affected Go package suites pass.
- [x] Unfixed-selector overlay reproduces canonical-success/shorthand-failure with Number omitted; the fixed suite passes.
- [x] CLI exercises `#2337`, `2337`, and `digitaldrywood/detent#2337` with `--explain --project detent --format json` against an ephemeral HTTP server backed by the explanation service.
