### PR TITLE
fix(watchdog): account for completed slow refreshes

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -936,6 +936,9 @@ func (o *Orchestrator) finishTick(state *State) {
 	if o == nil {
 		return
 	}
+	if state != nil && state.PollInterval > 0 {
+		state.NextRefreshAt = o.clockNow().Add(state.PollInterval)
+	}
 	o.publishState(state)
 	o.refreshProgress.Store(nil)
 	o.refreshInProgress.Store(false)

--- a/internal/orchestrator/tick_watchdog.go
+++ b/internal/orchestrator/tick_watchdog.go
@@ -77,7 +77,15 @@ func (w *tickWatchdog) Schedule(nextRefreshAt time.Time, interval time.Duration)
 	if interval > 0 {
 		w.interval = interval
 	}
+	recovered := w.status == telemetry.TickLivenessStatusNeedsAttention
+	if !w.lastTickAt.IsZero() {
+		w.status = telemetry.TickLivenessStatusReady
+		w.frozenAt = time.Time{}
+	}
 	w.mu.Unlock()
+	if recovered {
+		w.logger.Info("orchestrator tick loop recovered", "project_id", w.projectID, "next_refresh_at", nextRefreshAt)
+	}
 }
 
 func (w *tickWatchdog) Evaluate(now time.Time) telemetry.TickLiveness {
@@ -87,11 +95,11 @@ func (w *tickWatchdog) Evaluate(now time.Time) telemetry.TickLiveness {
 	now = now.UTC()
 	w.mu.Lock()
 	previous := w.status
-	missed := missedTickIntervals(w.lastTickAt, now, w.interval)
+	missed := missedTickIntervals(w.intervalStartLocked(), now, w.interval)
 	if !w.lastTickAt.IsZero() && missed >= tickWatchdogIntervalCount {
 		w.status = telemetry.TickLivenessStatusNeedsAttention
 		if w.frozenAt.IsZero() {
-			w.frozenAt = w.lastTickAt
+			w.frozenAt = w.intervalStartLocked()
 		}
 	}
 	liveness := w.livenessLocked(now)
@@ -155,9 +163,16 @@ func (w *tickWatchdog) livenessLocked(now time.Time) telemetry.TickLiveness {
 		NextRefreshAt:         watchdogTimePointer(w.nextRefreshAt),
 		NextRefreshOverdue:    !w.nextRefreshAt.IsZero() && !now.IsZero() && now.After(w.nextRefreshAt),
 		FrozenAt:              watchdogTimePointer(w.frozenAt),
-		MissedIntervals:       missedTickIntervals(w.lastTickAt, now, w.interval),
+		MissedIntervals:       missedTickIntervals(w.intervalStartLocked(), now, w.interval),
 		WatchdogIntervalCount: tickWatchdogIntervalCount,
 	}
+}
+
+func (w *tickWatchdog) intervalStartLocked() time.Time {
+	if w.lastTickAt.IsZero() || w.nextRefreshAt.IsZero() || w.interval <= 0 {
+		return w.lastTickAt
+	}
+	return w.nextRefreshAt.Add(-w.interval)
 }
 
 func missedTickIntervals(lastTickAt time.Time, now time.Time, interval time.Duration) int64 {

--- a/internal/orchestrator/tick_watchdog_test.go
+++ b/internal/orchestrator/tick_watchdog_test.go
@@ -1,8 +1,12 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -116,5 +120,92 @@ func TestTickWatchdogRunsOutsideTickLoop(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("watchdog did not stop after cancellation")
+	}
+}
+
+func TestTickWatchdogCompletedSlowRefresh(t *testing.T) {
+	t.Parallel()
+	for _, duration := range []time.Duration{560 * time.Second, 700 * time.Second} {
+		t.Run(duration.String(), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				interval := 300 * time.Second
+				var logs bytes.Buffer
+				watchdog := newTickWatchdog("parable", interval, slog.New(slog.NewTextHandler(&logs, nil)))
+				orch := &Orchestrator{tickWatchdog: watchdog}
+				started := time.Now()
+				state := State{PollInterval: interval, LastRefreshAt: started, NextRefreshAt: started.Add(interval)}
+				recordRefreshSourceSuccess(&state, telemetry.RefreshSourceCandidates, started)
+				orch.startTick(&state, started)
+				time.Sleep(duration)
+				active := watchdog.Evaluate(time.Now())
+				wantActive := telemetry.TickLivenessStatusReady
+				if duration >= 2*interval {
+					wantActive = telemetry.TickLivenessStatusNeedsAttention
+				}
+				if active.Status != wantActive {
+					t.Fatalf("active refresh status = %s", active.Status)
+				}
+				orch.finishTick(&state)
+				completed := time.Now()
+				wantNext := completed.Add(interval)
+				if !state.NextRefreshAt.Equal(wantNext) {
+					t.Fatalf("NextRefreshAt = %v, want completion plus interval %v", state.NextRefreshAt, wantNext)
+				}
+				if duration < 2*interval && strings.Contains(logs.String(), "tick loop") {
+					t.Fatalf("slow refresh caused liveness churn: %s", logs.String())
+				}
+				logs.Reset()
+				ticker := time.NewTicker(interval)
+				defer ticker.Stop()
+				resetTicker(ticker, interval)
+				time.Sleep(interval - time.Second)
+				got := watchdog.Evaluate(time.Now())
+				if got.Status != telemetry.TickLivenessStatusReady || got.NextRefreshOverdue || got.MissedIntervals != 0 || got.FrozenAt != nil {
+					t.Fatalf("legitimate polling wait = %+v", got)
+				}
+				if got.LastTickAt == nil || !got.LastTickAt.Equal(started) || !state.LastRefreshAt.Equal(started) {
+					t.Fatal("completion changed start-time evidence")
+				}
+				source := state.RefreshSources[telemetry.RefreshSourceCandidates]
+				if source.LastSuccessAt == nil || !source.LastSuccessAt.Equal(started) {
+					t.Fatal("completion changed source freshness evidence")
+				}
+				next := <-ticker.C
+				if !next.Equal(wantNext) {
+					t.Fatalf("timer fired at %v, want %v", next, wantNext)
+				}
+				orch.startTick(&state, next)
+				if strings.Contains(logs.String(), "tick loop") {
+					t.Fatalf("completed refresh caused liveness churn: %s", logs.String())
+				}
+			})
+		})
+	}
+}
+
+func TestTickWatchdogMissedScheduledTick(t *testing.T) {
+	t.Parallel()
+	started := time.Date(2026, 9, 9, 0, 14, 34, 0, time.UTC)
+	interval := 5 * time.Minute
+	next := started.Add(560*time.Second + interval)
+	for _, tt := range []struct {
+		name   string
+		offset time.Duration
+		missed int64
+		status telemetry.TickLivenessStatus
+	}{
+		{"waiting", -time.Second, 0, telemetry.TickLivenessStatusReady},
+		{"due", 0, 1, telemetry.TickLivenessStatusReady},
+		{"missed", interval, 2, telemetry.TickLivenessStatusNeedsAttention},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w := newTickWatchdog("parable", interval, nil)
+			w.Advance(started, started.Add(interval), interval)
+			w.Schedule(next, interval)
+			got := w.Evaluate(next.Add(tt.offset))
+			if got.Status != tt.status || got.MissedIntervals != tt.missed {
+				t.Fatalf("liveness = %+v, want status %s and missed %d", got, tt.status, tt.missed)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Account for completed slow refreshes by scheduling watchdog expectations one polling interval after completion, matching the existing timer reset.
- Preserve detection of stalled active refreshes and missed scheduled ticks, along with refresh timing and source freshness evidence.

Fixes #2373

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, first-viewport, or responsive visibility changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Deterministic tests cover a 560-second refresh followed by a 300-second polling wait without false frozen/recovered logs, a 700-second active stall, and missed scheduled ticks.
- [x] `go test -race ./internal/orchestrator -run 'TestTickWatchdog|TestRefresh' -count=1`
- [x] `make check` — all checks passed on restored commit 7f9bf8f8; 80.4% total coverage and configured package/file floors satisfied.

