### PR TITLE
fix(recovery): retain permission-wait evidence

### DIFF
--- a/internal/orchestrator/deliverable_recovery.go
+++ b/internal/orchestrator/deliverable_recovery.go
@@ -306,6 +306,9 @@ func (o *Orchestrator) blockHumanOwnedWorkerFailure(
 	metadata.BlockedRecovery.Owner = blockedRecoveryOwnerHuman
 	metadata.BlockedRecovery.HoldReason = cause
 	metadata.BlockedRecovery.OperatorRemedy = humanAction
+	metadata.BlockedRecovery.WorkAttemptID = running.WorkAttemptID
+	metadata.BlockedRecovery.AttemptNumber = running.Attempt
+	metadata.BlockedRecovery.AttemptError = detail
 	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issue.ID, issue, blockedStatusState, event.CompletedAt, cause, metadata, laneMutationRevokeWorker); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(eventName+" state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
@@ -340,6 +343,8 @@ func (o *Orchestrator) blockHumanOwnedWorkerFailure(
 	state.Blocked[issue.ID] = Blocked{
 		Issue:               issue,
 		Reason:              cause,
+		AttemptError:        detail,
+		WorkAttemptID:       running.WorkAttemptID,
 		RecoveryReason:      "human acknowledgement required",
 		RecoveryTarget:      autoPromoteReworkState,
 		RecoveryRemedy:      humanAction,

--- a/internal/orchestrator/permission_wait.go
+++ b/internal/orchestrator/permission_wait.go
@@ -1,0 +1,92 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
+)
+
+const permissionWaitReason = "permission_wait"
+
+type permissionWaitRecord struct {
+	Question      string `json:"question"`
+	Kind          string `json:"kind"`
+	Source        string `json:"source"`
+	WorkAttemptID int64  `json:"work_attempt_id"`
+	SessionID     string `json:"session_id,omitempty"`
+}
+
+func terminalPermissionWait(output string) (permissionWaitRecord, bool) {
+	if signal, ok := workpad.SignalFromComment(output, "", ""); ok && signal != nil && signal.Invalid == nil && signal.Status == workpad.StatusBlocked && strings.TrimSpace(signal.HumanAction) != "" {
+		return permissionWaitRecord{Question: strings.TrimSpace(signal.HumanAction), Kind: "approval_or_input", Source: "terminal_detent_status"}, true
+	}
+	inFence := false
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		lower := strings.ToLower(line)
+		questionEnd := strings.IndexByte(line, '?')
+		if questionEnd < 0 {
+			continue
+		}
+		request := false
+		for _, prefix := range []string{"may i ", "can i ", "do you authorize ", "do you approve ", "will you approve "} {
+			request = request || strings.HasPrefix(lower, prefix)
+		}
+		if !request {
+			continue
+		}
+		question := line[:questionEnd+1]
+		kind := "approval_or_input"
+		lower = strings.ToLower(question)
+		if (strings.HasPrefix(lower, "may i ") || strings.HasPrefix(lower, "can i ")) &&
+			(strings.Contains(lower, "implement") || strings.Contains(lower, "edit") || strings.Contains(lower, "changes for #")) {
+			kind = "implementation_permission"
+		}
+		for _, gate := range []string{"product", "architecture", "access", "withdraw", "deploy", "publish", "production", "delete", "credential", "merge"} {
+			if strings.Contains(lower, gate) {
+				kind = "approval_or_input"
+			}
+		}
+		return permissionWaitRecord{Question: question, Kind: kind, Source: "terminal_assistant_question"}, true
+	}
+	return permissionWaitRecord{}, false
+}
+
+func (o *Orchestrator) handlePermissionWaitCompletion(ctx context.Context, state *State, event runpkg.Completion, running Running) bool {
+	if event.Err != nil || (event.Result.FinalState != "" && event.Result.FinalState != runpkg.FinalStateCompleted && event.Result.FinalState != runpkg.FinalStateNeedsHumanAttention) {
+		return false
+	}
+	wait, ok := terminalPermissionWait(event.Result.FinalMessage)
+	if !ok {
+		return false
+	}
+	wait.Question = o.operatorText(wait.Question)
+	wait.WorkAttemptID = running.WorkAttemptID
+	wait.SessionID = running.SessionID
+	detail := fmt.Sprintf("%s (source: %s, work attempt: %d, session: %s, kind: %s)", wait.Question, wait.Source, wait.WorkAttemptID, wait.SessionID, wait.Kind)
+	remedy := "Record direction for this question, then move the issue to Rework: " + wait.Question
+	if wait.Kind == "implementation_permission" {
+		remedy = "The worker requested implementation permission. Check the assigned scope and record direction, preserving explicit approval gates, then move the issue to Rework: " + wait.Question
+	}
+	parkEvent := event
+	parkEvent.Err = errors.New(detail)
+	if !o.blockHumanOwnedWorkerFailure(ctx, state, parkEvent, running, permissionWaitReason, detail, remedy, "worker_permission_wait") {
+		o.deferTrackerUnavailableCompletion(ctx, state, event, running, errors.New("persist permission-wait hold failed"))
+		return true
+	}
+	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalNoProgress, nil, permissionWaitReason, detail)
+	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalNoProgress, permissionWaitReason, detail, "blocked", wait.Question, map[string]any{permissionWaitReason: wait})
+	return true
+}

