### PR TITLE
test(runner): diagnose workspace reap timeouts

### DIFF
--- a/.detent/validation/2410/README.md
+++ b/.detent/validation/2410/README.md
@@ -1,0 +1,54 @@
+# Workspace reap verification diagnostics
+
+## Baseline
+
+On macOS, unchanged head `525d2915` reproduced three failures in twelve cases:
+
+```sh
+env -u DETENT_API_TOKEN go test -race ./internal/runner -run '^TestRunnerTerminalSessionReapsEscapedWorkspaceProcess$' -count=3 -v
+```
+
+Two session-cancellation cases reported `workspace reap = (1, verify workspace processes: signal: killed)`; one completed nested-directory case returned the same verification failure from Run. Total runner package duration: 148.456s. This reproduces the issue symptom, but the original error does not distinguish context cancellation from an independent signal.
+
+## Instrumented results
+
+The first three focused race repetitions passed all twelve cases. Successful reaping took 7.2–8.0s against the unchanged ten-second cleanup budget. Every post-reap snapshot recorded `holder_exited=true observer_exited=false`.
+
+A full workspace/runner race run passed workspace (179.982s), while runner failed in other fixtures. Two artifact-cleanup failures already tracked by #2398 now reported:
+
+```text
+scan workspace processes: workspace scan command stage=wait pid=23264 start_elapsed=8.385083ms wait_elapsed=4.553818917s deadline_set=true deadline_remaining=4.559731917s context_at_start=<nil> context_error=context deadline exceeded output_bytes=0: signal: killed
+scan workspace processes: workspace scan command stage=wait pid=23301 start_elapsed=5.7585ms wait_elapsed=4.4944855s deadline_set=true deadline_remaining=4.498127334s context_at_start=<nil> context_error=context deadline exceeded output_bytes=0: signal: killed
+```
+
+These establish deadline cancellation while waiting for lsof in those artifact fixtures. A separate cancelled scratch-cleanup failure was filed as Backlog #2411.
+
+## Target failure under concurrent race load
+
+A focused target run alongside the repository gate reproduced two verification failures (55.088s package duration):
+
+```text
+workspace reap: elapsed=10.000640875s count=1 error=verify workspace processes: workspace scan command stage=wait pid=85749 start_elapsed=2.649375ms wait_elapsed=1.940652291s deadline_set=true deadline_remaining=1.942808584s context_at_start=<nil> context_error=context deadline exceeded output_bytes=0: signal: killed holder_exited=true observer_exited=false
+workspace reap: elapsed=10.002503083s count=1 error=verify workspace processes: workspace scan command stage=wait pid=87426 start_elapsed=3.199459ms wait_elapsed=4.127730292s deadline_set=true deadline_remaining=4.128606416s context_at_start=<nil> context_error=context deadline exceeded output_bytes=0: signal: killed holder_exited=true observer_exited=false
+```
+
+The failures occurred in session cancellation and completed nested-directory cases. They demonstrate expiry of the shared cleanup budget during verification, after the known workspace holder had exited and while the outside observer remained alive. The OS launch call was short, and no PID output was available from the canceled verification command. This does not prove the workspace had no other descendants, nor attribute the historical incident or the underlying scan slowness to a specific host mechanism. The scope remains diagnostic; cleanup policy and deadlines are unchanged.
+
+## Full-gate and scan-cost observations
+
+The unconstrained `make check` passed lint and reproduced the target timeout during the race gate: Start 2.67ms, Wait 3.36s until deadline cancellation, total reap 10.002s, holder exited and observer alive. It also failed in #2398 artifact fixtures and scratch-cleanup fixtures tracked in #2411. No test assertions were relaxed.
+
+Four sequential read-only lsof probes against an isolated empty temporary directory took 3.682s and 3.674s with existing flags, and 3.666s and 3.656s with additional `-nP`. Every probe exited 1 with no matches. Disabling name resolution did not explain or improve the scan cost, so those options were not added.
+
+The final local gate is run as `GOMAXPROCS=2 make check` to reduce host concurrency while retaining every build, lint, vet, NilAway, race, and coverage step with unchanged test deadlines. The unconstrained failures remain evidence; a constrained passing gate does not establish that the underlying flake is fixed.
+
+## Diagnostic contract
+
+- Errors retain the original command error for `errors.Is`/`errors.As`, including lsof exit-status handling and partial output behavior.
+- Start duration measures `exec.Cmd.Start`; wait duration includes executable initialization and scanning. Neither proves loader pressure or the time at which lsof begins scanning.
+- Deadline remaining is sampled before Start; context state is sampled before Start and after failure. No raw stdout, environment, or process arguments are added to production errors.
+- The runner fixture records reap elapsed time and both known helpers' exit-channel states before fatal assertions. These are instantaneous observations; a false exit snapshot alone does not prove a surviving descendant. Existing completion and lock assertions remain authoritative.
+- The existing pre-reap lsof diagnostic probe now has its own five-second bound; production cleanup selection, signals, grace periods, and total budget are unchanged.
+- Stdlib table-driven command tests use pipe readiness before cancellation, with no timing sleeps. They distinguish pre-start cancellation/deadline, missing executable, exit status, partial output, an uncanceled signal, and cancellation after readiness.
+
+`GOMAXPROCS=2 make check` passed all steps and configured coverage floors in 14m20.9s. Runner passed race (22.596s) and coverage (86.4%); workspace passed race (112.342s) and coverage (73.9%). Current-head CI results are recorded in the issue Workpad and `.detent/notes.md`.

