### PR TITLE
feat(capacity): allow immediate dispatch recovery

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -257,3 +257,33 @@ top-level `truncation` object always reports that limit and contains
 The one-MiB shared-client response limit also bounds non-collection content.
 JSON is written to stdout, pretty output is only a human-readable projection,
 and diagnostics remain on stderr.
+
+## Provider capacity recovery
+
+After restoring subscription usage, request full configured dispatch capacity:
+
+```sh
+detent capacity clear --scope codex --recovery immediate
+```
+
+Use `--project detent` to select one project. Scope accepts a backend ID, kind,
+provider, or backend/provider; omitting it selects all backend scopes.
+The default `--recovery ramping` and automatic recovery retain the gradual
+progress-based ramp. Immediate recovery also removes a matching ramp left by an
+earlier clear, making repeated clears safe.
+
+Immediate recovery preserves unrelated backend outages and recovery ramps,
+GitHub and tracker holds, project breakers, human holds, configured global,
+project and provider concurrency, and budget limits. It does not reset provider
+usage. A renewed usage-limit response pauses dispatch normally.
+
+The command queues work asynchronously. JSON output reports
+`recovery_requested` (`ramping` or `immediate`) and `recovery_applied: pending`;
+HTTP 202 means accepted, not yet applied. The orchestrator emits a structured
+`backend capacity clear applied` log with `scope`, `recovery_requested`,
+`recovery_applied`, and the number of outages `cleared` when it processes the
+request. Other holds may still prevent dispatch after immediate recovery.
+
+Immediate mode requires a server that supports this option. If an older server
+accepts the clear but ignores the mode, the CLI reports that immediate recovery
+was not acknowledged; that older server may still apply its default ramp.

