### PR TITLE
fix(doctor): diagnose reachable unhealthy runtimes

### DIFF
--- a/internal/cli/doctor_dispatch_stall.go
+++ b/internal/cli/doctor_dispatch_stall.go
@@ -2,10 +2,7 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -21,7 +18,8 @@ func checkDoctorDispatchStalls(ctx context.Context, boot BootConfig, projectID s
 	}
 	stalls, err := readDoctorDispatchStalls(ctx, doctorLiveBoot(boot, &boot.Global), deps)
 	if err != nil {
-		check.Detail = "live dispatch-stall check skipped because no Detent instance was reachable"
+		check.Status = doctorWarn
+		check.Detail = "live dispatch-stall check unavailable: " + err.Error()
 		return check
 	}
 	projectID = strings.TrimSpace(projectID)
@@ -47,26 +45,11 @@ func checkDoctorDispatchStalls(ctx context.Context, boot BootConfig, projectID s
 }
 
 func readDoctorDispatchStalls(ctx context.Context, boot BootConfig, deps doctorDeps) ([]telemetry.DispatchStatus, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, doctorHealthProbeURL(boot), nil)
+	probe, err := probeDoctorHealth(ctx, boot, deps)
 	if err != nil {
 		return nil, err
 	}
-	response, err := deps.httpDo(request)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("health returned HTTP %d", response.StatusCode)
-	}
-	var health doctorHealthResponse
-	if err := json.NewDecoder(response.Body).Decode(&health); err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(health.Mode) == "" || !doctorHealthHasDetentChecks(health.Checks) {
-		return nil, errors.New("response was not Detent health")
-	}
-	return health.DispatchStalls, nil
+	return probe.Health.DispatchStalls, nil
 }
 
 func doctorDispatchStallDetail(stall telemetry.DispatchStatus) string {

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -64,7 +64,7 @@ func resolveDoctorBinaryEnvironment(ctx context.Context, resolution globalconfig
 	}
 	probe, err := probeDoctorHealth(ctx, boot, deps)
 	orchestratorPath := probe.Health.Environment.Path
-	if probe.Health.Mode != "" && doctorHealthHasDetentChecks(probe.Health.Checks) {
+	if err == nil {
 		if orchestratorPath != "" {
 			return doctorBinaryEnvironment{
 				Source:           doctorBinaryPathSourceOrchestrator,
@@ -75,10 +75,7 @@ func resolveDoctorBinaryEnvironment(ctx context.Context, resolution globalconfig
 		}
 		return fallback("orchestrator PATH is unavailable because the running instance did not report it")
 	}
-	if err != nil {
-		return fallback(fmt.Sprintf("orchestrator PATH is unavailable because no running instance was reachable at %s: %v", probe.URL, err))
-	}
-	return fallback("orchestrator PATH is unavailable because the running instance did not report it")
+	return fallback(fmt.Sprintf("orchestrator PATH is unavailable because no running instance was reachable at %s: %v", probe.URL, err))
 }
 
 func checkDoctorConfigReload(ctx context.Context, cfg globalconfig.Config, run CommandRunner) doctorCheck {
@@ -764,16 +761,20 @@ func checkDoctorServerPort(ctx context.Context, cfg BootConfig, deps doctorDeps)
 			Detail: fmt.Sprintf("%s is not available for pre-start bind: %v", addr, err),
 			Hint:   "Stop the process using the port or pass --port with an available value.",
 		}
-		if !doctorListenErrIndicatesOccupied(err) || doctorServerPort(cfg) == 0 {
+		if (!doctorListenErrIndicatesOccupied(err) && !errors.Is(err, syscall.EADDRNOTAVAIL)) || doctorServerPort(cfg) == 0 {
 			return check
 		}
 		probe, probeErr := probeDoctorHealth(ctx, cfg, deps)
 		if probeErr != nil {
-			check.Detail = fmt.Sprintf("%s is occupied for pre-start bind; health probe %s %v", addr, probe.URL, probeErr)
+			check.Detail += fmt.Sprintf("; health probe %s %v", probe.URL, probeErr)
+			return check
+		}
+		if probe.Health.Mode != "running" {
+			check.Detail += "; Detent mode is " + probe.Health.Mode
 			return check
 		}
 		detail := fmt.Sprintf(
-			"%s is occupied for pre-start bind; health probe %s found healthy Detent instance (status %s, mode %s)%s",
+			"%s serves the running Detent instance; health probe %s (status %s, mode %s)%s",
 			addr,
 			probe.URL,
 			probe.Health.Status,
@@ -782,9 +783,8 @@ func checkDoctorServerPort(ctx context.Context, cfg BootConfig, deps doctorDeps)
 		)
 		return doctorCheck{
 			Name:   "Server port",
-			Status: doctorWarn,
+			Status: doctorOK,
 			Detail: detail,
-			Hint:   "No action is needed if doctor is checking the live instance; stop Detent before a clean pre-start availability check.",
 		}
 	}
 	if err := listener.Close(); err != nil {
@@ -846,6 +846,11 @@ func checkDoctorDetentService(ctx context.Context, cfg BootConfig, installedBuil
 			check.Status = doctorWarn
 			check.Detail += "; health check: " + err.Error()
 			check.Hint = "Review the running Detent service health, then rerun detent doctor."
+		}
+		if err == nil && probe.Health.Status != "ok" {
+			check.Status = doctorWarn
+			check.Detail += "; operational health: " + probe.Health.Status
+			check.Hint = "Review the live diagnostic findings, then rerun detent doctor."
 		}
 		checks := []doctorCheck{check}
 		if probe.Health.OrphanedAgentProcesses.Count > 0 {
@@ -1001,12 +1006,10 @@ func probeDoctorHealth(ctx context.Context, cfg BootConfig, deps doctorDeps) (do
 	}
 	probe.Health.Status = strings.TrimSpace(probe.Health.Status)
 	probe.Health.Mode = strings.TrimSpace(probe.Health.Mode)
-	if probe.Health.Mode == "" || !doctorHealthHasDetentChecks(probe.Health.Checks) {
+	if probe.Health.Status == "" || probe.Health.Mode == "" || !doctorHealthHasDetentChecks(probe.Health.Checks) {
 		return probe, errors.New("did not return Detent health")
 	}
-	if probe.Health.Status != "ok" {
-		return probe, fmt.Errorf("did not report healthy status: status %s, mode %s", probe.Health.Status, probe.Health.Mode)
-	}
+
 	return probe, nil
 }
 

--- a/internal/cli/doctor_health_notifications.go
+++ b/internal/cli/doctor_health_notifications.go
@@ -2,10 +2,7 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/digitaldrywood/detent/internal/healthnotify"
@@ -19,7 +16,8 @@ func checkDoctorHealthNotificationDelivery(ctx context.Context, boot BootConfig,
 	}
 	found, err := readDoctorHealthNotificationFailures(ctx, doctorLiveBoot(boot, &boot.Global), deps)
 	if err != nil {
-		check.Detail = "live notification check skipped because no healthy Detent instance was reachable"
+		check.Status = doctorWarn
+		check.Detail = "live notification check unavailable: " + err.Error()
 		return check
 	}
 	projectID = strings.TrimSpace(projectID)
@@ -46,24 +44,9 @@ func checkDoctorHealthNotificationDelivery(ctx context.Context, boot BootConfig,
 }
 
 func readDoctorHealthNotificationFailures(ctx context.Context, boot BootConfig, deps doctorDeps) ([]healthnotify.Failure, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, doctorHealthProbeURL(boot), nil)
+	probe, err := probeDoctorHealth(ctx, boot, deps)
 	if err != nil {
 		return nil, err
 	}
-	response, err := deps.httpDo(request)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("health returned HTTP %d", response.StatusCode)
-	}
-	var health doctorHealthResponse
-	if err := json.NewDecoder(response.Body).Decode(&health); err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(health.Mode) == "" || !doctorHealthHasDetentChecks(health.Checks) {
-		return nil, errors.New("response was not Detent health")
-	}
-	return health.HealthNotificationFailures, nil
+	return probe.Health.HealthNotificationFailures, nil
 }

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -59,8 +59,8 @@ func checkDoctorWorkflowDrift(ctx context.Context, cfg globalconfig.Config, boot
 	if err != nil {
 		return []doctorCheck{{
 			Name:   "Workflow runtime drift",
-			Status: doctorOK,
-			Detail: "runtime comparison skipped because no healthy live Detent instance was reachable",
+			Status: doctorWarn,
+			Detail: "runtime comparison unavailable: " + err.Error(),
 		}}
 	}
 

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -64,6 +64,14 @@ func checkDoctorWorkflowDrift(ctx context.Context, cfg globalconfig.Config, boot
 		}}
 	}
 
+	if probe.Health.Status == "draining" {
+		return []doctorCheck{{
+			Name:   "Workflow runtime drift",
+			Status: doctorWarn,
+			Detail: "runtime comparison unavailable while the live Detent instance is draining",
+		}}
+	}
+
 	runtimeByProject := make(map[string]doctorHealthWorkflow, len(probe.Health.Workflows))
 	for _, workflow := range probe.Health.Workflows {
 		runtimeByProject[strings.TrimSpace(workflow.ProjectID)] = workflow

--- a/internal/cli/doctor_reachability_test.go
+++ b/internal/cli/doctor_reachability_test.go
@@ -23,6 +23,7 @@ func TestDoctorLiveReachability(t *testing.T) {
 		err                                   error
 	}{
 		{name: "healthy", status: "ok", mode: "running"},
+		{name: "draining", status: "draining", mode: "running"},
 		{name: "remote unhealthy", listenErr: syscall.EADDRNOTAVAIL, status: "needs_attention", mode: "running"},
 		{name: "unhealthy", status: "needs_attention", mode: "running"},
 		{name: "stopped", err: syscall.ECONNREFUSED, unavailable: "could not be reached"},
@@ -83,7 +84,11 @@ func TestDoctorLiveReachability(t *testing.T) {
 			if len(stranded.StrandedIssues) != 1 || len(stale.StalenessWarnings) != 1 {
 				t.Errorf("live findings suppressed: stranded=%+v stale=%+v", stranded, stale)
 			}
-			if len(drift) != 1 || drift[0].Name != "Project detent workflow runtime" || drift[0].Status == doctorOK {
+			if tt.status == "draining" {
+				if len(drift) != 1 || drift[0].Status != doctorWarn || !strings.Contains(drift[0].Detail, "unavailable while the live Detent instance is draining") || drift[0].Hint != "" {
+					t.Errorf("draining runtime comparison = %+v, want explicit unavailable evidence without upgrade advice", drift)
+				}
+			} else if len(drift) != 1 || drift[0].Name != "Project detent workflow runtime" || drift[0].Status == doctorOK {
 				t.Errorf("runtime comparison did not execute: %+v", drift)
 			}
 			if port.Status != doctorOK || strings.Contains(port.Detail, "occupied") {

--- a/internal/cli/doctor_reachability_test.go
+++ b/internal/cli/doctor_reachability_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestDoctorLiveReachability(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, status, mode, body, unavailable string
+		listenErr                             error
+		code                                  int
+		err                                   error
+	}{
+		{name: "healthy", status: "ok", mode: "running"},
+		{name: "remote unhealthy", listenErr: syscall.EADDRNOTAVAIL, status: "needs_attention", mode: "running"},
+		{name: "unhealthy", status: "needs_attention", mode: "running"},
+		{name: "stopped", err: syscall.ECONNREFUSED, unavailable: "could not be reached"},
+		{name: "unrelated", body: `{"status":"ok"}`, unavailable: "did not return Detent health"},
+		{name: "unauthorized", code: http.StatusUnauthorized, unavailable: "HTTP 401"},
+		{name: "timeout", err: context.DeadlineExceeded, unavailable: "deadline exceeded"},
+		{name: "incompatible", body: `{"status":`, unavailable: "did not return Detent health"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			calls := 0
+			deps := doctorDeps{httpDo: func(*http.Request) (*http.Response, error) {
+				calls++
+				if tt.err != nil {
+					return nil, tt.err
+				}
+				body := tt.body
+				if body == "" {
+					body = fmt.Sprintf(`{"status":%q,"mode":%q,"ready":true,"lifecycle":"ready","version":"v1","commit":"abc","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},"stranded_active_issues":[{"project_id":"detent","identifier":"detent#1"}],"staleness_warnings":[{"project_id":"detent","class":"fault","identifier":"detent#2","reason":"stalled"}]}`, tt.status, tt.mode)
+				}
+				code := tt.code
+				if code == 0 {
+					code = http.StatusOK
+				}
+				return &http.Response{StatusCode: code, Body: io.NopCloser(strings.NewReader(body))}, nil
+			}, listen: func(string, string) (net.Listener, error) {
+				if tt.listenErr != nil {
+					return nil, tt.listenErr
+				}
+				return nil, syscall.EADDRINUSE
+			}}.withDefaults()
+			boot := BootConfig{}
+			stranded := checkDoctorStrandedActive(t.Context(), boot, "", deps)
+			dispatch := checkDoctorDispatchStalls(t.Context(), boot, "", deps)
+			notifications := checkDoctorHealthNotificationDelivery(t.Context(), boot, "", deps)
+			service := checkDoctorDetentService(t.Context(), boot, buildinfo.Info{}, deps)
+			stale := checkDoctorFleetStaleness(t.Context(), boot, "", deps)
+			drift := checkDoctorWorkflowDrift(t.Context(), globalconfig.Config{Projects: []globalconfig.Project{{ID: "detent"}}}, boot, deps)
+			port := checkDoctorServerPort(t.Context(), boot, deps)
+			if calls != 7 {
+				t.Fatalf("health calls = %d, want 7", calls)
+			}
+			if tt.unavailable != "" {
+				for _, check := range []doctorCheck{stranded, stale, drift[0], dispatch, notifications} {
+					if check.Status != doctorWarn || !strings.Contains(check.Detail, tt.unavailable) {
+						t.Errorf("unavailable evidence = %+v, want warning containing %q", check, tt.unavailable)
+					}
+				}
+				if port.Status != doctorFail {
+					t.Errorf("port = %+v, want failure", port)
+				}
+				return
+			}
+			if tt.status == "needs_attention" && (len(service) == 0 || service[0].Status != doctorWarn || !strings.Contains(service[0].Detail, tt.status)) {
+				t.Errorf("unhealthy service warning missing: %+v", service)
+			}
+			if len(stranded.StrandedIssues) != 1 || len(stale.StalenessWarnings) != 1 {
+				t.Errorf("live findings suppressed: stranded=%+v stale=%+v", stranded, stale)
+			}
+			if len(drift) != 1 || drift[0].Name != "Project detent workflow runtime" || drift[0].Status == doctorOK {
+				t.Errorf("runtime comparison did not execute: %+v", drift)
+			}
+			if port.Status != doctorOK || strings.Contains(port.Detail, "occupied") {
+				t.Errorf("running listener = %+v, want OK without startup conflict", port)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_staleness.go
+++ b/internal/cli/doctor_staleness.go
@@ -17,7 +17,8 @@ func checkDoctorFleetStaleness(ctx context.Context, boot BootConfig, projectID s
 	}
 	probe, err := probeDoctorHealth(ctx, doctorLiveBoot(boot, &boot.Global), deps)
 	if err != nil {
-		check.Detail = "live condition check skipped because no healthy Detent instance was reachable"
+		check.Status = doctorWarn
+		check.Detail = "live condition check unavailable: " + err.Error()
 		return check
 	}
 	projectID = strings.TrimSpace(projectID)

--- a/internal/cli/doctor_stranded_active.go
+++ b/internal/cli/doctor_stranded_active.go
@@ -17,7 +17,8 @@ func checkDoctorStrandedActive(ctx context.Context, boot BootConfig, projectID s
 	}
 	probe, err := probeDoctorHealth(ctx, doctorLiveBoot(boot, &boot.Global), deps)
 	if err != nil {
-		check.Detail = "live stranded-work check skipped because no healthy Detent instance was reachable"
+		check.Status = doctorWarn
+		check.Detail = "live stranded-work check unavailable: " + err.Error()
 		return check
 	}
 	projectID = strings.TrimSpace(projectID)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -5308,10 +5308,9 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 			host:       "0.0.0.0",
 			statusCode: http.StatusOK,
 			body:       `{"status":"ok","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},"budgets":[{"project_id":"detent","enabled":true,"per_day_max_usd":250,"per_issue_max_usd":25}]}`,
-			want:       doctorWarn,
+			want:       doctorOK,
 			wantDetail: []string{
-				"pre-start bind",
-				"healthy Detent instance",
+				"running Detent instance",
 				"http://127.0.0.1:",
 				"/health",
 				"status ok",
@@ -5324,11 +5323,10 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 			host:       "127.0.0.1",
 			statusCode: http.StatusOK,
 			body:       `{"status":"error","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"}}`,
-			want:       doctorFail,
+			want:       doctorOK,
 			wantDetail: []string{
-				"pre-start bind",
-				"health probe",
-				"did not report healthy status",
+				"running Detent instance",
+				"status error",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- Run live doctor diagnostics against supported running services even when operational health needs attention.
- Report unavailable evidence with a warning and cause, preserve authentication and compatibility checks, and recognize running listeners without startup conflicts.
- Defer workflow comparison while draining because that health payload omits workflows.

Fixes #2422

## UI Surface Contract

- [x] N/A: CLI diagnostic changes only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens.

## Test Plan

- [x] Table regressions cover healthy, unhealthy, remote unhealthy, draining, stopped, unrelated listener, unauthorized, timeout, and incompatible responses.
- [x] Focused doctor tests and full CLI race suite pass.
- [x] `GOMAXPROCS=2 make check CHECK_LOCK_WAIT=1h` passes on d5ed9cd9: 80.5% coverage and all package/file floors. Queue wait 33m08s; execution 14m27s.
- All current-head CI checks passed (run 34423099510, attempt 2). Windows portability passed on an unchanged retry after the existing hub outbox drain failure tracked in #2389.