--- a/.detent/validation/2410/README.md
+++ b/.detent/validation/2410/README.md
@@ -44,7 +44,7 @@ The final local gate is run as `GOMAXPROCS=2 make check` to reduce host concurre
 
 ## Diagnostic contract
 
-- Errors retain the original command error for `errors.Is`/`errors.As`, including lsof exit-status handling and partial output behavior.
+- Errors retain the original command error for `errors.Is`/`errors.As`, including lsof exit-status handling and partial output behavior. Stderr is retained on the wrapped `exec.ExitError` using the repository head/tail buffer capped at 64 KiB; explicitly configured stderr writers remain untouched.
 - Start duration measures `exec.Cmd.Start`; wait duration includes executable initialization and scanning. Neither proves loader pressure or the time at which lsof begins scanning.
 - Deadline remaining is sampled before Start; context state is sampled before Start and after failure. No raw stdout, environment, or process arguments are added to production errors.
 - The runner fixture records reap elapsed time and both known helpers' exit-channel states before fatal assertions. These are instantaneous observations; a false exit snapshot alone does not prove a surviving descendant. Existing completion and lock assertions remain authoritative.
@@ -52,3 +52,5 @@ The final local gate is run as `GOMAXPROCS=2 make check` to reduce host concurre
 - Stdlib table-driven command tests use pipe readiness before cancellation, with no timing sleeps. They distinguish pre-start cancellation/deadline, missing executable, exit status, partial output, an uncanceled signal, and cancellation after readiness.
 
 `GOMAXPROCS=2 make check` passed all steps and configured coverage floors in 14m20.9s. Runner passed race (22.596s) and coverage (86.4%); workspace passed race (112.342s) and coverage (73.9%). Current-head CI results are recorded in the issue Workpad and `.detent/notes.md`.
+
+Review follow-up: `TestWorkspaceScanOutputStderr` reproduced discarded stderr before the fix (short diagnostic and bounded head/tail cases failed). After restoring capture, ten race repetitions passed for all command diagnostic tests, including caller-supplied stderr writers. `GOMAXPROCS=2 make check` passed again after the review fix in 16m54.706s: total coverage 80.4%, runner 86.4%, workspace 74.1%; all configured floors passed.

