### PR TITLE
fix(telemetry): serve state during completion

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -658,7 +658,9 @@ func publishSnapshotOnce(
 		if !state.LastRefreshAt.IsZero() {
 			snapshot.Tracker = liveSnapshotSection(state.LastRefreshAt)
 		}
-		snapshot.Runtime = liveSnapshotSection(now)
+		if snapshot.Runtime.IsZero() {
+			snapshot.Runtime = liveSnapshotSection(now)
+		}
 		snapshot.DashboardURL = cleanDashboardURL(dashboardURL)
 		merged = mergeSnapshot(merged, snapshot)
 	}

--- a/internal/cli/telemetry_liveness_test.go
+++ b/internal/cli/telemetry_liveness_test.go
@@ -183,6 +183,128 @@ func TestTelemetryPublicationSurvivesStalledSourceAfterRestart(t *testing.T) {
 	}
 }
 
+func TestTelemetryPublicationDuringCompletionFence(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		registry := project.NewRegistry()
+		snapshots := hub.New[telemetry.Snapshot]()
+		tracker := &completionTelemetryConnector{
+			Connector: memory.New(memory.Config{Issues: []connector.Issue{{ID: "alpha", Identifier: "alpha#1", Title: "alpha active worker", State: "In Progress", AssignedToWorker: true}}}),
+			armed:     make(chan struct{}), started: make(chan struct{}), release: make(chan struct{}),
+		}
+		releaseWorker := make(chan struct{})
+		runner := &shutdownBlockingRunner{started: make(chan struct{}, 1), canceled: make(chan struct{}, 1), release: releaseWorker}
+		alpha := newTelemetryProject(t, "alpha", tracker, runner)
+		betaRunner := newRestartRecoveryRunner()
+		beta := newTelemetryProject(t, "beta", memory.New(memory.Config{Issues: []connector.Issue{{ID: "beta", Identifier: "beta#1", Title: "beta active worker", State: "In Progress", AssignedToWorker: true}}}), betaRunner)
+		for _, tracked := range []*project.Project{alpha, beta} {
+			if err := tracked.Start(ctx); err != nil {
+				t.Fatal(err)
+			}
+			mustSetProject(t, registry, tracked)
+		}
+		select {
+		case <-runner.started:
+		case <-time.After(10 * time.Second):
+			state, err := alpha.Orchestrator().State(ctx)
+			t.Fatalf("alpha worker did not start: dispatch %#v, error %v", state.DispatchStatus, err)
+		}
+		var betaRequest orchestrator.RunRequest
+		select {
+		case betaRequest = <-betaRunner.started:
+		case <-time.After(10 * time.Second):
+			state, err := beta.Orchestrator().State(ctx)
+			t.Fatalf("beta worker did not start: dispatch %#v, error %v", state.DispatchStatus, err)
+		}
+		synctest.Wait()
+		var seq atomic.Uint64
+		var observedAt time.Time
+		for index, tt := range []struct {
+			name   string
+			source telemetry.SnapshotSource
+		}{
+			{name: "before completion", source: telemetry.SnapshotSourceLive},
+			{name: "blocked completion", source: telemetry.SnapshotSourceCached},
+			{name: "still blocked", source: telemetry.SnapshotSourceCached},
+			{name: "completed", source: telemetry.SnapshotSourceLive},
+		} {
+			if index == 1 {
+				close(tracker.armed)
+				close(releaseWorker)
+				<-tracker.started
+			}
+			if index == 3 {
+				close(tracker.release)
+				synctest.Wait()
+			}
+			time.Sleep(time.Second)
+			if err := betaRequest.OnUsageUpdate(orchestrator.UsageUpdate{LastEventAt: time.Now(), LastMessage: tt.name, Tokens: orchestrator.TokenTotals{TotalTokens: int64(index + 1)}}); err != nil {
+				t.Fatal(err)
+			}
+			if err := publishSnapshotOnce(ctx, registry, nil, snapshots, &seq, nil, time.Now(), nil, nil, "", nil); err != nil {
+				t.Fatal(err)
+			}
+			snapshot, ok := snapshots.Latest()
+			if !ok || len(snapshot.Projects) != 2 || snapshot.Seq != uint64(index+1) {
+				t.Fatalf("%s: snapshot did not advance: %#v", tt.name, snapshot)
+			}
+			alphaSnapshot, betaSnapshot := snapshot.Projects[0], snapshot.Projects[1]
+			if alphaSnapshot.Project.ID != "alpha" || alphaSnapshot.Runtime.Source != tt.source || !alphaSnapshot.Runtime.Complete {
+				t.Fatalf("%s: alpha runtime = %#v", tt.name, alphaSnapshot.Runtime)
+			}
+			if tt.source == telemetry.SnapshotSourceCached {
+				if observedAt.IsZero() {
+					observedAt = alphaSnapshot.Runtime.ObservedAt
+				}
+				if observedAt.IsZero() || alphaSnapshot.Runtime.ObservedAt != observedAt || !observedAt.Before(snapshot.GeneratedAt) {
+					t.Fatalf("%s: cached observation time = %v", tt.name, alphaSnapshot.Runtime.ObservedAt)
+				}
+				if !alphaSnapshot.Refresh.Ready() || snapshot.Runtime.Source != telemetry.SnapshotSourceMixed {
+					t.Fatalf("%s: tracker or fleet provenance incorrect: refresh %#v, runtime %#v", tt.name, alphaSnapshot.Refresh, snapshot.Runtime)
+				}
+			}
+			if betaSnapshot.Runtime.Source != telemetry.SnapshotSourceLive {
+				t.Fatalf("%s: healthy project stopped advancing: %#v", tt.name, betaSnapshot)
+			}
+			var betaRunning []telemetry.Running
+			for _, running := range snapshot.Running {
+				if running.ProjectID == "beta" {
+					betaRunning = append(betaRunning, running)
+				}
+			}
+			if len(betaRunning) != 1 || betaRunning[0].Tokens.Total != int64(index+1) {
+				t.Fatalf("%s: healthy worker stopped advancing: %#v", tt.name, betaRunning)
+			}
+		}
+	})
+}
+
+type completionTelemetryConnector struct {
+	connector.Connector
+	armed   chan struct{}
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *completionTelemetryConnector) FetchIssueStatesByIDs(ctx context.Context, ids []string) ([]connector.Issue, error) {
+	select {
+	case <-c.armed:
+		select {
+		case <-c.started:
+		default:
+			close(c.started)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-c.release:
+		}
+	default:
+	}
+	return c.Connector.FetchIssueStatesByIDs(ctx, ids)
+}
+
 func TestReadTelemetrySource(t *testing.T) {
 	sourceErr := errors.New("source unavailable")
 	for _, tt := range []struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -955,7 +955,11 @@ func (o *Orchestrator) signalSnapshotAvailable() {
 }
 
 func (o *Orchestrator) startCompletion(state *State) {
-	cloned := state.clone()
+	cloned := o.observableState(state.clone())
+	for id, running := range cloned.Running {
+		running.progress = nil
+		cloned.Running[id] = running
+	}
 	cloned.RuntimeObservation = telemetry.SnapshotSection{
 		Source:     telemetry.SnapshotSourceCached,
 		ObservedAt: time.Now(),
@@ -1158,7 +1162,7 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 
 func (o *Orchestrator) publishedState() State {
 	if state := o.completionState.Load(); state != nil {
-		return o.observableState(state.clone())
+		return state.clone()
 	}
 	state := o.latestState.Load().clone()
 	if runtime := o.latestRuntimeState.Load(); runtime != nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -333,8 +333,8 @@ type Orchestrator struct {
 	ciTriggerLabelMu        sync.Mutex
 	ciTriggerLabelHeads     map[string]ciTriggerLabelHead
 	stateRequests           chan stateRequest
-	refreshSignalMu         sync.Mutex
-	refreshStarted          chan struct{}
+	snapshotSignalMu        sync.Mutex
+	snapshotAvailable       chan struct{}
 	initialStateReady       chan struct{}
 	initialStatePublished   sync.Once
 	drainRequests           chan drainRequest
@@ -363,6 +363,7 @@ type Orchestrator struct {
 	refreshSeq              atomic.Uint64
 	workerGeneration        atomic.Uint64
 	latestState             atomic.Pointer[State]
+	completionState         atomic.Pointer[State]
 	latestRuntimeState      atomic.Pointer[runtimeState]
 	refreshInProgress       atomic.Bool
 	refreshProgress         atomic.Pointer[telemetry.RefreshProgress]
@@ -704,7 +705,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		dispatchGateSamples:     map[dispatchGateSampleKey]time.Time{},
 		ciTriggerLabelHeads:     map[string]ciTriggerLabelHead{},
 		stateRequests:           make(chan stateRequest),
-		refreshStarted:          make(chan struct{}),
+		snapshotAvailable:       make(chan struct{}),
 		initialStateReady:       make(chan struct{}),
 		drainRequests:           make(chan drainRequest),
 		forceRequests:           make(chan forceRequest),
@@ -863,7 +864,11 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			request.reply <- o.handleModelPermitRequest(&state, request.issueID)
 		case result := <-o.runResults:
 			state.syncWorkerProgress()
+			o.startCompletion(&state)
 			o.handleRunResult(ctx, &state, result)
+			o.publishState(&state)
+			o.completionState.Store(nil)
+			continue
 		case update := <-o.runUpdates:
 			state.syncWorkerProgress()
 			o.handleRunUpdate(&state, update)
@@ -916,12 +921,7 @@ func (o *Orchestrator) startTick(state *State, at time.Time) {
 	}
 	state.syncWorkerProgress()
 	o.refreshInProgress.Store(true)
-	o.refreshSignalMu.Lock()
-	if o.refreshStarted != nil {
-		close(o.refreshStarted)
-	}
-	o.refreshStarted = make(chan struct{})
-	o.refreshSignalMu.Unlock()
+	o.signalSnapshotAvailable()
 	if o.tickWatchdog == nil || state == nil {
 		return
 	}
@@ -943,6 +943,26 @@ func (o *Orchestrator) finishTick(state *State) {
 		return
 	}
 	o.tickWatchdog.Schedule(state.NextRefreshAt, state.PollInterval)
+}
+
+func (o *Orchestrator) signalSnapshotAvailable() {
+	o.snapshotSignalMu.Lock()
+	defer o.snapshotSignalMu.Unlock()
+	if o.snapshotAvailable != nil {
+		close(o.snapshotAvailable)
+	}
+	o.snapshotAvailable = make(chan struct{})
+}
+
+func (o *Orchestrator) startCompletion(state *State) {
+	cloned := state.clone()
+	cloned.RuntimeObservation = telemetry.SnapshotSection{
+		Source:     telemetry.SnapshotSourceCached,
+		ObservedAt: time.Now(),
+		Complete:   true,
+	}
+	o.completionState.Store(&cloned)
+	o.signalSnapshotAvailable()
 }
 
 func (o *Orchestrator) ClearBackendCapacity(ctx context.Context, scope string) ([]BackendOutage, error) {
@@ -1108,10 +1128,10 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 		case <-o.initialStateReady:
 		}
 	}
-	o.refreshSignalMu.Lock()
-	refreshStarted := o.refreshStarted
-	o.refreshSignalMu.Unlock()
-	if o.refreshInProgress.Load() {
+	o.snapshotSignalMu.Lock()
+	snapshotAvailable := o.snapshotAvailable
+	o.snapshotSignalMu.Unlock()
+	if o.completionState.Load() != nil || o.refreshInProgress.Load() {
 		return o.publishedState(), nil
 	}
 	request := stateRequest{reply: make(chan State, 1)}
@@ -1120,7 +1140,7 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 		return State{}, ctx.Err()
 	case <-o.done:
 		return State{}, ErrStopped
-	case <-refreshStarted:
+	case <-snapshotAvailable:
 		return o.publishedState(), nil
 	case o.stateRequests <- request:
 	}
@@ -1129,7 +1149,7 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 		return State{}, ctx.Err()
 	case <-o.done:
 		return State{}, ErrStopped
-	case <-refreshStarted:
+	case <-snapshotAvailable:
 		return o.publishedState(), nil
 	case state := <-request.reply:
 		return o.observableState(state), nil
@@ -1137,6 +1157,9 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 }
 
 func (o *Orchestrator) publishedState() State {
+	if state := o.completionState.Load(); state != nil {
+		return o.observableState(state.clone())
+	}
 	state := o.latestState.Load().clone()
 	if runtime := o.latestRuntimeState.Load(); runtime != nil {
 		state.Running = cloneRunning(runtime.Running)

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -102,6 +102,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	s.applyAutoPromoteDecisionSnapshots(pipelineIssueSnapshots, pipeline, now)
 	s.applyArtifactGateWaitDispatchSnapshots(pipelineIssueSnapshots, pipeline)
 	snapshot := telemetry.Snapshot{
+		Runtime:                 s.RuntimeObservation,
 		GeneratedAt:             now,
 		Instance:                s.Instance,
 		Auth:                    telemetryAuthHealth(s.Auth),

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -107,6 +108,63 @@ func TestCompletionSnapshotExcludesPartialMutations(t *testing.T) {
 			}
 			if len(got.Running) != 1 || got.Claimed[issue.ID].Issue.Labels[0] != "original" {
 				t.Fatalf("completion snapshot exposes partial mutation: running %#v, claimed %#v", got.Running, got.Claimed)
+			}
+		})
+	}
+}
+
+func TestCompletionSnapshotFreezesWorkerProgress(t *testing.T) {
+	t.Parallel()
+	for _, persisted := range []bool{false, true} {
+		t.Run(fmt.Sprintf("persisted heartbeat=%t", persisted), func(t *testing.T) {
+			state := newState(normalizeConfig(Config{}))
+			running := Running{Issue: connector.Issue{ID: "other-worker"}, WorkAttemptID: 2361}
+			base := store.WorkAttemptHeartbeat{AttemptID: running.WorkAttemptID}
+			progress := newWorkerProgress(running, base, nil, 4096)
+			running.progress = progress
+			state.Running[running.Issue.ID] = running
+			state.WorkAttempts = []telemetry.WorkAttempt{{AttemptID: running.WorkAttemptID}}
+			observe := func(message string) {
+				t.Helper()
+				if err := progress.observe(t.Context(), runpkg.UsageUpdate{LastMessage: message}); err != nil {
+					t.Fatal(err)
+				}
+				if persisted {
+					heartbeat := progress.heartbeat(base, time.Now())
+					progress.persisted.Store(&heartbeat)
+				}
+			}
+			read := func(orch *Orchestrator) State {
+				t.Helper()
+				got, err := orch.State(t.Context())
+				if err != nil {
+					t.Fatal(err)
+				}
+				return got
+			}
+			orch := &Orchestrator{done: make(chan struct{})}
+			orch.publishState(&state)
+			observe("before completion")
+			orch.startCompletion(&state)
+			before := read(orch)
+			if before.Running[running.Issue.ID].LastMessage != "before completion" || (persisted && before.WorkAttempts[0].StatusMessage != "before completion") {
+				t.Fatal("completion snapshot omitted existing worker progress")
+			}
+			observe("during completion")
+			after := read(orch)
+			if !reflect.DeepEqual(before.Running, after.Running) || !reflect.DeepEqual(before.WorkAttempts, after.WorkAttempts) || before.RuntimeObservation != after.RuntimeObservation {
+				t.Fatal("cached completion snapshot changed after worker progress")
+			}
+			after.Running = cloneRunning(after.Running)
+			if !reflect.DeepEqual(before.Running, after.Running) {
+				t.Fatal("cloning cached running state reloaded worker progress")
+			}
+			orch.publishState(&state)
+			orch.completionState.Store(nil)
+			orch.refreshInProgress.Store(true)
+			resumed := read(orch)
+			if resumed.Running[running.Issue.ID].LastMessage != "during completion" || (persisted && resumed.WorkAttempts[0].StatusMessage != "during completion") || !resumed.RuntimeObservation.IsZero() {
+				t.Fatal("live publication did not resume worker progress after completion")
 			}
 		})
 	}

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -19,17 +19,21 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
-func TestStateReadersCrossStartupAndRefreshBoundaries(t *testing.T) {
-	for _, starting := range []bool{false, true} {
-		name := "refresh starts with reader waiting"
-		if starting {
-			name = "reader precedes initial publication"
-		}
-		t.Run(name, func(t *testing.T) {
+func TestStateReadersCrossPublicationBoundaries(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		starting   bool
+		completion bool
+	}{
+		{name: "refresh starts with reader waiting"},
+		{name: "reader precedes initial publication", starting: true},
+		{name: "completion starts with reader waiting", completion: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				state := newState(normalizeConfig(Config{}))
-				orch := &Orchestrator{done: make(chan struct{}), initialStateReady: make(chan struct{}), refreshStarted: make(chan struct{}), stateRequests: make(chan stateRequest)}
-				if !starting {
+				orch := &Orchestrator{done: make(chan struct{}), initialStateReady: make(chan struct{}), snapshotAvailable: make(chan struct{}), stateRequests: make(chan stateRequest)}
+				if !tt.starting {
 					orch.publishState(&state)
 				}
 				done := make(chan error, 1)
@@ -38,8 +42,12 @@ func TestStateReadersCrossStartupAndRefreshBoundaries(t *testing.T) {
 					done <- err
 				}()
 				synctest.Wait()
-				orch.startTick(&state, time.Now())
-				orch.publishState(&state)
+				if tt.completion {
+					orch.startCompletion(&state)
+				} else {
+					orch.startTick(&state, time.Now())
+					orch.publishState(&state)
+				}
 				if err := <-done; err != nil {
 					t.Fatal(err)
 				}
@@ -73,6 +81,32 @@ func TestRefreshProgressPreservesTrackerFreshness(t *testing.T) {
 			later := refresh.WithFreshness(now.Add(time.Second))
 			if later.InFlight.ElapsedSeconds != 11 || refresh.InFlight.ElapsedSeconds != 10 {
 				t.Fatal("freshness update failed to advance duration on an independent copy")
+			}
+		})
+	}
+}
+
+func TestCompletionSnapshotExcludesPartialMutations(t *testing.T) {
+	for _, publishRuntime := range []bool{false, true} {
+		t.Run(fmt.Sprintf("runtime publication=%t", publishRuntime), func(t *testing.T) {
+			state := newState(normalizeConfig(Config{}))
+			issue := connector.Issue{ID: "worker", State: "In Progress", Labels: []string{"original"}}
+			state.Running[issue.ID] = Running{Issue: issue}
+			state.Claimed[issue.ID] = Claimed{Issue: issue}
+			orch := &Orchestrator{done: make(chan struct{})}
+			orch.publishState(&state)
+			orch.startCompletion(&state)
+			delete(state.Running, issue.ID)
+			state.Claimed[issue.ID].Issue.Labels[0] = "partial"
+			if publishRuntime {
+				orch.publishRuntimeState(&state)
+			}
+			got, err := orch.State(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Running) != 1 || got.Claimed[issue.ID].Issue.Labels[0] != "original" {
+				t.Fatalf("completion snapshot exposes partial mutation: running %#v, claimed %#v", got.Running, got.Claimed)
 			}
 		})
 	}

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -152,11 +152,11 @@ func TestCompletionSnapshotFreezesWorkerProgress(t *testing.T) {
 			}
 			observe("during completion")
 			after := read(orch)
-			if !reflect.DeepEqual(before.Running, after.Running) || !reflect.DeepEqual(before.WorkAttempts, after.WorkAttempts) || before.RuntimeObservation != after.RuntimeObservation {
+			if before.Running[running.Issue.ID].LastMessage != after.Running[running.Issue.ID].LastMessage || !reflect.DeepEqual(before.WorkAttempts, after.WorkAttempts) || before.RuntimeObservation != after.RuntimeObservation {
 				t.Fatal("cached completion snapshot changed after worker progress")
 			}
 			after.Running = cloneRunning(after.Running)
-			if !reflect.DeepEqual(before.Running, after.Running) {
+			if before.Running[running.Issue.ID].LastMessage != after.Running[running.Issue.ID].LastMessage {
 				t.Fatal("cloning cached running state reloaded worker progress")
 			}
 			orch.publishState(&state)

--- a/internal/orchestrator/startup_observability_test.go
+++ b/internal/orchestrator/startup_observability_test.go
@@ -2,6 +2,7 @@ package orchestrator_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -111,4 +112,107 @@ func (r *startupStalledReaper) ReconcileWorkspaces(ctx context.Context, _ []conn
 	case <-r.release:
 		return orchestrator.WorkspaceReconcileResult{}, nil
 	}
+}
+
+func TestCompletionFenceKeepsStateObservable(t *testing.T) {
+	for _, cancelCompletion := range []bool{false, true} {
+		name := "complete fence"
+		if cancelCompletion {
+			name = "cancel fence"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				issue := testIssue("completion-worker", "digitaldrywood/detent#2361", "In Progress")
+				tracker := &completionStalledConnector{fakeConnector: newFakeConnector(issue), armed: make(chan struct{}), started: make(chan struct{}), release: make(chan struct{})}
+				runner := newBlockingRunner()
+				orch, err := orchestrator.New(orchestrator.Config{
+					PollInterval: time.Hour, MaxConcurrentAgents: 1,
+					ActiveStates: []string{"In Progress"}, TerminalStates: []string{"Done"},
+				}, orchestrator.Dependencies{Connector: tracker, Runner: runner})
+				if err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := context.WithCancel(t.Context())
+				done := make(chan error, 1)
+				go func() { done <- orch.Run(ctx) }()
+				defer func() { cancel(); <-done }()
+				request := <-runner.started
+				synctest.Wait()
+				if request.Generation == 0 {
+					t.Fatal("worker lacks completion fence generation")
+				}
+				close(tracker.armed)
+				close(runner.release)
+				<-tracker.started
+				state := startupState(t, orch)
+				if state.RefreshProgress.Stage != "" {
+					t.Fatalf("completion unexpectedly inside refresh: %#v", state.RefreshProgress)
+				}
+				if state.Running[issue.ID].Generation != request.Generation || state.Claimed[issue.ID].Issue.ID != issue.ID {
+					t.Fatal("pending completion lost worker ownership")
+				}
+				observed := state.Snapshot(time.Now()).Runtime
+				if observed.Source != telemetry.SnapshotSourceCached || observed.ObservedAt.IsZero() || !observed.Complete {
+					t.Fatalf("pending runtime observation = %#v", observed)
+				}
+				time.Sleep(time.Second)
+				delete(state.Running, issue.ID)
+				delete(state.Claimed, issue.ID)
+				state = startupState(t, orch)
+				if len(state.Running) != 1 || len(state.Claimed) != 1 {
+					t.Fatal("reader mutated published ownership")
+				}
+				if got := state.Snapshot(time.Now()).Runtime; got != observed {
+					t.Fatalf("cached runtime freshness advanced: %#v, want %#v", got, observed)
+				}
+				readCtx, cancelRead := context.WithCancel(t.Context())
+				cancelRead()
+				if _, err := orch.State(readCtx); !errors.Is(err, context.Canceled) {
+					t.Fatalf("canceled State() = %v", err)
+				}
+				if cancelCompletion {
+					cancel()
+					synctest.Wait()
+					if _, err := orch.State(t.Context()); !errors.Is(err, orchestrator.ErrStopped) {
+						t.Fatalf("stopped State() = %v", err)
+					}
+				} else {
+					close(tracker.release)
+					synctest.Wait()
+					state = startupState(t, orch)
+					if len(state.Running) != 0 {
+						t.Fatal("completed worker remains running")
+					}
+					if !state.RuntimeObservation.IsZero() {
+						t.Fatalf("completed fence retained cached observation: %#v", state.RuntimeObservation)
+					}
+				}
+			})
+		})
+	}
+}
+
+type completionStalledConnector struct {
+	*fakeConnector
+	armed   chan struct{}
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *completionStalledConnector) FetchIssueStatesByIDs(ctx context.Context, ids []string) ([]connector.Issue, error) {
+	select {
+	case <-c.armed:
+		select {
+		case <-c.started:
+		default:
+			close(c.started)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-c.release:
+		}
+	default:
+	}
+	return c.fakeConnector.FetchIssueStatesByIDs(ctx, ids)
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -27,6 +27,7 @@ import (
 )
 
 type State struct {
+	RuntimeObservation       telemetry.SnapshotSection
 	PollInterval             time.Duration
 	RefreshFailureThreshold  int
 	MaxConcurrentAgents      int
@@ -436,6 +437,7 @@ func newState(cfg Config) State {
 
 func (s State) clone() State {
 	cloned := State{
+		RuntimeObservation:       s.RuntimeObservation,
 		PollInterval:             s.PollInterval,
 		RefreshFailureThreshold:  s.RefreshFailureThreshold,
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,

--- a/internal/orchestrator/stop_run_integration_test.go
+++ b/internal/orchestrator/stop_run_integration_test.go
@@ -233,7 +233,7 @@ func TestStopRunAppliesTodoPriorityBeforeRedispatch(t *testing.T) {
 		t.Fatalf("StopRun() = %#v, %v", stopped.result, stopped.err)
 	}
 	waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
-		return len(tracker.operationsSnapshot()) >= 2
+		return slices.Contains(tracker.operationsSnapshot(), "state:Todo")
 	})
 	operations := tracker.operationsSnapshot()
 	priorityAt := slices.Index(operations, "priority:High")

--- a/internal/orchestrator/stop_run_integration_test.go
+++ b/internal/orchestrator/stop_run_integration_test.go
@@ -49,10 +49,9 @@ func TestStopRunTargetsOneRunAndBlocksRedispatch(t *testing.T) {
 		t.Fatalf("StopRun() result = %#v, want pending Blocked acknowledgement", result)
 	}
 	waitForOperatorStopCompletion(t, completionStore.completed, issue.ID)
-	state, err = orch.State(t.Context())
-	if err != nil {
-		t.Fatalf("State() error = %v", err)
-	}
+	state = waitForOperatorStopState(t, orch, func(state orchestrator.State) bool {
+		return state.RuntimeObservation.IsZero()
+	})
 	if _, stoppedRunning := state.Running[issue.ID]; stoppedRunning {
 		t.Fatalf("stopped issue %q remains active", issue.ID)
 	}


### PR DESCRIPTION
## Summary

- Keep project-state reads available while worker completion waits on the tracker. Publish an immutable snapshot before completion starts and wake readers already waiting on the event loop, then publish completed state before removing the fallback.
- Materialize worker usage and persisted work-attempt heartbeats when completion starts, detach live progress pointers in the cached copy, and report the fallback as cached with a fixed observation time so telemetry does not imply fresh runtime state during a prolonged completion. Preserve the existing 500 ms read deadline, degraded-source fallback, cancellation and stopped-runtime behavior, and worker ownership and dispatch rules.

The deterministic reproduction blocks the tracker completion-lane read after refresh and workspace cleanup finish, before tracker locking. Disabling only the completion snapshot wrapper makes both regression cases hit the 500 ms State deadline, identifying event-loop starvation rather than tracker locking or snapshot processing. This establishes a reproducible path without attributing every historical live warning to it.

Fixes #2361

## UI Surface Contract

- [x] N/A: no layout, density, viewport, or responsive visibility changes.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens; telemetry behavior is covered by integration regressions.

## Test Plan

- [x] Focused orchestrator and CLI race regressions for blocked completion, waiting readers, immutable snapshots, cached observation time, cancellation and stopped runtime, refresh observability, degraded-source fallback, and continued publication for a healthy second project.
- [x] Independently reproduce both 500 ms State failures by disabling only the completion wrapper in a disposable Go overlay (expected exit 1).
- [x] Full orchestrator race suite after synchronizing the operator-stop regression with completed state publication; twenty consecutive targeted race repetitions also passed.
- [x] Table-driven regression reproduces cached worker progress changing before the fix, verifies persisted and unpersisted progress stays frozen, and confirms current progress returns after completion. Five focused orchestrator race repetitions passed after the fix.
- [x] Current head `7b9de5ae`: exact `make check` passed in an isolated Linux Go 1.26/Node 24 container (build, lint, vet, NilAway, all race and coverage tests; 79.7% total coverage and package/file floors). Native macOS gates passed the telemetry packages but failed unrelated installer/process-reaping tests; evidence is tracked in #2370, #2398, and #2410. Lower native concurrency did not clear the reaper verification failure.

- [x] Linux-targeted `make lint` passed; the snapshot regression compares observable values without comparing error-bearing state.
- [x] Priority-before-redispatch regression waits for the Todo transition while preserving operation-order assertions; twenty consecutive race runs passed.

- [x] All 11 current-head CI checks passed in run 34373452417 after retrying the unrelated Windows process-environment inspection failure.
