### PR TITLE
test(subprocess): synchronize lifecycle readiness

### DIFF
--- a/.detent/skills/subprocess-lifecycle-fixture-testing.md
+++ b/.detent/skills/subprocess-lifecycle-fixture-testing.md
@@ -1,0 +1,15 @@
+---
+name: subprocess-lifecycle-fixture-testing
+description: Separate subprocess readiness from lifecycle actions and verify that emergency test cleanup cannot hide broken production cleanup.
+when_to_use: Use when subprocess cancellation or parent-exit tests fail readiness deadlines, leak helpers after failures, or need to preserve strict child-termination assertions under scheduler pressure.
+---
+
+# Verify subprocess lifecycle fixtures
+
+- Retrieve the original failing job log, not only the latest attempt of a rerun. Separate observed errors from hypotheses about scheduling or production cleanup.
+- Reproduce startup sensitivity with a controlled delay before readiness publication. Keep the real process-group setup and lifecycle implementation intact. A delayed-start reproduction proves a fixture timing assumption, not the cause of an untraced historical incident.
+- Wait for backend startup acknowledgement as well as child readiness before cancellation. Hold parent-exit fixtures on a separate control pipe or stdin command until the test confirms the child is alive, then release the parent. Preserve inherited output descriptors when they are the behavior under test.
+- Use bounded OS deadlock guards around readiness and completion; retain exact cancellation, exit-status, and descendant-termination assertions. Do not substitute fake time for external process scheduling.
+- Register cancellation and joining before waiting for readiness, with cleanup ordered before temporary directory removal. Once a child PID is known, register independent emergency termination that runs only after the assertions. Isolate coverage output for Go test-binary helpers.
+- Use temporary Go overlays to verify negative controls without editing the production worktree: restore the old readiness guard to prove the regression fails; omit production post-exit cleanup to prove the lifecycle assertion still fails. Independently check the recorded child PID after each failing test exits to verify emergency fixture cleanup removed it.
+- Repeat focused race and coverage tests for each affected package, run the repository gate, and verify Linux execution with a proper init process or hosted runner. Record what each negative control establishes and leave unsupported historical causes explicitly unresolved.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Repeat subprocess lifecycle readiness
+        run: go test -race ./internal/claudecode ./internal/codex -run '^(TestRunTurnCancellationKillsChildProcessGroup|TestRunTurnDetectsExitedParentWithInheritedStdout|TestLocalTransportCloseKillsChildProcessGroup|TestLocalTransportReapsChildAfterParentExits)$' -count=20 -timeout=5m
+
       - name: Race test
         run: make test-race
 

--- a/internal/claudecode/process_unix_test.go
+++ b/internal/claudecode/process_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,86 +19,177 @@ import (
 	"github.com/digitaldrywood/detent/internal/runner"
 )
 
+const lifecycleWaitTimeout = 10 * time.Second
+
 func TestRunTurnCancellationKillsChildProcessGroup(t *testing.T) {
 	t.Parallel()
 
-	pidPath := filepath.Join(t.TempDir(), "child.pid")
-	backend := newTestBackend(t, Options{
-		CommandFactory: func(ctx context.Context) *exec.Cmd {
-			script := "sleep 3600 & printf '%s\n' \"$!\" > " + shellQuote(pidPath) + "; wait"
-			return exec.CommandContext(ctx, "sh", "-c", script)
-		},
-	})
+	for _, startup := range []struct {
+		name  string
+		delay string
+	}{
+		{name: "immediate", delay: "0"},
+		{name: "delayed readiness", delay: "1.2"},
+	} {
+		t.Run(startup.name, func(t *testing.T) {
+			t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	workspace := t.TempDir()
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := backend.RunTurn(ctx, runner.AgentTurnRequest{
-			Workspace: workspace,
-			Prompt:    "cancel",
-			Model:     "fable",
-		}, nil)
-		errCh <- err
-	}()
+			pidPath := filepath.Join(t.TempDir(), "child.pid")
+			backend := newTestBackend(t, Options{
+				CommandFactory: func(ctx context.Context) *exec.Cmd {
+					script := "sleep " + startup.delay + "; sleep 3600 & printf '%s\n' \"$!\" > " + shellQuote(pidPath) + "; wait"
+					return exec.CommandContext(ctx, "sh", "-c", script)
+				},
+			})
 
-	pid := waitForPIDFile(t, pidPath)
-	cancel()
+			ctx, cancel := context.WithCancel(context.Background())
+			workspace := t.TempDir()
+			errCh := make(chan error, 1)
+			done := make(chan struct{})
+			started := make(chan struct{})
+			t.Cleanup(func() {
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(lifecycleWaitTimeout):
+					t.Error("RunTurn cleanup did not finish")
+				}
+			})
+			go func() {
+				defer close(done)
+				_, err := backend.RunTurn(ctx, runner.AgentTurnRequest{
+					Workspace: workspace,
+					Prompt:    "cancel",
+					Model:     "fable",
+				}, func(update runner.AgentUpdate) error {
+					if update.Type == runner.AgentUpdateProcessStarted {
+						close(started)
+					}
+					return nil
+				})
+				errCh <- err
+			}()
 
-	select {
-	case err := <-errCh:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("RunTurn() error = %v, want context canceled", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("RunTurn() did not return after context cancellation")
+			pid := waitForPIDFile(t, pidPath)
+			select {
+			case <-started:
+			case err := <-errCh:
+				t.Fatalf("RunTurn exited before startup: %v", err)
+			case <-time.After(lifecycleWaitTimeout):
+				t.Fatal("RunTurn did not report process startup")
+			}
+			if !processAlive(pid) {
+				t.Fatalf("child process %d exited before lifecycle action", pid)
+			}
+			cancel()
+
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("RunTurn() error = %v, want context canceled", err)
+				}
+			case <-time.After(lifecycleWaitTimeout):
+				t.Fatal("RunTurn() did not return after context cancellation")
+			}
+			waitForProcessExit(t, pid)
+		})
 	}