--- a/internal/runner/duration_limit_unix_test.go
+++ b/internal/runner/duration_limit_unix_test.go
@@ -70,10 +70,16 @@ func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
 						backend.command.Process.Pid, backend.command.Dir, lockPath,
 						observer.command.Process.Pid, observer.command.Dir, observerLockPath)
 					if runtime.GOOS != "linux" {
-						output, err := exec.CommandContext(ctx, "lsof", "-FpcRfn", "+D", path).CombinedOutput()
-						t.Logf("workspace file matches before reap: error=%v\n%s", err, output)
+						probeCtx, cancelProbe := context.WithTimeout(ctx, 5*time.Second)
+						probeStarted := time.Now()
+						output, err := exec.CommandContext(probeCtx, "lsof", "-FpcRfn", "+D", path).CombinedOutput()
+						t.Logf("workspace file matches before reap: elapsed=%s context_error=%v error=%v\n%s", time.Since(probeStarted), probeCtx.Err(), err, output)
+						cancelProbe()
 					}
+					reapStarted := time.Now()
 					reaped, reapErr = workspace.ReapProcesses(ctx, path, grace)
+					t.Logf("workspace reap: elapsed=%s count=%d error=%v holder_exited=%t observer_exited=%t",
+						time.Since(reapStarted), reaped, reapErr, processWaitFinished(backend.waitDone), processWaitFinished(observer.waitDone))
 					return reaped, reapErr
 				},
 			})
@@ -233,5 +239,14 @@ func assertLockAvailable(t *testing.T, path string) {
 	}
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
 		t.Fatalf("unlock gate file: %v", err)
+	}
+}
+
+func processWaitFinished(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -3,6 +3,7 @@
 package workspace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -214,7 +215,7 @@ func linuxWorkspaceProcessIDs(path string) ([]int, error) {
 
 func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
 	cmd := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-t", "+D", path) // #nosec G204 -- the workspace path is passed as an lsof argument without a shell.
-	output, err := cmd.Output()
+	output, err := workspaceScanOutput(ctx, cmd)
 	if err != nil && len(output) == 0 {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
@@ -241,6 +242,32 @@ func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
 		pids = append(pids, pid)
 	}
 	return pids, nil
+}
+
+func workspaceScanOutput(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	started := time.Now()
+	remaining := time.Duration(0)
+	hasDeadline := false
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining = time.Until(deadline)
+		hasDeadline = true
+	}
+	contextAtStart := fmt.Sprint(ctx.Err())
+	startErr := cmd.Start()
+	startElapsed := time.Since(started)
+	if startErr != nil {
+		return nil, fmt.Errorf("workspace scan command stage=start start_elapsed=%s deadline_set=%t deadline_remaining=%s context_at_start=%v context_error=%v: %w",
+			startElapsed, hasDeadline, remaining, contextAtStart, fmt.Sprint(ctx.Err()), startErr)
+	}
+	waiting := time.Now()
+	err := cmd.Wait()
+	if err != nil {
+		return output.Bytes(), fmt.Errorf("workspace scan command stage=wait pid=%d start_elapsed=%s wait_elapsed=%s deadline_set=%t deadline_remaining=%s context_at_start=%v context_error=%v output_bytes=%d: %w",
+			cmd.Process.Pid, startElapsed, time.Since(waiting), hasDeadline, remaining, contextAtStart, fmt.Sprint(ctx.Err()), output.Len(), err)
+	}
+	return output.Bytes(), nil
 }
 
 func pathInside(root string, path string) bool {

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 )
 
 const defaultProcessTerminationGrace = 250 * time.Millisecond
@@ -244,7 +246,21 @@ func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
 	return pids, nil
 }
 
