### PR TITLE
test(cli): isolate process-reaping scan fixtures

### DIFF
--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -178,8 +178,6 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 }
 
 func TestBuildRunnerSupportsClaudeCodeBackendRoutes(t *testing.T) {
-	t.Parallel()
-
 	source := initRunnerSourceRepo(t)
 	claudeCommand, argsPath, stdinPath := writeRunnerClaudeStub(t)
 	sessionStore := &runnerSessionStore{sessionID: 833}

--- a/internal/cli/worker_processes_test.go
+++ b/internal/cli/worker_processes_test.go
@@ -299,7 +299,7 @@ func TestReapWorkerProcessesPreservesInterruptedSession(t *testing.T) {
 				t.Fatalf("active worker processes = %#v, error = %v", active, err)
 			}
 			if failures == 5 {
-				if err := reapWorkerProcesses(ctx, backend, logger, "startup", time.Millisecond, time.Now, reap); err != nil {
+				if err := reapWorkerProcessesWithCleanup(ctx, backend, logger, "startup", time.Millisecond, time.Now, reap, cleanupWorkerProcessArtifacts); err != nil {
 					t.Fatalf("later recovery failed: %v", err)
 				}
 			}
@@ -359,7 +359,7 @@ func TestReapWorkerProcessesCleansArtifactsOnlyAfterVerifiedExit(t *testing.T) {
 				CleanupPath: cleanupPath,
 			}}}
 
-			err := reapWorkerProcesses(
+			err := reapWorkerProcessesWithCleanup(
 				context.Background(),
 				processStore,
 				slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
@@ -369,8 +369,9 @@ func TestReapWorkerProcessesCleansArtifactsOnlyAfterVerifiedExit(t *testing.T) {
 				func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
 					return procgroup.TerminationOutcomeTerminated, tt.reapErr
 				},
+				cleanupWorkerProcessArtifacts,
 			)
-			if got := errors.Is(err, reapErr); got != (tt.reapErr != nil) {
+			if !errors.Is(err, tt.reapErr) {
 				t.Fatalf("reapWorkerProcesses() error = %v, want reap error %v", err, tt.reapErr != nil)
 			}
 			_, statErr := os.Stat(cleanupPath)
@@ -453,5 +454,75 @@ func TestReapWorkerProcessesAtStartup(t *testing.T) {
 		if !strings.Contains(logs.String(), want) {
 			t.Fatalf("logs missing %q:\n%s", want, logs.String())
 		}
+	}
+}
+
+func TestReapWorkerProcessesPreservesArtifactsOnFailure(t *testing.T) {
+	t.Parallel()
+
+	livenessErr := errors.New("process group remained alive")
+	scanErr := fmt.Errorf("reap worker artifact processes: scan workspace processes: %w", context.DeadlineExceeded)
+	removalErr := fmt.Errorf("clean worker process artifacts: %w", os.ErrPermission)
+	tests := []struct {
+		name        string
+		reapErr     error
+		cleanupErr  error
+		wantErr     error
+		wantCleanup bool
+	}{
+		{name: "worker liveness", reapErr: livenessErr, wantErr: livenessErr},
+		{name: "artifact process scan deadline", cleanupErr: scanErr, wantErr: context.DeadlineExceeded, wantCleanup: true},
+		{name: "artifact removal", cleanupErr: removalErr, wantErr: os.ErrPermission, wantCleanup: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			scratch := filepath.Join(root, "worker")
+			if err := os.Mkdir(scratch, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			artifact := filepath.Join(scratch, "checkpoint")
+			if err := os.WriteFile(artifact, []byte("resume"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			processStore := &shutdownWorkerProcessStore{processes: []store.WorkerProcess{{
+				SessionID: 2418, CleanupRoot: root, CleanupPath: scratch,
+			}}}
+			var logs bytes.Buffer
+			cleanupCalled := false
+			err := reapWorkerProcessesWithCleanup(t.Context(), processStore,
+				slog.New(slog.NewTextHandler(&logs, nil)), "startup", time.Millisecond, time.Now,
+				func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
+					return procgroup.TerminationOutcomeAlreadyExited, tt.reapErr
+				},
+				func(store.WorkerProcess) error {
+					cleanupCalled = true
+					return tt.cleanupErr
+				})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("recovery error = %v, want %v", err, tt.wantErr)
+			}
+			if cleanupCalled != tt.wantCleanup || len(processStore.reaped) != 0 {
+				t.Fatalf("cleanup called = %t, reaped = %#v", cleanupCalled, processStore.reaped)
+			}
+			if data, err := os.ReadFile(artifact); err != nil || string(data) != "resume" {
+				t.Fatalf("retained checkpoint = %q, error = %v", data, err)
+			}
+			if !strings.Contains(logs.String(), err.Error()) {
+				t.Fatalf("lifecycle log lost failure stage: %s", logs.String())
+			}
+			err = reapWorkerProcessesWithCleanup(t.Context(), processStore,
+				slog.New(slog.NewTextHandler(&logs, nil)), "startup", time.Millisecond, time.Now,
+				func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
+					return procgroup.TerminationOutcomeAlreadyExited, nil
+				}, cleanupWorkerProcessArtifacts)
+			if err != nil || len(processStore.reaped) != 1 {
+				t.Fatalf("later recovery error = %v, reaped = %#v", err, processStore.reaped)
+			}
+			if _, err := os.Stat(scratch); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("recovered artifact path stat = %v, want not exist", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Report unexpected process-scan errors before checking artifact removal. Previously, the verified-exit CLI test accepted every error except a particular liveness sentinel, hiding scan timeouts behind an artifact-exists assertion.
- Isolate synthetic-PID bookkeeping fixtures from redundant host scans while keeping real filesystem cleanup; run the Claude Code integration serially within the CLI package to reduce scan overlap.
- Add table-driven coverage distinguishing liveness, scan-deadline, and artifact-removal failures while preserving checkpoints and reap bookkeeping until subsequent filesystem cleanup succeeds. Existing real process integration coverage is unchanged.
- A disposable `lsof` wrapper reproduced the recorded five-second failure. The corrected assertion exposes the existing scan telemetry: `stage=wait`, `context_error=context deadline exceeded`, and `signal: killed`. A full macOS gate also reproduced the Claude Code failure with real lsof: 4.773s waiting, deadline exceeded, zero PID output. This establishes scan deadline exhaustion; underlying host slowness remains unproven. No production deadlines or ownership checks change.

Fixes #2418

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: tests only.

## Test Plan

- [x] Deliberate disposable `lsof` timeout injection reproduces the original artifact assertion before the change and the detailed scan error afterward (expected nonzero test exits).
- [x] Final isolated bookkeeping fixtures pass even with the deliberately stalled lsof wrapper.
- [x] Focused CLI race tests, three repetitions after isolation changes.
- [x] Complete CLI race package (`GOMAXPROCS=2 env -u DETENT_API_TOKEN go test -race ./internal/cli -count=1`).
- [x] `GOMAXPROCS=2 make check CHECK_LOCK_WAIT=1h` (all checks passed; 80.5% overall coverage, 77.5% CLI coverage). The wait override only extends shared-lock acquisition.
