### PR TITLE
fix(runtime): refresh orphan completion lease

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1762,6 +1762,7 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 		turnPrompt = orphanResumePrompt
 		if req.WorkAttemptID > 0 && req.Generation > 0 {
 			turnPrompt = appendBlockedHandoffBlock(turnPrompt+"\n\nThe current attempt fields below supersede any completion lease values in earlier provider history. Use these values for the completion handshake when this attempt succeeds.", promptOptions)
+			turnPrompt = appendNativeIssueInstructions(turnPrompt, req.Issue)
 		}
 	}
 	var extraWritableRoots []string

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1760,6 +1760,9 @@ func (r *Runner) run(ctx context.Context, req RunRequest) (RunResult, error) {
 	turnPrompt := prompt
 	if req.ForgeRetry == nil && orphanRecovery && !agentResumeStateEmpty(resumeState) {
 		turnPrompt = orphanResumePrompt
+		if req.WorkAttemptID > 0 && req.Generation > 0 {
+			turnPrompt = appendBlockedHandoffBlock(turnPrompt+"\n\nThe current attempt fields below supersede any completion lease values in earlier provider history. Use these values for the completion handshake when this attempt succeeds.", promptOptions)
+		}
 	}
 	var extraWritableRoots []string
 	if req.Admission == nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2767,6 +2767,75 @@ func TestRunnerRunPersistsResumedSessionDeltaAndCumulativeCost(t *testing.T) {
 	}
 }
 
+func TestRunnerRunCompletionLeaseOnOrphanResume(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		workAttemptID int64
+		generation    uint64
+		orphaned      bool
+	}{
+		{name: "initial", workAttemptID: 4898, generation: 17},
+		{name: "resumed", workAttemptID: 4917, generation: 18, orphaned: true},
+		{name: "resumed again", workAttemptID: 4925, generation: 19, orphaned: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := &fakeCodexClient{}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{Config: config.Config{}, Prompt: "Implement the issue"},
+				Workspace: &fakeWorkspaceBackend{
+					info: workspace.Info{Path: t.TempDir(), Key: "issue-2355", Branch: "detent/issue-2355"},
+				},
+				AgentBackend: backend,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+			req := RunRequest{
+				Issue:         connector.Issue{ID: "issue-2355", Identifier: "digitaldrywood/detent#2355", ModelOverride: "gpt-5.6-codex"},
+				WorkAttemptID: tt.workAttemptID,
+				Generation:    tt.generation,
+			}
+			if tt.orphaned {
+				req.RetryMode = RetryModeResume
+				req.ResumeState = store.AgentResumeState{
+					DetentSessionID: 5811, ProviderThreadID: "original-thread", RequestedModel: "gpt-5.6-codex",
+					AgentBackendID: "codex", AgentBackendKind: "codex", AgentRole: RoleCode, Orphaned: true,
+				}
+			}
+			if _, err := runner.Run(context.Background(), req); err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			prompt := backend.request.Prompt
+			for _, want := range []string{
+				fmt.Sprintf("completion_work_attempt_id: %q", strconv.FormatInt(tt.workAttemptID, 10)),
+				fmt.Sprintf("completion_generation: %q", strconv.FormatUint(tt.generation, 10)),
+				"Detent owns the completion-lane transition",
+			} {
+				if !strings.Contains(prompt, want) {
+					t.Errorf("prompt missing %q", want)
+				}
+			}
+			if tt.orphaned {
+				if backend.request.Resume.ThreadID != "original-thread" {
+					t.Errorf("resume thread = %q, want original-thread", backend.request.Resume.ThreadID)
+				}
+				if !strings.HasPrefix(prompt, orphanResumePrompt) || !strings.Contains(prompt, "supersede any completion lease values in earlier provider history") {
+					t.Error("resume prompt must preserve restart instruction and supersede historical completion leases")
+				}
+				for _, stale := range []string{`completion_work_attempt_id: "4898"`, `completion_generation: "17"`} {
+					if strings.Contains(prompt, stale) {
+						t.Errorf("resume prompt contains stale lease %q", stale)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestRunnerRunResumesOrphanedSessionWithRestartPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2775,10 +2775,13 @@ func TestRunnerRunCompletionLeaseOnOrphanResume(t *testing.T) {
 		workAttemptID int64
 		generation    uint64
 		orphaned      bool
+		native        bool
 	}{
 		{name: "initial", workAttemptID: 4898, generation: 17},
 		{name: "resumed", workAttemptID: 4917, generation: 18, orphaned: true},
 		{name: "resumed again", workAttemptID: 4925, generation: 19, orphaned: true},
+		{name: "native initial", workAttemptID: 4898, generation: 17, native: true},
+		{name: "native resumed", workAttemptID: 4917, generation: 18, orphaned: true, native: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -2799,6 +2802,9 @@ func TestRunnerRunCompletionLeaseOnOrphanResume(t *testing.T) {
 				WorkAttemptID: tt.workAttemptID,
 				Generation:    tt.generation,
 			}
+			if tt.native {
+				req.Issue.Metadata = map[string]string{"hub_profile": "native", "hub_project_id": "project-2355"}
+			}
 			if tt.orphaned {
 				req.RetryMode = RetryModeResume
 				req.ResumeState = store.AgentResumeState{
@@ -2810,6 +2816,17 @@ func TestRunnerRunCompletionLeaseOnOrphanResume(t *testing.T) {
 				t.Fatalf("Run() error = %v", err)
 			}
 			prompt := backend.request.Prompt
+			if tt.native {
+				authority := strings.Index(prompt, "## Native Detent issue authority")
+				if authority < 0 || authority < strings.LastIndex(prompt, "gh api --method POST") {
+					t.Error("native authority must follow GitHub dependency instructions")
+				}
+				for _, want := range []string{"detent hub issue", "Use --project project-2355 and work-item issue-2355", "do not use gh issue, GitHub issue labels, or GitHub issue comments"} {
+					if !strings.Contains(prompt, want) {
+						t.Errorf("native prompt missing %q", want)
+					}
+				}
+			}
 			for _, want := range []string{
 				fmt.Sprintf("completion_work_attempt_id: %q", strconv.FormatInt(tt.workAttemptID, 10)),
 				fmt.Sprintf("completion_generation: %q", strconv.FormatUint(tt.generation, 10)),


### PR DESCRIPTION
## Summary

- Refresh orphan-session resume instructions with the current completion attempt ID and generation, explicitly superseding lease values in provider history.
- Preserve the provider thread and existing work through the existing handoff renderer, without changing completion ownership or handshake validation.
- Restore native Detent tracker authority after the handoff so native workers use the correct issue and dependency commands.
- Cover initial and repeated resumed lease values, stale-value exclusion, provider thread preservation, and native tracker authority with stdlib table-driven tests.

Fixes #2355

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual changes.

## Test Plan

- [x] Focused completion-lease and orphan-resume tests pass on the rebased head.
- [x] Prior regression verification: resumed leases failed before the lease fix; native resume authority failed before the review correction.
- [x] `make check` on 126f4522: build, lint, vet, NilAway, race suites, 80.4% coverage, and all configured coverage floors passed.
