### PR TITLE
fix(checklock): renew waits on healthy handoffs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ GOSEC_EXCLUDES ?= G115,G301,G304,G306
 GOSEC_EXCLUDE_DIRS ?= .detent
 GOSEC_EXCLUDE_DIR_FLAGS := $(addprefix -exclude-dir=,$(GOSEC_EXCLUDE_DIRS))
 CHECK_LOCK_WAIT ?= 15m
+CHECK_LOCK_MAX_WAIT ?= 4h
 
 .PHONY: dev generate check-migrations check-generated css css-watch build test test-race test-race-hub test-race-cover coverage-check test-cover test-cover-packages soak visual-e2e visual-e2e-update lint vet gosec-build security-gosec-determinism security check check-unlocked modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
 
@@ -168,7 +169,7 @@ nilaway-audit:
 check: check-migrations
 	@mkdir -p tmp
 	@common_dir="$$(git rev-parse --path-format=absolute --git-common-dir)" && \
-	go run ./tools/checklock -lock "$$common_dir/detent-validation.lock" -wait-timeout "$(CHECK_LOCK_WAIT)" -events tmp/validation-events.jsonl -- $(MAKE) check-unlocked
+	go run ./tools/checklock -lock "$$common_dir/detent-validation.lock" -wait-timeout "$(CHECK_LOCK_WAIT)" -max-wait-timeout "$(CHECK_LOCK_MAX_WAIT)" -events tmp/validation-events.jsonl -- $(MAKE) check-unlocked
 
 check-unlocked: check-migrations check-generated build lint vet nilaway-audit test-race-cover
 	@echo "All checks passed."

--- a/tools/checklock/README.md
+++ b/tools/checklock/README.md
@@ -24,9 +24,22 @@ closing. Partial receipts left by a crash are also recoverable. Numeric tickets
 avoid wall-clock ordering assumptions. The queue admits up to 1024 live waiters;
 excess invocations fail explicitly instead of growing it without a bound.
 
-`-wait-timeout` (15 minutes by default) bounds registration and queue waiting.
-Interrupt/termination signals cancel waiting. Once validation starts, this wait
-budget does not limit execution. Parent cancellation and termination signals
+`-wait-timeout` (`CHECK_LOCK_WAIT` in Make, 15 minutes by default) bounds
+registration and waiting without progress. An observed change in valid owner
+identity (PID, hostname, acquisition time), or acquisition after an observed
+clear lock, renews that budget. Queue position
+improvement also renews it when the validation lock is not held. An unchanged
+live holder, unreadable owner metadata, periodic reports, and new arrivals do
+not renew the budget. Cancellations ahead of a waiter cannot extend a stalled
+holder's budget. Handoffs must be observed before the current budget expires;
+liveness alone does not prove that validation is progressing.
+
+`-max-wait-timeout` (`CHECK_LOCK_MAX_WAIT` in Make, 4 hours by default) bounds
+total registration and queue waiting even with repeated handoffs. This also
+bounds contention with older clients that do not honor FIFO. Both durations
+must be positive. The waiter retains its original ticket across renewals.
+Interrupt/termination signals and parent deadlines cancel waiting. Once
+validation starts, neither wait budget limits execution. Parent cancellation and termination signals
 stop the active command through the shared process-group helper. The wrapper
 retains the lock until command exit and process-group cleanup finish. The
 validation command controls its own active timeouts.
@@ -34,7 +47,9 @@ validation command controls its own active timeouts.
 Waiting diagnostics report queue position, queue size, elapsed wait, and the
 active owner's PID/acquisition time when available. They refresh when the queue
 or owner changes and at least every 30 seconds while polling the validation
-queue. Timeout messages identify waiting before validation has started. Normal
+queue. Renewal messages identify the observed progress and both budgets. Expiration
+messages distinguish no progress, the total cap, and parent cancellation or
+deadline expiry, and identify waiting before validation has started. Normal
 diagnostics omit repository paths and owner hostnames.
 
 Older checklock binaries still contend on the original exclusive validation