-	waitForProcessExit(t, pid)
 }
 
 func TestRunTurnDetectsExitedParentWithInheritedStdout(t *testing.T) {
 	t.Parallel()
 
-	pidPath := filepath.Join(t.TempDir(), "child.pid")
-	backend := newTestBackend(t, Options{
-		CommandFactory: func(ctx context.Context) *exec.Cmd {
-			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestClaudeCodeDeadParentHelper", "--")
-			cmd.Env = append(os.Environ(),
-				"CLAUDECODE_DEAD_PARENT_HELPER=1",
-				"CLAUDECODE_CHILD_PID_PATH="+pidPath,
-			)
-			return cmd
-		},
-	})
+	for _, startup := range []struct {
+		name  string
+		delay string
+	}{
+		{name: "immediate", delay: "0"},
+		{name: "delayed readiness", delay: "1.2"},
+	} {
+		t.Run(startup.name, func(t *testing.T) {
+			t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	workspace := t.TempDir()
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := backend.RunTurn(ctx, runner.AgentTurnRequest{
-			Workspace: workspace,
-			Prompt:    "detect dead parent",
-			Model:     "fable",
-		}, nil)
-		errCh <- err
-	}()
+			pidPath := filepath.Join(t.TempDir(), "child.pid")
+			releaseReader, releaseWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := errors.Join(releaseReader.Close(), releaseWriter.Close()); err != nil {
+					t.Error(err)
+				}
+			})
+			coverageDir := t.TempDir()
+			backend := newTestBackend(t, Options{
+				CommandFactory: func(ctx context.Context) *exec.Cmd {
+					cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestClaudeCodeDeadParentHelper", "--")
+					cmd.ExtraFiles = []*os.File{releaseReader}
+					cmd.Env = append(os.Environ(),
+						"GOCOVERDIR="+coverageDir,
+						"CLAUDECODE_START_DELAY="+startup.delay,
+						"CLAUDECODE_DEAD_PARENT_HELPER=1",
+						"CLAUDECODE_CHILD_PID_PATH="+pidPath,
+					)
+					return cmd
+				},
+			})
 
-	pid := waitForPIDFile(t, pidPath)
-	select {
-	case err := <-errCh:
-		if !errors.Is(err, ErrMissingResult) {
-			t.Fatalf("RunTurn() error = %v, want ErrMissingResult", err)
-		}
-		if !strings.Contains(err.Error(), "process exited: exit status 9") {
-			t.Fatalf("RunTurn() error = %q, want provider exit status", err)
-		}
-	case <-time.After(time.Second):
-		cancel()
-		<-errCh
-		t.Fatal("RunTurn() did not detect the exited provider parent")
+			ctx, cancel := context.WithCancel(context.Background())
+			workspace := t.TempDir()
+			errCh := make(chan error, 1)
+			done := make(chan struct{})
+			started := make(chan struct{})
+			t.Cleanup(func() {
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(lifecycleWaitTimeout):
+					t.Error("RunTurn cleanup did not finish")
+				}
+			})
+			go func() {
+				defer close(done)
+				_, err := backend.RunTurn(ctx, runner.AgentTurnRequest{
+					Workspace: workspace,
+					Prompt:    "detect dead parent",
+					Model:     "fable",
+				}, func(update runner.AgentUpdate) error {
+					if update.Type == runner.AgentUpdateProcessStarted {
+						close(started)
+					}
+					return nil
+				})
+				errCh <- err
+			}()
+
+			pid := waitForPIDFile(t, pidPath)
+			select {
+			case <-started:
+			case err := <-errCh:
+				t.Fatalf("RunTurn exited before startup: %v", err)
+			case <-time.After(lifecycleWaitTimeout):
+				t.Fatal("RunTurn did not report process startup")
+			}
+			if !processAlive(pid) {
+				t.Fatalf("child process %d exited before lifecycle action", pid)
+			}
+			if _, err := releaseWriter.Write([]byte{1}); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, ErrMissingResult) {
+					t.Fatalf("RunTurn() error = %v, want ErrMissingResult", err)
+				}
+				if !strings.Contains(err.Error(), "process exited: exit status 9") {
+					t.Fatalf("RunTurn() error = %q, want provider exit status", err)
+				}
+			case <-time.After(lifecycleWaitTimeout):
+				t.Fatal("RunTurn() did not detect the exited provider parent")
+			}
+			waitForProcessExit(t, pid)
+		})
 	}
