### PR TITLE
feat(merge): bound native queue integration

### DIFF
--- a/.detent/skills/provider-queue-removal-recovery.md
+++ b/.detent/skills/provider-queue-removal-recovery.md
@@ -1,0 +1,30 @@
+---
+name: provider-queue-removal-recovery
+description: Preserve remote queue failure and cancellation decisions when missing entries would otherwise be automatically re-enqueued.
+when_to_use: A scheduler treats an absent remote queue entry as retry permission, especially when local cache loss after restart can repeat failed integration work.
+---
+
+# Provider queue removal recovery
+
+An absent queue entry is ambiguous: it may represent failure, cancellation,
+completion, or a transient observation. Consult the provider's durable removal
+history before deciding to enqueue again. Local cache presence alone cannot
+preserve that decision across restart.
+
+Bind removal evidence to the immutable work identity. For GitHub merge queues,
+inspect the latest `RemovedFromMergeQueueEvent.beforeCommit.oid` alongside the
+current PR head and queue entry. A removal for the current head prevents an
+automatic retry; a newly checked head can be eligible again. Missing removal
+identity requires a conservative disposition. An existing provider entry can
+represent explicit re-enqueue and should be observed rather than duplicated.
+
+Keep admission fencing separate from cleanup inspection. An observed changed
+head must prevent admission, but inspection still needs to return the entry so
+a revoked configuration can dequeue it. Scope caches to the checked identity
+and use the provider's expected-head mutation precondition when available.
+
+Test with a fresh scheduler state, not only a reused cache: removed current
+identity, repaired identity, missing removal identity, explicit re-enqueue, and
+unrelated passing candidates. Verify that deferral consumes no worker and does
+not reserve the repository against those other candidates. Preserve existing
+authorization gates; provider history does not authorize a policy bypass.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     tags: ['v*']
   pull_request:
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '27 9 * * *'
   workflow_dispatch:

--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -420,6 +420,10 @@
 #         latest_codex_review_submitted_at: null
 #         # tracker.issues[].pull_request.merge_queue_entry | type: object | default: none | required: No | validation: None
 #         merge_queue_entry:
+#           # tracker.issues[].pull_request.merge_queue_entry.head_sha | type: string | default: none | required: No | validation: None
+#           head_sha: null
+#           # tracker.issues[].pull_request.merge_queue_entry.base_sha | type: string | default: none | required: No | validation: None
+#           base_sha: null
 #           # tracker.issues[].pull_request.merge_queue_entry.id | type: string | default: none | required: No | validation: None
 #           id: null
 #           # tracker.issues[].pull_request.merge_queue_entry.state | type: string | default: none | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -1384,9 +1384,11 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `tracker.issues[].pull_request.latest_codex_review_state` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.latest_codex_review_submitted_at` | `mapping` | `none` | No | None |
 | `tracker.issues[].pull_request.merge_queue_entry` | `object` | `none` | No | None |
+| `tracker.issues[].pull_request.merge_queue_entry.base_sha` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.merge_queue_entry.depth` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.merge_queue_entry.enqueued_at` | `mapping` | `none` | No | None |
 | `tracker.issues[].pull_request.merge_queue_entry.estimated_time_to_merge_seconds` | `integer` | `0 when configured` | No | None |