+type workspaceScanStderr struct {
+	*runtimeoutput.Buffer
+}
+
+func (w workspaceScanStderr) Write(data []byte) (int, error) {
+	w.Append(string(data))
+	return len(data), nil
+}
+
 func workspaceScanOutput(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
+	stderr := workspaceScanStderr{runtimeoutput.NewBuffer(runtimeoutput.Policy{MaxBytes: 64 << 10})}
+	captureStderr := cmd.Stderr == nil
+	if captureStderr {
+		cmd.Stderr = stderr
+	}
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	started := time.Now()
@@ -264,6 +280,10 @@ func workspaceScanOutput(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
 	waiting := time.Now()
 	err := cmd.Wait()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if captureStderr && errors.As(err, &exitErr) {
+			exitErr.Stderr = []byte(stderr.String())
+		}
 		return output.Bytes(), fmt.Errorf("workspace scan command stage=wait pid=%d start_elapsed=%s wait_elapsed=%s deadline_set=%t deadline_remaining=%s context_at_start=%v context_error=%v output_bytes=%d: %w",
 			cmd.Process.Pid, startElapsed, time.Since(waiting), hasDeadline, remaining, contextAtStart, fmt.Sprint(ctx.Err()), output.Len(), err)
 	}

--- a/internal/workspace/process_unix_test.go
+++ b/internal/workspace/process_unix_test.go
@@ -5,7 +5,11 @@ package workspace
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -145,6 +149,115 @@ func TestReapProcessesRejectsUnsafePaths(t *testing.T) {
 			if err == nil {
 				t.Fatal("ReapProcesses() error = nil, want non-nil")
 			}
+		})
+	}
+}
+
+func TestWorkspaceScanOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      string
+		missing      bool
+		cancelBefore bool
+		expired      bool
+		cancelReady  bool
+		wantStage    string
+		wantContext  string
+		wantOutput   string
+		wantExit     bool
+	}{
+		{name: "success", command: "printf 123", wantOutput: "123"},
+		{name: "missing executable", missing: true, wantStage: "start", wantContext: "<nil>"},
+		{name: "canceled before start", cancelBefore: true, wantStage: "start", wantContext: "context canceled"},
+		{name: "deadline before start", expired: true, wantStage: "start", wantContext: "context deadline exceeded"},
+		{name: "no matches exit", command: "exit 1", wantStage: "wait", wantContext: "<nil>", wantExit: true},
+		{name: "partial output failure", command: "printf 123; exit 2", wantOutput: "123", wantStage: "wait", wantContext: "<nil>", wantExit: true},
+		{name: "exit failure", command: "exit 2", wantStage: "wait", wantContext: "<nil>", wantExit: true},
+		{name: "signal without cancellation", command: "kill -KILL $$", wantStage: "wait", wantContext: "<nil>", wantExit: true},
+		{name: "canceled after readiness", command: "printf ready >&3; read value", cancelReady: true, wantStage: "wait", wantContext: "context canceled", wantExit: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			if tt.expired {
+				var expire context.CancelFunc
+				ctx, expire = context.WithDeadline(ctx, time.Time{})
+				defer expire()
+			}
+			cmd := exec.CommandContext(ctx, "sh", "-c", tt.command)
+			if tt.missing {
+				cmd = exec.CommandContext(ctx, filepath.Join(t.TempDir(), "missing"))
+			}
+			if tt.cancelBefore {
+				cancel()
+			}
+			if tt.cancelReady {
+				readyReader, readyWriter, err := os.Pipe()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer readyReader.Close()
+				defer readyWriter.Close()
+				inputReader, inputWriter, err := os.Pipe()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer inputReader.Close()
+				defer inputWriter.Close()
+				cmd.Stdin = inputReader
+				cmd.ExtraFiles = []*os.File{readyWriter}
+				if err := readyReader.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+					t.Fatal(err)
+				}
+				ready := make(chan error, 1)
+				go func() {
+					_, err := io.ReadFull(readyReader, make([]byte, 5))
+					cancel()
+					ready <- err
+				}()
+				defer func() {
+					if err := <-ready; err != nil {
+						t.Errorf("readiness: %v", err)
+					}
+				}()
+			}
+			output, err := workspaceScanOutput(ctx, cmd)
+			if string(output) != tt.wantOutput {
+				t.Errorf("output = %q, want %q", output, tt.wantOutput)
+			}
+			if tt.wantStage == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected command error")
+			}
+			for _, field := range []string{"stage=" + tt.wantStage, "start_elapsed=", "deadline_set=true", "deadline_remaining=", "context_error=" + tt.wantContext} {
+				if !strings.Contains(err.Error(), field) {
+					t.Errorf("error %q missing %q", err, field)
+				}
+			}
+			if tt.wantStage == "wait" {
+				for _, field := range []string{"wait_elapsed=", "pid=", "output_bytes=" + strconv.Itoa(len(tt.wantOutput)), "context_at_start=<nil>"} {
+					if !strings.Contains(err.Error(), field) {
+						t.Errorf("error %q missing %q", err, field)
+					}
+				}
+			}
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) != tt.wantExit {
+				t.Errorf("exit error = %v, want %t", err, tt.wantExit)
+			}
+			if tt.cancelBefore && !errors.Is(err, context.Canceled) {
+				t.Errorf("cancellation identity lost: %v", err)
+			}
+			if tt.expired && !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("deadline identity lost: %v", err)
+			}
+			t.Log(err)
 		})
 	}
 }

