### PR TITLE
fix(github): scope REST reserves to core

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -487,6 +487,14 @@ pages never create a condition or influence dispatch and recovery. Statuspage
 incident webhooks are a possible future optimization, not part of the current
 polling integration.
 
+The tracker setting `github_rest_min_remaining_reserve` is an absolute reserve
+for the REST `core` resource (default `1000`). It does not reserve requests in
+smaller resources such as `search`; those resources still enforce GitHub's
+primary and secondary rate limits and shared backoff. Recovery probes and
+reserve diagnostics use the same resource rule. Responses without a resource
+name retain the core reserve for compatibility. No configuration migration or
+new setting is required; the worker's separate core-budget policy is unchanged.
+
 ### Workspace, deliverable, and worker placement
 
 `workspace` controls isolation, source and output roots, branch creation, cache

--- a/docs/config.md
+++ b/docs/config.md
@@ -490,8 +490,10 @@ polling integration.
 The tracker setting `github_rest_min_remaining_reserve` is an absolute reserve
 for the REST `core` resource (default `1000`). It does not reserve requests in
 smaller resources such as `search`; those resources still enforce GitHub's
-primary and secondary rate limits and shared backoff. Recovery probes and
-reserve diagnostics use the same resource rule. Responses without a resource
+primary and secondary rate limits and shared backoff. Recovery probes,
+reserve diagnostics, and scheduler lookup gates use the same resource rule.
+The aggregate REST quota snapshot retains core capacity; resource-specific
+budgets continue to report search usage separately. Responses without a resource
 name retain the core reserve for compatibility. No configuration migration or
 new setting is required; the worker's separate core-budget policy is unchanged.
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -868,7 +868,7 @@ func (c *Client) restBudgetPolicyError(ctx context.Context, credentialIdentity s
 
 	resource := restEndpointRateLimitResource(family)
 	rateLimit, hasRateLimit := c.restRateLimitForResourceLocked(resource)
-	reserve := restResourceReserve(resource, c.restPolicy.MinRemainingReserve)
+	reserve := RESTResourceReserve(resource, c.restPolicy.MinRemainingReserve)
 	requestCost := restFanoutCostUnitsPerRequest
 	if conditional {
 		requestCost = restConditionalFanoutCostUnits
@@ -929,7 +929,7 @@ func (c *Client) restBudgetPolicyError(ctx context.Context, credentialIdentity s
 	return nil
 }
 
-func restResourceReserve(resource string, coreReserve int64) int64 {
+func RESTResourceReserve(resource string, coreReserve int64) int64 {
 	if resource == "" || resource == "core" {
 		return max(coreReserve, 0)
 	}
@@ -998,7 +998,7 @@ func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, metho
 		"credential_identity", credentialIdentity,
 		"resource", rateLimit.Resource,
 		"remaining", rateLimit.Remaining,
-		"reserve", restResourceReserve(rateLimit.Resource, c.restPolicy.MinRemainingReserve),
+		"reserve", RESTResourceReserve(rateLimit.Resource, c.restPolicy.MinRemainingReserve),
 		"gate_branch", branch,
 		"fanout_count", fanoutCount,
 		"fanout_cap", c.restPolicy.FanoutMaxRequests,
@@ -1114,7 +1114,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 				snapshot,
 				status != http.StatusNotModified,
 				restDivergenceAttribution(credentialIdentity),
-				restResourceReserve(resource, c.restPolicy.MinRemainingReserve),
+				RESTResourceReserve(resource, c.restPolicy.MinRemainingReserve),
 			)
 			if divergence.ObservedRequests > 0 {
 				if c.restDivergenceKeys == nil {
@@ -2126,7 +2126,7 @@ func (c *Client) logRESTUsageDivergence(ctx context.Context, divergence connecto
 		"window_started_at", divergence.WindowStartedAt,
 		"last_observed_at", divergence.LastObservedAt,
 		"reset_at", divergence.ResetAt,
-		"reserve", restResourceReserve(divergence.Resource, c.restPolicy.MinRemainingReserve),
+		"reserve", RESTResourceReserve(divergence.Resource, c.restPolicy.MinRemainingReserve),
 	)
 }
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -866,7 +866,9 @@ func (c *Client) restBudgetPolicyError(ctx context.Context, credentialIdentity s
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	rateLimit, hasRateLimit := c.restRateLimitForResourceLocked(restEndpointRateLimitResource(family))
+	resource := restEndpointRateLimitResource(family)
+	rateLimit, hasRateLimit := c.restRateLimitForResourceLocked(resource)
+	reserve := restResourceReserve(resource, c.restPolicy.MinRemainingReserve)
 	requestCost := restFanoutCostUnitsPerRequest
 	if conditional {
 		requestCost = restConditionalFanoutCostUnits
@@ -905,12 +907,12 @@ func (c *Client) restBudgetPolicyError(ctx context.Context, credentialIdentity s
 			}
 		}
 	}
-	if c.restPolicy.MinRemainingReserve > 0 &&
+	if reserve > 0 &&
 		!conditional &&
 		hasRateLimit &&
 		rateLimit.Limit > 0 &&
 		!restRateLimitSnapshotExpired(rateLimit, now) &&
-		rateLimit.Remaining <= c.restPolicy.MinRemainingReserve {
+		rateLimit.Remaining <= reserve {
 		if reservedScoped {
 			budget.Add(-requestCost)
 		}
@@ -925,6 +927,13 @@ func (c *Client) restBudgetPolicyError(ctx context.Context, credentialIdentity s
 		c.restFanoutUnits += requestCost
 	}
 	return nil
+}
+
+func restResourceReserve(resource string, coreReserve int64) int64 {
+	if resource == "" || resource == "core" {
+		return max(coreReserve, 0)
+	}
+	return 0
 }
 
 func restRateLimitSnapshotExpired(rateLimit connector.RESTRateLimit, now time.Time) bool {
@@ -989,7 +998,7 @@ func (c *Client) recordRESTBudgetThrottleLocked(credentialIdentity string, metho
 		"credential_identity", credentialIdentity,
 		"resource", rateLimit.Resource,
 		"remaining", rateLimit.Remaining,
-		"reserve", c.restPolicy.MinRemainingReserve,
+		"reserve", restResourceReserve(rateLimit.Resource, c.restPolicy.MinRemainingReserve),
 		"gate_branch", branch,
 		"fanout_count", fanoutCount,
 		"fanout_cap", c.restPolicy.FanoutMaxRequests,
@@ -1105,7 +1114,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 				snapshot,
 				status != http.StatusNotModified,
 				restDivergenceAttribution(credentialIdentity),
-				c.restPolicy.MinRemainingReserve,
+				restResourceReserve(resource, c.restPolicy.MinRemainingReserve),
 			)
 			if divergence.ObservedRequests > 0 {
 				if c.restDivergenceKeys == nil {
@@ -2117,7 +2126,7 @@ func (c *Client) logRESTUsageDivergence(ctx context.Context, divergence connecto
 		"window_started_at", divergence.WindowStartedAt,
 		"last_observed_at", divergence.LastObservedAt,
 		"reset_at", divergence.ResetAt,
-		"reserve", c.restPolicy.MinRemainingReserve,
+		"reserve", restResourceReserve(divergence.Resource, c.restPolicy.MinRemainingReserve),
 	)
 }
 

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -2754,13 +2754,16 @@ func TestConnectorRESTResourceReserveRecovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				limit := 5000
-				if tt.resource == "search" {
+				resource, limit, remaining := tt.resource, 5000, tt.remaining
+				if resource == "search" {
 					limit = 30
 				}
+				if r.URL.Path == "/rate_limit" {
+					resource, limit, remaining = "core", 5000, 4900
+				}
 				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
-				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(tt.remaining))
-				w.Header().Set("X-RateLimit-Resource", tt.resource)
+				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+				w.Header().Set("X-RateLimit-Resource", resource)
 				w.Header().Set("X-RateLimit-Reset", "4070908800")
 				_, _ = w.Write([]byte(`{}`))
 			}))
@@ -2769,21 +2772,24 @@ func TestConnectorRESTResourceReserveRecovery(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			conn.client.restBackoffs = newRESTBackoffRegistry()
-			conn.client.restBackoffUntil = time.Now().Add(time.Hour)
-			if _, err := conn.ProbeRESTRateLimit(context.Background(), 1000); err != nil {
-				t.Fatal(err)
-			}
 			path := "/repos/o/r/pulls"
 			if tt.resource == "search" {
 				path = "/search/issues"
 			}
-			err = conn.client.REST(context.Background(), http.MethodGet, path, nil, nil)
-			if errors.Is(err, ErrRateLimited) != tt.wantHeld {
-				t.Fatalf("REST after recovery = %v, want held %v", err, tt.wantHeld)
-			}
-			if !tt.wantHeld && err != nil {
+			key := conn.client.restSharedBackoffKey("test")
+			conn.client.restBackoffs = newRESTBackoffRegistry()
+			conn.client.restBackoffs.set(key, time.Now().Add(-time.Minute), http.MethodGet, path, tt.resource)
+			conn.client.restBackoffKey = key
+			conn.client.restRateLimitStatus = true
+			quota, err := conn.ProbeRESTRateLimit(t.Context(), 1000)
+			if err != nil {
 				t.Fatal(err)
+			}
+			if quota.Resource != tt.resource || quota.Remaining != int64(tt.remaining) {
+				t.Fatalf("recovery quota = %#v, want resource %s remaining %d", quota, tt.resource, tt.remaining)
+			}
+			if held := conn.RESTRateLimitStatus().RateLimited; held != tt.wantHeld {
+				t.Fatalf("REST after recovery held = %v, want %v", held, tt.wantHeld)
 			}
 		})
 	}

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -2634,3 +2634,157 @@ func (s *refreshingTokenTestSource) RefreshToken(ctx context.Context) (string, e
 	s.token = s.refreshToken
 	return s.token, nil
 }
+
+func TestClientRESTSearchReserveAndRateLimits(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		status    int
+		remaining string
+		want      error
+		wantCalls int
+	}{
+		{name: "healthy search", status: http.StatusOK, remaining: "29", wantCalls: 2},
+		{name: "primary exhaustion", status: http.StatusForbidden, remaining: "0", want: ErrRateLimited, wantCalls: 1},
+		{name: "secondary throttle", status: http.StatusTooManyRequests, remaining: "29", want: ErrRateLimited, wantCalls: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var calls int
+			var logs bytes.Buffer
+			client, err := NewClient(ClientConfig{
+				Endpoint:    "https://github-search-reserve.test",
+				TokenSource: StaticTokenSource("test"),
+				RESTPolicy:  RESTBudgetPolicy{MinRemainingReserve: 1000},
+				Logger:      slog.New(slog.NewTextHandler(&logs, nil)),
+				HTTPClient: staticHTTPClient{do: func(r *http.Request) (*http.Response, error) {
+					calls++
+					headers := http.Header{}
+					headers.Set("X-RateLimit-Limit", "30")
+					headers.Set("X-RateLimit-Remaining", tt.remaining)
+					if tt.want == nil && calls == 2 {
+						headers.Set("X-RateLimit-Remaining", "27")
+					}
+					headers.Set("X-RateLimit-Resource", "search")
+					headers.Set("X-RateLimit-Reset", "4070908800")
+					if tt.want != nil {
+						headers.Set("Retry-After", "60")
+					}
+					return jsonResponse(r, tt.status, `{}`, headers), nil
+				}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			client.restBackoffs = newRESTBackoffRegistry()
+			client.restDivergences = newRESTDivergenceRegistry()
+			for range 2 {
+				err := client.REST(context.Background(), http.MethodGet, "/search/issues", nil, nil)
+				if !errors.Is(err, tt.want) {
+					t.Fatalf("REST error = %v, want %v", err, tt.want)
+				}
+			}
+			if calls != tt.wantCalls {
+				t.Fatalf("HTTP calls = %d, want %d", calls, tt.wantCalls)
+			}
+			if strings.Contains(logs.String(), "report_reason=reserve_threat") {
+				t.Fatalf("search incorrectly threatened core reserve: %s", logs.String())
+			}
+		})
+	}
+}
+
+func TestClientRESTResourceReserveAdmission(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name            string
+		path            string
+		coreRemaining   int64
+		searchRemaining int64
+		conditional     bool
+		expired         bool
+		want            error
+	}{
+		{name: "healthy search with reserved core", path: "/search/issues", coreRemaining: 900, searchRemaining: 29},
+		{name: "last search request", path: "/search/issues", coreRemaining: 4900, searchRemaining: 1},
+		{name: "core at reserve", path: "/repos/o/r/pulls", coreRemaining: 1000, searchRemaining: 29, want: ErrRESTBudgetReserved},
+		{name: "core above reserve with empty search", path: "/repos/o/r/pulls", coreRemaining: 1001, searchRemaining: 0},
+		{name: "conditional core at reserve", path: "/repos/o/r/pulls", coreRemaining: 1000, conditional: true},
+		{name: "expired core reserve", path: "/repos/o/r/pulls", coreRemaining: 900, expired: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reset := now.Add(time.Hour)
+			if tt.expired {
+				reset = now.Add(-time.Hour)
+			}
+			client := &Client{
+				logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+				restPolicy: RESTBudgetPolicy{MinRemainingReserve: 1000},
+				restRateLimits: map[string]connector.RESTRateLimit{
+					"core":   {Resource: "core", Limit: 5000, Remaining: tt.coreRemaining, ResetAt: reset},
+					"search": {Resource: "search", Limit: 30, Remaining: tt.searchRemaining, ResetAt: reset},
+				},
+			}
+			err := client.restBudgetPolicyError(context.Background(), "test", http.MethodGet, tt.path, tt.conditional, now)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("admission error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectorRESTResourceReserveRecovery(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		resource  string
+		remaining int
+		wantHeld  bool
+	}{
+		{name: "healthy search", resource: "search", remaining: 29},
+		{name: "exhausted search", resource: "search", remaining: 0, wantHeld: true},
+		{name: "core at reserve", resource: "core", remaining: 1000, wantHeld: true},
+		{name: "healthy core", resource: "core", remaining: 1001},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				limit := 5000
+				if tt.resource == "search" {
+					limit = 30
+				}
+				w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit))
+				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(tt.remaining))
+				w.Header().Set("X-RateLimit-Resource", tt.resource)
+				w.Header().Set("X-RateLimit-Reset", "4070908800")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+			conn, err := NewConnector(Config{Endpoint: server.URL, TokenSource: StaticTokenSource("test"), HTTPClient: server.Client(), RESTMinRemainingReserve: 1000})
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.client.restBackoffs = newRESTBackoffRegistry()
+			conn.client.restBackoffUntil = time.Now().Add(time.Hour)
+			if _, err := conn.ProbeRESTRateLimit(context.Background(), 1000); err != nil {
+				t.Fatal(err)
+			}
+			path := "/repos/o/r/pulls"
+			if tt.resource == "search" {
+				path = "/search/issues"
+			}
+			err = conn.client.REST(context.Background(), http.MethodGet, path, nil, nil)
+			if errors.Is(err, ErrRateLimited) != tt.wantHeld {
+				t.Fatalf("REST after recovery = %v, want held %v", err, tt.wantHeld)
+			}
+			if !tt.wantHeld && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/internal/connector/github/rest_recovery.go
+++ b/internal/connector/github/rest_recovery.go
@@ -28,7 +28,7 @@ func (c *Client) probeRESTRecovery(ctx context.Context, minimumRemaining int64, 
 	if err := c.restBackoffError(key, time.Now()); err != nil {
 		return connector.RESTRateLimit{}, err
 	}
-	if quota.Remaining <= minimumRemaining {
+	if quota.Remaining <= RESTResourceReserve(quota.Resource, minimumRemaining) {
 		return quota, nil
 	}
 
@@ -64,7 +64,7 @@ func (c *Client) probeRESTRecovery(ctx context.Context, minimumRemaining int64, 
 	if result.backoffKey != key {
 		return connector.RESTRateLimit{}, fmt.Errorf("%w: credential changed during REST recovery", ErrInvalidResponse)
 	}
-	if quota.Remaining <= minimumRemaining {
+	if quota.Remaining <= RESTResourceReserve(quota.Resource, minimumRemaining) {
 		return quota, nil
 	}
 	c.mu.Lock()

--- a/internal/orchestrator/github_lookup_backoff.go
+++ b/internal/orchestrator/github_lookup_backoff.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -169,13 +170,14 @@ func (o *Orchestrator) probeGitHubRESTLookupBackoff(
 		return true
 	}
 	o.captureGitHubRESTLookupProbe(state, rateLimit, now)
-	if rateLimit.Limit <= 0 || rateLimit.Remaining <= o.cfg.GitHubRESTMinReserve {
+	reserve := github.RESTResourceReserve(rateLimit.Resource, o.cfg.GitHubRESTMinReserve)
+	if rateLimit.Limit <= 0 || rateLimit.Remaining <= reserve {
 		o.advanceGitHubLookupBackoff(state, outage, githubLookupSignal{
 			trigger: githubLookupTriggerREST,
 			reason: fmt.Sprintf(
 				"GitHub REST remaining %d is at or below lookup floor %d",
 				rateLimit.Remaining,
-				o.cfg.GitHubRESTMinReserve,
+				reserve,
 			),
 			resetAt: rateLimit.ResetAt,
 		}, now, time.Time{})
@@ -279,7 +281,7 @@ func (o *Orchestrator) currentGitHubLookupSignal(state *State, now time.Time) (g
 				reason: fmt.Sprintf(
 					"GitHub REST remaining %d is at or below lookup floor %d",
 					usage.RateLimit.Remaining,
-					o.cfg.GitHubRESTMinReserve,
+					github.RESTResourceReserve(usage.RateLimit.Resource, o.cfg.GitHubRESTMinReserve),
 				),
 				resetAt: usage.RateLimit.ResetAt,
 			}, true
@@ -325,8 +327,8 @@ func graphQLLookupReserveExceeded(rateLimit connector.GraphQLRateLimit, floor in
 }
 
 func restLookupReserveExceeded(rateLimit connector.RESTRateLimit, hasRateLimit bool, floor int64, now time.Time) bool {
-	return floor > 0 &&
-		hasRateLimit &&
+	floor = github.RESTResourceReserve(rateLimit.Resource, floor)
+	return hasRateLimit &&
 		rateLimit.Limit > 0 &&
 		rateLimit.Remaining <= floor &&
 		(rateLimit.ResetAt.IsZero() || !now.After(rateLimit.ResetAt.Add(githubRateLimitResetSkew)))
@@ -431,10 +433,12 @@ func (o *Orchestrator) captureGitHubRESTLookupProbe(state *State, rateLimit conn
 	if state.RateLimits == nil {
 		state.RateLimits = &telemetry.RateLimits{}
 	}
-	state.RateLimits.GitHubREST = gitHubRESTBucket(connector.RESTRateLimitUsage{
+	if bucket := gitHubRESTBucket(connector.RESTRateLimitUsage{
 		RateLimit:    rateLimit,
 		HasRateLimit: true,
-	}, now)
+	}, now); bucket != nil {
+		state.RateLimits.GitHubREST = bucket
+	}
 	state.RateLimits.RESTUsage = nil
 }
 

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -2151,3 +2151,95 @@ type rateLimitWorkspaceReaper struct{}
 func (rateLimitWorkspaceReaper) ReapWorkspace(context.Context, connector.Issue) (WorkspaceReapResult, error) {
 	return WorkspaceReapResult{}, nil
 }
+
+func TestGitHubRESTResourceReserveLookupAdmission(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		resource    string
+		remaining   int64
+		rateLimited bool
+		backoff     bool
+		priorCore   bool
+		wantHeld    bool
+	}{
+		{name: "healthy search", resource: "search", remaining: 29},
+		{name: "core at reserve", resource: "core", remaining: 1000, wantHeld: true},
+		{name: "unnamed core at reserve", remaining: 1000, wantHeld: true},
+		{name: "healthy core", resource: "core", remaining: 1001},
+		{name: "exhausted search snapshot", resource: "search", wantHeld: true},
+		{name: "primary search throttle", resource: "search", rateLimited: true, wantHeld: true},
+		{name: "secondary search backoff", resource: "search", remaining: 29, backoff: true, wantHeld: true},
+		{name: "search preserves core reserve", resource: "search", remaining: 29, priorCore: true, wantHeld: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{GitHubRESTMinReserve: 1000})
+			usage := connector.RESTRateLimitUsage{HasRateLimit: true, RateLimited: tt.rateLimited,
+				RateLimit: connector.RESTRateLimit{Resource: tt.resource, Limit: 5000, Remaining: tt.remaining, ResetAt: now.Add(time.Hour)},
+			}
+			if tt.resource == "search" {
+				usage.RateLimit.Limit = 30
+			}
+			if tt.backoff {
+				usage.BackoffUntil = now.Add(time.Minute)
+			}
+			tracker := &rateLimitConnector{restStatus: usage, restUsage: usage}
+			orch := newRateLimitTestOrchestrator(cfg, tracker)
+			state := newState(cfg)
+			if tt.priorCore {
+				orch.captureGitHubRESTLookupProbe(&state, connector.RESTRateLimit{Resource: "core", Limit: 5000, Remaining: 900, ResetAt: now.Add(time.Hour)}, now)
+			}
+			if _, held := orch.currentGitHubLookupSignal(&state, now); held != tt.wantHeld {
+				t.Fatalf("live lookup held = %v, want %v", held, tt.wantHeld)
+			}
+			orch.captureConnectorRESTRateLimits(&state, now)
+			if _, held := orch.currentGitHubLookupSignal(&state, now); held != tt.wantHeld {
+				t.Fatalf("captured lookup held = %v, want %v", held, tt.wantHeld)
+			}
+		})
+	}
+}
+
+func TestGitHubRESTResourceReserveLookupRecovery(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		resource  string
+		remaining int64
+		priorCore bool
+		wantHeld  bool
+	}{
+		{name: "healthy search", resource: "search", remaining: 29},
+		{name: "exhausted search", resource: "search", wantHeld: true},
+		{name: "core at reserve", resource: "core", remaining: 1000, wantHeld: true},
+		{name: "healthy core", resource: "core", remaining: 1001},
+		{name: "search preserves core reserve", resource: "search", remaining: 29, priorCore: true, wantHeld: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{GitHubRESTMinReserve: 1000})
+			limit := int64(5000)
+			if tt.resource == "search" {
+				limit = 30
+			}
+			tracker := &rateLimitConnector{restProbeRateLimits: []connector.RESTRateLimit{{Resource: tt.resource, Limit: limit, Remaining: tt.remaining, ResetAt: now.Add(time.Hour)}}}
+			orch := newRateLimitTestOrchestrator(cfg, tracker)
+			state := newState(cfg)
+			if tt.priorCore {
+				orch.captureGitHubRESTLookupProbe(&state, connector.RESTRateLimit{Resource: "core", Limit: 5000, Remaining: 900, ResetAt: now.Add(time.Hour)}, now)
+			}
+			outage := orch.advanceGitHubLookupBackoff(&state, BackendOutage{}, githubLookupSignal{trigger: githubLookupTriggerREST, reason: "rate limited"}, now, time.Time{})
+			if held := orch.githubLookupBackoffGate(t.Context(), &state, outage.NextProbeAt); held != tt.wantHeld {
+				t.Fatalf("recovery held = %v, want %v", held, tt.wantHeld)
+			}
+			if tracker.restProbeCalls != 1 {
+				t.Fatalf("REST probe calls = %d, want 1", tracker.restProbeCalls)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -140,7 +140,9 @@ func (o *Orchestrator) captureConnectorRESTRateLimits(state *State, now time.Tim
 	if state.RateLimits == nil {
 		state.RateLimits = &telemetry.RateLimits{}
 	}
-	state.RateLimits.GitHubREST = bucket
+	if bucket != nil {
+		state.RateLimits.GitHubREST = bucket
+	}
 	state.RateLimits.GitHubRESTBudgets = replaceRESTConsumerBudgets(state.RateLimits.GitHubRESTBudgets, budgets, telemetry.RESTConsumerOrchestrator)
 	state.RateLimits.RESTUsage = summary
 	return restRateLimitCycle{
@@ -269,6 +271,9 @@ func restBudgetSummaries(budgets []connector.RESTRateLimitBudget) []telemetry.RE
 
 func gitHubRESTBucket(usage connector.RESTRateLimitUsage, now time.Time) *telemetry.RateLimitBucket {
 	rateLimit := usage.RateLimit
+	if rateLimit.Resource != "" && rateLimit.Resource != "core" {
+		return nil
+	}
 	var resetAt *time.Time
 	var observedAt *time.Time
 	var resetInSeconds int64


### PR DESCRIPTION
## Summary

Scope the configured REST minimum remaining reserve to core and unnamed legacy snapshots. Healthy smaller resources such as search use no synthetic reserve. GitHub primary exhaustion, secondary limits, and shared backoff remain enforced.

Share the resource rule across connector admission, recovery, diagnostics, and scheduler lookup gates. Preserve known core capacity in aggregate REST telemetry when search snapshots arrive, while retaining resource-specific usage reporting. Document the semantics; no configuration migration is required.

Search already bypasses normal fanout admission on this baseline. The recovery and scheduler regressions reproduce the incorrect healthy-search hold, including the P1 review finding.

Fixes #2362

## Test Plan

- Deterministic table-driven connector and scheduler regressions cover healthy search with reserve 1000, core/search isolation, exhausted capacity, conditional requests, expired snapshots, and admission/recovery with retained core capacity.
- HTTP regressions cover primary exhaustion and secondary throttling.
- `make check CHECK_LOCK_WAIT=120m` passed on integrated head 342f8a4: build, generated-file checks, lint, vet, nilaway, all race tests, 80.4% total coverage, and all package/file floors. GitHub connector coverage is 79.8%; orchestrator coverage is 86.3%.
- Integrated main's confirmed REST recovery (#2379), preserving representative-read confirmation and applying resource floors in the new recovery path. The updated healthy-search recovery test failed before that integration fix and passed afterward.
- Unrelated validation failures are tracked separately: Windows overlay deletion (#2390; earlier-head CI passed on retry) and runner process discovery (#2398; three focused race runs and the final full gate passed).
- Current-head CI run [34363565101](https://github.com/digitaldrywood/detent/actions/runs/34363565101) passed all checks after a Windows-only retry. The initial Windows failures are tracked in #2389 (outbox drain) and #2398 (runner process discovery); no source changes or test bypasses were used for the retry.