--- a/internal/orchestrator/permission_wait.go
+++ b/internal/orchestrator/permission_wait.go
@@ -25,14 +25,21 @@ func terminalPermissionWait(output string) (permissionWaitRecord, bool) {
 	if signal, ok := workpad.SignalFromComment(output, "", ""); ok && signal != nil && signal.Invalid == nil && signal.Status == workpad.StatusBlocked && strings.TrimSpace(signal.HumanAction) != "" {
 		return permissionWaitRecord{Question: strings.TrimSpace(signal.HumanAction), Kind: "approval_or_input", Source: "terminal_detent_status"}, true
 	}
-	inFence := false
+	fence := ""
 	for line := range strings.SplitSeq(output, "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "```") {
-			inFence = !inFence
+		if fence != "" {
+			if strings.HasPrefix(line, fence) && strings.Trim(line, string(fence[0])+" \t") == "" {
+				fence = ""
+			}
 			continue
 		}
-		if inFence {
+		if strings.HasPrefix(line, "```") || strings.HasPrefix(line, "~~~") {
+			length := 0
+			for length < len(line) && line[length] == line[0] {
+				length++
+			}
+			fence = line[:length]
 			continue
 		}
 		lower := strings.ToLower(line)
@@ -80,11 +87,25 @@ func (o *Orchestrator) handlePermissionWaitCompletion(ctx context.Context, state
 	if wait.Kind == "implementation_permission" {
 		remedy = "The worker requested implementation permission. Check the assigned scope and record direction, preserving explicit approval gates, then move the issue to Rework: " + wait.Question
 	}
+	if diffStatsPresent(event.Result.DiffStats) {
+		running.DiffStats = event.Result.DiffStats
+	}
 	parkEvent := event
 	parkEvent.Err = errors.New(detail)
 	if !o.blockHumanOwnedWorkerFailure(ctx, state, parkEvent, running, permissionWaitReason, detail, remedy, "worker_permission_wait") {
 		o.deferTrackerUnavailableCompletion(ctx, state, event, running, errors.New("persist permission-wait hold failed"))
 		return true
+	}
+	tokens := event.Result.Tokens
+	if tokens == (TokenTotals{}) {
+		tokens = running.Tokens
+	}
+	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
+	if event.Result.RateLimits != nil {
+		state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
+	}
+	if diffStatsPresent(running.DiffStats) {
+		state.DiffStats[event.IssueID] = running.DiffStats
 	}
 	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalNoProgress, nil, permissionWaitReason, detail)
 	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalNoProgress, permissionWaitReason, detail, "blocked", wait.Question, map[string]any{permissionWaitReason: wait})

--- a/internal/orchestrator/permission_wait_test.go
+++ b/internal/orchestrator/permission_wait_test.go
@@ -33,10 +33,18 @@ func TestHandleRunResultPermissionWait(t *testing.T) {
 			cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"Todo", "In Progress", "Rework"}, ObservedStates: []string{"Blocked"}})
 			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
 			state := newState(cfg)
