### PR TITLE
test(workspace): cover inherited Git output pipes

### DIFF
--- a/.detent/validation/2369/README.md
+++ b/.detent/validation/2369/README.md
@@ -1,0 +1,66 @@
+# Worktree prune I/O wait investigation
+
+Baseline: `15993b0d` (includes reported baseline `3b1d2dae`). Host: macOS,
+Go 1.26.6, `/opt/homebrew/bin/git`. Before the full gate, the branch was
+fast-forwarded to `3962d001`; its merge-reservation change does not overlap
+the regression.
+
+## Evidence and limits
+
+`initRunnerSourceRepo` executes init, local config, add, and commit serially
+through `exec.CommandContext(...).CombinedOutput()`. The workspace then calls
+Git directly with `-C <source> worktree prune`; there is no fixture shell or
+background helper on this path. CLI TestMain clears inherited `GIT_*` variables.
+The inspected user Git configuration had no fsmonitor, maintenance, gc.auto,
+or hooksPath override. These are current observations, not historical proof.
+
+Go's `os/exec.Cmd.awaitGoroutines` starts its WaitDelay timer after process wait
+when output copying has not completed. Expiration closes the read pipes and
+returns `exec.ErrWaitDelay`. With a live context and this error, the direct
+process exited successfully, but the copy goroutine did not finish within the
+one-second bound. This is not evidence that `git worktree prune` itself timed
+out. A descendant retaining stdout/stderr can cause it; delayed scheduling of
+the I/O completion is another possibility. The original report contains no
+process/descriptor trace to distinguish them.
+
+## Reproduction results
+
+- Original focused CLI test under coverage, 30 consecutive runs: PASS (7.566s).
+- Full CLI coverage with a PATH wrapper that logs PID and arguments then execs
+  the absolute Git executable: PASS (55.371s, 77.5% coverage).
+- Trace: 726 Git launches, including four worktree prune calls. No wait failure.
+  The wrapper records invocations, not every descendant or descriptor owner.
+  Disposable raw logs remain in the Detent per-turn temp directory.
+
+The historical failure did not reproduce. No timeout increase, retry, ignored
+error, or production behavior change is justified by this evidence.
+
+## Deterministic regression
+
+`TestRunGitAtBoundsInheritedOutput` installs a temporary shell Git fixture.
+A descendant retains selected output descriptors and waits on a FIFO that the
+test owns. The command exits before the test releases the descendant. Cases
+cover retained stdout, retained stderr, a nonzero exit, and redirected child
+output. Assertions verify ErrWaitDelay, CommandError output preservation,
+nonzero exit preservation, and success when the descendant closes output.
+Cleanup releases the FIFO and joins the command even when assertions fail.
+The test skips Windows because its fixture uses POSIX shell and mkfifo.
+
+Three focused coverage repetitions passed. Temporarily setting only
+runGitAtWithEnv's WaitDelay to zero made the retained-stdout case fail at its
+ten-second guard (10.295s total), then cleanup completed. Production code was
+restored immediately. This is a regression against removing bounded cleanup,
+not a claim to reproduce the unknown historical host cause.
+
+## Validation
+
+Focused race regression, three repetitions: PASS (12.315s).
+`make check CHECK_LOCK_WAIT=2h`: PASS, overall coverage 80.3%, CLI 77.5%,
+workspace 73.0%; package and exact-file floors passed. Lint, vet, NilAway,
+and the full race suite passed. The first plain `make check` exited before
+validation started because its 15-minute shared-lock wait expired. The retry
+waited about 50 minutes for the same lock; test timeouts and gate steps were
+unchanged. Current-head PR CI is tracked in the issue Workpad.
+
+Skill draft: no — existing subprocess-pressure-tracing and inherited-pipe
+regressions already describe this method; no new reusable method was found.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -2899,3 +2899,112 @@ func TestLocalGitPrepareMergeValidatesResolvedHead(t *testing.T) {
 		})
 	}
 }