+| `tracker.issues[].pull_request.merge_queue_entry.head_sha` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.merge_queue_entry.id` | `string` | `none` | No | None |
 | `tracker.issues[].pull_request.merge_queue_entry.position` | `integer` | `0 when configured` | No | None |
 | `tracker.issues[].pull_request.merge_queue_entry.state` | `string` | `none` | No | None |

--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -14,8 +14,8 @@ Do not cap `Todo`, `In Progress`, or `Rework` unless you have a specific
 operational reason. Those states should share the global agent pool so workers
 stay busy while merge candidates wait for CI or a clean base branch.
 
-When GitHub reports `HAS_MERGE_QUEUE`, Detent delegates every eligible green
-candidate to the repository's native merge queue instead of rebasing each PR
+When GitHub reports a required native merge queue and the configured gate
+permits delegation, Detent delegates every eligible green candidate to the repository's native merge queue instead of rebasing each PR
 through the serialized worker. GitHub owns merge-group validation and batching;
 Detent keeps the issues in `Merging`, observes their queue entries, and
 reconciles them to `Done` after GitHub reports the PR merged. Without a native
@@ -92,3 +92,114 @@ Scheduler decisions report project saturation as `project_capacity_full` and
 shared pool saturation as `global_capacity_full`. A project that already used
 its control operation reports `ready_merge_control_limit` for another ready
 merge when implementation capacity remains full.
+
+
+## Native queue migration and limits
+
+The queue path requires a nonempty checked PR head. Enqueue sends GitHub's
+`expectedHeadOid`; a concurrent push fails admission. Inspection also compares
+the current PR head before adopting an existing entry, including after restart.
+The entry cache is scoped to that head, so a head change forces inspection.
+GitHub removal history also survives restart: an absent entry removed on the
+same head is deferred, not automatically re-enqueued after integration failure
+or cancellation. A newly checked head can retry. Missing removal identity
+fails closed; an operator can explicitly re-enqueue in GitHub, which Detent
+then observes. This preserves removal decisions without a local-only tombstone.
+Admission uses the repository queue's `maximumEntriesToBuild` as its window:
+when queue depth reaches that limit, further candidates wait without worker
+fallback. This leaves the next open slot available to configured priority and
+aging instead of enqueueing the entire backlog ahead of a new urgent fix.
+Missing or invalid limit metadata defers new admission until a valid window
+is observed. Existing provider entries can still be recovered.
+
+Base advancement alone does not rewrite queued PRs: GitHub validates its new
+integration group. Cancelling a dispatch stops further admissions; it does not
+withdraw already admitted work from GitHub.
+
+This repository's CI accepts `merge_group: checks_requested`. Checkout uses the
+merge-group commit, all required jobs run, and visual detection defaults to the
+full visual gate when there is no PR base ref. PR workflow cancellation is
+scoped to that PR; it cannot cancel an integration-group run.
+
+Migration is an operator action, never a side effect of starting Detent:
+
+1. Verify every required workflow runs on the merge-group SHA, including any
+   required checks outside `ci.yml`. Keep expected GitHub App identities pinned.
+2. Preserve required human reviews and stale-review dismissal on head updates,
+   failed-check rejection, and all existing protection requirements. Configure
+   GitHub's queue with squash merging and a bounded build concurrency and merge
+   group size appropriate to the repository's CI capacity.
+3. Configure urgent labels through `agent.dispatch_priority_by_label` and retain
+   `merge_fairness_age`. Urgency orders admissions; aged ordinary candidates
+   retain precedence. Detent does not jump an urgent entry ahead of an active
+   group, because that rebuilds already-running integration checks.
+4. Trial with two passing PRs and a failing candidate; verify GitHub reports the
+   required trusted checks on each integration SHA and ejects failures. Verify
+   restart observes entries without enqueueing them again.
+5. Keep implementation states uncapped as described above. Native queue waits
+   consume no implementation worker. Retain the serialized reservation path
+   for repositories without a native queue.
+
+Detent **does not delegate PR-required or security-audit gates**. Their mutable
+approval, audit freshness, and revocation rules are not atomically enforced by
+GitHub's eventual queue merge. Enabling a repository queue does not remove this
+exclusion. A trusted required merge-group policy service with equivalent
+revocation enforcement must be designed before migrating such configurations;
+pre-enqueue checks or a configuration assertion are insufficient. This includes
+the audited dogfood configuration: the changes above prepare supported native
+queue use, but do not eliminate that configuration's repeated validation.
+
+A custom aggregate batch is not an equivalent strict-protection fallback.
+Passing `base+A+B` does not prove `base+A` passed, and squash merging A changes
+the base identity for B. An aggregate PR would need its own reviews and would
+change constituent PR semantics.
+
+See [GitHub queue configuration](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+and [GitHub enqueue inputs](https://docs.github.com/en/graphql/reference/pulls).
+
+## Measuring integration retries
+
+Queue diagnostics include entry ID and integration head/base SHAs returned by
+GitHub; absent identities remain empty while GitHub prepares an entry.
+Correlate recorded work attempts and reservation events with PR head, base, and
+CI run identity; count distinct CI runs, not commit rollups or scheduler samples.
+Keep source-changing repairs, failed-predecessor rebuilds, and changed integration
+inputs separate from repeated validation of identical inputs. A green PR rollup
+alone does not establish that its later integration would pass.
+
+The September 8 incident was correlated using the read-only
+`detent.before-v0.109.0-20260908T211309Z.db` backup, `work_attempts`,
+`scheduler_decisions`, and GitHub Actions runs queried by exact SHA. The sample
+window is 18:00–21:13:09 UTC. The unavailable live HTTP endpoint was not needed.
+
+| PR | Recorded work / validation | Interpretation |
+| --- | --- | --- |
+| #2336 (#2332) | Implementation attempt 4864 ended with green `9491aad6`, base `a862df33`. Merge attempt 4872 refreshed to `28b349d1`, base `1040032d`, and saved a reservation. Attempt 4889 resumed with the same integrated identities and did not push. | One integration refresh, two merge attempts, not two integration reruns. |
+| #2336 CI | Original-head run [34266907982](https://github.com/digitaldrywood/detent/actions/runs/34266907982) succeeded; integrated-head run [34270866489](https://github.com/digitaldrywood/detent/actions/runs/34270866489) succeeded. Both have run_attempt 1. | One additional CI cycle after a passing original head; required under strict changed-base validation. No duplicate same-head rerun observed. |
+| #2335 (#2333) | No recorded work attempt in this window. Six CI runs belong to `fix/astra-effort-ceiling`: three successful, three cancelled. Each has run_attempt 1. | Work outside recorded attempts must not be counted as Detent redispatches. Cancelled workflow outcomes differ from failed check rollups. |
+
+For #2336, the integrated CI run spans 19:46:00–20:11:17 UTC from creation to
+last update (25m17s, not summed job CPU time). Attempt 4872 spans
+19:44:59–19:45:55; attempt 4889 spans 20:16:46–20:17:43. Its reservation began
+19:44:59 with a 20:44:59 expiry. Eleven current_head_ci_wait decision samples
+span 19:46:46–20:13:42. #2333 and #2338 each have eleven reservation samples
+behind that same `28b349d1`/`1040032d` owner over that interval. At 19:46:46 the
+recorded capacity snapshot has five of ten global slots available and zero of
+one Merging slots used. This establishes a repository reservation wait despite
+spare worker capacity; sample counts are not dispatch or CI retry counts.
+
+For #2335, successful original `0f894f0c` ran in
+[34265532272](https://github.com/digitaldrywood/detent/actions/runs/34265532272).
+Integration `c511e44e` ran in
+[34268198744](https://github.com/digitaldrywood/detent/actions/runs/34268198744)
+(cancelled, with a failed check rollup); fixture repair `b2ea948d` succeeded in
+[34268924073](https://github.com/digitaldrywood/detent/actions/runs/34268924073).
+Initial `c5cb21d3` and later source correction `c851a471` were also cancelled;
+final integration `b91f41b0` succeeded in
+[34274232899](https://github.com/digitaldrywood/detent/actions/runs/34274232899).
+The apparent fourth successful commit rollup, `61f5eaca`, belongs to another
+branch (#2344), not a separate validation of #2335. `c2921a63` has no run.
+Source-changing repairs and changed-base integrations are legitimate validation;
+the opportunity is avoiding PR-head refresh cycles through provider-owned
+integration, not accepting old-base green checks. The available evidence does
+not establish any duplicate CI rerun of identical integrated inputs.

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -150,12 +150,19 @@ type PullRequestMergeQueue interface {
 }
 
 type PullRequestMergeQueueStatus struct {
+	RemovalObserved   bool
+	RemovedHeadSHA    string
+	Depth             int
+	AdmissionLimit    int
+	HeadSHA           string
 	Available         bool
 	PullRequestNodeID string
 	Entry             *PullRequestMergeQueueEntry
 }
 
 type PullRequestMergeQueueEntry struct {
+	HeadSHA                     string     `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
+	BaseSHA                     string     `json:"base_sha,omitempty" yaml:"base_sha,omitempty"`
 	ID                          string     `json:"id,omitempty" yaml:"id,omitempty"`
 	State                       string     `json:"state,omitempty" yaml:"state,omitempty"`
 	Position                    int        `json:"position,omitempty" yaml:"position,omitempty"`

