### PR TITLE
fix(github): require confirmed REST quota recovery

### DIFF
--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -97,10 +97,12 @@ type Client struct {
 }
 
 type restProbeResult struct {
-	StatusCode int
-	Headers    http.Header
-	Body       string
-	FullBody   string
+	backoffKey         string
+	credentialIdentity string
+	StatusCode         int
+	Headers            http.Header
+	Body               string
+	FullBody           string
 }
 
 func NewClient(cfg ClientConfig) (*Client, error) {
@@ -426,10 +428,12 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	c.recordRESTRateLimitFromHeaders(ctx, backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest probe response", method, path, family, resp.StatusCode)
 	result := restProbeResult{
-		StatusCode: resp.StatusCode,
-		Headers:    resp.Header.Clone(),
-		Body:       summarizeBody(raw),
-		FullBody:   string(bytes.TrimSpace(raw)),
+		backoffKey:         backoffKey,
+		credentialIdentity: credentialIdentity,
+		StatusCode:         resp.StatusCode,
+		Headers:            resp.Header.Clone(),
+		Body:               summarizeBody(raw),
+		FullBody:           string(bytes.TrimSpace(raw)),
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		err := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
@@ -823,18 +827,6 @@ func (c *Client) RESTRateLimitStatus() connector.RESTRateLimitUsage {
 	return usage
 }
 
-func (c *Client) clearRESTBackoff() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	backoffKey := c.restBackoffKey
-	c.restBackoffUntil = time.Time{}
-	c.restRateLimitStatus = false
-	if c.restBackoffs != nil && backoffKey != "" {
-		c.restBackoffs.clear(backoffKey)
-	}
-}
-
 func (c *Client) restBackoffError(backoffKey string, now time.Time) error {
 	c.mu.RLock()
 	backoffUntil := c.restBackoffUntil
@@ -1006,6 +998,11 @@ func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, metho
 }
 
 func (c *Client) restSharedBackoffKey(token string) string {
+	if source, ok := c.tokenSource.(CredentialIdentitySource); ok {
+		if identity := strings.TrimSpace(source.CredentialIdentity(token)); identity != "" {
+			return c.restEndpoint + "\x00" + identity
+		}
+	}
 	sum := sha256.Sum256([]byte(c.restEndpoint + "\x00" + token))
 	return c.restEndpoint + "\x00" + string(sum[:])
 }
@@ -1025,6 +1022,14 @@ func (c *Client) rememberRESTBackoffKey(backoffKey string) {
 		return
 	}
 	c.mu.Lock()
+	if c.restBackoffKey != "" && c.restBackoffKey != backoffKey {
+		c.restBackoffUntil = time.Time{}
+		c.restRateLimitStatus = false
+		c.restRateLimit = connector.RESTRateLimit{}
+		c.restRateLimits = nil
+		c.hasRestRateLimit = false
+		c.restReserveHeld = false
+	}
 	c.restBackoffKey = backoffKey
 	c.mu.Unlock()
 }
@@ -1055,10 +1060,10 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if backoffKey != "" {
-		c.restBackoffKey = backoffKey
+	currentCredential := backoffKey == c.restBackoffKey
+	if currentCredential {
+		c.restRateLimitStatus = c.restRateLimitStatus || rateLimited
 	}
-	c.restRateLimitStatus = c.restRateLimitStatus || rateLimited
 	snapshot := c.restRateLimit
 	if resource != "" && c.restRateLimits != nil {
 		snapshot = c.restRateLimits[resource]
@@ -1092,30 +1097,35 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 	}
 	if hasSnapshot {
 		snapshot.UpdatedAt = now
-		divergenceKey := restDivergenceKey(c.restEndpoint, credentialIdentity, resource)
-		divergence, report := c.restDivergences.observe(
-			divergenceKey,
-			credentialIdentity,
-			snapshot,
-			status != http.StatusNotModified,
-			restDivergenceAttribution(credentialIdentity),
-			c.restPolicy.MinRemainingReserve,
-		)
-		if divergence.ObservedRequests > 0 {
-			if c.restDivergenceKeys == nil {
-				c.restDivergenceKeys = make(map[string]struct{})
+		if path != "/rate_limit" {
+			divergenceKey := restDivergenceKey(c.restEndpoint, credentialIdentity, resource)
+			divergence, report := c.restDivergences.observe(
+				divergenceKey,
+				credentialIdentity,
+				snapshot,
+				status != http.StatusNotModified,
+				restDivergenceAttribution(credentialIdentity),
+				c.restPolicy.MinRemainingReserve,
+			)
+			if divergence.ObservedRequests > 0 {
+				if c.restDivergenceKeys == nil {
+					c.restDivergenceKeys = make(map[string]struct{})
+				}
+				c.restDivergenceKeys[divergenceKey] = struct{}{}
 			}
-			c.restDivergenceKeys[divergenceKey] = struct{}{}
+			c.logRESTUsageDivergence(ctx, divergence, report)
 		}
-		c.logRESTUsageDivergence(ctx, divergence, report)
-		c.restRateLimit = snapshot
-		if resource != "" {
-			if c.restRateLimits == nil {
-				c.restRateLimits = make(map[string]connector.RESTRateLimit)
+		canUpdateQuota := path != "/rate_limit" || !c.hasRestRateLimit && c.restBackoffs.failure(backoffKey) == nil
+		if currentCredential && canUpdateQuota && (rateLimited || !c.restBackoffUntil.After(now)) {
+			c.restRateLimit = snapshot
+			if resource != "" {
+				if c.restRateLimits == nil {
+					c.restRateLimits = make(map[string]connector.RESTRateLimit)
+				}
+				c.restRateLimits[resource] = snapshot
 			}
-			c.restRateLimits[resource] = snapshot
+			c.hasRestRateLimit = true
 		}
-		c.hasRestRateLimit = true
 		if c.restBudgets == nil {
 			c.restBudgets = make(map[string]connector.RESTRateLimitBudget)
 		}
@@ -1176,11 +1186,11 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 
 	if sharedBackoff {
 		backoffUntil := restBackoffUntil(now, retryAfter, hasRetryAfter, resetAt, hasReset, remaining, hasRemaining)
-		if c.restBackoffUntil.IsZero() || backoffUntil.After(c.restBackoffUntil) {
+		if currentCredential && (c.restBackoffUntil.IsZero() || backoffUntil.After(c.restBackoffUntil)) {
 			c.restBackoffUntil = backoffUntil
 		}
 		if c.restBackoffs != nil && backoffKey != "" {
-			c.restBackoffs.set(backoffKey, backoffUntil)
+			c.restBackoffs.set(backoffKey, backoffUntil, method, path, resource)
 		}
 		c.logger.Warn(
 			"github rest shared backoff recorded",
@@ -2112,12 +2122,13 @@ func (c *Client) logRESTUsageDivergence(ctx context.Context, divergence connecto
 }
 
 type restBackoffRegistry struct {
-	mu     sync.RWMutex
-	untils map[string]time.Time
+	mu       sync.RWMutex
+	untils   map[string]time.Time
+	failures map[string]*restRecoveryEvidence
 }
 
 func newRESTBackoffRegistry() *restBackoffRegistry {
-	return &restBackoffRegistry{untils: map[string]time.Time{}}
+	return &restBackoffRegistry{untils: map[string]time.Time{}, failures: map[string]*restRecoveryEvidence{}}
 }
 
 func (r *restBackoffRegistry) until(key string, now time.Time) time.Time {
@@ -2138,7 +2149,7 @@ func (r *restBackoffRegistry) until(key string, now time.Time) time.Time {
 	return time.Time{}
 }
 
-func (r *restBackoffRegistry) set(key string, until time.Time) {
+func (r *restBackoffRegistry) set(key string, until time.Time, method, path, resource string) {
 	if r == nil || strings.TrimSpace(key) == "" || until.IsZero() {
 		return
 	}
@@ -2147,15 +2158,14 @@ func (r *restBackoffRegistry) set(key string, until time.Time) {
 	if current := r.untils[key]; current.IsZero() || until.After(current) {
 		r.untils[key] = until
 	}
-}
-
-func (r *restBackoffRegistry) clear(key string) {
-	if r == nil || strings.TrimSpace(key) == "" {
-		return
+	evidence := &restRecoveryEvidence{resource: resource}
+	if method == http.MethodGet && path != "/rate_limit" {
+		evidence.path = path
+	} else if previous := r.failures[key]; previous != nil {
+		evidence.path = previous.path
+		evidence.resource = previous.resource
 	}
-	r.mu.Lock()
-	delete(r.untils, key)
-	r.mu.Unlock()
+	r.failures[key] = evidence
 }
 
 func restEndpointFamily(method string, path string) string {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -359,7 +359,7 @@ func TestClientGraphQLSuccessfulMutationClearsRateLimitResponse(t *testing.T) {
 	}
 }
 
-func TestConnectorProbeRESTRateLimitClearsRecoveredBackoff(t *testing.T) {
+func TestConnectorProbeRESTRateLimitPreservesRetryAfter(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int64
@@ -375,6 +375,7 @@ func TestConnectorProbeRESTRateLimitClearsRecoveredBackoff(t *testing.T) {
 		w.Header().Set("X-RateLimit-Remaining", "2000")
 		w.Header().Set("X-RateLimit-Used", "3000")
 		w.Header().Set("X-RateLimit-Reset", "2082758400")
+		w.Header().Set("X-RateLimit-Resource", "core")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))
 	}))
@@ -392,18 +393,14 @@ func TestConnectorProbeRESTRateLimitClearsRecoveredBackoff(t *testing.T) {
 	if err := conn.client.REST(context.Background(), http.MethodGet, "/user", nil, nil); !errors.Is(err, ErrRateLimited) {
 		t.Fatalf("REST() error = %v, want ErrRateLimited", err)
 	}
-	rateLimit, err := conn.ProbeRESTRateLimit(context.Background(), 1000)
-	if err != nil {
-		t.Fatalf("ProbeRESTRateLimit() error = %v", err)
+	if _, err := conn.ProbeRESTRateLimit(context.Background(), 1000); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("ProbeRESTRateLimit() error = %v, want ErrRateLimited", err)
 	}
-	if rateLimit.Remaining != 2000 {
-		t.Fatalf("ProbeRESTRateLimit().Remaining = %d, want 2000", rateLimit.Remaining)
+	if err := conn.client.REST(context.Background(), http.MethodGet, "/user", nil, nil); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("REST() during retry-after error = %v, want ErrRateLimited", err)
 	}
-	if err := conn.client.REST(context.Background(), http.MethodGet, "/user", nil, nil); err != nil {
-		t.Fatalf("REST() after recovery error = %v", err)
-	}
-	if got := calls.Load(); got != 3 {
-		t.Fatalf("HTTP calls = %d, want rate limit, probe, recovered request", got)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("HTTP calls = %d, want rate limit and quota probe", got)
 	}
 }
 
@@ -1654,12 +1651,16 @@ func TestClientRESTCredentialIdentityStaysStableAcrossInstallationTokenRotation(
 			source := &InstallationTokenSource{installationID: "4242", cachedToken: "first-token"}
 			client := &Client{restEndpoint: "https://api.github.com", tokenSource: test.source(source)}
 			first := client.restCredentialIdentity("first-token")
+			firstBackoffKey := client.restSharedBackoffKey("first-token")
 			source.mu.Lock()
 			source.cachedToken = "second-token"
 			source.mu.Unlock()
 			second := client.restCredentialIdentity("second-token")
 			if first != "github-app-installation:4242" || second != first {
 				t.Fatalf("identities = %q, %q, want stable installation identity", first, second)
+			}
+			if secondBackoffKey := client.restSharedBackoffKey("second-token"); secondBackoffKey != firstBackoffKey {
+				t.Fatal("installation token rotation changed the shared backoff key")
 			}
 		})
 	}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -298,27 +297,11 @@ func (c *Connector) ProbeGraphQLRateLimit(ctx context.Context) (connector.GraphQ
 }
 
 func (c *Connector) ProbeRESTRateLimit(ctx context.Context, minimumRemaining int64) (connector.RESTRateLimit, error) {
-	result, err := c.client.restProbe(ctx, http.MethodGet, "/rate_limit", nil)
-	if err != nil {
-		return connector.RESTRateLimit{}, err
+	path := "/user"
+	if c.repository.Owner != "" && c.repository.Name != "" {
+		path = "/repos/" + c.repository.Owner + "/" + c.repository.Name + "/issues?per_page=1&state=all"
 	}
-	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
-		return connector.RESTRateLimit{}, classifyStatusAt(result.StatusCode, result.Headers, []byte(result.FullBody), c.now())
-	}
-	if _, ok := int64Header(result.Headers, "X-RateLimit-Limit"); !ok {
-		return connector.RESTRateLimit{}, ErrInvalidResponse
-	}
-	if _, ok := int64Header(result.Headers, "X-RateLimit-Remaining"); !ok {
-		return connector.RESTRateLimit{}, ErrInvalidResponse
-	}
-	usage := c.client.RESTRateLimitStatus()
-	if !usage.HasRateLimit {
-		return connector.RESTRateLimit{}, ErrInvalidResponse
-	}
-	if usage.RateLimit.Remaining > minimumRemaining {
-		c.client.clearRESTBackoff()
-	}
-	return usage.RateLimit, nil
+	return c.client.probeRESTRecovery(ctx, minimumRemaining, path)
 }
 
 func (c *Connector) AuthHealth() (connector.AuthHealth, bool) {

--- a/internal/connector/github/rest_recovery.go
+++ b/internal/connector/github/rest_recovery.go
@@ -1,0 +1,116 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+type restRecoveryEvidence struct {
+	path     string
+	resource string
+}
+
+func (c *Client) probeRESTRecovery(ctx context.Context, minimumRemaining int64, path string) (connector.RESTRateLimit, error) {
+	result, err := c.restProbe(ctx, http.MethodGet, "/rate_limit", nil)
+	if err != nil {
+		return connector.RESTRateLimit{}, err
+	}
+	quota, err := restRecoveryQuota(result, "core", time.Now())
+	if err != nil {
+		return connector.RESTRateLimit{}, err
+	}
+	key := result.backoffKey
+	if err := c.restBackoffError(key, time.Now()); err != nil {
+		return connector.RESTRateLimit{}, err
+	}
+	if quota.Remaining <= minimumRemaining {
+		return quota, nil
+	}
+
+	evidence := c.restBackoffs.failure(key)
+	resource := "core"
+	if path == "/user" && strings.HasPrefix(result.credentialIdentity, "github-app-installation:") {
+		path = "/installation/repositories?per_page=1"
+	}
+	if evidence != nil {
+		resource = evidence.resource
+		if evidence.path != "" {
+			path = evidence.path
+		}
+	}
+	result, err = c.restProbe(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return connector.RESTRateLimit{}, err
+	}
+	quota, err = restRecoveryQuota(result, resource, time.Now())
+	if err != nil {
+		return connector.RESTRateLimit{}, err
+	}
+	if result.backoffKey != key {
+		return connector.RESTRateLimit{}, fmt.Errorf("%w: credential changed during REST recovery", ErrInvalidResponse)
+	}
+	if quota.Remaining <= minimumRemaining {
+		return quota, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.restBackoffKey != key || c.restBackoffUntil.After(time.Now()) || !c.restBackoffs.recover(key, evidence, time.Now()) {
+		return connector.RESTRateLimit{}, fmt.Errorf("%w: newer REST exhaustion evidence", ErrRateLimited)
+	}
+	c.restBackoffUntil = time.Time{}
+	c.restRateLimitStatus = false
+	c.restReserveHeld = false
+	c.restRateLimit = quota
+	if c.restRateLimits == nil {
+		c.restRateLimits = make(map[string]connector.RESTRateLimit)
+	}
+	c.restRateLimits[quota.Resource] = quota
+	c.hasRestRateLimit = true
+	return quota, nil
+}
+
+func restRecoveryQuota(result restProbeResult, resource string, now time.Time) (connector.RESTRateLimit, error) {
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		return connector.RESTRateLimit{}, classifyStatusAt(result.StatusCode, result.Headers, []byte(result.FullBody), now)
+	}
+	limit, hasLimit := int64Header(result.Headers, "X-RateLimit-Limit")
+	remaining, hasRemaining := int64Header(result.Headers, "X-RateLimit-Remaining")
+	reset, hasReset := int64Header(result.Headers, "X-RateLimit-Reset")
+	used, _ := int64Header(result.Headers, "X-RateLimit-Used")
+	actualResource := strings.TrimSpace(result.Headers.Get("X-RateLimit-Resource"))
+	if !hasLimit || limit <= 0 || !hasRemaining || remaining < 0 || remaining > limit || !hasReset || !time.Unix(reset, 0).After(now) || actualResource != resource {
+		return connector.RESTRateLimit{}, ErrInvalidResponse
+	}
+	return connector.RESTRateLimit{
+		Limit: limit, Remaining: remaining, Used: used, Resource: resource,
+		ResetAt: time.Unix(reset, 0).UTC(), UpdatedAt: now,
+	}, nil
+}
+
+func (r *restBackoffRegistry) failure(key string) *restRecoveryEvidence {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.failures[key]
+}
+
+func (r *restBackoffRegistry) recover(key string, evidence *restRecoveryEvidence, now time.Time) bool {
+	if r == nil {
+		return true
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failures[key] != evidence || r.untils[key].After(now) {
+		return false
+	}
+	delete(r.untils, key)
+	delete(r.failures, key)
+	return true
+}

--- a/internal/connector/github/rest_recovery.go
+++ b/internal/connector/github/rest_recovery.go
@@ -37,6 +37,7 @@ func (c *Client) probeRESTRecovery(ctx context.Context, minimumRemaining int64, 
 	if path == "/user" && strings.HasPrefix(result.credentialIdentity, "github-app-installation:") {
 		path = "/installation/repositories?per_page=1"
 	}
+	fallbackPath := path
 	if evidence != nil {
 		resource = evidence.resource
 		if evidence.path != "" {
@@ -46,6 +47,15 @@ func (c *Client) probeRESTRecovery(ctx context.Context, minimumRemaining int64, 
 	result, err = c.restProbe(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return connector.RESTRateLimit{}, err
+	}
+	if path != fallbackPath && (result.StatusCode == http.StatusNotFound || result.StatusCode == http.StatusUnprocessableEntity) {
+		if err := c.restBackoffError(key, time.Now()); err != nil {
+			return connector.RESTRateLimit{}, err
+		}
+		result, err = c.restProbe(ctx, http.MethodGet, fallbackPath, nil)
+		if err != nil {
+			return connector.RESTRateLimit{}, err
+		}
 	}
 	quota, err = restRecoveryQuota(result, resource, time.Now())
 	if err != nil {

--- a/internal/connector/github/rest_recovery_test.go
+++ b/internal/connector/github/rest_recovery_test.go
@@ -104,6 +104,9 @@ func TestRESTRecoveryEvidence(t *testing.T) {
 		value             string
 		credentialChanged bool
 		concurrentFailure bool
+		failedReadStatus  int
+		fallbackStatus    int
+		fallbackResource  string
 		wantErr           error
 	}{
 		{name: "new window with unused bucket"},
@@ -116,6 +119,11 @@ func TestRESTRecoveryEvidence(t *testing.T) {
 		{name: "expired window", omit: "X-RateLimit-Reset", value: "1", wantErr: ErrInvalidResponse},
 		{name: "invalid capacity", omit: "X-RateLimit-Remaining", value: "5001", wantErr: ErrInvalidResponse},
 		{name: "newer shared failure", concurrentFailure: true, wantErr: ErrRateLimited},
+		{name: "deleted recovery resource", failedReadStatus: http.StatusNotFound},
+		{name: "invalid recovery resource", failedReadStatus: http.StatusUnprocessableEntity},
+		{name: "fallback resource mismatch", failedReadStatus: http.StatusNotFound, fallbackResource: "search", wantErr: ErrInvalidResponse},
+		{name: "fallback remains throttled", failedReadStatus: http.StatusNotFound, fallbackStatus: http.StatusForbidden, wantErr: ErrRateLimited},
+		{name: "fallback resource missing", failedReadStatus: http.StatusNotFound, omit: "X-RateLimit-Resource", wantErr: ErrInvalidResponse},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -123,6 +131,7 @@ func TestRESTRecoveryEvidence(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				registry := newRESTBackoffRegistry()
 				seed := true
+				fallbackReads := 0
 				var conn *Connector
 				conn, err := NewConnector(Config{
 					Endpoint:    "https://evidence.test/graphql",
@@ -139,6 +148,18 @@ func TestRESTRecoveryEvidence(t *testing.T) {
 							status = http.StatusForbidden
 							headers.Set("X-RateLimit-Remaining", "0")
 						} else if r.URL.Path != "/rate_limit" {
+							if r.URL.Path == "/user" {
+								fallbackReads++
+								if tt.fallbackStatus != 0 {
+									status = tt.fallbackStatus
+									headers.Set("X-RateLimit-Remaining", "0")
+								}
+								if tt.fallbackResource != "" {
+									headers.Set("X-RateLimit-Resource", tt.fallbackResource)
+								}
+							} else if tt.failedReadStatus != 0 {
+								status = tt.failedReadStatus
+							}
 							if tt.omit != "" {
 								headers.Del(tt.omit)
 								if tt.value != "" {
@@ -156,7 +177,7 @@ func TestRESTRecoveryEvidence(t *testing.T) {
 					t.Fatal(err)
 				}
 				conn.client.restBackoffs = registry
-				if err := conn.client.REST(t.Context(), http.MethodGet, "/user", nil, nil); !errors.Is(err, ErrRateLimited) {
+				if err := conn.client.REST(t.Context(), http.MethodGet, "/repos/example/repo/check-runs/123", nil, nil); !errors.Is(err, ErrRateLimited) {
 					t.Fatal(err)
 				}
 				seed = false
@@ -168,6 +189,9 @@ func TestRESTRecoveryEvidence(t *testing.T) {
 				_, err = conn.ProbeRESTRateLimit(t.Context(), 1000)
 				if !errors.Is(err, tt.wantErr) {
 					t.Fatalf("recovery error = %v, want %v", err, tt.wantErr)
+				}
+				if tt.failedReadStatus != 0 && fallbackReads != 1 {
+					t.Fatalf("fallback reads = %d, want 1", fallbackReads)
 				}
 				if tt.wantErr != nil && registry.failure(conn.client.restSharedBackoffKey("old-token")) == nil {
 					t.Fatal("indeterminate recovery discarded exhaustion evidence")

--- a/internal/connector/github/rest_recovery_test.go
+++ b/internal/connector/github/rest_recovery_test.go
@@ -1,0 +1,225 @@
+package github
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+type recoveryHTTPClient func(*http.Request) (*http.Response, error)
+
+func (f recoveryHTTPClient) Do(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestRESTRecoveryPreservesActualExhaustion(t *testing.T) {
+	t.Parallel()
+	for _, remaining := range []int{5000, 4000} {
+		t.Run(strconv.Itoa(remaining), func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				reset := time.Now().Add(13 * time.Minute).Truncate(time.Second)
+				reads, probes := 0, 0
+				healthy := false
+				conn, err := NewConnector(Config{
+					Endpoint:    "https://example.test/graphql",
+					TokenSource: StaticTokenSource("test-token"),
+					HTTPClient: recoveryHTTPClient(func(r *http.Request) (*http.Response, error) {
+						headers := http.Header{}
+						headers.Set("X-RateLimit-Limit", "5000")
+						headers.Set("X-RateLimit-Resource", "core")
+						status := http.StatusOK
+						if r.URL.Path == "/rate_limit" {
+							probes++
+							headers.Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+							headers.Set("X-RateLimit-Used", strconv.Itoa(5000-remaining))
+							headers.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+						} else {
+							if r.Method != http.MethodGet || r.URL.Path != "/repos/example/repo/issues" {
+								t.Fatalf("unexpected recovery request: %s %s", r.Method, r.URL.Path)
+							}
+							reads++
+							if healthy {
+								headers.Set("X-RateLimit-Remaining", "5000")
+								headers.Set("X-RateLimit-Used", "0")
+								reset = time.Now().Add(time.Hour)
+							} else {
+								status = http.StatusForbidden
+								headers.Set("X-RateLimit-Remaining", "0")
+								headers.Set("X-RateLimit-Used", "5000")
+							}
+							headers.Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+						}
+						return &http.Response{StatusCode: status, Header: headers, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+					}),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				conn.client.restBackoffs = newRESTBackoffRegistry()
+				if err := conn.client.REST(t.Context(), http.MethodGet, "/repos/example/repo/issues", nil, nil); !errors.Is(err, ErrRateLimited) {
+					t.Fatalf("initial request = %v", err)
+				}
+				for range 5 {
+					time.Sleep(35 * time.Second)
+					if _, err := conn.ProbeRESTRateLimit(t.Context(), 1000); !errors.Is(err, ErrRateLimited) {
+						t.Errorf("contradictory probe = %v, want continued throttling", err)
+					}
+					usage := conn.RESTRateLimitStatus()
+					if usage.RateLimit.Remaining != 0 || !usage.BackoffUntil.Equal(reset) {
+						t.Errorf("exhaustion overwritten: %+v", usage)
+					}
+				}
+				if reads != 1 || probes > 5 {
+					t.Fatalf("requests before reset: reads=%d probes=%d", reads, probes)
+				}
+				time.Sleep(time.Until(reset) + time.Second)
+				if _, err := conn.ProbeRESTRateLimit(t.Context(), 1000); !errors.Is(err, ErrRateLimited) {
+					t.Fatalf("repeated real throttling = %v", err)
+				}
+				healthy = true
+				time.Sleep(time.Minute + time.Second)
+				quota, err := conn.ProbeRESTRateLimit(t.Context(), 1000)
+				if err != nil || quota.Remaining != 5000 {
+					t.Fatalf("representative recovery = %+v, %v", quota, err)
+				}
+				if conn.RESTRateLimitStatus().RateLimited {
+					t.Fatal("healthy representative read did not recover")
+				}
+			})
+		})
+	}
+}
+
+func TestRESTRecoveryEvidence(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		omit              string
+		value             string
+		credentialChanged bool
+		concurrentFailure bool
+		wantErr           error
+	}{
+		{name: "new window with unused bucket"},
+		{name: "changed credential before reset", credentialChanged: true},
+		{name: "missing limit", omit: "X-RateLimit-Limit", wantErr: ErrInvalidResponse},
+		{name: "missing remaining", omit: "X-RateLimit-Remaining", wantErr: ErrInvalidResponse},
+		{name: "missing reset", omit: "X-RateLimit-Reset", wantErr: ErrInvalidResponse},
+		{name: "missing resource", omit: "X-RateLimit-Resource", wantErr: ErrInvalidResponse},
+		{name: "wrong resource", omit: "X-RateLimit-Resource", value: "search", wantErr: ErrInvalidResponse},
+		{name: "expired window", omit: "X-RateLimit-Reset", value: "1", wantErr: ErrInvalidResponse},
+		{name: "invalid capacity", omit: "X-RateLimit-Remaining", value: "5001", wantErr: ErrInvalidResponse},
+		{name: "newer shared failure", concurrentFailure: true, wantErr: ErrRateLimited},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				registry := newRESTBackoffRegistry()
+				seed := true
+				var conn *Connector
+				conn, err := NewConnector(Config{
+					Endpoint:    "https://evidence.test/graphql",
+					TokenSource: StaticTokenSource("old-token"),
+					HTTPClient: recoveryHTTPClient(func(r *http.Request) (*http.Response, error) {
+						headers := http.Header{}
+						headers.Set("X-RateLimit-Limit", "5000")
+						headers.Set("X-RateLimit-Remaining", "5000")
+						headers.Set("X-RateLimit-Used", "0")
+						headers.Set("X-RateLimit-Resource", "core")
+						headers.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+						status := http.StatusOK
+						if seed {
+							status = http.StatusForbidden
+							headers.Set("X-RateLimit-Remaining", "0")
+						} else if r.URL.Path != "/rate_limit" {
+							if tt.omit != "" {
+								headers.Del(tt.omit)
+								if tt.value != "" {
+									headers.Set(tt.omit, tt.value)
+								}
+							}
+							if tt.concurrentFailure {
+								registry.set(conn.client.restSharedBackoffKey("old-token"), time.Now().Add(time.Minute), http.MethodGet, "/user", "core")
+							}
+						}
+						return &http.Response{StatusCode: status, Header: headers, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+					}),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				conn.client.restBackoffs = registry
+				if err := conn.client.REST(t.Context(), http.MethodGet, "/user", nil, nil); !errors.Is(err, ErrRateLimited) {
+					t.Fatal(err)
+				}
+				seed = false
+				if tt.credentialChanged {
+					conn.client.tokenSource = StaticTokenSource("new-token")
+				} else {
+					time.Sleep(time.Hour + time.Second)
+				}
+				_, err = conn.ProbeRESTRateLimit(t.Context(), 1000)
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("recovery error = %v, want %v", err, tt.wantErr)
+				}
+				if tt.wantErr != nil && registry.failure(conn.client.restSharedBackoffKey("old-token")) == nil {
+					t.Fatal("indeterminate recovery discarded exhaustion evidence")
+				}
+				if tt.credentialChanged && !registry.until(conn.client.restSharedBackoffKey("old-token"), time.Now()).After(time.Now()) {
+					t.Fatal("changed credential cleared old credential backoff")
+				}
+			})
+		})
+	}
+}
+
+func TestRESTRecoveryFallbackMatchesCredential(t *testing.T) {
+	t.Parallel()
+	for _, installation := range []bool{false, true} {
+		t.Run(strconv.FormatBool(installation), func(t *testing.T) {
+			t.Parallel()
+			source := StaticTokenSource("test-token")
+			path := "/user"
+			if installation {
+				source = &InstallationTokenSource{installationID: "4242", cachedToken: "test-token", expiresAt: time.Now().Add(time.Hour), now: time.Now, details: InstallationTokenDetails{Token: "test-token"}}
+				path = "/installation/repositories?per_page=1"
+			}
+			reads := 0
+			conn, err := NewConnector(Config{
+				Endpoint:    "https://fallback.test/graphql",
+				TokenSource: source,
+				HTTPClient: recoveryHTTPClient(func(r *http.Request) (*http.Response, error) {
+					if r.URL.Path != "/rate_limit" {
+						reads++
+						if r.URL.RequestURI() != path {
+							t.Errorf("recovery path = %s, want %s", r.URL.RequestURI(), path)
+						}
+					}
+					headers := http.Header{}
+					headers.Set("X-RateLimit-Limit", "5000")
+					headers.Set("X-RateLimit-Remaining", "5000")
+					headers.Set("X-RateLimit-Resource", "core")
+					headers.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+					return &http.Response{StatusCode: http.StatusOK, Header: headers, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+				}),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.client.restBackoffs = newRESTBackoffRegistry()
+			if _, err := conn.ProbeRESTRateLimit(t.Context(), 1000); err != nil {
+				t.Fatal(err)
+			}
+			if reads != 1 {
+				t.Fatalf("representative reads = %d, want 1", reads)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/github_lookup_backoff.go
+++ b/internal/orchestrator/github_lookup_backoff.go
@@ -157,10 +157,14 @@ func (o *Orchestrator) probeGitHubRESTLookupBackoff(
 	outage.LastProbeAt = now.UTC()
 	rateLimit, err := prober.ProbeRESTRateLimit(ctx, o.cfg.GitHubRESTMinReserve)
 	if err != nil {
+		resetAt := outage.ResetAt
+		if signal, active := o.currentGitHubLookupSignal(state, now); active && signal.trigger == githubLookupTriggerREST && signal.resetAt.After(resetAt) {
+			resetAt = signal.resetAt
+		}
 		o.advanceGitHubLookupBackoff(state, outage, githubLookupSignal{
 			trigger: githubLookupTriggerREST,
 			reason:  "GitHub REST rate-limit probe failed: " + err.Error(),
-			resetAt: outage.ResetAt,
+			resetAt: resetAt,
 		}, now, time.Time{})
 		return true
 	}
@@ -179,7 +183,7 @@ func (o *Orchestrator) probeGitHubRESTLookupBackoff(
 	}
 
 	outage.LastProbeResult = "capacity_available"
-	outage.LastProbeDetail = fmt.Sprintf("GitHub REST probe reports %d remaining", rateLimit.Remaining)
+	outage.LastProbeDetail = fmt.Sprintf("GitHub REST recovery read confirms %d remaining", rateLimit.Remaining)
 	if signal, active := o.currentGitHubLookupSignal(state, now); active {
 		o.advanceGitHubLookupBackoff(state, outage, signal, now, time.Time{})
 		return true

--- a/internal/orchestrator/github_rest_recovery_test.go
+++ b/internal/orchestrator/github_rest_recovery_test.go
@@ -1,0 +1,107 @@
+package orchestrator
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+type restRecoveryHTTPClient func(*http.Request) (*http.Response, error)
+
+func (f restRecoveryHTTPClient) Do(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestGitHubRESTOutageSurvivesContradictoryProbes(t *testing.T) {
+	t.Parallel()
+	for _, remaining := range []int{5000, 4000} {
+		t.Run(strconv.Itoa(remaining), func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				started := time.Now()
+				reset := started.Add(13 * time.Minute)
+				healthy := false
+				reads, probes := 0, 0
+				tracker, err := github.NewConnector(github.Config{
+					Endpoint:    fmt.Sprintf("https://recovery-%d.test/graphql", remaining),
+					Repository:  "example/repo",
+					TokenSource: github.StaticTokenSource("test-token"),
+					HTTPClient: restRecoveryHTTPClient(func(r *http.Request) (*http.Response, error) {
+						headers := http.Header{}
+						headers.Set("X-RateLimit-Limit", "5000")
+						headers.Set("X-RateLimit-Resource", "core")
+						status := http.StatusOK
+						headers.Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+						headers.Set("X-RateLimit-Used", strconv.Itoa(5000-remaining))
+						headers.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+						if r.URL.Path == "/rate_limit" {
+							probes++
+						} else {
+							reads++
+							if !healthy {
+								status = http.StatusForbidden
+								headers.Set("X-RateLimit-Remaining", "0")
+								headers.Set("X-RateLimit-Used", "5000")
+								headers.Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+							}
+						}
+						return &http.Response{StatusCode: status, Header: headers, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+					}),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := tracker.RepositoryMergeSettings(t.Context(), "example/repo"); !errors.Is(err, github.ErrRateLimited) {
+					t.Fatalf("seed = %v", err)
+				}
+				cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, GitHubRESTMinReserve: 1000})
+				orch := newRateLimitTestOrchestrator(cfg, tracker)
+				var logs bytes.Buffer
+				orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+				state := newState(cfg)
+				if !orch.githubLookupBackoffGate(t.Context(), &state, time.Now()) {
+					t.Fatal("initial outage missing")
+				}
+				for step := 1; step <= 6; step++ {
+					_, outage, active := githubLookupBackoff(state.BackendOutages)
+					if !active || outage.ProbeAttempts != step || !outage.DetectedAt.Equal(started) {
+						t.Fatalf("outage lost continuity: %+v", outage)
+					}
+					if !orch.githubLookupBackoffGate(t.Context(), &state, time.Now()) {
+						t.Fatal("early recovery")
+					}
+					time.Sleep(time.Until(outage.NextProbeAt))
+					if !orch.githubLookupBackoffGate(t.Context(), &state, time.Now()) {
+						t.Fatal("contradictory quota recovered outage")
+					}
+				}
+				if strings.Contains(logs.String(), "github lookup backoff recovered") {
+					t.Fatal("false recovery event")
+				}
+				if reads != 3 || probes != 6 {
+					t.Fatalf("outage requests: reads=%d probes=%d, want 3/6", reads, probes)
+				}
+				healthy = true
+				_, outage, _ := githubLookupBackoff(state.BackendOutages)
+				time.Sleep(time.Until(outage.NextProbeAt))
+				if orch.githubLookupBackoffGate(t.Context(), &state, time.Now()) {
+					t.Fatal("representative success did not recover")
+				}
+				if strings.Count(logs.String(), "github lookup backoff recovered") != 1 || !strings.Contains(logs.String(), "backoff_steps=7") {
+					t.Fatalf("recovery telemetry: %s", logs.String())
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve actual REST exhaustion and reset/retry-after deadlines when quota probes contradict failed requests. Require a successful representative GET with matching credential/resource evidence before recovery; reject incomplete responses and newer concurrent throttling. If a remembered read target disappears with 404/422, use one stable credential-appropriate fallback while retaining the resource and deadline checks.
- Keep lookup outage history and exponential backoff continuous until confirmed recovery, including changed credentials and installation token rotation. Preserve existing cached inspection behavior.
- Add deterministic regressions for the recorded full-bucket/403 sequence, legitimate unused buckets, retry deadlines, credential changes, and recovery telemetry. The recorded loop explains avoidable retries; broader quota consumption remains unattributed.

Fixes #2357

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, first-viewport, or responsive visibility change.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Focused connector and orchestrator recovery regressions after rebasing onto main.
- [x] `make check CHECK_LOCK_WAIT=90m GO_TEST="env -u DETENT_API_TOKEN go test -p 2"`: all checks passed; overall coverage 80.4%, with all package/file floors satisfied.
- [x] Regressions fail before the corresponding fixes for contradictory 5000/4000 buckets and disappearing 404/422 recovery targets. They pass with the fixes, including rejection of wrong/missing fallback evidence and continued throttling.
- [x] All 11 CI checks passed on `47c91969` (run 34314494525); Windows portability passed on retry.

The initial full race run hit four unchanged watcher wait timeouts. Ten isolated watcher race runs passed, followed by the complete gate with package concurrency limited to two. Follow-up: #2375. Windows CI also hit an unchanged Hub outbox shutdown timeout; ten isolated local race runs and the unchanged CI retry passed. Follow-up: #2389.