--- a/internal/workspace/process_unix_test.go
+++ b/internal/workspace/process_unix_test.go
@@ -3,6 +3,7 @@
 package workspace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -258,6 +259,53 @@ func TestWorkspaceScanOutput(t *testing.T) {
 				t.Errorf("deadline identity lost: %v", err)
 			}
 			t.Log(err)
+		})
+	}
+}
+
+func TestWorkspaceScanOutputStderr(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		custom bool
+	}{
+		{name: "exit diagnostic", stderr: "lsof: resource unavailable\n"},
+		{name: "bounded head and tail", stderr: "begin\n" + strings.Repeat("x", 96<<10) + "\nend"},
+		{name: "caller supplied writer", stderr: "caller diagnostic\n", custom: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "sh", "-c", "cat >&2; exit 2")
+			cmd.Stdin = strings.NewReader(tt.stderr)
+			var custom bytes.Buffer
+			if tt.custom {
+				cmd.Stderr = &custom
+			}
+			output, err := workspaceScanOutput(ctx, cmd)
+			if len(output) != 0 {
+				t.Fatalf("stdout = %q, want empty", output)
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("error = %v, want wrapped exit error", err)
+			}
+			if tt.custom {
+				if custom.String() != tt.stderr || len(exitErr.Stderr) != 0 {
+					t.Fatalf("custom stderr = %q, exit stderr = %q", custom.String(), exitErr.Stderr)
+				}
+				return
+			}
+			if len(tt.stderr) <= 64<<10 {
+				if string(exitErr.Stderr) != tt.stderr {
+					t.Fatalf("stderr = %q, want %q", exitErr.Stderr, tt.stderr)
+				}
+				return
+			}
+			if len(exitErr.Stderr) > 64<<10 || !bytes.HasPrefix(exitErr.Stderr, []byte("begin\n")) || !bytes.HasSuffix(exitErr.Stderr, []byte("\nend")) {
+				t.Fatalf("stderr does not retain bounded head and tail: bytes=%d", len(exitErr.Stderr))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Workspace verification previously reported only `signal: killed`. Add bounded command start/wait timing, remaining deadline, cancellation state, PID, and output-size diagnostics while preserving command error identity and existing scan handling. Keep stderr available on wrapped exit errors with bounded head/tail capture, and respect caller-supplied stderr writers. The lifecycle fixture logs the holder and outside observer states before assertions and bounds its diagnostic probe.

Reproduced the target failure under concurrent macOS race load: verification exhausted the ten-second reap budget after the known workspace holder exited, while the outside observer remained alive. Preserve cleanup selection, signals, deadlines, and strict ownership assertions. Retained evidence distinguishes this result from the still-unproven cause of scan slowness; this diagnostic PR does not claim to eliminate the timing flake. Separate scratch-cleanup failures are tracked in #2411, and artifact fixture failures in #2398.

Fixes #2410

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] No visual changes requiring browser verification.

## Test Plan

- [x] Focused lifecycle race tests: three repetitions, all twelve cases passed; a subsequent run under concurrent gate load captured two expected verification-timeout reproductions.
- [x] Command diagnostic table tests: ten race repetitions covering startup failure, cancellation/deadline before startup, exit status and partial output, independent signal termination, and cancellation after pipe readiness.
- [x] `GOMAXPROCS=2 make check` (complete gate with reduced local concurrency; no test skips or deadline changes).
- [x] Stderr regression table: short diagnostics, bounded long output, and caller-supplied writers; reproduced the missing capture before the fix and passed ten focused race repetitions afterward.
- [x] Recorded unconstrained `make check` reproduction and related fixture failures in the validation evidence.