+
+func TestRunGitAtBoundsInheritedOutput(t *testing.T) {
+	skipWindows(t)
+
+	for _, tt := range []struct {
+		name        string
+		redirection string
+		exitCode    int
+		wantDelay   bool
+	}{
+		{name: "stdout retained", redirection: "2>/dev/null", wantDelay: true},
+		{name: "stderr retained", redirection: ">/dev/null", wantDelay: true},
+		{name: "failed command", exitCode: 23},
+		{name: "output closed", redirection: ">/dev/null 2>&1"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			fifoPath := filepath.Join(dir, "release")
+			runCommand(t, dir, "mkfifo", fifoPath)
+			release, err := os.OpenFile(fifoPath, os.O_RDWR, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer release.Close()
+			donePath := filepath.Join(dir, "done")
+			script := fmt.Sprintf(`#!/bin/sh
+( read -r release < "$DETENT_PIPE_RELEASE"; printf done > "$DETENT_PIPE_DONE" ) %s &
+printf 'git stdout\n'
+printf 'git stderr\n' >&2
+exit %d
+`, tt.redirection, tt.exitCode)
+			if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			type result struct {
+				output string
+				err    error
+			}
+			results := make(chan result, 1)
+			joined := make(chan struct{})
+			go func() {
+				defer close(joined)
+				output, err := runGitAtWithEnv(ctx, dir, []string{
+					"DETENT_PIPE_RELEASE=" + fifoPath,
+					"DETENT_PIPE_DONE=" + donePath,
+				}, "worktree", "prune")
+				results <- result{output: output, err: err}
+			}()
+			defer func() {
+				cancel()
+				if _, err := release.WriteString("release\n"); err != nil {
+					t.Errorf("release descendant: %v", err)
+				}
+				timer := time.NewTimer(10 * time.Second)
+				defer timer.Stop()
+				ticker := time.NewTicker(10 * time.Millisecond)
+				defer ticker.Stop()
+				for {
+					if _, err := os.Stat(donePath); err == nil {
+						break
+					}
+					select {
+					case <-timer.C:
+						t.Error("descendant did not acknowledge release")
+						return
+					case <-ticker.C:
+					}
+				}
+				select {
+				case <-joined:
+				case <-timer.C:
+					t.Error("Git command did not join after descendant release")
+				}
+			}()
+
+			var got result
+			select {
+			case got = <-results:
+			case <-time.After(10 * time.Second):
+				t.Fatal("Git command did not return while descendant retained output")
+			}
+			if errors.Is(got.err, exec.ErrWaitDelay) != tt.wantDelay {
+				t.Fatalf("runGitAtWithEnv() error = %v, want WaitDelay = %t", got.err, tt.wantDelay)
+			}
+			output := got.output
+			if tt.wantDelay || tt.exitCode != 0 {
+				var commandErr *CommandError
+				if !errors.As(got.err, &commandErr) {
+					t.Fatalf("error = %v, want CommandError", got.err)
+				}
+				if got.output != "" {
+					t.Fatalf("output = %q, want empty on failure", got.output)
+				}
+				output = commandErr.Output
+				if tt.exitCode != 0 && commandErr.ExitCode != tt.exitCode {
+					t.Fatalf("exit code = %d, want %d", commandErr.ExitCode, tt.exitCode)
+				}
+			} else if got.err != nil {
+				t.Fatal(got.err)
+			}
+			if !strings.Contains(output, "git stdout") || !strings.Contains(output, "git stderr") {
+				t.Fatalf("captured output = %q, want stdout and stderr", output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add a deterministic regression for Git commands whose descendants retain stdout or stderr after the direct command exits. Verify bounded I/O cleanup, captured diagnostics, nonzero exit preservation, and success when child output is redirected.
- Record the CLI fixture investigation: 30 focused coverage runs and a traced full CLI coverage run passed. The historical host cause remains unconfirmed; production timeout and error handling are unchanged.

Fixes #2369

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Original CLI fixture test under coverage, 30 repetitions.
- [x] Full CLI coverage with Git launch tracing: 77.5%, 726 Git invocations and four prune calls, no failure.
- [x] New regression under coverage and race, three repetitions each.
- [x] Mutation check: removing Git WaitDelay makes the retained-stdout test fail, then cleanup releases the helper and joins the command.
- [x] `make check CHECK_LOCK_WAIT=2h`: all checks pass, 80.3% overall coverage. Only the shared-lock wait allowance changed after the default 15-minute queue timeout; test limits and gate steps are unchanged.

The POSIX FIFO regression skips Windows. Investigation details and attribution limits are in `.detent/validation/2369/README.md`.
