### PR TITLE
fix(watcher): reconcile git-ref overlay deletion

### DIFF
--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -29,6 +29,7 @@ type workflowGitRefSource struct {
 	sourceRoot string
 	ref        string
 	path       string
+	readFile   func(string) ([]byte, error)
 }
 
 type gitRefWorkflowWatcher struct {
@@ -131,6 +132,7 @@ func newWorkflowGitRefSource(cfg globalconfig.Project) (workflowGitRefSource, er
 		sourceRoot: sourceRoot,
 		ref:        ref,
 		path:       workflowPath,
+		readFile:   os.ReadFile,
 	}, nil
 }
 
@@ -207,12 +209,12 @@ func (s workflowGitRefSource) load(ctx context.Context) (workflowconfig.Workflow
 		return workflowconfig.Workflow{}, revision, err
 	}
 	localWorkflowPath := s.localPath()
-	localRaw, hasLocalWorkflow, err := readOptionalWorkflowSourceFile(localWorkflowPath)
+	localRaw, hasLocalWorkflow, err := readOptionalWorkflowSourceFile(ctx, localWorkflowPath, s.readFile)
 	if err != nil {
 		return workflowconfig.Workflow{}, revision, fmt.Errorf("read local workflow overlay: %w", err)
 	}
 	localConfigPath := s.localConfigPath()
-	localConfigRaw, hasLocalConfig, err := readOptionalWorkflowSourceFile(localConfigPath)
+	localConfigRaw, hasLocalConfig, err := readOptionalWorkflowSourceFile(ctx, localConfigPath, s.readFile)
 	if err != nil {
 		return workflowconfig.Workflow{}, revision, fmt.Errorf("read local project config: %w", err)
 	}
@@ -250,8 +252,34 @@ func (s workflowGitRefSource) loadOptionalRefFile(ctx context.Context, revision 
 	return nil, false, fmt.Errorf("load project config from %s:%s: %w", revision, refPath, err)
 }
 