--- a/tools/checklock/main.go
+++ b/tools/checklock/main.go
@@ -31,7 +31,8 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	flags.SetOutput(stderr)
 
 	lockPath := flags.String("lock", "", "validation lock path")
-	waitTimeout := flags.Duration("wait-timeout", 15*time.Minute, "maximum time to wait for another validation gate")
+	waitTimeout := flags.Duration("wait-timeout", 15*time.Minute, "maximum wait without an owner handoff or unheld queue advancement")
+	maxWaitTimeout := flags.Duration("max-wait-timeout", 4*time.Hour, "maximum total registration and queue wait")
 	eventsPath := flags.String("events", "", "append local gate timing events as JSON lines")
 
 	if err := flags.Parse(args); err != nil {
@@ -43,6 +44,10 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	}
 	if *waitTimeout <= 0 {
 		fmt.Fprintln(stderr, "-wait-timeout must be positive")
+		return 2
+	}
+	if *maxWaitTimeout <= 0 {
+		fmt.Fprintln(stderr, "-max-wait-timeout must be positive")
 		return 2
 	}
 	command := flags.Args()
@@ -69,10 +74,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	event := validationEvent{Schema: 1, PID: os.Getpid(), StartedAt: started, CommandHash: fmt.Sprintf("%x", sha256.Sum256(encodedCommand))}
 	event.write(events, stderr, "waiting")
 
-	waitCtx, cancel := context.WithTimeout(ctx, *waitTimeout)
-	defer cancel()
-
-	lock, waited, err := acquireValidationLock(waitCtx, *lockPath, stderr)
+	lock, waited, err := acquireValidationLockWithTimeouts(ctx, *lockPath, stderr, *waitTimeout, *maxWaitTimeout, validationPosition)
 	if err != nil {
 		event.WaitSeconds = time.Since(started).Seconds()
 		event.write(events, stderr, "wait_failed")

--- a/tools/checklock/main_test.go
+++ b/tools/checklock/main_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/instancelock"
@@ -35,6 +36,7 @@ func TestRunValidatesArguments(t *testing.T) {
 	}{
 		{name: "missing lock", args: []string{"--", "go", "version"}, wantErr: "-lock is required"},
 		{name: "invalid wait timeout", args: []string{"-lock", "gate.lock", "-wait-timeout", "0s", "--", "go", "version"}, wantErr: "-wait-timeout must be positive"},
+		{name: "invalid total wait timeout", args: []string{"-lock", "gate.lock", "-max-wait-timeout", "0s", "--", "go", "version"}, wantErr: "-max-wait-timeout must be positive"},
 		{name: "missing command", args: []string{"-lock", "gate.lock"}, wantErr: "command is required after --"},
 	}
 
@@ -369,4 +371,53 @@ func TestValidationCancellationHelper(t *testing.T) {
 	if _, err := io.ReadFull(os.Stdin, make([]byte, 1)); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestRunRetainsWaitAcrossHandoffs(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+		path := filepath.Join(t.TempDir(), "validation.lock")
+		holder := acquireTestLock(t, path)
+		older, err := registerValidationWaiter(t.Context(), path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { older.lock.Close() })
+		ownersDone := make(chan struct{})
+		go func() {
+			defer close(ownersDone)
+			defer older.lock.Close()
+			for i := range 4 {
+				time.Sleep(400 * time.Millisecond)
+				if err := holder.Close(); err != nil {
+					t.Error(err)
+					return
+				}
+				if i < 3 {
+					var err error
+					for {
+						holder, err = instancelock.Acquire(path)
+						if !errors.Is(err, instancelock.ErrHeld) {
+							break
+						}
+						if err = waitValidationPoll(ctx); err != nil {
+							break
+						}
+					}
+					if err != nil {
+						t.Error(err)
+						return
+					}
+				}
+			}
+		}()
+		var stderr bytes.Buffer
+		code := run(ctx, []string{"-lock", path, "-wait-timeout", "1s", "--", filepath.Join(t.TempDir(), "missing-command")}, nil, io.Discard, &stderr)
+		<-ownersDone
+		if code != 1 || !strings.Contains(stderr.String(), "resolve validation command") || strings.Count(stderr.String(), "reason=owner_handoff") != 3 {
+			t.Fatalf("run failed to reach command after healthy handoffs: code=%d stderr=%s", code, &stderr)
+		}
+	})
 }