-			state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: 5112, Generation: 169, SessionID: "session-5898", Mode: runpkg.RunModeImplement, StartedAt: time.Now()}
-			orch.handleRunResult(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: time.Now(), Request: runpkg.RunRequest{WorkAttemptID: 5112, Generation: 169}, Result: runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, FinalMessage: tt.output, DiffStats: DiffStats{Status: "clean", HeadSHA: "53c6b1c"}}})
+			state.TokenTotals.TotalTokens = 10
+			resultTokens := TokenTotals{TotalTokens: 42}
+			if tt.name == "structured input" {
+				resultTokens = TokenTotals{}
+			}
+			state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: 5112, Generation: 169, SessionID: "session-5898", Mode: runpkg.RunModeImplement, Tokens: TokenTotals{TotalTokens: 42}, DiffStats: DiffStats{HeadSHA: "previous"}, StartedAt: time.Now()}
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: time.Now(), Request: runpkg.RunRequest{WorkAttemptID: 5112, Generation: 169}, Result: runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, FinalMessage: tt.output, Tokens: resultTokens, DiffStats: DiffStats{Status: "clean", HeadSHA: "53c6b1c"}}})
 			if len(attempts.completions) != 1 {
 				t.Fatalf("completions = %d", len(attempts.completions))
+			}
+			if state.TokenTotals.TotalTokens != 52 || state.DiffStats[issue.ID].HeadSHA != "53c6b1c" {
+				t.Fatalf("completion telemetry lost: tokens=%#v diff=%#v", state.TokenTotals, state.DiffStats[issue.ID])
 			}
 			completion := attempts.completions[0]
 			if completion.ErrorClass != "permission_wait" || !strings.Contains(completion.ErrorMessage, tt.question) {
@@ -84,6 +92,10 @@ func TestTerminalPermissionWait(t *testing.T) {
 		{"completed", "Implemented the fix and ran tests.", false},
 		{"quoted example", "> May I deploy to production?", false},
 		{"code example", "```text\nMay I deploy to production?\n```", false},
+		{"tilde example", "~~~text\nMay I deploy to production?\n~~~", false},
+		{"nested shorter fence", "````text\n```\nMay I deploy to production?\n````", false},
+		{"mixed fence", "~~~text\n```\nMay I deploy to production?\n~~~", false},
+		{"after fence", "~~~text\nexample\n~~~\nMay I deploy to production?", true},
 		{"implementation", "Can I edit the assigned files?", true},
 		{"architecture", "Do you approve the storage architecture?", true},
 		{"access", "May I access the production database?", true},

--- a/internal/orchestrator/permission_wait_test.go
+++ b/internal/orchestrator/permission_wait_test.go
@@ -1,0 +1,117 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+func TestHandleRunResultPermissionWait(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		output   string
+		question string
+		kind     string
+	}{
+		{"assigned edits", "May I make the coordinated scheduling, connector, CI, test, and migration-documentation changes for #2346?\nNo implementation or tests have run.", "May I make the coordinated scheduling, connector, CI, test, and migration-documentation changes for #2346?", "implementation_permission"},
+		{"explicit gate", "May I deploy these changes to production?", "May I deploy these changes to production?", "approval_or_input"},
+		{"structured input", "## Codex Workpad\n```detent-status\nschema: 1\nstatus: blocked\nblockers: []\nhuman_action: Choose the storage architecture\n```", "Choose the storage architecture", "approval_or_input"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := connector.Issue{ID: "issue-2415", Identifier: "digitaldrywood/detent#2415", State: "In Progress"}
+			tracker := &implementProgressConnector{refreshed: issue}
+			attempts := &implementProgressAttemptStore{}
+			cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"Todo", "In Progress", "Rework"}, ObservedStates: []string{"Blocked"}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{Issue: issue, WorkAttemptID: 5112, Generation: 169, SessionID: "session-5898", Mode: runpkg.RunModeImplement, StartedAt: time.Now()}
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: time.Now(), Request: runpkg.RunRequest{WorkAttemptID: 5112, Generation: 169}, Result: runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, FinalMessage: tt.output, DiffStats: DiffStats{Status: "clean", HeadSHA: "53c6b1c"}}})
+			if len(attempts.completions) != 1 {
+				t.Fatalf("completions = %d", len(attempts.completions))
+			}
+			completion := attempts.completions[0]
+			if completion.ErrorClass != "permission_wait" || !strings.Contains(completion.ErrorMessage, tt.question) {
+				t.Fatalf("completion lost question: %#v", completion)
+			}
+			var metadata struct {
+				PermissionWait struct {
+					Kind          string
+					WorkAttemptID int64  `json:"work_attempt_id"`
+					SessionID     string `json:"session_id"`
+				} `json:"permission_wait"`
+			}
+			if err := json.Unmarshal([]byte(completion.WorkerMetadataJSON), &metadata); err != nil {
+				t.Fatal(err)
+			}
+			if metadata.PermissionWait.Kind != tt.kind || metadata.PermissionWait.WorkAttemptID != 5112 || metadata.PermissionWait.SessionID != "session-5898" {
+				t.Fatalf("handoff = %#v", metadata.PermissionWait)
+			}
+			blocked, ok := state.Blocked[issue.ID]
+			if !ok || blocked.Recovery.Owner != blockedRecoveryOwnerHuman || !strings.Contains(blocked.RecoveryRemedy, tt.question) {
+				t.Fatalf("blocked = %#v", blocked)
+			}
+			for _, elapsed := range []time.Duration{time.Minute, 24 * time.Hour} {
+				if orch.recoverCauseBlockedIssue(t.Context(), &state, blocked.Issue, time.Now().Add(elapsed)) {
+					t.Fatal("unchanged question recovered automatically")
+				}
+			}
+			if !strings.Contains(blocked.Recovery.AttemptError, "terminal_") || blocked.Recovery.WorkAttemptID != 5112 {
+				t.Fatalf("durable recovery lost provenance: %#v", blocked.Recovery)
+			}
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatal("permission wait scheduled a retry")
+			}
+		})
+	}
+}
+
+func TestTerminalPermissionWait(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, output string
+		want         bool
+	}{
+		{"ordinary no progress", "No implementation or tests have run.", false},
+		{"completed", "Implemented the fix and ran tests.", false},
+		{"quoted example", "> May I deploy to production?", false},
+		{"code example", "```text\nMay I deploy to production?\n```", false},
+		{"implementation", "Can I edit the assigned files?", true},
+		{"architecture", "Do you approve the storage architecture?", true},
+		{"access", "May I access the production database?", true},
+		{"withdrawal", "Do you authorize withdrawing the release?", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := terminalPermissionWait(tt.output)
+			if got != tt.want {
+				t.Fatalf("wait = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPermissionWaitIgnoresNonterminalOutput(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		result runpkg.RunResult
+	}{
+		{"earlier question", runpkg.RunResult{Output: "May I deploy to production?", FinalMessage: "The authorized fix is complete."}},
+		{"failed run", runpkg.RunResult{FinalState: runpkg.FinalStateFailed, FinalMessage: "May I deploy to production?"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			orch := &Orchestrator{}
+			if orch.handlePermissionWaitCompletion(t.Context(), nil, runpkg.Completion{Result: tt.result}, Running{}) {
+				t.Fatal("unexpected wait")
+			}
+		})
+	}
+}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -320,6 +320,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.handleWorkspacePreparationFailure(ctx, state, event, running)
 		return
 	}
+	if o.handlePermissionWaitCompletion(ctx, state, event, running) {
+		return
+	}
 
 	if event.Err != nil {
 		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1214,6 +1214,7 @@ func (r *Runner) runAgentTurn(
 		}
 	}
 	result.Output = progress.outputText()
+	result.FinalMessage = progress.finalMessage()
 	result.SkillDraftProposed = skillDraftProposed(result.Output)
 	result.PullRequestUpdated = progress.pullRequestUpdated()
 	result.PullRequestHeadPushed = progress.pullRequestHeadPushed()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -262,6 +262,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 
+	if result.FinalMessage != "hello\nSkill draft: yes — `.detent/skills/debug.md` captures the workflow." {
+		t.Fatalf("FinalMessage = %q", result.FinalMessage)
+	}
 	if result.FinalState != FinalStateCompleted {
 		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
 	}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -728,6 +728,7 @@ type RunResult struct {
 	Checkpoint              *workspace.CheckpointRecord
 	FinalState              string
 	Output                  string
+	FinalMessage            string
 	Model                   string
 	TurnStarted             bool
 	RuntimeIdentity         agentidentity.Identity


### PR DESCRIPTION
## Summary

- Preserve terminal permission and structured human-input requests with their question, classification, source, work attempt, and session in recovery telemetry.
- Hold unresolved requests through durable human-owned recovery instead of repeatedly redispatching unchanged work. Implementation-permission classification is informational and never grants approval.
- Preserve ordinary no-progress handling and ignore earlier or quoted questions, including tilde and longer Markdown fences.
- Retain final token totals, rate limits, and workspace diff evidence when parking permission waits.

Fixes #2415

## UI Surface Contract

- [x] N/A: no UI surface changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes; browser verification is not applicable.

## Test Plan

- [x] `GOMAXPROCS=2 make check` — all checks passed; 80.5% overall coverage and configured package/file floors passed.
- [x] Table-driven regression coverage for the recorded #2346 permission question, explicit gates, structured human actions, retained provenance, and unchanged holds.
- [x] Coverage for ordinary completions, quoted questions, earlier output, and failed turns.
- [x] Review regressions for completion telemetry and Markdown fence handling; full local gate passed on f6cca047.