--- a/internal/cli/capacity.go
+++ b/internal/cli/capacity.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,11 +16,13 @@ import (
 )
 
 type capacityClearResult struct {
-	Status    string `json:"status"`
-	Project   string `json:"project,omitempty"`
-	Scope     string `json:"scope,omitempty"`
-	Cleared   int    `json:"cleared,omitempty"`
-	Requested int    `json:"requested,omitempty"`
+	RecoveryRequested string `json:"recovery_requested,omitempty"`
+	RecoveryApplied   string `json:"recovery_applied,omitempty"`
+	Status            string `json:"status"`
+	Project           string `json:"project,omitempty"`
+	Scope             string `json:"scope,omitempty"`
+	Cleared           int    `json:"cleared,omitempty"`
+	Requested         int    `json:"requested,omitempty"`
 }
 
 type dashboardAddress struct {
@@ -53,13 +56,14 @@ func newCapacityCommand(configPath *string, host *string, port *int, opts option
 func newCapacityClearCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
 	var projectID string
 	var scope string
+	var recovery string
 	cmd := &cobra.Command{
 		Use:     "clear",
 		Short:   "Clear recorded provider capacity outages",
 		Example: "detent capacity clear\n  detent capacity clear --project detent --scope codex",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			result, err := runCapacityClear(cmd.Context(), derefString(configPath), derefString(host), derefInt(port, -1), flagChanged(cmd, "port"), projectID, scope, opts)
+			result, err := runCapacityClear(cmd.Context(), derefString(configPath), derefString(host), derefInt(port, -1), flagChanged(cmd, "port"), projectID, scope, opts, recovery)
 			if err != nil {
 				return err
 			}
@@ -69,7 +73,7 @@ func newCapacityClearCommand(configPath *string, host *string, port *int, opts o
 			}
 			return out.Write(func(writer io.Writer) error {
 				if result.Status == "requested" {
-					_, err := fmt.Fprintf(writer, "requested capacity clear for %d project(s)\n", result.Requested)
+					_, err := fmt.Fprintf(writer, "requested capacity clear for %d project(s); recovery requested: %s, applied: %s\n", result.Requested, result.RecoveryRequested, result.RecoveryApplied)
 					return err
 				}
 				_, err := fmt.Fprintf(writer, "cleared %d capacity outage(s)\n", result.Cleared)
@@ -78,6 +82,7 @@ func newCapacityClearCommand(configPath *string, host *string, port *int, opts o
 		},
 	}
 	cmd.Flags().StringVar(&projectID, "project", "", "limit the clear to one project ID")
+	cmd.Flags().StringVar(&recovery, "recovery", "ramping", "dispatch recovery mode: ramping or immediate")
 	cmd.Flags().StringVar(&scope, "scope", "", "limit the clear to a backend ID, kind, provider, or backend/provider")
 	return cmd
 }
@@ -91,12 +96,21 @@ func runCapacityClear(
 	projectID string,
 	scope string,
 	opts options,
+	recovery ...string,
 ) (capacityClearResult, error) {
+	mode := "ramping"
+	if len(recovery) > 0 {
+		mode = recovery[0]
+	}
+	if mode != "ramping" && mode != "immediate" {
+		return capacityClearResult{}, fmt.Errorf("invalid recovery mode %q: want ramping or immediate", mode)
+	}
 	boot, address, err := resolveDashboardBoot(ctx, configPath, host, port, portSet, opts)
 	if err != nil {
 		return capacityClearResult{}, err
 	}
 	form := url.Values{}
+	form.Set("recovery", mode)
 	form.Set("project_id", strings.TrimSpace(projectID))
 	form.Set("scope", strings.TrimSpace(scope))
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+dashboardServerAddr(boot)+"/api/v1/capacity/clear", strings.NewReader(form.Encode()))
@@ -126,6 +140,9 @@ func runCapacityClear(
 	var result capacityClearResult
 	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
 		return capacityClearResult{}, fmt.Errorf("decode capacity clear response: %w", err)
+	}
+	if mode == "immediate" && result.RecoveryRequested != mode {
+		return capacityClearResult{}, errors.New("server did not acknowledge immediate recovery; upgrade the running Detent service before retrying")
 	}
 	return result, nil
 }

--- a/internal/cli/capacity_test.go
+++ b/internal/cli/capacity_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -229,4 +230,83 @@ func dashboardAddressOptions(cfg globalconfig.Config) options {
 	opts.lookupEnv = func(string) string { return "" }
 	opts.service = serviceFactoryFor(&serviceRunnerStub{status: servicepkg.Status{State: servicepkg.StateStopped}})
 	return opts
+}
+
+func TestCapacityClearRecoveryMode(t *testing.T) {
+	for _, mode := range []string{"ramping", "immediate", "invalid"} {
+		t.Run(mode, func(t *testing.T) {
+			opts := dashboardAddressOptions(globalconfig.Config{})
+			called := false
+			opts.httpDo = func(request *http.Request) (*http.Response, error) {
+				called = true
+				if err := request.ParseForm(); err != nil {
+					t.Fatal(err)
+				}
+				if request.Form.Get("recovery") != mode {
+					t.Fatalf("form = %v", request.Form)
+				}
+				return &http.Response{StatusCode: http.StatusAccepted, Body: io.NopCloser(strings.NewReader(`{"status":"requested","recovery_requested":"` + mode + `","recovery_applied":"pending","requested":1}`))}, nil
+			}
+			result, err := runCapacityClear(t.Context(), "/config/global.yaml", "localhost", 4101, true, "detent", "codex", opts, mode)
+			if mode == "invalid" {
+				if err == nil || called {
+					t.Fatal("invalid mode reached server")
+				}
+			} else if err != nil || result.RecoveryRequested != mode || result.RecoveryApplied != "pending" {
+				t.Fatalf("result = %#v, error = %v", result, err)
+			}
+		})
+	}
+}
+
+func TestCapacityClearCommandRecoveryFlag(t *testing.T) {
+	for _, mode := range []string{"", "immediate"} {
+		t.Run(mode, func(t *testing.T) {
+			opts := dashboardAddressOptions(globalconfig.Config{})
+			expected := mode
+			if expected == "" {
+				expected = "ramping"
+			}
+			opts.httpDo = func(request *http.Request) (*http.Response, error) {
+				if err := request.ParseForm(); err != nil {
+					t.Fatal(err)
+				}
+				if request.Form.Get("recovery") != expected {
+					t.Fatalf("form = %v", request.Form)
+				}
+				return &http.Response{StatusCode: http.StatusAccepted, Body: io.NopCloser(strings.NewReader(`{"status":"requested","recovery_requested":"` + expected + `","recovery_applied":"pending","requested":1}`))}, nil
+			}
+			configPath, host, port := "/config/global.yaml", "localhost", 4101
+			cmd := newCapacityCommand(&configPath, &host, &port, opts)
+			cmd.SetContext(withCommandOutputOptions(t.Context(), commandOutputOptions{lookupEnv: opts.lookupEnv, stdoutTTY: func() bool { return false }}))
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			args := []string{"clear", "--scope", "codex"}
+			if mode != "" {
+				args = append(args, "--recovery", mode)
+			}
+			cmd.SetArgs(args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(output.String(), expected) || !strings.Contains(output.String(), "pending") {
+				t.Fatalf("output = %s", output.String())
+			}
+		})
+	}
+}
+
+func TestCapacityClearRejectsUnacknowledgedImmediateRecovery(t *testing.T) {
+	for _, reported := range []string{"", "ramping"} {
+		t.Run(reported, func(t *testing.T) {
+			opts := dashboardAddressOptions(globalconfig.Config{})
+			opts.httpDo = func(*http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusAccepted, Body: io.NopCloser(strings.NewReader(`{"status":"requested","recovery_requested":"` + reported + `","requested":1}`))}, nil
+			}
+			_, err := runCapacityClear(t.Context(), "/config/global.yaml", "localhost", 4101, true, "detent", "codex", opts, "immediate")
+			if err == nil || !strings.Contains(err.Error(), "did not acknowledge immediate recovery") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
 }

--- a/internal/orchestrator/backend_capacity.go
+++ b/internal/orchestrator/backend_capacity.go
@@ -534,13 +534,7 @@ func (o *Orchestrator) completeBackendCapacityRecovery(
 		state.BackendRecoveries = map[string]BackendRecovery{}
 	}
 	state.BackendRecoveries[key] = BackendRecovery{Outage: outage, RecoveredAt: recoveredAt}
-	o.activateDispatchRecovery(
-		state,
-		dispatchRecoveryBackendCapacity,
-		backendCapacityStatusMessage(outage),
-		recoveredAt,
-		"",
-	)
+	o.activateBackendDispatchRecovery(state, outage, recoveredAt)
 	releaseBackendCapacityRetries(state, outage.Scope, recoveredAt)
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      recoveredAt,
@@ -607,7 +601,8 @@ func releaseBackendCapacityRetries(state *State, scope backendcapacity.Scope, re
 	}
 }
 
-func (o *Orchestrator) clearBackendCapacity(state *State, scopeFilter string, clearedAt time.Time) []BackendOutage {
+func (o *Orchestrator) clearBackendCapacity(state *State, scopeFilter string, clearedAt time.Time, immediate ...bool) []BackendOutage {
+	full := len(immediate) > 0 && immediate[0]
 	if clearedAt.IsZero() {
 		clearedAt = o.clockNow()
 	}
@@ -625,13 +620,9 @@ func (o *Orchestrator) clearBackendCapacity(state *State, scopeFilter string, cl
 			state.BackendRecoveries = map[string]BackendRecovery{}
 		}
 		state.BackendRecoveries[key] = BackendRecovery{Outage: outage, RecoveredAt: clearedAt}
-		o.activateDispatchRecovery(
-			state,
-			dispatchRecoveryBackendCapacity,
-			backendCapacityStatusMessage(outage),
-			clearedAt,
-			"",
-		)
+		if !full {
+			o.activateBackendDispatchRecovery(state, outage, clearedAt)
+		}
 		releaseBackendCapacityRetries(state, outage.Scope, clearedAt)
 		cleared = append(cleared, outage)
 		recordStateEvent(state, telemetry.ActivityEvent{
@@ -647,6 +638,20 @@ func (o *Orchestrator) clearBackendCapacity(state *State, scopeFilter string, cl
 				"cleared_at", clearedAt,
 			)
 		}
+	}
+	if full {
+		for key, recovery := range state.DispatchRecoveries {
+			if recovery.Kind == dispatchRecoveryBackendCapacity && backendCapacityScopeMatchesFilter(recovery.BackendScope, scopeFilter) {
+				delete(state.DispatchRecoveries, key)
+			}
+		}
+	}
+	if o.logger != nil {
+		mode := "ramping"
+		if full {
+			mode = "immediate"
+		}
+		o.logger.Info("backend capacity clear applied", "scope", scopeFilter, "recovery_requested", mode, "recovery_applied", mode, "cleared", len(cleared))
 	}
 	return cleared
 }

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -2174,3 +2174,168 @@ func (v *backendCapacityTestValidator) Validate(_ context.Context, request Valid
 	v.requests <- request
 	return gate.ValidatorResult{}, v.err
 }
+
+func TestOperatorCapacityRecoveryModes(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		immediate bool
+		filter    string
+		wantRamp  bool
+	}{
+		{"default ramp", false, "codex", true},
+		{"immediate backend", true, "codex", false},
+		{"immediate provider", true, "openai", false},
+		{"immediate pair", true, "codex/openai", false},
+		{"unmatched scope", true, "missing", true},
+		{"all scopes", true, "", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 10})
+			orch := &Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+			orch.capacityController = backendCapacityTestController{scope: scope}
+			var logs bytes.Buffer
+			orch.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+			outage := BackendOutage{Scope: scope, ResumeAt: now.Add(time.Hour)}
+			state.BackendOutages[scope.Key()] = outage
+			state.Running["active"] = Running{Issue: connector.Issue{ID: "active"}, CapacityScope: scope}
+			orch.activateBackendDispatchRecovery(&state, outage, now)
+			for range 2 {
+				orch.clearBackendCapacity(&state, tt.filter, now, tt.immediate)
+				_, first, _ := tryReserveDispatchRecovery(&state, "one", now)
+				_, second, _ := tryReserveDispatchRecovery(&state, "two", now)
+				if !first || second == tt.wantRamp {
+					t.Fatalf("admissions = %v, %v; want ramp %v", first, second, tt.wantRamp)
+				}
+				releaseDispatchRecoveryAdmission(&state, "one")
+				releaseDispatchRecoveryAdmission(&state, "two")
+			}
+			if len(state.Running) != 1 || orch.cfg.MaxConcurrentAgents != 10 {
+				t.Fatal("active workers or configured concurrency changed")
+			}
+			if !tt.wantRamp {
+				orch.recoverBackendCapacity(&state, Running{CapacityScope: scope, CapacityProbe: true}, now)
+				if reason := dispatchRecoveryBlockReason(&state, now); reason != "" {
+					t.Fatalf("active probe reintroduced recovery: %s", reason)
+				}
+				if _, _, blocked := orch.backendCapacityDispatch(&state, runpkg.RunRequest{}, now); blocked {
+					t.Fatal("cleared outage still blocks dispatch")
+				}
+				if !strings.Contains(logs.String(), `"recovery_applied":"immediate"`) {
+					t.Fatalf("application evidence missing: %s", logs.String())
+				}
+				for i := range 10 {
+					if _, allowed, reason := tryReserveDispatchRecovery(&state, strconv.Itoa(i), now); !allowed {
+						t.Fatalf("admission %d refused: %s", i, reason)
+					}
+				}
+			}
+			renewed := orch.registerBackendOutage(&state, &backendcapacity.Error{Scope: scope, Details: backendcapacity.Details{Type: backendcapacity.ErrorTypeUsageLimit, Reason: "renewed quota limit"}}, now, false)
+			if _, ok := state.BackendOutages[scope.Key()]; !ok || !renewed.ResumeAt.After(now) {
+				t.Fatal("renewed outage did not pause capacity")
+			}
+			if _, _, blocked := orch.backendCapacityDispatch(&state, runpkg.RunRequest{}, now); !blocked {
+				t.Fatal("renewed outage permits dispatch")
+			}
+			orch.completeBackendCapacityRecovery(&state, scope.Key(), renewed, now.Add(time.Hour), "live_status")
+			_, first, _ := tryReserveDispatchRecovery(&state, "new-one", now.Add(time.Hour))
+			_, second, _ := tryReserveDispatchRecovery(&state, "new-two", now.Add(time.Hour))
+			if !first || second {
+				t.Fatal("automatic recovery did not restore cautious ramp")
+			}
+		})
+	}
+}
+
+func TestImmediateCapacityClearPreservesOtherHolds(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{dispatchRecoveryGitHubREST, dispatchRecoveryTrackerUnavailable, dispatchRecoveryProjectFailureBreaker, dispatchRecoveryBackendCapacity} {
+		t.Run(kind, func(t *testing.T) {
+			now := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 10})
+			orch := &Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			codex := BackendOutage{Scope: backendcapacity.Scope{BackendID: "codex", Provider: "openai"}}
+			other := BackendOutage{Scope: backendcapacity.Scope{BackendID: "claude", Provider: "anthropic"}}
+			state.BackendOutages[other.Scope.Key()] = other
+			orch.activateBackendDispatchRecovery(&state, codex, now)
+			if kind == dispatchRecoveryBackendCapacity {
+				orch.activateBackendDispatchRecovery(&state, other, now)
+			} else {
+				orch.activateDispatchRecovery(&state, kind, "unrelated hold", now, "")
+			}
+			state.FailureBreaker.Class = "human hold"
+			orch.clearBackendCapacity(&state, "codex", now, true)
+			if len(state.DispatchRecoveries) != 1 || len(state.BackendOutages) != 1 || state.FailureBreaker.Class != "human hold" {
+				t.Fatalf("unrelated holds changed: %#v", state.DispatchRecoveries)
+			}
+			_, first, _ := tryReserveDispatchRecovery(&state, "one", now)
+			_, second, reason := tryReserveDispatchRecovery(&state, "two", now)
+			if !first || second || reason != kind+"_recovery" {
+				t.Fatalf("other recovery no longer limits admissions: %v %v %s", first, second, reason)
+			}
+		})
+	}
+}
+
+func TestCapacityClearQueueRecoveryMode(t *testing.T) {
+	for _, immediate := range []bool{false, true} {
+		t.Run(strconv.FormatBool(immediate), func(t *testing.T) {
+			orch := &Orchestrator{capacityClearRequests: make(chan capacityClearRequest, 1), done: make(chan struct{})}
+			if err := orch.RequestBackendCapacityClear(t.Context(), " codex ", immediate); err != nil {
+				t.Fatal(err)
+			}
+			request := <-orch.capacityClearRequests
+			if request.scope != "codex" || request.immediate != immediate {
+				t.Fatalf("request = %#v", request)
+			}
+		})
+	}
+}
+
+func TestCapacityClearRespectsConfiguredDispatchSlots(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		immediate    bool
+		active, want int
+	}{
+		{"cautious", false, 0, 1},
+		{"full", true, 0, 10},
+		{"active workers", true, 3, 7},
+		{"already full", true, 10, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 10, ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}})
+			orch := &Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			scope := backendcapacity.Scope{BackendID: "codex", Provider: "openai"}
+			state.BackendOutages[scope.Key()] = BackendOutage{Scope: scope}
+			for i := range tt.active {
+				id := fmt.Sprintf("active-%d", i)
+				state.Running[id] = Running{Issue: dispatchTestIssue(id, "Todo")}
+			}
+			orch.clearBackendCapacity(&state, "codex", now, tt.immediate)
+			issues := make([]connector.Issue, 12)
+			for i := range issues {
+				issues[i] = dispatchTestIssue(fmt.Sprintf("ready-%d", i), "Todo")
+			}
+			admitted := 0
+			orch.dispatchPlanner().plan(&state, issues, now, dispatchPlanHooks{dispatch: func(action dispatchAction) bool {
+				_, allowed, _ := tryReserveDispatchRecovery(&state, action.issue.ID, now)
+				if allowed {
+					admitted++
+					state.Running[action.issue.ID] = Running{Issue: action.issue}
+				}
+				return allowed
+			}})
+			if admitted != tt.want {
+				t.Fatalf("admitted = %d, want %d", admitted, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/dispatch_recovery.go
+++ b/internal/orchestrator/dispatch_recovery.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -21,13 +22,14 @@ const (
 )
 
 type DispatchRecovery struct {
-	Kind       string
-	Reason     string
-	Status     string
-	StartedAt  time.Time
-	ResumeAt   time.Time
-	Limit      int
-	Admissions map[string]bool
+	BackendScope backendcapacity.Scope
+	Kind         string
+	Reason       string
+	Status       string
+	StartedAt    time.Time
+	ResumeAt     time.Time
+	Limit        int
+	Admissions   map[string]bool
 }
 
 func dispatchRecoverySnapshots(
@@ -123,31 +125,40 @@ func (o *Orchestrator) activateDispatchRecovery(
 	now time.Time,
 	progressedIssueID string,
 ) {
+	o.activateScopedDispatchRecovery(state, kind, reason, now, progressedIssueID, backendcapacity.Scope{})
+}
+
+func (o *Orchestrator) activateScopedDispatchRecovery(state *State, kind string, reason string, now time.Time, progressedIssueID string, scope backendcapacity.Scope) {
 	if state == nil || strings.TrimSpace(kind) == "" {
 		return
 	}
+	kind = strings.TrimSpace(kind)
+	key := kind
+	if scope != (backendcapacity.Scope{}) {
+		key += ":" + scope.Key()
+	}
 	if o.cfg.MaxConcurrentAgents <= 1 {
-		delete(state.DispatchRecoveries, strings.TrimSpace(kind))
+		delete(state.DispatchRecoveries, key)
 		return
 	}
 	if state.DispatchRecoveries == nil {
 		state.DispatchRecoveries = map[string]DispatchRecovery{}
 	}
-	kind = strings.TrimSpace(kind)
 	limit := 1
 	admissions := map[string]bool{}
 	if issueID := strings.TrimSpace(progressedIssueID); issueID != "" {
 		admissions[issueID] = true
 		limit = min(2, o.cfg.MaxConcurrentAgents)
 	}
-	state.DispatchRecoveries[kind] = DispatchRecovery{
-		Kind:       kind,
-		Reason:     strings.TrimSpace(reason),
-		Status:     dispatchRecoveryStatusRamping,
-		StartedAt:  now,
-		ResumeAt:   now,
-		Limit:      limit,
-		Admissions: admissions,
+	state.DispatchRecoveries[key] = DispatchRecovery{
+		BackendScope: scope,
+		Kind:         kind,
+		Reason:       strings.TrimSpace(reason),
+		Status:       dispatchRecoveryStatusRamping,
+		StartedAt:    now,
+		ResumeAt:     now,
+		Limit:        limit,
+		Admissions:   admissions,
 	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      now,
@@ -317,4 +328,8 @@ func (o *Orchestrator) backoffDispatchRecovery(state *State, issueID string, fai
 			Message: "dispatch recovery canary failed before progress; retrying after " + recovery.Kind,
 		})
 	}
+}
+
+func (o *Orchestrator) activateBackendDispatchRecovery(state *State, outage BackendOutage, at time.Time) {
+	o.activateScopedDispatchRecovery(state, dispatchRecoveryBackendCapacity, backendCapacityStatusMessage(outage), at, "", outage.Scope)
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -419,9 +419,10 @@ type runUpdate struct {
 }
 
 type capacityClearRequest struct {
-	scope string
-	at    time.Time
-	reply chan capacityClearReply
+	immediate bool
+	scope     string
+	at        time.Time
+	reply     chan capacityClearReply
 }
 
 type capacityClearReply struct {
@@ -825,7 +826,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.capacityClearRequests:
 			state.syncWorkerProgress()
-			cleared := o.clearBackendCapacity(&state, request.scope, request.at)
+			cleared := o.clearBackendCapacity(&state, request.scope, request.at, request.immediate)
 			if request.reply != nil {
 				request.reply <- capacityClearReply{cleared: cleared}
 			}
@@ -971,13 +972,14 @@ func (o *Orchestrator) ClearBackendCapacity(ctx context.Context, scope string) (
 	}
 }
 
-func (o *Orchestrator) RequestBackendCapacityClear(ctx context.Context, scope string) error {
+func (o *Orchestrator) RequestBackendCapacityClear(ctx context.Context, scope string, immediate ...bool) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	request := capacityClearRequest{
-		scope: strings.TrimSpace(scope),
-		at:    o.clockNow(),
+		immediate: len(immediate) > 0 && immediate[0],
+		scope:     strings.TrimSpace(scope),
+		at:        o.clockNow(),
 	}
 	o.capacityClearMu.Lock()
 	defer o.capacityClearMu.Unlock()

--- a/internal/web/capacity.go
+++ b/internal/web/capacity.go
@@ -12,15 +12,24 @@ import (
 )
 
 type capacityClearResponse struct {
-	Status    string `json:"status"`
-	Project   string `json:"project,omitempty"`
-	Scope     string `json:"scope,omitempty"`
-	Requested int    `json:"requested"`
+	RecoveryRequested string `json:"recovery_requested"`
+	RecoveryApplied   string `json:"recovery_applied"`
+	Status            string `json:"status"`
+	Project           string `json:"project,omitempty"`
+	Scope             string `json:"scope,omitempty"`
+	Requested         int    `json:"requested"`
 }
 
 func (s *Server) apiCapacityClear(c echo.Context) error {
 	projectID := strings.TrimSpace(c.FormValue("project_id"))
 	scope := strings.TrimSpace(c.FormValue("scope"))
+	mode := strings.TrimSpace(c.FormValue("recovery"))
+	if mode == "" {
+		mode = "ramping"
+	}
+	if mode != "ramping" && mode != "immediate" {
+		return c.JSON(http.StatusBadRequest, errorResponse("invalid_recovery", "recovery must be ramping or immediate"))
+	}
 	projects := s.registry.List()
 	if projectID != "" {
 		selected, ok := s.registry.Get(project.ID(projectID))
@@ -32,7 +41,7 @@ func (s *Server) apiCapacityClear(c echo.Context) error {
 
 	requested := 0
 	for _, candidate := range projects {
-		err := candidate.Orchestrator().RequestBackendCapacityClear(c.Request().Context(), scope)
+		err := candidate.Orchestrator().RequestBackendCapacityClear(c.Request().Context(), scope, mode == "immediate")
 		if err != nil {
 			if errors.Is(err, orchestrator.ErrStopped) {
 				continue
@@ -49,9 +58,11 @@ func (s *Server) apiCapacityClear(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	return c.JSON(http.StatusAccepted, capacityClearResponse{
-		Status:    "requested",
-		Project:   projectID,
-		Scope:     scope,
-		Requested: requested,
+		Status:            "requested",
+		RecoveryRequested: mode,
+		RecoveryApplied:   "pending",
+		Project:           projectID,
+		Scope:             scope,
+		Requested:         requested,
 	})
 }

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -643,6 +643,7 @@ paths:
               properties:
                 project_id: {type: string}
                 scope: {type: string}
+                recovery: {type: string, enum: [ramping, immediate], default: ramping}
       responses:
         "202":
           description: Capacity outage clear requested.
@@ -650,12 +651,15 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [status, requested]
+                required: [status, requested, recovery_requested, recovery_applied]
                 properties:
                   status: {type: string, enum: [requested]}
                   project: {type: string}
                   scope: {type: string}
                   requested: {type: integer}
+                  recovery_requested: {type: string, enum: [ramping, immediate]}
+                  recovery_applied: {type: string, enum: [pending]}
+        "400": {$ref: "#/components/responses/Problem"}
         "404": {$ref: "#/components/responses/Problem"}
         "503": {$ref: "#/components/responses/Unavailable"}
   /api/v1/projects/{project_id}/security-audits/dispositions:

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -14197,3 +14197,76 @@ func (p *refreshProbe) RequestRefresh(context.Context) (web.RefreshResponse, err
 func int64Pointer(value int64) *int64 {
 	return &value
 }
+
+func TestCapacityClearEndpointRecoveryMode(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		mode, project string
+		status        int
+	}{
+		{"", "", http.StatusAccepted},
+		{"ramping", "", http.StatusAccepted},
+		{"immediate", "", http.StatusAccepted},
+		{"invalid", "", http.StatusBadRequest},
+		{"immediate", "missing", http.StatusNotFound},
+	} {
+		t.Run(tt.mode+tt.project, func(t *testing.T) {
+			server, err := web.NewServer(web.Config{}, testDeps(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/capacity/clear", strings.NewReader(url.Values{"recovery": {tt.mode}, "project_id": {tt.project}}.Encode()))
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			server.Handler().ServeHTTP(recorder, request)
+			if recorder.Code != tt.status {
+				t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+			}
+			if tt.status == http.StatusAccepted {
+				mode := tt.mode
+				if mode == "" {
+					mode = "ramping"
+				}
+				if body := recorder.Body.String(); !strings.Contains(body, `"recovery_requested":"`+mode+`"`) || !strings.Contains(body, `"recovery_applied":"pending"`) {
+					t.Fatalf("body = %s", body)
+				}
+			}
+		})
+	}
+}
+
+func TestCapacityClearEndpointProjectIsolation(t *testing.T) {
+	t.Parallel()
+	for _, selected := range []string{"first", ""} {
+		t.Run(selected, func(t *testing.T) {
+			deps := testDeps(t)
+			projects := []*project.Project{newBudgetTestProject(t, "first", 100, 10), newBudgetTestProject(t, "second", 100, 10)}
+			for _, candidate := range projects {
+				if err := deps.Registry.Set(candidate); err != nil {
+					t.Fatal(err)
+				}
+			}
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatal(err)
+			}
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/capacity/clear", strings.NewReader(url.Values{"recovery": {"immediate"}, "project_id": {selected}, "scope": {"codex"}}.Encode()))
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			server.Handler().ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusAccepted {
+				t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+			}
+			for _, candidate := range projects {
+				err := candidate.Orchestrator().RequestBackendCapacityClear(t.Context(), "codex")
+				queued := selected == "" || string(candidate.ID()) == selected
+				if queued && !errors.Is(err, orchestrator.ErrCapacityClearQueueFull) {
+					t.Fatalf("project %s did not receive clear: %v", candidate.ID(), err)
+				}
+				if !queued && err != nil {
+					t.Fatalf("unselected project %s received clear: %v", candidate.ID(), err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `detent capacity clear --recovery immediate` to remove the selected backend recovery ramp after subscription usage is restored. The default remains `ramping`, and automatic recovery stays cautious.
- Keep backend recovery entries scoped so repeated clears preserve unrelated outages and ramps. Existing workers, concurrency limits, budgets, and other holds remain enforced; renewed usage-limit responses pause dispatch normally.
- Report the requested recovery mode and pending application in asynchronous API/CLI output, with structured application logs when the orchestrator processes the request. Document the command and reporting contract.

Fixes #2388

## UI Surface Contract

- [x] N/A: this change adds a CLI option and API fields without changing the dashboard layout.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens; browser verification is not applicable.

## Test Plan

- [x] Deterministic CLI/API tests cover defaults, explicit immediate mode, invalid values, old-server acknowledgement, project isolation, and request propagation.
- [x] Orchestrator tests cover scope isolation, repeated clears, active workers, all ten configured slots, occupied slots, renewed outages, and cautious automatic recovery.
- [x] Complete orchestrator suite: 86.3% package coverage; safety-critical backend capacity coverage: 92.08% (90% required).
- [x] Safety boundary fuzz seeds and 30-second fuzz run passed (774,105 executions).
- [x] `make check CHECK_LOCK_WAIT=2h` passed; only the queue wait allowance changed. Overall coverage: 80.4%; all configured package/file floors passed.