-func readOptionalWorkflowSourceFile(path string) ([]byte, bool, error) {
-	raw, err := os.ReadFile(path)
+func readOptionalWorkflowSourceFile(ctx context.Context, path string, readFile func(string) ([]byte, error)) ([]byte, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	raw, err := readFile(path)
+	if errors.Is(err, os.ErrPermission) {
+		deadline := time.NewTimer(150 * time.Millisecond)
+		defer deadline.Stop()
+		retry := time.NewTicker(20 * time.Millisecond)
+		defer retry.Stop()
+		for errors.Is(err, os.ErrPermission) {
+			finalAttempt := false
+			select {
+			case <-ctx.Done():
+				return nil, false, ctx.Err()
+			case <-deadline.C:
+				finalAttempt = true
+			case <-retry.C:
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, false, err
+			}
+			raw, err = readFile(path)
+			if finalAttempt {
+				break
+			}
+		}
+	}
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, false, nil
 	}

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -550,6 +551,17 @@ func TestGitRefWorkflowWatcherReloadsLocalOverlayLifecycle(t *testing.T) {
 	if deleted.Workflow.Overlay.Path != "" {
 		t.Fatalf("delete Overlay = %#v, want inactive", deleted.Workflow.Overlay)
 	}
+	cancel()
+	for {
+		select {
+		case _, ok := <-updates:
+			if !ok {
+				return
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("watcher did not stop after cancellation")
+		}
+	}
 }
 
 func assertNoWorkflowSourceUpdate(t *testing.T, updates <-chan configwatcher.Update) {
@@ -771,5 +783,160 @@ func waitForWorkflowGitHelperExit(t *testing.T, pid int) {
 			t.Fatalf("helper process %d did not stop after termination", pid)
 		}
 		t.Fatalf("helper process %d did not exit after release", pid)
+	}
+}
+
+func TestReadOptionalWorkflowSourceFileReconcilesPermission(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		settleAfter  time.Duration
+		settledError error
+		initialError error
+		cancelAfter  time.Duration
+		wantError    error
+		wantPresent  bool
+	}{
+		{name: "absent", initialError: os.ErrNotExist},
+		{name: "readable", wantPresent: true},
+		{name: "error changes", settleAfter: time.Millisecond, settledError: os.ErrInvalid, wantError: os.ErrInvalid},
+		{name: "deleted", settleAfter: time.Millisecond, settledError: os.ErrNotExist},
+		{name: "deleted before final read", settleAfter: 149 * time.Millisecond, settledError: os.ErrNotExist},
+		{name: "replacement readable", settleAfter: time.Millisecond, wantPresent: true},
+		{name: "persistent permission", settleAfter: time.Hour, wantError: os.ErrPermission},
+		{name: "other error", initialError: os.ErrInvalid, wantError: os.ErrInvalid},
+		{name: "canceled before read", cancelAfter: -1, wantError: context.Canceled},
+		{name: "canceled during retry", cancelAfter: time.Millisecond, settleAfter: time.Hour, wantError: context.Canceled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				if tt.cancelAfter < 0 {
+					cancel()
+				} else if tt.cancelAfter > 0 {
+					done := make(chan struct{})
+					defer func() { <-done }()
+					go func() {
+						defer close(done)
+						time.Sleep(tt.cancelAfter)
+						cancel()
+					}()
+				}
+				start := time.Now()
+				reads := 0
+				readFile := func(path string) ([]byte, error) {
+					reads++
+					if ctx.Err() != nil {
+						t.Error("read after cancellation")
+					}
+					err := tt.initialError
+					if err == nil {
+						err = os.ErrPermission
+						if time.Since(start) >= tt.settleAfter {
+							err = tt.settledError
+						}
+					}
+					if err != nil {
+						return nil, &os.PathError{Op: "open", Path: path, Err: err}
+					}
+					return []byte("replacement"), nil
+				}
+				raw, present, err := readOptionalWorkflowSourceFile(ctx, "WORKFLOW.local.md", readFile)
+				if !errors.Is(err, tt.wantError) || present != tt.wantPresent {
+					t.Fatalf("read = (%q, %v, %v), want present=%v, error=%v", raw, present, err, tt.wantPresent, tt.wantError)
+				}
+				if present && string(raw) != "replacement" {
+					t.Fatalf("content = %q", raw)
+				}
+				if elapsed := time.Since(start); elapsed > 150*time.Millisecond {
+					t.Fatalf("retry exceeded bound: %v", elapsed)
+				}
+				if errors.Is(tt.wantError, os.ErrPermission) && time.Since(start) != 150*time.Millisecond {
+					t.Fatalf("persistent permission error returned before final read: %v", time.Since(start))
+				}
+				if tt.initialError != nil && reads != 1 {
+					t.Fatalf("non-permission error retried: %d reads", reads)
+				}
+			})
+		})
+	}
+}
+
+func TestGitRefWorkflowWatcherReconcilesOverlayDeletion(t *testing.T) {
+	t.Parallel()
+
+	for _, operation := range []string{"seed", "poll"} {
+		for _, overlay := range []string{"WORKFLOW.local.md", "detent.local.yaml"} {
+			t.Run(operation+"/"+overlay, func(t *testing.T) {
+				t.Parallel()
+				repo := initWorkflowSourceRepo(t)
+				writeWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "shared")
+				if overlay == "detent.local.yaml" {
+					if err := os.WriteFile(filepath.Join(repo, "WORKFLOW.md"), []byte("shared\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(filepath.Join(repo, "detent.yaml"), []byte("schema: 1\ntracker:\n  kind: memory\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					runWorkflowSourceGit(t, repo, "add", "detent.yaml")
+				}
+				commitWorkflowSourceRepo(t, repo, "shared workflow")
+				watcher, err := newGitRefWorkflowWatcher(globalconfig.Project{
+					Workflow: "WORKFLOW.md", WorkflowRef: "HEAD", Workdir: repo,
+				}, time.Hour, slog.New(slog.DiscardHandler))
+				if err != nil {
+					t.Fatal(err)
+				}
+				localPath := filepath.Join(repo, overlay)
+				for _, prompt := range []string{"created", "edited"} {
+					content := "---\ntracker:\n  kind: memory\n---\n" + prompt + "\n"
+					if overlay == "detent.local.yaml" {
+						content = "schema: 1\ntracker:\n  kind: memory\n"
+					}
+					if err := os.WriteFile(localPath, []byte(content), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					loaded, _, err := watcher.source.load(t.Context())
+					if err != nil {
+						t.Fatal(err)
+					}
+					if overlay == "WORKFLOW.local.md" && !strings.Contains(loaded.Prompt, prompt) {
+						t.Fatalf("overlay prompt = %q, want %q", loaded.Prompt, prompt)
+					}
+				}
+				if err := os.Remove(localPath); err != nil {
+					t.Fatal(err)
+				}
+				denied := false
+				watcher.source.readFile = func(path string) ([]byte, error) {
+					if path == localPath && !denied {
+						denied = true
+						return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+					}
+					return os.ReadFile(path)
+				}
+				updates := make(chan configwatcher.Update, 1)
+				var revision, lastErr string
+				if operation == "seed" {
+					revision, lastErr = watcher.seed(t.Context(), updates)
+				} else {
+					revision, lastErr = watcher.reload(t.Context(), updates, "", "")
+				}
+				if !denied || lastErr != "" || revision == "" {
+					t.Fatalf("%s after deletion: denied=%v revision=%q error=%q", operation, denied, revision, lastErr)
+				}
+				if operation == "seed" {
+					assertNoWorkflowSourceUpdate(t, updates)
+					return
+				}
+				update := readWorkflowSourceUpdate(t, updates)
+				if update.Err != nil || strings.TrimSpace(update.Workflow.Prompt) != "shared" || update.Workflow.Overlay.Path != "" {
+					t.Fatalf("delete update = %#v", update)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Git-ref startup seeding and polling could publish a permission-denied overlay read immediately after successful deletion because those loads bypass the generic file watcher retry path. Reconcile local workflow and project-config permission errors for a bounded 150 ms window, including a final read at expiry. A later missing-file result restores the shared definition; persistent permission errors still surface and cancellation stops retries.

Deterministic regressions inject the recorded delete-then-permission-denied sequence into both git-ref load paths. The Windows lifecycle check retains its 50 repetitions and active watcher deletion, with an added cancellation completion assertion. Exact Windows kernel/event ordering remains unverified.

Fixes #2390

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes requiring browser verification.

## Test Plan

- [x] Complete project/watcher race test suites, 10 repetitions; lint, vet, NilAway, and Windows/amd64 cross-compilation.
- [x] Virtual-time reconciliation table, 100 race-enabled repetitions: deletion, final-expiry read, readable replacement, persistent and non-permission errors, cancellation.
- [x] `make check`: build, lint, vet, NilAway, race tests, 80.4% coverage, and configured coverage floors.
- [x] [Current-head CI](https://github.com/digitaldrywood/detent/actions/runs/34365667198): all 11 jobs passed, including 50 Windows workflow overlay lifecycle repetitions.