--- a/internal/connector/github/merge_queue.go
+++ b/internal/connector/github/merge_queue.go
@@ -15,8 +15,14 @@ query DetentInspectPullRequestMergeQueue($owner: String!, $name: String!, $numbe
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       id
-      mergeQueue { url }
+      headRefOid
+      timelineItems(last: 1, itemTypes: [REMOVED_FROM_MERGE_QUEUE_EVENT]) {
+        nodes { ... on RemovedFromMergeQueueEvent { beforeCommit { oid } } }
+      }
+      mergeQueue { url entries { totalCount } configuration { maximumEntriesToBuild } }
       mergeQueueEntry {
+        headCommit { oid }
+        baseCommit { oid }
         id
         state
         position
@@ -33,9 +39,11 @@ query DetentInspectPullRequestMergeQueue($owner: String!, $name: String!, $numbe
 }`
 
 const enqueuePullRequestMutation = `
-mutation DetentEnqueuePullRequest($pullRequestId: ID!) {
-  enqueuePullRequest(input: {pullRequestId: $pullRequestId}) {
+mutation DetentEnqueuePullRequest($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
+  enqueuePullRequest(input: {pullRequestId: $pullRequestId, expectedHeadOid: $expectedHeadOid}) {
     mergeQueueEntry {
+      headCommit { oid }
+      baseCommit { oid }
       id
       state
       position
@@ -59,6 +67,12 @@ mutation DetentDequeuePullRequest($mergeQueueEntryId: ID!) {
 }`
 
 type mergeQueueEntryNode struct {
+	HeadCommit struct {
+		OID string `json:"oid"`
+	} `json:"headCommit"`
+	BaseCommit struct {
+		OID string `json:"oid"`
+	} `json:"baseCommit"`
 	ID                   string     `json:"id"`
 	State                string     `json:"state"`
 	Position             int        `json:"position"`
@@ -80,9 +94,23 @@ func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue conn
 	var response struct {
 		Repository *struct {
 			PullRequest *struct {
-				ID         string `json:"id"`
+				ID            string `json:"id"`
+				HeadRefOid    string `json:"headRefOid"`
+				TimelineItems struct {
+					Nodes []struct {
+						BeforeCommit struct {
+							OID string `json:"oid"`
+						} `json:"beforeCommit"`
+					} `json:"nodes"`
+				} `json:"timelineItems"`
 				MergeQueue *struct {
-					URL string `json:"url"`
+					URL     string `json:"url"`
+					Entries struct {
+						TotalCount int `json:"totalCount"`
+					} `json:"entries"`
+					Configuration struct {
+						MaximumEntriesToBuild int `json:"maximumEntriesToBuild"`
+					} `json:"configuration"`
 				} `json:"mergeQueue"`
 				MergeQueueEntry *mergeQueueEntryNode `json:"mergeQueueEntry"`
 			} `json:"pullRequest"`
@@ -100,8 +128,17 @@ func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue conn
 	}
 	pullRequest := response.Repository.PullRequest
 	status := connector.PullRequestMergeQueueStatus{
+		HeadSHA:           strings.TrimSpace(pullRequest.HeadRefOid),
 		Available:         pullRequest.MergeQueue != nil || pullRequest.MergeQueueEntry != nil,
 		PullRequestNodeID: strings.TrimSpace(pullRequest.ID),
+	}
+	if pullRequest.MergeQueue != nil {
+		status.Depth = pullRequest.MergeQueue.Entries.TotalCount
+		status.AdmissionLimit = pullRequest.MergeQueue.Configuration.MaximumEntriesToBuild
+	}
+	if len(pullRequest.TimelineItems.Nodes) > 0 {
+		status.RemovalObserved = true
+		status.RemovedHeadSHA = strings.TrimSpace(pullRequest.TimelineItems.Nodes[0].BeforeCommit.OID)
 	}
 	status.Entry = connectorMergeQueueEntry(pullRequest.MergeQueueEntry)
 	return status, nil
@@ -111,11 +148,18 @@ func (c *Connector) EnqueuePullRequest(ctx context.Context, issue connector.Issu
 	if issue.PullRequest == nil {
 		return connector.PullRequestMergeQueueEntry{}, errors.New("enqueue github pull request: missing pull request")
 	}
+	headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA)
+	if headSHA == "" {
+		return connector.PullRequestMergeQueueEntry{}, errors.New("enqueue github pull request: missing expected head sha")
+	}
 	nodeID := strings.TrimSpace(issue.PullRequest.NodeID)
 	if nodeID == "" {
 		status, err := c.InspectPullRequestMergeQueue(ctx, issue)
 		if err != nil {
 			return connector.PullRequestMergeQueueEntry{}, err
+		}
+		if status.HeadSHA != headSHA {
+			return connector.PullRequestMergeQueueEntry{}, errors.New("enqueue github pull request: pull request head changed")
 		}
 		if !status.Available {
 			return connector.PullRequestMergeQueueEntry{}, errors.New("enqueue github pull request: repository does not require a merge queue")
@@ -134,7 +178,8 @@ func (c *Connector) EnqueuePullRequest(ctx context.Context, issue connector.Issu
 		} `json:"enqueuePullRequest"`
 	}
 	if err := c.client.GraphQLWithType(ctx, graphQLQueryEnqueuePR, enqueuePullRequestMutation, map[string]any{
-		"pullRequestId": nodeID,
+		"pullRequestId":   nodeID,
+		"expectedHeadOid": headSHA,
 	}, &response); err != nil {
 		return connector.PullRequestMergeQueueEntry{}, fmt.Errorf("enqueue github pull request: %w", err)
 	}
@@ -177,6 +222,8 @@ func connectorMergeQueueEntry(entry *mergeQueueEntryNode) *connector.PullRequest
 		return nil
 	}
 	out := &connector.PullRequestMergeQueueEntry{
+		HeadSHA:                     strings.TrimSpace(entry.HeadCommit.OID),
+		BaseSHA:                     strings.TrimSpace(entry.BaseCommit.OID),
 		ID:                          strings.TrimSpace(entry.ID),
 		State:                       strings.ToUpper(strings.TrimSpace(entry.State)),
 		Position:                    entry.Position,

--- a/internal/connector/github/merge_queue_test.go
+++ b/internal/connector/github/merge_queue_test.go
@@ -21,7 +21,7 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 	}{
 		{
 			name:      "detects merge queue policy",
-			response:  `{"data":{"repository":{"pullRequest":{"id":"PR_42","mergeStateStatus":"CLEAN","mergeQueue":{"url":"https://github.test/example/repo/queue/main"},"mergeQueueEntry":null}}}}`,
+			response:  `{"data":{"repository":{"pullRequest":{"id":"PR_42","mergeStateStatus":"CLEAN","mergeQueue":{"url":"https://github.test/example/repo/queue/main","entries":{"totalCount":2},"configuration":{"maximumEntriesToBuild":3}},"mergeQueueEntry":null}}}}`,
 			available: true,
 		},
 		{
@@ -31,9 +31,11 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 		},
 		{
 			name:      "recognizes existing queue entry",
-			response:  `{"data":{"repository":{"pullRequest":{"id":"PR_42","mergeStateStatus":"BLOCKED","mergeQueueEntry":{"id":"MQE_42","state":"AWAITING_CHECKS","position":2,"estimatedTimeToMerge":420,"enqueuedAt":"2026-07-13T18:00:00Z","mergeQueue":{"url":"https://github.test/example/repo/queue/main","entries":{"totalCount":5}}}}}}}`,
+			response:  `{"data":{"repository":{"pullRequest":{"id":"PR_42","mergeStateStatus":"BLOCKED","mergeQueueEntry":{"headCommit":{"oid":"group-head"},"baseCommit":{"oid":"group-base"},"id":"MQE_42","state":"AWAITING_CHECKS","position":2,"estimatedTimeToMerge":420,"enqueuedAt":"2026-07-13T18:00:00Z","mergeQueue":{"url":"https://github.test/example/repo/queue/main","entries":{"totalCount":5}}}}}}}`,
 			available: true,
 			wantEntry: &connector.PullRequestMergeQueueEntry{
+				HeadSHA:                     "group-head",
+				BaseSHA:                     "group-base",
 				ID:                          "MQE_42",
 				State:                       "AWAITING_CHECKS",
 				Position:                    2,
@@ -66,9 +68,12 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 			if !reflect.DeepEqual(status.Entry, tt.wantEntry) {
 				t.Fatalf("entry = %#v, want %#v", status.Entry, tt.wantEntry)
 			}
+			if tt.name == "detects merge queue policy" && (status.Depth != 2 || status.AdmissionLimit != 3) {
+				t.Fatalf("queue limits = %#v, want depth 2 and admission 3", status)
+			}
 			request := server.requests()[0]
 			query := request["query"].(string)
-			if !strings.Contains(query, "mergeQueue { url }") || strings.Contains(query, "mergeStateStatus") {
+			if !strings.Contains(query, "configuration { maximumEntriesToBuild }") || strings.Contains(query, "mergeStateStatus") {
 				t.Fatalf("query = %q, want mergeQueue capability field without mergeStateStatus", query)
 			}
 			variables := request["variables"].(map[string]any)
@@ -90,8 +95,9 @@ func TestConnectorEnqueuePullRequest(t *testing.T) {
 		Identifier:   "example/repo#1",
 		PRRepository: "example/repo",
 		PullRequest: &connector.PullRequest{
-			NodeID: "PR_42",
-			Number: 42,
+			NodeID:  "PR_42",
+			HeadSHA: "reviewed-head",
+			Number:  42,
 		},
 	})
 	if err != nil {
@@ -101,10 +107,16 @@ func TestConnectorEnqueuePullRequest(t *testing.T) {
 		t.Fatalf("entry = %#v, want queued position 3 of 6 with 300s ETA", entry)
 	}
 	request := server.requests()[0]
+	if !strings.Contains(request["query"].(string), "expectedHeadOid: $expectedHeadOid") {
+		t.Fatalf("query = %q, want expected-head fence", request["query"])
+	}
 	if !strings.Contains(request["query"].(string), "enqueuePullRequest") {
 		t.Fatalf("query = %q, want enqueuePullRequest mutation", request["query"])
 	}
 	variables := request["variables"].(map[string]any)
+	if variables["expectedHeadOid"] != "reviewed-head" {
+		t.Fatalf("expectedHeadOid = %v, want reviewed-head", variables["expectedHeadOid"])
+	}
 	if variables["pullRequestId"] != "PR_42" {
 		t.Fatalf("pullRequestId = %v, want PR_42", variables["pullRequestId"])
 	}
@@ -198,4 +210,54 @@ func mergeQueueTestTime(value string) *time.Time {
 		panic(err)
 	}
 	return &parsed
+}
+
+func TestConnectorMergeQueueHeadFence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		head         string
+		node         string
+		response     string
+		wantError    string
+		wantRequests int
+	}{
+		{name: "missing head", node: "PR_42", wantError: "missing expected head sha"},
+		{name: "changed head on restart", head: "reviewed", response: `{"data":{"repository":{"pullRequest":{"id":"PR_42","headRefOid":"unreviewed","mergeQueueEntry":{"id":"MQE_42"}}}}}`, wantError: "head changed", wantRequests: 1},
+		{name: "same head on restart", head: "reviewed", response: `{"data":{"repository":{"pullRequest":{"id":"PR_42","headRefOid":"reviewed","mergeQueueEntry":{"id":"MQE_42"}}}}}`, wantRequests: 1},
+		{name: "head changes during enqueue", head: "reviewed", node: "PR_42", response: `{"errors":[{"message":"expected head does not match"}]}`, wantError: "expected head does not match", wantRequests: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{body: tt.response}})
+			client := newGitHubTestConnector(t, server, Config{})
+			entry, err := client.EnqueuePullRequest(context.Background(), connector.Issue{
+				PRRepository: "example/repo",
+				PullRequest:  &connector.PullRequest{Number: 42, NodeID: tt.node, HeadSHA: tt.head},
+			})
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error = %v, want %q", err, tt.wantError)
+				}
+			} else if err != nil || entry.ID != "MQE_42" {
+				t.Fatalf("entry = %#v, error = %v", entry, err)
+			}
+			if got := len(server.requests()); got != tt.wantRequests {
+				t.Fatalf("requests = %d, want %d", got, tt.wantRequests)
+			}
+		})
+	}
+}
+
+func TestConnectorInspectChangedQueueHeadAllowsCleanup(t *testing.T) {
+	t.Parallel()
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{body: `{"data":{"repository":{"pullRequest":{"id":"PR_42","headRefOid":"new-head","timelineItems":{"nodes":[{"beforeCommit":{"oid":"removed-head"}}]},"mergeQueueEntry":{"id":"MQE_42"}}}}}`}})
+	client := newGitHubTestConnector(t, server, Config{})
+	status, err := client.InspectPullRequestMergeQueue(context.Background(), connector.Issue{PRRepository: "example/repo", PullRequest: &connector.PullRequest{Number: 42, HeadSHA: "old-head"}})
+	if !status.RemovalObserved || status.RemovedHeadSHA != "removed-head" {
+		t.Fatalf("removal = %#v, want removed-head", status)
+	}
+	if err != nil || status.HeadSHA != "new-head" || status.Entry == nil || status.Entry.ID != "MQE_42" {
+		t.Fatalf("status = %#v, error = %v; want current entry available for revocation", status, err)
+	}
 }

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -20,6 +20,7 @@ const (
 
 type nativeMergeQueueEntry struct {
 	Entry     connector.PullRequestMergeQueueEntry
+	HeadSHA   string
 	CheckedAt time.Time
 }
 
@@ -50,6 +51,10 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 	stickyIssueID := stickyMergingIssueID(state, out, now, o.cfg.MergeFairnessAge)
 
 	for _, candidate := range staleMergingQueueIssues(out, o.cfg, state, now) {
+		if ctx.Err() != nil {
+			state.nativeMergeQueueDeferred[strings.TrimSpace(candidate.ID)] = struct{}{}
+			continue
+		}
 		if _, reserved := mergeReservationBlocks(state, candidate, now); reserved {
 			continue
 		}
@@ -57,7 +62,7 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 		if !nativeMergeQueueCandidate(candidate, o.cfg) || staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
-		if cached, ok := state.nativeMergeQueueEntries[issueID]; ok && now.Sub(cached.CheckedAt) < nativeMergeQueueEntryRefresh {
+		if cached, ok := state.nativeMergeQueueEntries[issueID]; ok && now.Sub(cached.CheckedAt) < nativeMergeQueueEntryRefresh && cached.HeadSHA == strings.TrimSpace(candidate.PullRequest.HeadSHA) {
 			applyNativeMergeQueueEntry(out, issueID, cached.Entry)
 			continue
 		}
@@ -81,12 +86,20 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			o.logNativeMergeQueueFailure(candidate, "inspection_failed", err)
 			continue
 		}
+		if strings.TrimSpace(status.HeadSHA) != strings.TrimSpace(candidate.PullRequest.HeadSHA) {
+			state.nativeMergeQueueDeferred[issueID] = struct{}{}
+			o.logNativeMergeQueueFailure(candidate, "head_changed", nil)
+			continue
+		}
 		state.nativeMergeQueueRepos[repositoryKey] = nativeMergeQueueRepository{
 			Available: status.Available,
 			CheckedAt: now,
 		}
 		if status.Entry != nil {
 			cacheNativeMergeQueueEntry(state, issueID, *status.Entry, now)
+			cached := state.nativeMergeQueueEntries[issueID]
+			cached.HeadSHA = strings.TrimSpace(candidate.PullRequest.HeadSHA)
+			state.nativeMergeQueueEntries[issueID] = cached
 			applyNativeMergeQueueEntry(out, issueID, *status.Entry)
 			o.logNativeMergeQueueDelegated(candidate, *status.Entry, "observed")
 			continue
@@ -97,6 +110,15 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			o.logNativeMergeQueueFailure(candidate, "entry_missing", nil)
 		}
 		if !status.Available {
+			continue
+		}
+		if status.RemovalObserved && (strings.TrimSpace(status.RemovedHeadSHA) == "" || strings.TrimSpace(status.RemovedHeadSHA) == strings.TrimSpace(status.HeadSHA)) {
+			state.nativeMergeQueueDeferred[issueID] = struct{}{}
+			o.logNativeMergeQueueFailure(candidate, "head_removed_from_queue", nil)
+			continue
+		}
+		if status.AdmissionLimit <= 0 || status.Depth >= status.AdmissionLimit {
+			state.nativeMergeQueueDeferred[issueID] = struct{}{}
 			continue
 		}
 		enqueueIssue := cloneIssue(candidate)
@@ -110,6 +132,9 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			continue
 		}
 		cacheNativeMergeQueueEntry(state, issueID, entry, now)
+		cached := state.nativeMergeQueueEntries[issueID]
+		cached.HeadSHA = strings.TrimSpace(candidate.PullRequest.HeadSHA)
+		state.nativeMergeQueueEntries[issueID] = cached
 		applyNativeMergeQueueEntry(out, issueID, entry)
 		o.logNativeMergeQueueDelegated(candidate, entry, "enqueued")
 		recordStateEvent(state, telemetry.ActivityEvent{
@@ -308,6 +333,7 @@ func nativeMergeQueueCandidate(issue connector.Issue, cfg Config) bool {
 	}
 	return normalizePullRequestState(pullRequest.State) == "open" &&
 		!pullRequest.Draft &&
+		strings.TrimSpace(pullRequest.HeadSHA) != "" &&
 		mergeWorkerCIGreen(pullRequest.CIStatus) &&
 		pullRequestRepository(issue) != "" &&
 		pullRequestNumber(issue) > 0
@@ -408,6 +434,9 @@ func (o *Orchestrator) logNativeMergeQueueDelegated(issue connector.Issue, entry
 	}
 	o.logger.Info("merge_worker_native_queue_delegated", mergeWorkerLogAttrs(issue,
 		"source", source,
+		"integration_head_sha", entry.HeadSHA,
+		"integration_base_sha", entry.BaseSHA,
+		"queue_entry_id", entry.ID,
 		"queue_state", entry.State,
 		"queue_position", entry.Position,
 		"queue_depth", entry.Depth,

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -414,6 +414,7 @@ func TestNativeMergeQueueCandidate(t *testing.T) {
 		want   bool
 	}{
 		{name: "green current head", want: true},
+		{name: "missing checked head", mutate: func(issue *connector.Issue) { issue.PullRequest.HeadSHA = "" }},
 		{name: "pending CI", mutate: func(issue *connector.Issue) { issue.PullRequest.CIStatus = "pending" }},
 		{name: "failed CI", mutate: func(issue *connector.Issue) { issue.PullRequest.CIStatus = "failure" }},
 		{name: "draft", mutate: func(issue *connector.Issue) { issue.PullRequest.Draft = true }},
@@ -1007,14 +1008,17 @@ func nativeMergeQueueTestIssue(number int, ciStatus string) connector.Issue {
 
 type nativeMergeQueueConnector struct {
 	*autoPromoteTickMergeConnector
-	available   *bool
-	inspectErr  error
-	dequeueErr  error
-	statusErr   error
-	inspections int
-	entries     map[string]connector.PullRequestMergeQueueEntry
-	enqueued    []string
-	dequeued    []connector.PullRequestMergeQueueEntry
+	available      *bool
+	inspectErr     error
+	inspectedHead  string
+	admissionLimit *int
+	removedHeads   map[string]string
+	dequeueErr     error
+	statusErr      error
+	inspections    int
+	entries        map[string]connector.PullRequestMergeQueueEntry
+	enqueued       []string
+	dequeued       []connector.PullRequestMergeQueueEntry
 }
 
 func (c *nativeMergeQueueConnector) FetchIssuesByStates(ctx context.Context, states []string) ([]connector.Issue, error) {
@@ -1033,7 +1037,18 @@ func (c *nativeMergeQueueConnector) InspectPullRequestMergeQueue(_ context.Conte
 	if c.available != nil {
 		available = *c.available
 	}
-	status := connector.PullRequestMergeQueueStatus{Available: available}
+	limit := 100
+	if c.admissionLimit != nil {
+		limit = *c.admissionLimit
+	}
+	status := connector.PullRequestMergeQueueStatus{Available: available, AdmissionLimit: limit, Depth: len(c.enqueued)}
+	status.RemovedHeadSHA, status.RemovalObserved = c.removedHeads[issue.ID]
+	if issue.PullRequest != nil {
+		status.HeadSHA = issue.PullRequest.HeadSHA
+	}
+	if c.inspectedHead != "" {
+		status.HeadSHA = c.inspectedHead
+	}
 	if entry, ok := c.entries[issue.ID]; ok {
 		status.Entry = &entry
 	}
@@ -1056,4 +1071,205 @@ func (c *nativeMergeQueueConnector) EnqueuePullRequest(_ context.Context, issue 
 func (c *nativeMergeQueueConnector) DequeuePullRequest(_ context.Context, entry connector.PullRequestMergeQueueEntry) error {
 	c.dequeued = append(c.dequeued, entry)
 	return c.dequeueErr
+}
+
+func TestNativeMergeQueueIntegrationContinuity(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name        string
+		changeHead  bool
+		advanceBase bool
+		restart     bool
+		cancel      bool
+	}{
+		{name: "passing heads retain integration"},
+		{name: "advancing main retains provider integration", advanceBase: true},
+		{name: "unreviewed head cannot reuse cache", changeHead: true},
+		{name: "restart observes provider entries", restart: true},
+		{name: "cancellation stops admission", cancel: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+			issues := []connector.Issue{nativeMergeQueueTestIssue(501, "success"), nativeMergeQueueTestIssue(502, "success"), nativeMergeQueueTestIssue(503, "failure")}
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancel {
+				cancel()
+			}
+			queued := orch.delegateNativeMergeQueueIssues(ctx, &state, issues, now)
+			if tt.cancel {
+				if tracker.inspections != 0 || len(tracker.enqueued) != 0 {
+					t.Fatal("cancelled admission contacted provider")
+				}
+				if candidates := orch.mergeWorkerDispatchCandidates(&state, queued, now); len(candidates) != 0 {
+					t.Fatalf("cancelled admission left %d worker candidates", len(candidates))
+				}
+				return
+			}
+			if len(tracker.enqueued) != 2 {
+				t.Fatalf("enqueued = %v, want two passing candidates", tracker.enqueued)
+			}
+			tracker.entries = map[string]connector.PullRequestMergeQueueEntry{}
+			for _, issue := range queued {
+				if issue.PullRequest.MergeQueueEntry != nil {
+					tracker.entries[issue.ID] = *issue.PullRequest.MergeQueueEntry
+				}
+			}
+			if tt.advanceBase {
+				issues[0].PullRequest.BaseSHA = "new-main"
+				issues[1].PullRequest.BaseSHA = "new-main"
+			}
+			if tt.changeHead {
+				issues[0].PullRequest.HeadSHA = "unreviewed"
+				tracker.inspectedHead = "another-head"
+			}
+			if tt.restart {
+				state = newState(cfg)
+			}
+			orch.delegateNativeMergeQueueIssues(ctx, &state, issues, now.Add(time.Second))
+			wantInspections := 2
+			if tt.changeHead {
+				wantInspections++
+			}
+			if tt.restart {
+				wantInspections += 2
+			}
+			if tracker.inspections != wantInspections || len(tracker.enqueued) != 2 {
+				t.Fatalf("inspections = %d, enqueue = %v", tracker.inspections, tracker.enqueued)
+			}
+			if tt.changeHead {
+				if _, deferred := state.nativeMergeQueueDeferred[issues[0].ID]; !deferred {
+					t.Fatal("changed head was not deferred")
+				}
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueUrgentAdmissionPreservesAging(t *testing.T) {
+	t.Parallel()
+	for _, aged := range []bool{false, true} {
+		t.Run(fmt.Sprintf("ordinary_aged_%t", aged), func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+			ordinary := nativeMergeQueueTestIssue(601, "success")
+			urgent := nativeMergeQueueTestIssue(602, "success")
+			urgent.Labels = []string{"hotfix"}
+			recent := now.Add(-time.Minute)
+			ordinary.StageUpdatedAt = &recent
+			urgent.StageUpdatedAt = &recent
+			if aged {
+				old := now.Add(-3 * time.Hour)
+				ordinary.StageUpdatedAt = &old
+			}
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, MergeFairnessAge: time.Hour, DispatchPriorityByLabel: []string{"hotfix"}, ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{ordinary, urgent}, now)
+			want := []string{urgent.ID, ordinary.ID}
+			if aged {
+				want = []string{ordinary.ID, urgent.ID}
+			}
+			if !reflect.DeepEqual(tracker.enqueued, want) {
+				t.Fatalf("enqueued = %v, want %v", tracker.enqueued, want)
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueBoundsAdmissionWithoutWorkerFallback(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	limit := 2
+	tracker := &nativeMergeQueueConnector{admissionLimit: &limit, autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+	cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, DispatchPriorityByLabel: []string{"hotfix"}, ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	issues := []connector.Issue{nativeMergeQueueTestIssue(701, "success"), nativeMergeQueueTestIssue(702, "success"), nativeMergeQueueTestIssue(703, "success")}
+	queued := orch.delegateNativeMergeQueueIssues(context.Background(), &state, issues, now)
+	if len(tracker.enqueued) != 2 {
+		t.Fatalf("enqueued = %v, want bounded pair", tracker.enqueued)
+	}
+	if _, deferred := state.nativeMergeQueueDeferred[issues[2].ID]; !deferred {
+		t.Fatal("full window candidate not deferred")
+	}
+	if candidates := orch.mergeWorkerDispatchCandidates(&state, queued, now); len(candidates) != 0 {
+		t.Fatalf("worker candidates = %v, want no integration fallback", candidates)
+	}
+	urgent := nativeMergeQueueTestIssue(704, "success")
+	urgent.Labels = []string{"hotfix"}
+	tracker.enqueued = nil
+	orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{issues[2], urgent}, now.Add(time.Minute))
+	if want := []string{urgent.ID, issues[2].ID}; !reflect.DeepEqual(tracker.enqueued, want) {
+		t.Fatalf("next window = %v, want %v", tracker.enqueued, want)
+	}
+}
+
+func TestNativeMergeQueueRemovalSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name            string
+		removedHead     string
+		wantReenqueue   bool
+		manualReenqueue bool
+	}{
+		{name: "failed integrated head", removedHead: "head-802"},
+		{name: "cancelled entry with missing identity"},
+		{name: "explicit provider reenqueue", removedHead: "head-802", manualReenqueue: true},
+		{name: "new checked head after repair", removedHead: "old-head", wantReenqueue: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issues := []connector.Issue{nativeMergeQueueTestIssue(801, "success"), nativeMergeQueueTestIssue(802, "success"), nativeMergeQueueTestIssue(803, "success")}
+			tracker := &nativeMergeQueueConnector{removedHeads: map[string]string{issues[1].ID: tt.removedHead}, autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			if tt.manualReenqueue {
+				tracker.entries = map[string]connector.PullRequestMergeQueueEntry{issues[1].ID: {ID: "operator-entry", State: "QUEUED"}}
+			}
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			for range 2 {
+				state := newState(cfg)
+				tracker.enqueued = nil
+				queued := orch.delegateNativeMergeQueueIssues(context.Background(), &state, issues, time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC))
+				if tt.manualReenqueue && (queued[1].PullRequest.MergeQueueEntry == nil || queued[1].PullRequest.MergeQueueEntry.ID != "operator-entry") {
+					t.Fatal("explicit provider entry not observed")
+				}
+				want := []string{issues[0].ID, issues[2].ID}
+				if tt.wantReenqueue {
+					want = []string{issues[0].ID, issues[1].ID, issues[2].ID}
+				}
+				if !reflect.DeepEqual(tracker.enqueued, want) {
+					t.Fatalf("enqueued = %v, want %v", tracker.enqueued, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueUnknownAdmissionLimit(t *testing.T) {
+	t.Parallel()
+	for _, limit := range []int{0, -1} {
+		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
+			t.Parallel()
+			issue := nativeMergeQueueTestIssue(901, "success")
+			tracker := &nativeMergeQueueConnector{admissionLimit: &limit, autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+			queued := orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{issue}, now)
+			if len(tracker.enqueued) != 0 {
+				t.Fatalf("enqueued = %v, want unknown window deferred", tracker.enqueued)
+			}
+			if candidates := orch.mergeWorkerDispatchCandidates(&state, queued, now); len(candidates) != 0 {
+				t.Fatalf("candidates = %v, want no worker fallback", candidates)
+			}
+		})
+	}
 }

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -1285,6 +1285,8 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 	}
 	if pullRequest.MergeQueueEntry != nil {
 		out.MergeQueueEntry = &telemetry.PullRequestMergeQueueEntry{
+			HeadSHA:                     pullRequest.MergeQueueEntry.HeadSHA,
+			BaseSHA:                     pullRequest.MergeQueueEntry.BaseSHA,
 			ID:                          pullRequest.MergeQueueEntry.ID,
 			State:                       pullRequest.MergeQueueEntry.State,
 			Position:                    pullRequest.MergeQueueEntry.Position,

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -1844,3 +1844,31 @@ func completedTelemetryIssues(rows []telemetry.Completed) []telemetry.Issue {
 	}
 	return issues
 }
+
+func TestTelemetryPullRequestMergeQueueIdentities(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name  string
+		entry *connector.PullRequestMergeQueueEntry
+	}{
+		{name: "not queued"},
+		{name: "awaiting integration", entry: &connector.PullRequestMergeQueueEntry{ID: "entry"}},
+		{name: "integrated", entry: &connector.PullRequestMergeQueueEntry{ID: "entry", HeadSHA: "group-head", BaseSHA: "group-base"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := telemetryPullRequest(connector.Issue{PullRequest: &connector.PullRequest{HeadSHA: "pr-head", BaseSHA: "pr-base", MergeQueueEntry: tt.entry}}, 0, 0)
+			if tt.entry == nil {
+				if got.MergeQueueEntry != nil {
+					t.Fatalf("unexpected queue entry: %#v", got.MergeQueueEntry)
+				}
+				return
+			}
+			if got.MergeQueueEntry == nil || got.MergeQueueEntry.HeadSHA != tt.entry.HeadSHA || got.MergeQueueEntry.BaseSHA != tt.entry.BaseSHA {
+				t.Fatalf("queue identities = %#v, want %#v", got.MergeQueueEntry, tt.entry)
+			}
+			if got.HeadSHA != "pr-head" || got.BaseSHA != "pr-base" {
+				t.Fatalf("PR identities changed: %#v", got)
+			}
+		})
+	}
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1249,6 +1249,8 @@ type PullRequest struct {
 }
 
 type PullRequestMergeQueueEntry struct {
+	HeadSHA                     string     `json:"head_sha,omitempty"`
+	BaseSHA                     string     `json:"base_sha,omitempty"`
 	ID                          string     `json:"id,omitempty"`
 	State                       string     `json:"state,omitempty"`
 	Position                    int        `json:"position,omitempty"`


### PR DESCRIPTION
## Summary

- Bound native queue admission to GitHub's configured build window. Urgent priority and ordinary aging select the next window without rebuilding active groups or occupying implementation workers.
- Pin enqueue to the checked head, fence cached observations, and use durable provider removal history to prevent repeated admission after integration failure or cancellation. A cancelled admission cannot fall through to a merge worker.
- Run CI on merge groups, retain integration head/base identities, and document measured incident history and repository migration requirements. The incident analysis distinguishes worker retries, CI runs, necessary integration validation, and cancelled runs.

Existing PR-required/security-audit delegation exclusions remain. Audited dogfood configurations continue serialized merging; this PR does not enable their production native queue or change branch protection. A migration must preserve equivalent provider-enforced policy.

Fixes #2346

## UI Surface Contract

- [x] N/A — no product UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] N/A — no visual changes requiring browser evidence.

## Test Plan

- [x] Focused stdlib queue tests: passing candidates, advancing main, failed/cancelled removal, restart, changed heads, urgent priority, aging, unknown/full windows, and cancellation without worker fallback.
- [x] Safety-boundary fuzzing for 30 seconds (545,718 executions).
- [x] `make generate`, configdoc tests, and generated-reference verification.
- [x] Read-only GitHub schema verification of the inspection query.
- [x] `make check CHECK_LOCK_WAIT=45m` — same shared gate and checks; longer queue-idle allowance only. 80.5% coverage and all configured floors pass.
- [x] Latest-head GitHub CI: all 11 jobs passed on `e607958e` in run [34423783083](https://github.com/digitaldrywood/detent/actions/runs/34423783083). Telemetry review correction validated by focused regression and the full local gate; review thread resolved.

Backlog follow-up #2427 tracks cheap generated-reference preflight before queue admission. This PR includes a draft skill for durable provider removal recovery.