--- a/tools/checklock/queue.go
+++ b/tools/checklock/queue.go
@@ -26,10 +26,22 @@ func acquireValidationLock(ctx context.Context, path string, stderr io.Writer) (
 }
 
 func acquireValidationLockWithPosition(ctx context.Context, path string, stderr io.Writer, lookupPosition func(context.Context, string, string) (int, int, error)) (*instancelock.Lock, bool, error) {
+	return acquireValidationLockWithTimeouts(ctx, path, stderr, 15*time.Minute, 4*time.Hour, lookupPosition)
+}
+
+func acquireValidationLockWithTimeouts(ctx context.Context, path string, stderr io.Writer, idleTimeout, maxTimeout time.Duration, lookupPosition func(context.Context, string, string) (int, int, error)) (*instancelock.Lock, bool, error) {
 	started := time.Now()
+	maxCtx, stop := context.WithTimeoutCause(ctx, maxTimeout, fmt.Errorf("total queue wait limit reached: %w", context.DeadlineExceeded))
+	defer stop()
+	ctx, cancel := validationIdleContext(maxCtx, idleTimeout)
+	defer func() { cancel() }()
+	lastProgress := started
+	lastPosition := 0
+	var lastOwner instancelock.Owner
+	var lastOwnerStatus instancelock.Status
 	waiter, err := registerValidationWaiter(ctx, path)
 	if err != nil {
-		return nil, false, fmt.Errorf("register validation waiter after %s: %w", time.Since(started).Round(time.Millisecond), err)
+		return nil, false, fmt.Errorf("register validation waiter after %s: %w", time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
 	}
 	defer func() {
 		if err := waiter.lock.Close(); err != nil {
@@ -40,13 +52,13 @@ func acquireValidationLockWithPosition(ctx context.Context, path string, stderr 
 	waited := false
 	lastDiagnostic := ""
 	lastReport := time.Time{}
-	for {
+	for ctx := ctx; ; {
 		position, size, err := lookupPosition(ctx, path, waiter.name)
 		if err != nil {
-			return nil, waited, fmt.Errorf("wait for validation queue after %s: %w", time.Since(started).Round(time.Millisecond), err)
+			return nil, waited, fmt.Errorf("wait for validation queue after %s: %w", time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
 		}
 		if err := ctx.Err(); err != nil {
-			return nil, waited, fmt.Errorf("validation queue wait ended (position=%d queued=%d waited=%s; validation has not started): %w", position, size, time.Since(started).Round(time.Millisecond), err)
+			return nil, waited, fmt.Errorf("validation queue wait ended (position=%d queued=%d waited=%s; validation has not started): %w", position, size, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
 		}
 		if position == 1 {
 			lock, err := instancelock.Acquire(path)
@@ -61,20 +73,44 @@ func acquireValidationLockWithPosition(ctx context.Context, path string, stderr 
 		if err != nil {
 			return nil, waited, err
 		}
+		progress := ""
+		if owner.Status == instancelock.StatusHeld && owner.MetadataError == nil {
+			if (!lastOwner.StartedAt.IsZero() && owner.Owner != lastOwner) || (lastPosition > 0 && lastOwnerStatus != instancelock.StatusHeld) {
+				progress = "owner_handoff"
+			}
+			lastOwner = owner.Owner
+		} else if owner.Status != instancelock.StatusHeld && lastPosition > position {
+			progress = "queue_advanced_without_owner"
+		}
+		lastPosition = position
+		lastOwnerStatus = owner.Status
+		if err := ctx.Err(); err != nil {
+			return nil, waited, fmt.Errorf("validation queue wait ended (position=%d queued=%d waited=%s; validation has not started): %w", position, size, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
+		}
+		if progress != "" {
+			cancel()
+			ctx, cancel = validationIdleContext(maxCtx, idleTimeout)
+			lastProgress = time.Now()
+			fmt.Fprintf(stderr, "validation queue progress: reason=%s position=%d waited=%s; renewing idle wait budget=%s (total limit=%s)\n", progress, position, time.Since(started).Round(time.Millisecond), idleTimeout, maxTimeout)
+		}
 		diagnostic := fmt.Sprintf("position=%d queued=%d owner=%s", position, size, owner.Status)
 		if owner.Status == instancelock.StatusHeld && owner.MetadataError == nil {
 			diagnostic += fmt.Sprintf(" owner_pid=%d owner_since=%s", owner.Owner.PID, owner.Owner.StartedAt.Format(time.RFC3339Nano))
 		}
 		if diagnostic != lastDiagnostic || time.Since(lastReport) >= 30*time.Second {
-			fmt.Fprintf(stderr, "validation gate waiting: %s waited=%s\n", diagnostic, time.Since(started).Round(time.Millisecond))
+			fmt.Fprintf(stderr, "validation gate waiting: %s waited=%s idle=%s idle_limit=%s total_limit=%s\n", diagnostic, time.Since(started).Round(time.Millisecond), time.Since(lastProgress).Round(time.Millisecond), idleTimeout, maxTimeout)
 			lastDiagnostic = diagnostic
 			lastReport = time.Now()
 		}
 		waited = true
 		if err := waitValidationPoll(ctx); err != nil {
-			return nil, waited, fmt.Errorf("validation queue wait ended (%s waited=%s; validation has not started): %w", diagnostic, time.Since(started).Round(time.Millisecond), err)
+			return nil, waited, fmt.Errorf("validation queue wait ended (%s waited=%s; validation has not started): %w", diagnostic, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
 		}
 	}
+}
+
+func validationIdleContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeoutCause(ctx, timeout, fmt.Errorf("no validation owner handoff or unheld queue advancement for %s: %w", timeout, context.DeadlineExceeded))
 }
 
 func registerValidationWaiter(ctx context.Context, path string) (validationWaiter, error) {

--- a/tools/checklock/queue_test.go
+++ b/tools/checklock/queue_test.go
@@ -88,10 +88,10 @@ func TestValidationQueueDeadlines(t *testing.T) {
 					heldPath += ".queue.lock"
 				}
 				acquireTestLock(t, heldPath)
-				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				ctx, cancel := context.WithCancel(t.Context())
 				defer cancel()
 				var stderr bytes.Buffer
-				lock, _, err := acquireValidationLock(ctx, path, &stderr)
+				lock, _, err := acquireValidationLockWithTimeouts(ctx, path, &stderr, time.Second, time.Minute, validationPosition)
 				if !errors.Is(err, context.DeadlineExceeded) || lock != nil {
 					t.Fatalf("deadline result = %v, %v", lock, err)
 				}
@@ -472,4 +472,192 @@ func TestValidationQueueRejectsInvalidState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidationQueueHealthyHandoffs(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "validation.lock")
+		holder := acquireTestLock(t, path)
+		var older []validationWaiter
+		for range 3 {
+			waiter, err := registerValidationWaiter(t.Context(), path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { waiter.lock.Close() })
+			older = append(older, waiter)
+		}
+		var stderr bytes.Buffer
+		started := time.Now()
+		calls := 0
+		lock, waited, err := acquireValidationLockWithPosition(t.Context(), path, &stderr, func(ctx context.Context, path, name string) (int, int, error) {
+			if calls > 0 {
+				time.Sleep(6 * time.Minute)
+				if err := holder.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if calls < 4 {
+					if err := older[calls-1].lock.Close(); err != nil {
+						t.Fatal(err)
+					}
+					holder = acquireTestLock(t, path)
+				}
+			}
+			calls++
+			return validationPosition(ctx, path, name)
+		})
+		if err != nil {
+			t.Fatalf("healthy handoffs lost queue progress after %s: %v", time.Since(started), err)
+		}
+		defer lock.Close()
+		if !waited || time.Since(started) < 24*time.Minute || strings.Count(stderr.String(), "reason=owner_handoff") != 3 {
+			t.Fatalf("handoffs: waited=%t elapsed=%s diagnostics=%s", waited, time.Since(started), &stderr)
+		}
+	})
+}
+
+func TestValidationQueueWaitBudgets(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		activity   string
+		maxWait    time.Duration
+		wantWait   time.Duration
+		wantReason string
+	}{
+		{name: "owner starts after queueing", activity: "owner starts", maxWait: time.Minute, wantWait: 1500 * time.Millisecond, wantReason: "no validation owner handoff"},
+		{name: "live stalled holder", maxWait: time.Minute, wantWait: time.Second, wantReason: "no validation owner handoff"},
+		{name: "queue advancement does not renew stalled holder", activity: "cancel older", maxWait: time.Minute, wantWait: time.Second, wantReason: "no validation owner handoff"},
+		{name: "new arrivals do not renew wait", activity: "new waiter", maxWait: time.Minute, wantWait: time.Second, wantReason: "no validation owner handoff"},
+		{name: "handoffs stop at total bound", activity: "handoff", maxWait: 2 * time.Second, wantWait: 2 * time.Second, wantReason: "total queue wait limit reached"},
+		{name: "cancellation after handoff", activity: "cancel", maxWait: time.Minute, wantWait: time.Second, wantReason: "context canceled"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				path := filepath.Join(t.TempDir(), "validation.lock")
+				var holder *instancelock.Lock
+				if tt.activity != "owner starts" {
+					holder = acquireTestLock(t, path)
+				}
+				older, err := registerValidationWaiter(ctx, path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer older.lock.Close()
+				var stderr bytes.Buffer
+				started := time.Now()
+				calls := 0
+				var ticket string
+				lock, _, err := acquireValidationLockWithTimeouts(ctx, path, &stderr, time.Second, tt.maxWait, func(ctx context.Context, path, name string) (int, int, error) {
+					ticket = name
+					if calls > 0 {
+						time.Sleep(400 * time.Millisecond)
+						switch tt.activity {
+						case "owner starts":
+							if calls == 1 {
+								holder = acquireTestLock(t, path)
+							}
+						case "handoff", "cancel":
+							if err := holder.Close(); err != nil {
+								t.Fatal(err)
+							}
+							holder = acquireTestLock(t, path)
+							if tt.activity == "cancel" && calls == 2 {
+								cancel()
+							}
+						case "cancel older":
+							if err := older.lock.Close(); err != nil {
+								t.Fatal(err)
+							}
+						case "new waiter":
+							waiter, err := registerValidationWaiter(t.Context(), path)
+							if err != nil {
+								t.Fatal(err)
+							}
+							t.Cleanup(func() { waiter.lock.Close() })
+						}
+					}
+					calls++
+					return validationPosition(ctx, path, name)
+				})
+				wantErr := context.DeadlineExceeded
+				if tt.activity == "cancel" {
+					wantErr = context.Canceled
+				}
+				if lock != nil || !errors.Is(err, wantErr) || !strings.Contains(err.Error(), tt.wantReason) || time.Since(started) != tt.wantWait {
+					t.Fatalf("wait result: lock=%v err=%v elapsed=%s; want %s after %s", lock, err, time.Since(started), tt.wantReason, tt.wantWait)
+				}
+				if (tt.activity == "handoff" || tt.activity == "cancel" || tt.activity == "owner starts") && !strings.Contains(stderr.String(), "reason=owner_handoff") {
+					t.Fatalf("missing renewal reason: %s", &stderr)
+				}
+				if tt.activity != "handoff" && tt.activity != "cancel" && tt.activity != "owner starts" && strings.Contains(stderr.String(), "renewing") {
+					t.Fatalf("non-progress renewed wait: %s", &stderr)
+				}
+				inspection, err := instancelock.Inspect(path)
+				if err != nil || inspection.Status != instancelock.StatusHeld {
+					t.Fatalf("wait expiration released holder: %+v, %v", inspection, err)
+				}
+				inspection, err = instancelock.Inspect(filepath.Join(path+".queue", ticket))
+				if err != nil || inspection.Status == instancelock.StatusHeld {
+					t.Fatalf("expired ticket remains live: %+v, %v", inspection, err)
+				}
+				if err := older.lock.Close(); err != nil {
+					t.Fatal(err)
+				}
+				next, err := registerValidationWaiter(t.Context(), path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer next.lock.Close()
+				if _, err := os.Stat(filepath.Join(path+".queue", ticket)); next.name != ticket && !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("retry did not prune expired ticket: %v", err)
+				}
+			})
+		})
+	}
+}
+
+func TestValidationQueueUnheldAdvancement(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "validation.lock")
+		var older []validationWaiter
+		for range 3 {
+			waiter, err := registerValidationWaiter(t.Context(), path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { waiter.lock.Close() })
+			older = append(older, waiter)
+		}
+		var stderr bytes.Buffer
+		started := time.Now()
+		calls := 0
+		lock, _, err := acquireValidationLockWithTimeouts(t.Context(), path, &stderr, time.Second, time.Minute, func(ctx context.Context, path, name string) (int, int, error) {
+			if calls > 0 {
+				time.Sleep(500 * time.Millisecond)
+				if err := older[calls-1].lock.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			calls++
+			return validationPosition(ctx, path, name)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lock.Close()
+		if time.Since(started) <= time.Second || strings.Count(stderr.String(), "reason=queue_advanced_without_owner") != 2 {
+			t.Fatalf("queue progress: elapsed=%s diagnostics=%s", time.Since(started), &stderr)
+		}
+		time.Sleep(2 * time.Minute)
+		inspection, err := instancelock.Inspect(path)
+		if err != nil || inspection.Status != instancelock.StatusHeld {
+			t.Fatalf("wait budgets affected active gate: %+v, %v", inspection, err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Retain FIFO queue tickets across healthy owner handoffs by renewing the 15-minute idle wait budget. An unchanged live owner and unrelated queue activity do not renew it.
- Bound total waiting separately at four hours, configurable through `CHECK_LOCK_MAX_WAIT` / `-max-wait-timeout`, and report renewal and expiration reasons. Waiting deadlines remain separate from active validation.
- Preserve exclusive locking, cancellation, crashed-waiter cleanup, and portability behavior.

Fixes #2392

## UI Surface Contract

- [x] N/A: this change affects validation tooling only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens.

## Test Plan

- [x] Reproduce the old absolute deadline expiring at 15 minutes despite healthy handoffs.
- [x] Deterministic tests: three handoffs over 24 minutes, stalled holder despite queue churn, total cap, cancellation after renewal, retry cleanup, and active-gate independence.
- [x] `go test -race ./tools/checklock ./internal/instancelock -count=10`
- [x] Repeat the new deadline and CLI regression cases under the race detector.
- [x] Pinned Go 1.26.6 golangci-lint for validation tooling.
- [x] Windows test-binary cross-compilation; existing Windows runtime coverage retained in Portability Stress.
- [x] `make check` — 80.4% coverage; all package/file floors passed.
- [x] Live queue validation retained one ticket across five handoffs, acquired after 42m27.924s, then passed the full gate in 9m21.318s.