-	waitForProcessExit(t, pid)
 }
 
 func TestClaudeCodeDeadParentHelper(t *testing.T) {
@@ -105,6 +197,11 @@ func TestClaudeCodeDeadParentHelper(t *testing.T) {
 		return
 	}
 
+	delay, err := time.ParseDuration(os.Getenv("CLAUDECODE_START_DELAY") + "s")
+	if err != nil {
+		os.Exit(4)
+	}
+	<-time.After(delay)
 	cmd := exec.CommandContext(t.Context(), "sleep", "3600")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -112,16 +209,28 @@ func TestClaudeCodeDeadParentHelper(t *testing.T) {
 		os.Exit(2)
 	}
 	if err := os.WriteFile(os.Getenv("CLAUDECODE_CHILD_PID_PATH"), []byte(strconv.Itoa(cmd.Process.Pid)), 0o600); err != nil {
+		if err := cmd.Process.Kill(); err == nil {
+			_ = cmd.Wait()
+		}
 		os.Exit(3)
 	}
 	fmt.Fprintln(os.Stdout, `{"type":"system","subtype":"init","session_id":"session-dead-parent","model":"fable"}`)
+	release := os.NewFile(3, "release-parent")
+	if _, err := io.ReadFull(release, make([]byte, 1)); err != nil {
+		if err := cmd.Process.Kill(); err == nil {
+			_ = cmd.Wait()
+		}
+		os.Exit(5)
+	}
 	os.Exit(9)
 }
 
 func waitForPIDFile(t *testing.T, path string) int {
 	t.Helper()
 
-	deadline := time.After(time.Second)
+	deadline := time.After(lifecycleWaitTimeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	var lastErr error
 	var lastRaw string
 	for {
@@ -130,6 +239,16 @@ func waitForPIDFile(t *testing.T, path string) int {
 			lastRaw = string(raw)
 			pid, parseErr := strconv.Atoi(strings.TrimSpace(lastRaw))
 			if parseErr == nil && pid > 0 {
+				t.Cleanup(func() {
+					if !processAlive(pid) {
+						return
+					}
+					if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+						t.Errorf("clean up child process %d: %v", pid, err)
+						return
+					}
+					waitForProcessExit(t, pid)
+				})
 				return pid
 			}
 			if parseErr != nil {
@@ -147,8 +266,7 @@ func waitForPIDFile(t *testing.T, path string) int {
 				t.Fatalf("timed out waiting for parseable pid file, last value %q: %v", lastRaw, lastErr)
 			}
 			t.Fatalf("timed out waiting for pid file: %v", lastErr)
-		default:
-			time.Sleep(time.Millisecond)
+		case <-ticker.C:
 		}
 	}
 }
@@ -156,7 +274,9 @@ func waitForPIDFile(t *testing.T, path string) int {
 func waitForProcessExit(t *testing.T, pid int) {
 	t.Helper()
 
-	deadline := time.After(time.Second)
+	deadline := time.After(lifecycleWaitTimeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		if !processAlive(pid) {
 			return
@@ -165,8 +285,7 @@ func waitForProcessExit(t *testing.T, pid int) {
 		select {
 		case <-deadline:
 			t.Fatalf("process %d is still alive", pid)
-		default:
-			time.Sleep(time.Millisecond)
+		case <-ticker.C:
 		}
 	}
 }

--- a/internal/codex/transport_unix_test.go
+++ b/internal/codex/transport_unix_test.go
@@ -14,62 +14,125 @@ import (
 	"time"
 )
 
+const lifecycleWaitTimeout = 10 * time.Second
+
 func TestLocalTransportReapsChildAfterParentExits(t *testing.T) {
 	t.Parallel()
 
-	pidPath := t.TempDir() + "/child.pid"
-	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "sleep 3600 >/dev/null 2>&1 & printf '%s\n' \"$!\" > "+shellQuote(pidPath))
-	})
-	if err != nil {
-		t.Fatalf("NewLocalTransportFactory() error = %v", err)
-	}
+	for _, startup := range []struct {
+		name  string
+		delay string
+	}{
+		{name: "immediate", delay: "0"},
+		{name: "delayed readiness", delay: "1.2"},
+	} {
+		t.Run(startup.name, func(t *testing.T) {
+			t.Parallel()
 
-	transport, err := factory.NewTransport(context.Background())
-	if err != nil {
-		t.Fatalf("NewTransport() error = %v", err)
-	}
-	pid := waitForPIDFile(t, pidPath)
+			pidPath := t.TempDir() + "/child.pid"
+			factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+				return exec.CommandContext(ctx, "sh", "-c", "sleep "+startup.delay+"; sleep 3600 >/dev/null 2>&1 & printf '%s\n' \"$!\" > "+shellQuote(pidPath)+"; read release")
+			})
+			if err != nil {
+				t.Fatalf("NewLocalTransportFactory() error = %v", err)
+			}
 
-	closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := transport.Close(closeCtx); err != nil {
-		t.Fatalf("Close() error = %v", err)
-	}
-	if processAlive(pid) {
-		t.Fatalf("Close() returned while child process %d was still alive", pid)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			transport, err := factory.NewTransport(ctx)
+			if err != nil {
+				t.Fatalf("NewTransport() error = %v", err)
+			}
+			t.Cleanup(func() {
+				cancel()
+				closeCtx, closeCancel := context.WithTimeout(context.Background(), lifecycleWaitTimeout)
+				defer closeCancel()
+				_ = transport.Close(closeCtx)
+				select {
+				case <-transport.(*localTransport).done:
+				case <-closeCtx.Done():
+					t.Error("transport cleanup did not finish")
+				}
+			})
+			pid := waitForPIDFile(t, pidPath)
+
+			if !processAlive(pid) {
+				t.Fatalf("child process %d exited before parent release", pid)
+			}
+			if _, err := transport.(*localTransport).stdin.Write([]byte("release\n")); err != nil {
+				t.Fatal(err)
+			}
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), lifecycleWaitTimeout)
+			defer closeCancel()
+			if err := transport.Close(closeCtx); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+			if processAlive(pid) {
+				t.Fatalf("Close() returned while child process %d was still alive", pid)
+			}
+		})
 	}
 }
 
 func TestLocalTransportCloseKillsChildProcessGroup(t *testing.T) {
 	t.Parallel()
 
-	pidPath := t.TempDir() + "/child.pid"
-	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "sleep 3600 & printf '%s\n' \"$!\" > "+shellQuote(pidPath)+"; wait")
-	})
-	if err != nil {
-		t.Fatalf("NewLocalTransportFactory() error = %v", err)
-	}
+	for _, startup := range []struct {
+		name  string
+		delay string
+	}{
+		{name: "immediate", delay: "0"},
+		{name: "delayed readiness", delay: "1.2"},
+	} {
+		t.Run(startup.name, func(t *testing.T) {
+			t.Parallel()
 
-	transport, err := factory.NewTransport(context.Background())
-	if err != nil {
-		t.Fatalf("NewTransport() error = %v", err)
-	}
-	pid := waitForPIDFile(t, pidPath)
+			pidPath := t.TempDir() + "/child.pid"
+			factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+				return exec.CommandContext(ctx, "sh", "-c", "sleep "+startup.delay+"; sleep 3600 & printf '%s\n' \"$!\" > "+shellQuote(pidPath)+"; wait")
+			})
+			if err != nil {
+				t.Fatalf("NewLocalTransportFactory() error = %v", err)
+			}
 
-	closeCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	if err := transport.Close(closeCtx); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Close() error = %v, want context deadline exceeded", err)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			transport, err := factory.NewTransport(ctx)
+			if err != nil {
+				t.Fatalf("NewTransport() error = %v", err)
+			}
+			t.Cleanup(func() {
+				cancel()
+				closeCtx, closeCancel := context.WithTimeout(context.Background(), lifecycleWaitTimeout)
+				defer closeCancel()
+				_ = transport.Close(closeCtx)
+				select {
+				case <-transport.(*localTransport).done:
+				case <-closeCtx.Done():
+					t.Error("transport cleanup did not finish")
+				}
+			})
+			pid := waitForPIDFile(t, pidPath)
+			if !processAlive(pid) {
+				t.Fatalf("child process %d exited before Close", pid)
+			}
+
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer closeCancel()
+			if err := transport.Close(closeCtx); !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("Close() error = %v, want context deadline exceeded", err)
+			}
+			waitForProcessExit(t, pid)
+		})
 	}
-	waitForProcessExit(t, pid)
 }
 
 func waitForPIDFile(t *testing.T, path string) int {
 	t.Helper()
 
-	deadline := time.After(time.Second)
+	deadline := time.After(lifecycleWaitTimeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	var lastErr error
 	lastRaw := ""
 	for {
@@ -79,6 +142,16 @@ func waitForPIDFile(t *testing.T, path string) int {
 			pidText := strings.TrimSpace(lastRaw)
 			pid, parseErr := strconv.Atoi(pidText)
 			if parseErr == nil && pid > 0 {
+				t.Cleanup(func() {
+					if !processAlive(pid) {
+						return
+					}
+					if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+						t.Errorf("clean up child process %d: %v", pid, err)
+						return
+					}
+					waitForProcessExit(t, pid)
+				})
 				return pid
 			}
 			if parseErr != nil {
@@ -96,8 +169,7 @@ func waitForPIDFile(t *testing.T, path string) int {
 				t.Fatalf("timed out waiting for parseable pid file, last value %q: %v", lastRaw, lastErr)
 			}
 			t.Fatalf("timed out waiting for pid file: %v", lastErr)
-		default:
-			time.Sleep(time.Millisecond)
+		case <-ticker.C:
 		}
 	}
 }
@@ -105,7 +177,9 @@ func waitForPIDFile(t *testing.T, path string) int {
 func waitForProcessExit(t *testing.T, pid int) {
 	t.Helper()
 
-	deadline := time.After(time.Second)
+	deadline := time.After(lifecycleWaitTimeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		if !processAlive(pid) {
 			return
@@ -114,8 +188,7 @@ func waitForProcessExit(t *testing.T, pid int) {
 		select {
 		case <-deadline:
 			t.Fatalf("process %d is still alive", pid)
-		default:
-			time.Sleep(time.Millisecond)
+		case <-ticker.C:
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Synchronize Claude Code and Codex lifecycle fixtures before cancellation or controlled parent exit, and exercise both immediate and delayed startup.
- Preserve cancellation, provider exit-status, and child-termination assertions; cancel and join helpers on failure, with emergency child cleanup after assertions.
- Repeat focused lifecycle race tests on Ubuntu and document the reusable fixture validation method.

A controlled 1.2-second startup delay reproduces the old PID-readiness failures. The original Linux job has no process-state trace, so this does not establish the historical Linux or macOS failure cause. No production lifecycle behavior changes.

Fixes #2372

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `make check` (80.3% overall coverage; package and file floors passed)
- [x] 20 focused race repetitions in both packages on macOS, repeated during recovery.
- [x] Five focused coverage repetitions in both packages, repeated during recovery.
- [x] Negative control restoring one-second readiness guard fails all four delayed cases (prior attempt).
- [x] Negative controls omitting production post-exit cleanup fail both parent-exit tests; independent PID checks confirm emergency cleanup (prior attempt).
- [x] All 11 current-head CI jobs passed, including Ubuntu with 20 focused race repetitions: https://github.com/digitaldrywood/detent/actions/runs/34352500352
