### PR TITLE
fix(release): persist retry and admission evidence

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -1198,6 +1198,8 @@
 #   rerun_flaky_once: false
 #   # release.flaky_check_names | type: list<string> | default: [] | required: No | validation: must not be empty when release.rerun_flaky_once is true
 #   flaky_check_names: []
+#   # release.required_check_names | type: list<string> | default: [] | required: No | validation: None
+#   required_check_names: []
 # # hooks | type: object | default: see child fields | required: No | validation: None
 # hooks:
 #   # hooks.shell | type: string | default: platform default shell | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -1178,6 +1178,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `release.max_age_hours` | `integer` | `24` | No | must be greater than 0 when release.enabled is true |
 | `release.min_merged_issues` | `integer` | `5` | No | must be greater than 0 when release.enabled is true |
 | `release.require_green_ci` | `boolean` | `true` | No | must be true when release.enabled is true |
+| `release.required_check_names` | `list<string>` | `[]` | No | None |
 | `release.rerun_flaky_once` | `boolean` | `false` | No | release.flaky_check_names must not be empty when release.rerun_flaky_once is true |
 | `release.version_bump` | `string` | `"auto"` | No | must be auto |
 | `retro` | `object` | `see child fields` | No | None |

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,3 +22,29 @@ pull requests, on the nightly schedule, and from manual workflow dispatch so
 release packaging is validated before the PR merge lane and after it lands.
 Required branch checks must not pass as path- or event-dependent no-ops on pull
 requests when the same check name runs real validation on `main`.
+
+## Automatic coordination
+
+The coordinator enforces `gate.required_status_checks` together with any
+additional `release.required_check_names`. Configure the complete list of mandatory
+check-run and status-context names for release candidates. Names are exact and
+case-sensitive. An empty combined manifest pauses automatic tagging. Every mandatory check must be present
+for the exact candidate SHA, completed, and successful. Missing or truncated
+responses, stale evidence, and cancelled, neutral, or skipped checks keep tagging
+closed. The coordinator continues to reject failing optional checks as well.
+
+When `release.rerun_flaky_once` is enabled, a durable intent comment on the
+originating issue reserves the existing single rerun before the request is sent.
+A restart or lost acknowledgment never grants another automatic rerun. If the
+process stops between reservation and dispatch, the reservation remains consumed;
+the issue report records the uncertainty for operator investigation. Current
+candidate checks are inspected again on every evaluation.
+
+Release progress and blockers use fingerprinted comments on the first sorted
+originating issue reference, without creating new coordination issues. Comment
+reconciliation reads all pages directly, avoiding search-index lag. Origin
+references are preserved in annotated tag metadata for reporting after restart.
+Tag publication reconciles the exact tag target before mutation and after an
+uncertain response; a tag pointing elsewhere is a failure. These operations rely
+on Detent's single service owner per project; concurrent evaluations within that
+owner are serialized.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -879,13 +879,14 @@ type StalenessWebhook struct {
 }
 
 type Release struct {
-	Enabled         bool     `yaml:"enabled"`
-	MinMergedIssues int      `yaml:"min_merged_issues"`
-	MaxAgeHours     int      `yaml:"max_age_hours"`
-	RequireGreenCI  bool     `yaml:"require_green_ci"`
-	VersionBump     string   `yaml:"version_bump"`
-	RerunFlakyOnce  bool     `yaml:"rerun_flaky_once,omitempty"`
-	FlakyCheckNames []string `yaml:"flaky_check_names,omitempty"`
+	Enabled            bool     `yaml:"enabled"`
+	MinMergedIssues    int      `yaml:"min_merged_issues"`
+	MaxAgeHours        int      `yaml:"max_age_hours"`
+	RequireGreenCI     bool     `yaml:"require_green_ci"`
+	VersionBump        string   `yaml:"version_bump"`
+	RerunFlakyOnce     bool     `yaml:"rerun_flaky_once,omitempty"`
+	FlakyCheckNames    []string `yaml:"flaky_check_names,omitempty"`
+	RequiredCheckNames []string `yaml:"required_check_names,omitempty"`
 }
 
 func (r *Release) normalize() {

--- a/internal/connector/github/release.go
+++ b/internal/connector/github/release.go
@@ -156,8 +156,10 @@ func (c *Connector) releaseTagOrigins(ctx context.Context, base, tag, sha string
 		if err := c.client.REST(ctx, http.MethodGet, base+"/git/tags/"+url.PathEscape(ref.Object.SHA), nil, &object); err != nil {
 			return nil, fmt.Errorf("read release origins: %w", err)
 		}
-		if _, suffix, found := strings.Cut(object.Message, "<!-- detent-release-origins:"); found {
-			value, _, closed := strings.Cut(suffix, " -->")
+		message := strings.TrimSpace(object.Message)
+		line := message[strings.LastIndex(message, "\n")+1:]
+		if suffix, found := strings.CutPrefix(line, "<!-- detent-release-origins:"); found {
+			value, closed := strings.CutSuffix(suffix, " -->")
 			var refs []string
 			if err := json.Unmarshal([]byte(value), &refs); err != nil || !closed {
 				return nil, errors.New("invalid release origin metadata")
@@ -280,7 +282,8 @@ func (c *Connector) CreateTag(ctx context.Context, tag releasepkg.Tag) error {
 	var object struct {
 		SHA string `json:"sha"`
 	}
-	payload := map[string]any{"tag": tag.Name, "message": tag.Message, "object": tag.SHA, "type": "commit"}
+	message := c.protectPublicationText(ctx, pullRequestRepoName(c.repository), tag.Message)
+	payload := map[string]any{"tag": tag.Name, "message": message, "object": tag.SHA, "type": "commit"}
 	if err := c.client.REST(ctx, http.MethodPost, base+"/git/tags", payload, &object); err != nil {
 		return fmt.Errorf("create annotated release tag: %w", err)
 	}

--- a/internal/connector/github/release.go
+++ b/internal/connector/github/release.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,11 +13,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/digitaldrywood/detent/internal/connector"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 )
 
-var closingIssuePattern = regexp.MustCompile(`(?i)(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+(?:[[:alnum:]_.-]+/[[:alnum:]_.-]+)?#([0-9]+)`)
+var closingIssuePattern = regexp.MustCompile(`(?i)(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+(?:([[:alnum:]_.-]+/[[:alnum:]_.-]+))?#([0-9]+)`)
 
 type releaseRESTRepository struct {
 	DefaultBranch string `json:"default_branch"`
@@ -24,7 +24,8 @@ type releaseRESTRepository struct {
 
 type releaseRESTRef struct {
 	Object struct {
-		SHA string `json:"sha"`
+		SHA  string `json:"sha"`
+		Type string `json:"type"`
 	} `json:"object"`
 }
 
@@ -52,6 +53,7 @@ type releaseRESTPullRequest struct {
 }
 
 type releaseRESTCheckRun struct {
+	HeadSHA    string `json:"head_sha"`
 	Name       string `json:"name"`
 	Status     string `json:"status"`
 	Conclusion string `json:"conclusion"`
@@ -59,11 +61,14 @@ type releaseRESTCheckRun struct {
 }
 
 type releaseRESTCheckRuns struct {
-	CheckRuns []releaseRESTCheckRun `json:"check_runs"`
+	TotalCount int                   `json:"total_count"`
+	CheckRuns  []releaseRESTCheckRun `json:"check_runs"`
 }
 
 type releaseRESTStatus struct {
-	Statuses []struct {
+	SHA        string `json:"sha"`
+	TotalCount int    `json:"total_count"`
+	Statuses   []struct {
 		Context string `json:"context"`
 		State   string `json:"state"`
 	} `json:"statuses"`
@@ -97,7 +102,7 @@ func (c *Connector) Inspect(ctx context.Context) (releasepkg.Repository, error) 
 	if err := c.client.REST(ctx, http.MethodGet, base+"/git/ref/heads/"+url.PathEscape(branch), nil, &ref); err != nil {
 		return releasepkg.Repository{}, fmt.Errorf("inspect release head: %w", err)
 	}
-	result := releasepkg.Repository{Name: pullRequestRepoName(c.repository), HeadSHA: strings.TrimSpace(ref.Object.SHA)}
+	result := releasepkg.Repository{RequiredCheckNames: append([]string(nil), c.requiredChecks...), Name: pullRequestRepoName(c.repository), HeadSHA: strings.TrimSpace(ref.Object.SHA)}
 	if result.HeadSHA == "" {
 		return releasepkg.Repository{}, errors.New("inspect release head: github returned an empty sha")
 	}
@@ -120,17 +125,47 @@ func (c *Connector) Inspect(ctx context.Context) (releasepkg.Repository, error) 
 		result.TaggedAt = tagged.Commit.Committer.Date
 	}
 
-	commits, err := c.releaseCommits(ctx, base, branch, result.LatestTag)
+	commits, err := c.releaseCommits(ctx, base, result.HeadSHA, result.LatestTag)
 	if err != nil {
 		return releasepkg.Repository{}, err
 	}
 	result.Commits = commits
+	if result.LatestSHA == result.HeadSHA {
+		result.IssueRefs, err = c.releaseTagOrigins(ctx, base, result.LatestTag, result.HeadSHA)
+		if err != nil {
+			return releasepkg.Repository{}, err
+		}
+	}
 	checks, err := c.releaseChecks(ctx, base, result.HeadSHA)
 	if err != nil {
 		return releasepkg.Repository{}, err
 	}
 	result.Checks = checks
 	return result, nil
+}
+
+func (c *Connector) releaseTagOrigins(ctx context.Context, base, tag, sha string) ([]string, error) {
+	var ref releaseRESTRef
+	if err := c.client.REST(ctx, http.MethodGet, base+"/git/ref/tags/"+url.PathEscape(tag), nil, &ref); err != nil {
+		return nil, fmt.Errorf("read release origin reference: %w", err)
+	}
+	if ref.Object.Type == "tag" {
+		var object struct {
+			Message string `json:"message"`
+		}
+		if err := c.client.REST(ctx, http.MethodGet, base+"/git/tags/"+url.PathEscape(ref.Object.SHA), nil, &object); err != nil {
+			return nil, fmt.Errorf("read release origins: %w", err)
+		}
+		if _, suffix, found := strings.Cut(object.Message, "<!-- detent-release-origins:"); found {
+			value, _, closed := strings.Cut(suffix, " -->")
+			var refs []string
+			if err := json.Unmarshal([]byte(value), &refs); err != nil || !closed {
+				return nil, errors.New("invalid release origin metadata")
+			}
+			return refs, nil
+		}
+	}
+	return c.releaseCommitIssueRefs(ctx, base, sha)
 }
 
 func (c *Connector) releaseCommits(ctx context.Context, base string, branch string, latestTag string) ([]releasepkg.Commit, error) {
@@ -174,10 +209,14 @@ func (c *Connector) releaseCommitIssueRefs(ctx context.Context, base string, sha
 	repository := pullRequestRepoName(c.repository)
 	for _, pull := range pulls {
 		for _, match := range closingIssuePattern.FindAllStringSubmatch(pull.Body, -1) {
-			if len(match) != 2 {
+			if len(match) != 3 {
 				continue
 			}
-			ref := repository + "#" + match[1]
+			origin := repository
+			if match[1] != "" {
+				origin = match[1]
+			}
+			ref := origin + "#" + match[2]
 			if _, ok := seen[ref]; ok {
 				continue
 			}
@@ -194,9 +233,13 @@ func (c *Connector) releaseChecks(ctx context.Context, base string, sha string) 
 	if err := c.client.REST(ctx, http.MethodGet, base+"/commits/"+url.PathEscape(sha)+"/check-runs?per_page=100", nil, &runs); err != nil {
 		return nil, fmt.Errorf("inspect release check runs: %w", err)
 	}
+	if runs.TotalCount > len(runs.CheckRuns) {
+		return nil, errors.New("release check evidence is truncated")
+	}
 	checks := make([]releasepkg.Check, 0, len(runs.CheckRuns))
 	for _, run := range runs.CheckRuns {
 		checks = append(checks, releasepkg.Check{
+			SHA:        run.HeadSHA,
 			Name:       run.Name,
 			Status:     run.Status,
 			Conclusion: run.Conclusion,
@@ -207,8 +250,11 @@ func (c *Connector) releaseChecks(ctx context.Context, base string, sha string) 
 	if err := c.client.REST(ctx, http.MethodGet, base+"/commits/"+url.PathEscape(sha)+"/status", nil, &combined); err != nil {
 		return nil, fmt.Errorf("inspect release statuses: %w", err)
 	}
+	if combined.TotalCount > len(combined.Statuses) {
+		return nil, errors.New("release status evidence is truncated")
+	}
 	for _, status := range combined.Statuses {
-		check := releasepkg.Check{Name: status.Context}
+		check := releasepkg.Check{SHA: combined.SHA, Name: status.Context}
 		switch strings.ToLower(strings.TrimSpace(status.State)) {
 		case "pending":
 			check.Status = "in_progress"
@@ -225,6 +271,11 @@ func (c *Connector) releaseChecks(ctx context.Context, base string, sha string) 
 }
 
 func (c *Connector) CreateTag(ctx context.Context, tag releasepkg.Tag) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if found, err := c.releaseTagMatches(ctx, tag); err != nil || found {
+		return err
+	}
 	base := restRepositoryPath(pullRequestRepoName(c.repository))
 	var object struct {
 		SHA string `json:"sha"`
@@ -240,11 +291,28 @@ func (c *Connector) CreateTag(ctx context.Context, tag releasepkg.Tag) error {
 	if err == nil {
 		return nil
 	}
-	var statusErr *StatusError
-	if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusUnprocessableEntity {
-		return releasepkg.ErrTagExists
+	if found, lookupErr := c.releaseTagMatches(ctx, tag); lookupErr != nil {
+		return errors.Join(err, lookupErr)
+	} else if found {
+		return nil
 	}
 	return fmt.Errorf("publish release tag: %w", err)
+}
+
+func (c *Connector) releaseTagMatches(ctx context.Context, tag releasepkg.Tag) (bool, error) {
+	var commit releaseRESTCommit
+	path := restRepositoryPath(pullRequestRepoName(c.repository)) + "/commits/" + url.PathEscape("refs/tags/"+tag.Name)
+	if err := c.client.REST(ctx, http.MethodGet, path, nil, &commit); err != nil {
+		var statusErr *StatusError
+		if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("reconcile release tag: %w", err)
+	}
+	if commit.SHA != tag.SHA {
+		return false, fmt.Errorf("release tag %s points to %s, expected %s", tag.Name, commit.SHA, tag.SHA)
+	}
+	return true, nil
 }
 
 func (c *Connector) ReleaseWorkflow(ctx context.Context, tag string) (releasepkg.WorkflowRun, bool, error) {
@@ -274,6 +342,23 @@ func (c *Connector) RerunFailedChecks(ctx context.Context, checks []releasepkg.C
 			continue
 		}
 		seen[check.RunID] = struct{}{}
+		var run struct {
+			HeadSHA string `json:"head_sha"`
+			Attempt int    `json:"run_attempt"`
+			Status  string `json:"status"`
+		}
+		path := restRepositoryPath(pullRequestRepoName(c.repository)) + "/actions/runs/" + strconv.FormatInt(check.RunID, 10)
+		if err := c.client.REST(ctx, http.MethodGet, path, nil, &run); err != nil {
+			errs = append(errs, fmt.Errorf("reconcile workflow %d: %w", check.RunID, err))
+			continue
+		}
+		if run.HeadSHA != check.SHA || run.Attempt < 1 {
+			errs = append(errs, fmt.Errorf("workflow %d has incomplete or stale retry evidence", check.RunID))
+			continue
+		}
+		if run.Status != "completed" {
+			continue
+		}
 		if err := c.client.REST(ctx, http.MethodPost, restWorkflowRunRerunFailedJobsPath(c.repository, check.RunID), nil, nil); err != nil {
 			errs = append(errs, fmt.Errorf("rerun workflow %d: %w", check.RunID, err))
 		}
@@ -281,52 +366,56 @@ func (c *Connector) RerunFailedChecks(ctx context.Context, checks []releasepkg.C
 	return errors.Join(errs...)
 }
 
-func (c *Connector) EnsureFailureIssue(ctx context.Context, failure releasepkg.Failure) (bool, error) {
+func (c *Connector) EnsureReleaseReport(ctx context.Context, failure releasepkg.Report) (bool, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	repository := pullRequestRepoName(c.repository)
-	marker := "detent-auto-release:" + failure.Fingerprint
-	query := "repo:" + repository + " is:issue \"" + marker + "\""
-	var search struct {
-		TotalCount int `json:"total_count"`
-		Items      []struct {
-			NodeID string `json:"node_id"`
-		} `json:"items"`
-	}
-	if err := c.client.REST(ctx, http.MethodGet, "/search/issues?q="+url.QueryEscape(query)+"&per_page=1", nil, &search); err != nil {
-		return false, fmt.Errorf("find auto-release failure issue: %w", err)
-	}
-	if search.TotalCount > 0 {
-		if len(search.Items) > 0 && strings.TrimSpace(search.Items[0].NodeID) != "" {
-			if err := c.moveReleaseIssueToTodo(ctx, search.Items[0].NodeID); err != nil {
-				return false, fmt.Errorf("restore auto-release failure issue to board: %w", err)
-			}
+	refs := append([]string(nil), failure.IssueRefs...)
+	sort.Strings(refs)
+	for _, ref := range refs {
+		repo, number, ok := strings.Cut(ref, "#")
+		n, err := strconv.Atoi(number)
+		if !ok || repo != repository || err != nil || n <= 0 {
+			continue
 		}
-		return false, nil
+		path := restRepositoryPath(repository) + "/issues/" + number + "/comments"
+		marker := "<!-- detent-auto-release:" + failure.Fingerprint + " -->"
+		if found, err := c.releaseReportExists(ctx, path, marker); err != nil || found {
+			return false, err
+		}
+		body := c.protectPublicationText(ctx, repository, failure.Body)
+		if !strings.Contains(body, marker) {
+			body += "\n\n" + marker
+		}
+		if err := c.client.REST(ctx, http.MethodPost, path, map[string]string{"body": body}, nil); err != nil {
+			found, lookupErr := c.releaseReportExists(ctx, path, marker)
+			if found && lookupErr == nil {
+				return false, nil
+			}
+			return false, errors.Join(err, lookupErr)
+		}
+		return true, nil
 	}
-	labels := []string(nil)
-	if c.usesLabelStatus() {
-		labels = []string{c.statusLabelForState("Todo")}
-	}
-	issue, err := c.CreateIssue(ctx, connector.IssueDraft{
-		Title:  failure.Title,
-		Body:   failure.Body,
-		Labels: labels,
-	})
-	if err != nil {
-		return false, err
-	}
-	if err := c.moveReleaseIssueToTodo(ctx, issue.ID); err != nil {
-		return false, fmt.Errorf("add auto-release failure issue to board: %w", err)
-	}
-	return true, nil
+	return false, errors.New("release report has no originating issue in this repository")
 }
 
-func (c *Connector) moveReleaseIssueToTodo(ctx context.Context, issueID string) error {
-	if !c.usesLabelStatus() && !c.usesIssueFieldStatus() {
-		if err := c.addIntakeIssueToProject(ctx, issueID); err != nil {
-			return err
+func (c *Connector) releaseReportExists(ctx context.Context, path, marker string) (bool, error) {
+	for page := 1; ; page++ {
+		var comments []struct {
+			Body string `json:"body"`
+		}
+		if err := c.client.REST(ctx, http.MethodGet, fmt.Sprintf("%s?per_page=100&page=%d", path, page), nil, &comments); err != nil {
+			return false, fmt.Errorf("read release evidence: %w", err)
+		}
+		for _, comment := range comments {
+			if strings.Contains(comment.Body, marker) {
+				return true, nil
+			}
+		}
+		if len(comments) < 100 {
+			return false, nil
 		}
 	}
-	return c.UpdateIssueState(ctx, issueID, "Todo")
 }
 
 func workflowRunID(detailsURL string) int64 {

--- a/internal/connector/github/release_test.go
+++ b/internal/connector/github/release_test.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/publication"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
 )
 
@@ -25,12 +28,12 @@ func TestConnectorInspectReleaseRepository(t *testing.T) {
 			writeReleaseJSON(t, w, []map[string]any{{"name": "v1.2.3"}, {"name": "not-a-release"}})
 		case "/repos/example/repo/commits/v1.2.3":
 			writeReleaseJSON(t, w, map[string]any{"sha": "previous", "commit": map[string]any{"committer": map[string]any{"date": "2026-07-09T20:00:00Z"}}})
-		case "/repos/example/repo/compare/v1.2.3...main":
+		case "/repos/example/repo/compare/v1.2.3...head":
 			writeReleaseJSON(t, w, map[string]any{"commits": []map[string]any{{"sha": "head", "commit": map[string]any{"message": "feat: release cadence", "committer": map[string]any{"date": "2026-07-10T20:00:00Z"}}}}})
 		case "/repos/example/repo/commits/head/pulls":
 			writeReleaseJSON(t, w, []map[string]any{{"number": 9, "body": "Fixes #1204"}})
 		case "/repos/example/repo/commits/head/check-runs":
-			writeReleaseJSON(t, w, map[string]any{"check_runs": []map[string]any{{"name": "CI", "status": "completed", "conclusion": "success", "details_url": "https://github.com/example/repo/actions/runs/42/job/1"}}})
+			writeReleaseJSON(t, w, map[string]any{"check_runs": []map[string]any{{"head_sha": "head", "name": "CI", "status": "completed", "conclusion": "success", "details_url": "https://github.com/example/repo/actions/runs/42/job/1"}}})
 		case "/repos/example/repo/commits/head/status":
 			writeReleaseJSON(t, w, map[string]any{"statuses": []any{}})
 		default:
@@ -39,7 +42,7 @@ func TestConnectorInspectReleaseRepository(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+	conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel, RequiredStatusChecks: []string{"CI"}})
 	if err != nil {
 		t.Fatalf("NewConnector() error = %v", err)
 	}
@@ -55,6 +58,9 @@ func TestConnectorInspectReleaseRepository(t *testing.T) {
 	if len(got.Commits) != 1 || got.Commits[0].Message != "feat: release cadence" || len(got.Commits[0].IssueRefs) != 1 || got.Commits[0].IssueRefs[0] != "example/repo#1204" {
 		t.Fatalf("Inspect() commits = %#v", got.Commits)
 	}
+	if len(got.RequiredCheckNames) != 1 || got.RequiredCheckNames[0] != "CI" {
+		t.Fatalf("required checks = %v", got.RequiredCheckNames)
+	}
 	if len(got.Checks) != 1 || got.Checks[0].RunID != 42 || got.Checks[0].Conclusion != "success" {
 		t.Fatalf("Inspect() checks = %#v", got.Checks)
 	}
@@ -67,11 +73,13 @@ func TestConnectorInspectReleaseRepository(t *testing.T) {
 func TestConnectorCreateTagPublishesAnnotatedReference(t *testing.T) {
 	t.Parallel()
 
-	requests := make(chan string, 2)
+	requests := make(chan string, 3)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests <- r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
+		case "/repos/example/repo/commits/refs/tags/v1.3.0":
+			http.Error(w, "missing", http.StatusNotFound)
 		case "/repos/example/repo/git/tags":
 			writeReleaseJSON(t, w, map[string]any{"sha": "tag-object"})
 		case "/repos/example/repo/git/refs":
@@ -90,50 +98,116 @@ func TestConnectorCreateTagPublishesAnnotatedReference(t *testing.T) {
 	if err := conn.CreateTag(t.Context(), releasepkg.Tag{Name: "v1.3.0", SHA: "head", Message: "notes"}); err != nil {
 		t.Fatalf("CreateTag() error = %v", err)
 	}
+	<-requests
 	if first, second := <-requests, <-requests; first != "/repos/example/repo/git/tags" || second != "/repos/example/repo/git/refs" {
 		t.Fatalf("CreateTag() paths = %q, %q", first, second)
 	}
 }
 
-func TestConnectorEnsureFailureIssueAddsProjectV2Item(t *testing.T) {
+func TestReleaseReportsReconcileResponseLoss(t *testing.T) {
 	t.Parallel()
+	for _, lost := range []bool{false, true} {
+		t.Run(strconv.FormatBool(lost), func(t *testing.T) {
+			t.Parallel()
+			var mu sync.Mutex
+			comments := make([]map[string]string, 100)
+			for i := range comments {
+				comments[i] = map[string]string{"body": "unrelated"}
+			}
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+				if r.URL.Path != "/repos/example/repo/issues/9/comments" {
+					t.Errorf("unexpected path %s", r.URL.Path)
+					http.Error(w, "unexpected", 404)
+					return
+				}
+				if r.Method == http.MethodGet {
+					if r.URL.Query().Get("page") == "1" {
+						writeReleaseJSON(t, w, comments[:100])
+					} else {
+						writeReleaseJSON(t, w, comments[100:])
+					}
+					return
+				}
+				posts++
+				var comment map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&comment); err != nil {
+					t.Error(err)
+				}
+				comments = append(comments, comment)
+				if lost {
+					http.Error(w, "response lost", 500)
+					return
+				}
+				writeReleaseJSON(t, w, comment)
+			}))
+			t.Cleanup(server.Close)
+			for range 2 {
+				conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err = conn.EnsureReleaseReport(t.Context(), releasepkg.Report{IssueRefs: []string{"example/repo#9"}, Fingerprint: "retry:head", Body: "evidence"})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if posts != 1 {
+				t.Fatalf("posts = %d", posts)
+			}
+		})
+	}
+}
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{method: http.MethodGet, body: `{"total_count":0,"items":[]}`},
-		{method: http.MethodPost, path: "/repos/example/repo/issues", body: `{"node_id":"I_9","number":9,"title":"fix(release): investigate ci failed for example/repo","body":"body","state":"open","html_url":"https://github.com/example/repo/issues/9"}`},
-		{method: http.MethodPost, path: "/", body: `{"data":{"addProjectV2ItemById":{"item":{"id":"PVTI_9"}}}}`},
-		{method: http.MethodPost, path: "/", body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_9","project":{"id":"PVT_1"}}]}}}}`},
-		{method: http.MethodPost, path: "/", body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_todo","name":"Todo"}]}}}}`},
-		{method: http.MethodPost, path: "/", body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_9"}}}}`},
-	})
-	conn := newGitHubTestConnector(t, server, Config{
-		Repository:  "example/repo",
-		ProjectSlug: "PVT_1",
-	})
-
-	created, err := conn.EnsureFailureIssue(t.Context(), releasepkg.Failure{
-		Fingerprint: "ci_failed:example/repo:head",
-		Title:       "fix(release): investigate ci failed for example/repo",
-		Body:        "body",
-	})
-	if err != nil {
-		t.Fatalf("EnsureFailureIssue() error = %v", err)
-	}
-	if !created {
-		t.Fatal("EnsureFailureIssue() created = false, want true")
-	}
-
-	requests := server.requests()
-	if len(requests) != 6 {
-		t.Fatalf("request count = %d, want 6", len(requests))
-	}
-	addQuery, _ := requests[2]["query"].(string)
-	if !strings.Contains(addQuery, "addProjectV2ItemById") {
-		t.Fatalf("query = %q, want addProjectV2ItemById before status update", addQuery)
-	}
-	variables := requests[2]["variables"].(map[string]any)
-	if variables["projectId"] != "PVT_1" || variables["contentId"] != "I_9" {
-		t.Fatalf("variables = %#v", variables)
+func TestReleaseTagReconciliation(t *testing.T) {
+	t.Parallel()
+	for _, target := range []string{"head", "other"} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			var mu sync.Mutex
+			published := false
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+				switch r.URL.Path {
+				case "/repos/example/repo/commits/refs/tags/v1.3.0":
+					if !published {
+						http.Error(w, "missing", 404)
+						return
+					}
+					writeReleaseJSON(t, w, map[string]string{"sha": target})
+				case "/repos/example/repo/git/tags":
+					writeReleaseJSON(t, w, map[string]string{"sha": "object"})
+				case "/repos/example/repo/git/refs":
+					posts++
+					published = true
+					http.Error(w, "lost response", 500)
+				default:
+					t.Errorf("unexpected %s", r.URL.Path)
+				}
+			}))
+			t.Cleanup(server.Close)
+			for range 2 {
+				conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = conn.CreateTag(t.Context(), releasepkg.Tag{Name: "v1.3.0", SHA: "head"})
+				if (err != nil) != (target == "other") {
+					t.Fatalf("CreateTag = %v", err)
+				}
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if posts != 1 {
+				t.Fatalf("tag posts = %d", posts)
+			}
+		})
 	}
 }
 
@@ -141,5 +215,181 @@ func writeReleaseJSON(t *testing.T, w http.ResponseWriter, value any) {
 	t.Helper()
 	if err := json.NewEncoder(w).Encode(value); err != nil {
 		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func TestReleaseCheckEvidenceCompleteness(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                    string
+		checkCount, statusCount int
+		wantError               bool
+	}{
+		{name: "complete", checkCount: 1, statusCount: 1},
+		{name: "truncated checks", checkCount: 2, statusCount: 1, wantError: true},
+		{name: "truncated statuses", checkCount: 1, statusCount: 2, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/example/repo/commits/head/check-runs":
+					writeReleaseJSON(t, w, map[string]any{"total_count": tc.checkCount, "check_runs": []map[string]any{{"head_sha": "head", "name": "CI", "status": "completed", "conclusion": "success"}}})
+				case "/repos/example/repo/commits/head/status":
+					writeReleaseJSON(t, w, map[string]any{"sha": "head", "total_count": tc.statusCount, "statuses": []map[string]any{{"context": "Security", "state": "success"}}})
+				default:
+					t.Errorf("unexpected path %s", r.URL.Path)
+				}
+			}))
+			t.Cleanup(server.Close)
+			conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			if err != nil {
+				t.Fatal(err)
+			}
+			checks, err := conn.releaseChecks(t.Context(), "/repos/example/repo", "head")
+			if (err != nil) != tc.wantError {
+				t.Fatalf("releaseChecks = %v", err)
+			}
+			if !tc.wantError && (len(checks) != 2 || checks[0].SHA != "head" || checks[1].SHA != "head" || checks[1].Name != "Security") {
+				t.Fatalf("checks = %#v", checks)
+			}
+		})
+	}
+}
+
+func TestReleaseTagOriginRecovery(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, message string
+		wantError     bool
+	}{
+		{"metadata", `notes\n<!-- detent-release-origins:["example/repo#9"] -->`, false},
+		{"invalid metadata", `<!-- detent-release-origins:broken -->`, true},
+		{"legacy tag", "notes", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/example/repo/git/ref/tags/v1.0.0":
+					writeReleaseJSON(t, w, map[string]any{"object": map[string]string{"sha": "object", "type": "tag"}})
+				case "/repos/example/repo/git/tags/object":
+					writeReleaseJSON(t, w, map[string]string{"message": tc.message})
+				case "/repos/example/repo/commits/head/pulls":
+					writeReleaseJSON(t, w, []map[string]any{{"number": 10, "body": "Fixes #9"}})
+				default:
+					t.Errorf("unexpected path %s", r.URL.Path)
+				}
+			}))
+			t.Cleanup(server.Close)
+			conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			if err != nil {
+				t.Fatal(err)
+			}
+			refs, err := conn.releaseTagOrigins(t.Context(), "/repos/example/repo", "v1.0.0", "head")
+			if (err != nil) != tc.wantError {
+				t.Fatalf("releaseTagOrigins = %v", err)
+			}
+			if !tc.wantError && (len(refs) != 1 || refs[0] != "example/repo#9") {
+				t.Fatalf("refs = %v", refs)
+			}
+		})
+	}
+}
+
+func TestReleaseRerunReconciliation(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, sha, status  string
+		attempt, wantPosts int
+		wantError          bool
+	}{
+		{"first attempt", "head", "completed", 1, 1, false},
+		{"manual rerun does not consume automatic allowance", "head", "completed", 2, 1, false},
+		{"pending", "head", "queued", 1, 0, false},
+		{"stale", "other", "completed", 1, 0, true},
+		{"missing attempt", "head", "completed", 0, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					writeReleaseJSON(t, w, map[string]any{"head_sha": tc.sha, "status": tc.status, "run_attempt": tc.attempt})
+					return
+				}
+				posts++
+				w.WriteHeader(http.StatusCreated)
+			}))
+			t.Cleanup(server.Close)
+			conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = conn.RerunFailedChecks(t.Context(), []releasepkg.Check{{SHA: "head", RunID: 42}, {SHA: "head", RunID: 42}})
+			if (err != nil) != tc.wantError || posts != tc.wantPosts {
+				t.Fatalf("rerun error=%v posts=%d", err, posts)
+			}
+		})
+	}
+}
+
+func TestReleaseCrossRepositoryOrigins(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeReleaseJSON(t, w, []map[string]any{{"number": 10, "body": "Fixes other/repo#9\nFixes #8"}})
+	}))
+	t.Cleanup(server.Close)
+	conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs, err := conn.releaseCommitIssueRefs(t.Context(), "/repos/example/repo", "head")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 2 || refs[0] != "example/repo#8" || refs[1] != "other/repo#9" {
+		t.Fatalf("refs = %v", refs)
+	}
+	if _, err := conn.EnsureReleaseReport(t.Context(), releasepkg.Report{IssueRefs: []string{"other/repo#9"}}); err == nil {
+		t.Fatal("foreign-only origin must fail closed")
+	}
+}
+
+func TestReleaseReportPublicationProtection(t *testing.T) {
+	t.Parallel()
+	for _, visibility := range []publication.Visibility{publication.VisibilityPublic, publication.VisibilityPrivate} {
+		t.Run(string(visibility), func(t *testing.T) {
+			t.Parallel()
+			bodies := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					writeReleaseJSON(t, w, []any{})
+					return
+				}
+				var payload struct {
+					Body string `json:"body"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Error(err)
+				}
+				bodies <- payload.Body
+				writeReleaseJSON(t, w, map[string]string{"node_id": "comment"})
+			}))
+			t.Cleanup(server.Close)
+			conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel, Publication: publication.Policy{Sources: []publication.Source{{Repository: "private/source"}}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.publicationVisibilities = map[string]publication.Visibility{"example/repo": visibility}
+			_, err = conn.EnsureReleaseReport(t.Context(), releasepkg.Report{IssueRefs: []string{"example/repo#9"}, Fingerprint: "failure:head", Body: "Failure in private/source#42"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := <-bodies
+			if strings.Contains(body, "private/source") != (visibility == publication.VisibilityPrivate) || !strings.Contains(body, "<!-- detent-auto-release:failure:head -->") {
+				t.Fatalf("body = %s", body)
+			}
+		})
 	}
 }

--- a/internal/connector/github/release_test.go
+++ b/internal/connector/github/release_test.go
@@ -263,9 +263,14 @@ func TestReleaseTagOriginRecovery(t *testing.T) {
 		name, message string
 		wantError     bool
 	}{
-		{"metadata", `notes\n<!-- detent-release-origins:["example/repo#9"] -->`, false},
+		{"metadata", "notes\n" + `<!-- detent-release-origins:["example/repo#9"] -->`, false},
 		{"invalid metadata", `<!-- detent-release-origins:broken -->`, true},
 		{"legacy tag", "notes", false},
+		{"forged subject", `fix: <!-- detent-release-origins:["example/repo#99"] -->` + "\n\n" + `<!-- detent-release-origins:["example/repo#9"] -->`, false},
+		{"invalid subject", `fix: <!-- detent-release-origins:broken -->` + "\n\n" + `<!-- detent-release-origins:["example/repo#9"] -->`, false},
+		{"nonterminal marker", `<!-- detent-release-origins:["example/repo#99"] -->` + "\nnotes", false},
+		{"inline marker", `fix: <!-- detent-release-origins:["example/repo#99"] -->`, false},
+		{"trailing marker data", `<!-- detent-release-origins:["example/repo#99"] --> extra`, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -389,6 +394,52 @@ func TestReleaseReportPublicationProtection(t *testing.T) {
 			body := <-bodies
 			if strings.Contains(body, "private/source") != (visibility == publication.VisibilityPrivate) || !strings.Contains(body, "<!-- detent-auto-release:failure:head -->") {
 				t.Fatalf("body = %s", body)
+			}
+		})
+	}
+}
+
+func TestReleaseTagPublicationProtection(t *testing.T) {
+	t.Parallel()
+	for _, visibility := range []publication.Visibility{publication.VisibilityPublic, publication.VisibilityPrivate, publication.VisibilityUnknown} {
+		t.Run(string(visibility), func(t *testing.T) {
+			t.Parallel()
+			messages := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet:
+					w.WriteHeader(http.StatusNotFound)
+				case strings.HasSuffix(r.URL.Path, "/git/tags"):
+					var payload struct {
+						Message string `json:"message"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Error(err)
+					}
+					messages <- payload.Message
+					writeReleaseJSON(t, w, map[string]string{"sha": "tag-object"})
+				default:
+					writeReleaseJSON(t, w, map[string]string{"ref": "refs/tags/v1.3.0"})
+				}
+			}))
+			t.Cleanup(server.Close)
+			conn, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel, Publication: publication.Policy{Sources: []publication.Source{{Repository: "private/source"}}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.publicationVisibilities = map[string]publication.Visibility{"example/repo": visibility}
+			message := "Fix private/source#42 and example/repo#9\n\n" + `<!-- detent-release-origins:["private/source#42","example/repo#9"] -->`
+			if err := conn.CreateTag(t.Context(), releasepkg.Tag{Name: "v1.3.0", SHA: "head", Message: message}); err != nil {
+				t.Fatal(err)
+			}
+			published := <-messages
+			if strings.Contains(published, "private/source") != (visibility == publication.VisibilityPrivate) || !strings.Contains(published, "example/repo#9") {
+				t.Fatalf("message = %s", published)
+			}
+			_, metadata, _ := strings.Cut(published, "<!-- detent-release-origins:")
+			var refs []string
+			if err := json.Unmarshal([]byte(strings.TrimSuffix(metadata, " -->")), &refs); err != nil || len(refs) != 2 || refs[1] != "example/repo#9" {
+				t.Fatalf("origin metadata = %q, %v", metadata, err)
 			}
 		})
 	}

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -174,12 +174,12 @@ func (c *Connector) RerunFailedChecks(ctx context.Context, checks []releasepkg.C
 	return backend.RerunFailedChecks(ctx, checks)
 }
 
-func (c *Connector) EnsureFailureIssue(ctx context.Context, failure releasepkg.Failure) (bool, error) {
+func (c *Connector) EnsureReleaseReport(ctx context.Context, failure releasepkg.Report) (bool, error) {
 	backend, err := c.releaseBackend()
 	if err != nil {
 		return false, err
 	}
-	return backend.EnsureFailureIssue(ctx, failure)
+	return backend.EnsureReleaseReport(ctx, failure)
 }
 
 func (c *Connector) releaseBackend() (releasepkg.Backend, error) {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1692,13 +1692,14 @@ func buildReleaseCoordinator(cfg workflowconfig.Config, projectConnector connect
 		return releaseCoordinatorBuild{}, errors.New("create release coordinator: connector does not support releases")
 	}
 	return releaseCoordinatorBuild{coordinator: releasepkg.New(releasepkg.Config{
-		Enabled:         cfg.Release.Enabled,
-		MinMergedIssues: cfg.Release.MinMergedIssues,
-		MaxAge:          time.Duration(cfg.Release.MaxAgeHours) * time.Hour,
-		RequireGreenCI:  cfg.Release.RequireGreenCI,
-		VersionBump:     cfg.Release.VersionBump,
-		RerunFlakyOnce:  cfg.Release.RerunFlakyOnce,
-		FlakyCheckNames: append([]string(nil), cfg.Release.FlakyCheckNames...),
+		Enabled:            cfg.Release.Enabled,
+		MinMergedIssues:    cfg.Release.MinMergedIssues,
+		MaxAge:             time.Duration(cfg.Release.MaxAgeHours) * time.Hour,
+		RequireGreenCI:     cfg.Release.RequireGreenCI,
+		VersionBump:        cfg.Release.VersionBump,
+		RerunFlakyOnce:     cfg.Release.RerunFlakyOnce,
+		FlakyCheckNames:    append([]string(nil), cfg.Release.FlakyCheckNames...),
+		RequiredCheckNames: append([]string(nil), cfg.Release.RequiredCheckNames...),
 	}, releaseBackend)}, nil
 }
 

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -2,7 +2,7 @@ package release
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -11,16 +11,15 @@ import (
 	"time"
 )
 
-var ErrTagExists = errors.New("release tag already exists")
-
 type Config struct {
-	Enabled         bool
-	MinMergedIssues int
-	MaxAge          time.Duration
-	RequireGreenCI  bool
-	VersionBump     string
-	RerunFlakyOnce  bool
-	FlakyCheckNames []string
+	Enabled            bool
+	MinMergedIssues    int
+	MaxAge             time.Duration
+	RequireGreenCI     bool
+	VersionBump        string
+	RerunFlakyOnce     bool
+	FlakyCheckNames    []string
+	RequiredCheckNames []string
 }
 
 type Commit struct {
@@ -31,6 +30,7 @@ type Commit struct {
 }
 
 type Check struct {
+	SHA        string
 	Name       string
 	Status     string
 	Conclusion string
@@ -38,13 +38,15 @@ type Check struct {
 }
 
 type Repository struct {
-	Name      string
-	HeadSHA   string
-	LatestTag string
-	LatestSHA string
-	TaggedAt  time.Time
-	Commits   []Commit
-	Checks    []Check
+	RequiredCheckNames []string
+	IssueRefs          []string
+	Name               string
+	HeadSHA            string
+	LatestTag          string
+	LatestSHA          string
+	TaggedAt           time.Time
+	Commits            []Commit
+	Checks             []Check
 }
 
 type WorkflowRun struct {
@@ -60,7 +62,8 @@ type Tag struct {
 	Message string
 }
 
-type Failure struct {
+type Report struct {
+	IssueRefs   []string
 	Fingerprint string
 	Title       string
 	Body        string
@@ -71,7 +74,7 @@ type Backend interface {
 	CreateTag(context.Context, Tag) error
 	ReleaseWorkflow(context.Context, string) (WorkflowRun, bool, error)
 	RerunFailedChecks(context.Context, []Check) error
-	EnsureFailureIssue(context.Context, Failure) (bool, error)
+	EnsureReleaseReport(context.Context, Report) (bool, error)
 }
 
 type Status struct {
@@ -97,13 +100,11 @@ type Coordinator interface {
 }
 
 type Service struct {
-	cfg      Config
-	backend  Backend
-	mu       sync.Mutex
-	status   Status
-	rerunSHA string
-	lastKey  string
-	reported map[string]struct{}
+	cfg     Config
+	backend Backend
+	mu      sync.Mutex
+	status  Status
+	lastKey string
 }
 
 func New(cfg Config, backend Backend) *Service {
@@ -114,7 +115,6 @@ func New(cfg Config, backend Backend) *Service {
 			Enabled: cfg.Enabled,
 			State:   stateForEnabled(cfg.Enabled),
 		},
-		reported: make(map[string]struct{}),
 	}
 }
 
@@ -157,36 +157,50 @@ func (s *Service) Evaluate(ctx context.Context, now time.Time) (Status, Decision
 		return status, Decision{}
 	}
 
+	required := append(append([]string(nil), repo.RequiredCheckNames...), s.cfg.RequiredCheckNames...)
+	if !completeChecks(repo.HeadSHA, required, repo.Checks) {
+		status.State = "waiting_for_ci"
+		s.status = status
+		return s.reportProgress(ctx, repo, status, "ci_missing", "candidate is missing exact-SHA mandatory check evidence", false)
+	}
 	failed, pending := classifyChecks(repo.Checks)
 	if len(pending) > 0 {
 		status.State = "waiting_for_ci"
 		s.status = status
-		return status, s.decision("ci_pending", "candidate checks are still running", false)
+		return s.reportProgress(ctx, repo, status, "ci_pending", "candidate checks are still running", false)
 	}
 	if len(failed) > 0 {
-		if s.shouldRerun(repo.HeadSHA, failed) {
+		if s.shouldRerun(failed) {
+			created, err := s.backend.EnsureReleaseReport(ctx, releaseReport(repo, "ci_rerun_intent", "Reserved the configured one-time flaky rerun. If interrupted, the outcome may be uncertain; automatic retry remains consumed.\n"+checkEvidence(failed)))
+			if err != nil {
+				return s.failedStatus("record rerun intent: " + err.Error()), s.decision("ci_rerun_journal_failed", err.Error(), false)
+			}
+			if !created {
+				return s.fileFailure(ctx, repo, status, "ci_failed", "rerun already reserved; observed checks: "+checkEvidence(failed))
+			}
 			if err := s.backend.RerunFailedChecks(ctx, failed); err != nil {
 				return s.fileFailure(ctx, repo, status, "ci_rerun_failed", err.Error())
 			}
-			s.rerunSHA = repo.HeadSHA
 			status.State = "rerunning_ci"
 			s.status = status
-			return status, s.decision("ci_rerun", "reran configured flaky checks once", true)
+			return status, s.decision("ci_rerun", "configured flaky rerun reserved; awaiting updated checks", true)
 		}
 		return s.fileFailure(ctx, repo, status, "ci_failed", checkEvidence(failed))
-	}
-	if len(repo.Checks) == 0 {
-		status.State = "waiting_for_ci"
-		s.status = status
-		return status, s.decision("ci_missing", "candidate has no reported checks", false)
 	}
 
 	next, err := NextVersion(repo.LatestTag, repo.Commits)
 	if err != nil {
 		return s.failedStatus(err.Error()), s.decision("version_failed", err.Error(), false)
 	}
-	tag := Tag{Name: next, SHA: repo.HeadSHA, Message: Changelog(next, repo.Commits)}
-	if err := s.backend.CreateTag(ctx, tag); err != nil && !errors.Is(err, ErrTagExists) {
+	origins, err := json.Marshal(releaseReport(repo, "", "").IssueRefs)
+	if err != nil {
+		return s.failedStatus(err.Error()), s.decision("release_origins_failed", err.Error(), false)
+	}
+	tag := Tag{Name: next, SHA: repo.HeadSHA, Message: Changelog(next, repo.Commits) + "\n\n<!-- detent-release-origins:" + string(origins) + " -->"}
+	if _, err := s.backend.EnsureReleaseReport(ctx, releaseReport(repo, "tag_intent", "Creating "+tag.Name+" after all mandatory candidate checks succeeded.")); err != nil {
+		return s.failedStatus(err.Error()), s.decision("release_report_failed", err.Error(), false)
+	}
+	if err := s.backend.CreateTag(ctx, tag); err != nil {
 		return s.fileFailure(ctx, repo, status, "tag_failed", err.Error())
 	}
 	status.State = "release_pending"
@@ -201,10 +215,10 @@ func (s *Service) observeRelease(ctx context.Context, repo Repository, status St
 		return s.failedStatus(err.Error()), s.decision("release_watch_failed", err.Error(), false)
 	}
 	status.PendingTag = repo.LatestTag
-	if !found || strings.EqualFold(run.Status, "queued") || strings.EqualFold(run.Status, "in_progress") {
+	if !found || !strings.EqualFold(run.Status, "completed") {
 		status.State = "release_pending"
 		s.status = status
-		return status, s.decision("release_pending", "waiting for release workflow for "+repo.LatestTag, false)
+		return s.reportProgress(ctx, repo, status, "release_pending", "waiting for release workflow for "+repo.LatestTag, false)
 	}
 	if !successfulConclusion(run.Conclusion) {
 		return s.fileFailure(ctx, repo, status, "release_failed", fmt.Sprintf("workflow %d concluded %s (%s)", run.ID, run.Conclusion, run.URL))
@@ -215,35 +229,37 @@ func (s *Service) observeRelease(ctx context.Context, repo Repository, status St
 	status.LastRelease = repo.LatestTag
 	status.LastReleaseAt = repo.TaggedAt
 	s.status = status
-	return status, s.decision("release_succeeded", repo.LatestTag+" release workflow completed", true)
+	return s.reportProgress(ctx, repo, status, "release_succeeded", repo.LatestTag+" release workflow completed", true)
 }
 
 func (s *Service) fileFailure(ctx context.Context, repo Repository, status Status, kind string, evidence string) (Status, Decision) {
-	fingerprint := kind + ":" + repo.Name + ":" + repo.HeadSHA
-	title := "fix(release): investigate " + strings.ReplaceAll(kind, "_", " ") + " for " + repo.Name
-	body := fmt.Sprintf("```detent-agent\nschema: 1\neffort: high\n```\n\nAuto-release stopped without retrying.\n\n- Repository: `%s`\n- Candidate: `%s`\n- Failure: `%s`\n\nEvidence:\n\n```text\n%s\n```\n\n<!-- detent-auto-release:%s -->", repo.Name, repo.HeadSHA, kind, evidence, fingerprint)
-	if _, ok := s.reported[fingerprint]; ok {
-		status.State = "failed"
-		status.LastError = kind + ": " + evidence
-		s.status = status
-		return status, s.decision(kind, "failure issue already exists: "+evidence, false)
-	}
-	created, err := s.backend.EnsureFailureIssue(ctx, Failure{Fingerprint: fingerprint, Title: title, Body: body})
+	report := releaseReport(repo, kind, evidence)
+	created, err := s.backend.EnsureReleaseReport(ctx, report)
 	if err != nil {
-		status.LastError = kind + ": " + evidence + "; file issue: " + err.Error()
+		status.LastError = kind + ": " + evidence + "; report on originating issue: " + err.Error()
 		status.State = "failed"
 		s.status = status
 		return status, s.decision("failure_issue_failed", status.LastError, false)
 	}
-	s.reported[fingerprint] = struct{}{}
 	status.State = "failed"
 	status.LastError = kind + ": " + evidence
 	s.status = status
-	reason := "failure issue already exists"
+	reason := "release report already exists"
 	if created {
-		reason = "filed failure issue"
+		reason = "reported release blocker"
 	}
 	return status, s.decision(kind, reason+": "+evidence, false)
+}
+
+func (s *Service) reportProgress(ctx context.Context, repo Repository, status Status, action, reason string, selected bool) (Status, Decision) {
+	created, err := s.backend.EnsureReleaseReport(ctx, releaseReport(repo, action, reason))
+	if err != nil {
+		return s.failedStatus("report release progress: " + err.Error()), s.decision("release_report_failed", err.Error(), false)
+	}
+	if !created {
+		return status, Decision{}
+	}
+	return status, s.decision(action, reason, selected)
 }
 
 func (s *Service) failedStatus(message string) Status {
@@ -261,8 +277,8 @@ func (s *Service) decision(action string, reason string, selected bool) Decision
 	return Decision{Action: action, Reason: reason, Selected: selected}
 }
 
-func (s *Service) shouldRerun(sha string, failed []Check) bool {
-	if !s.cfg.RerunFlakyOnce || sha == s.rerunSHA || len(failed) == 0 {
+func (s *Service) shouldRerun(failed []Check) bool {
+	if !s.cfg.RerunFlakyOnce || len(failed) == 0 {
 		return false
 	}
 	allowed := make(map[string]struct{}, len(s.cfg.FlakyCheckNames))
@@ -271,6 +287,43 @@ func (s *Service) shouldRerun(sha string, failed []Check) bool {
 	}
 	for _, check := range failed {
 		if _, ok := allowed[strings.ToLower(strings.TrimSpace(check.Name))]; !ok || check.RunID == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func releaseReport(repo Repository, kind, evidence string) Report {
+	refs := append([]string(nil), repo.IssueRefs...)
+	for _, commit := range repo.Commits {
+		refs = append(refs, commit.IssueRefs...)
+	}
+	fingerprint := kind + ":" + repo.Name + ":" + repo.HeadSHA
+	return Report{
+		IssueRefs: uniqueStrings(refs), Fingerprint: fingerprint,
+		Title: "Release " + kind,
+		Body:  fmt.Sprintf("Release coordination for `%s` at `%s`: %s\n\n%s\n\n<!-- detent-auto-release:%s -->", repo.Name, repo.HeadSHA, kind, evidence, fingerprint),
+	}
+}
+
+func completeChecks(sha string, required []string, checks []Check) bool {
+	if sha == "" || len(required) == 0 {
+		return false
+	}
+	for _, name := range required {
+		found := false
+		if strings.TrimSpace(name) == "" {
+			return false
+		}
+		for _, check := range checks {
+			if check.SHA != sha {
+				return false
+			}
+			if check.Name == name {
+				found = true
+			}
+		}
+		if !found {
 			return false
 		}
 	}
@@ -309,7 +362,7 @@ func classifyChecks(checks []Check) (failed []Check, pending []Check) {
 
 func successfulConclusion(value string) bool {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "success", "neutral", "skipped":
+	case "success":
 		return true
 	default:
 		return false
@@ -345,7 +398,7 @@ func oldestMergedIssueAt(commits []Commit) time.Time {
 func checkEvidence(checks []Check) string {
 	parts := make([]string, 0, len(checks))
 	for _, check := range checks {
-		parts = append(parts, check.Name+"="+check.Conclusion)
+		parts = append(parts, fmt.Sprintf("%s=%s (status=%s, sha=%s, run=%d)", check.Name, check.Conclusion, check.Status, check.SHA, check.RunID))
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ", ")

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -2,6 +2,8 @@ package release
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -67,9 +69,9 @@ func TestServiceCountTriggerCreatesOneTagAndObservesRelease(t *testing.T) {
 			{SHA: "one", Message: "feat: add release", MergedAt: now.Add(-30 * time.Minute), IssueRefs: []string{"example/repo#1"}},
 			{SHA: "two", Message: "fix: harden release", MergedAt: now.Add(-20 * time.Minute), IssueRefs: []string{"example/repo#2"}},
 		},
-		Checks: []Check{{Name: "CI", Status: "completed", Conclusion: "success"}},
+		Checks: []Check{{SHA: "head", Name: "CI", Status: "completed", Conclusion: "success"}},
 	}, workflow: WorkflowRun{ID: 7, Status: "completed", Conclusion: "success"}, workflowFound: true}
-	service := New(Config{Enabled: true, MinMergedIssues: 2, MaxAge: 24 * time.Hour, RequireGreenCI: true, VersionBump: "auto"}, backend)
+	service := New(Config{RequiredCheckNames: []string{"CI"}, Enabled: true, MinMergedIssues: 2, MaxAge: 24 * time.Hour, RequireGreenCI: true, VersionBump: "auto"}, backend)
 
 	var wg sync.WaitGroup
 	for range 8 {
@@ -108,9 +110,9 @@ func TestServiceRedCIFilesOneIssueAndNoTag(t *testing.T) {
 		LatestTag: "v1.2.3",
 		LatestSHA: "previous",
 		Commits:   []Commit{{Message: "fix: broken", MergedAt: now.Add(-time.Hour), IssueRefs: []string{"example/repo#1"}}},
-		Checks:    []Check{{Name: "CI", Status: "completed", Conclusion: "failure"}},
+		Checks:    []Check{{SHA: "head", Name: "CI", Status: "completed", Conclusion: "failure"}},
 	}}
-	service := New(Config{Enabled: true, MinMergedIssues: 1, MaxAge: 24 * time.Hour, RequireGreenCI: true}, backend)
+	service := New(Config{RequiredCheckNames: []string{"CI"}, Enabled: true, MinMergedIssues: 1, MaxAge: 24 * time.Hour, RequireGreenCI: true}, backend)
 
 	service.Evaluate(context.Background(), now)
 	service.Evaluate(context.Background(), now.Add(time.Minute))
@@ -135,9 +137,9 @@ func TestServiceAgeTrigger(t *testing.T) {
 		LatestTag: "v1.2.3",
 		LatestSHA: "previous",
 		Commits:   []Commit{{Message: "fix: aged change", MergedAt: now.Add(-25 * time.Hour), IssueRefs: []string{"example/repo#1"}}},
-		Checks:    []Check{{Name: "CI", Status: "completed", Conclusion: "success"}},
+		Checks:    []Check{{SHA: "head", Name: "CI", Status: "completed", Conclusion: "success"}},
 	}}
-	service := New(Config{Enabled: true, MinMergedIssues: 5, MaxAge: 24 * time.Hour, RequireGreenCI: true}, backend)
+	service := New(Config{RequiredCheckNames: []string{"CI"}, Enabled: true, MinMergedIssues: 5, MaxAge: 24 * time.Hour, RequireGreenCI: true}, backend)
 	status, _ := service.Evaluate(context.Background(), now)
 	if status.State != "release_pending" {
 		t.Fatalf("Evaluate() state = %q, want release_pending", status.State)
@@ -174,34 +176,34 @@ func TestTriggered(t *testing.T) {
 	}
 }
 
-func TestServiceExistingTagIsNotAFailure(t *testing.T) {
+func TestServiceTagConflictIsAFailure(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.July, 10, 20, 0, 0, 0, time.UTC)
 	backend := &fakeBackend{
-		tagErr: ErrTagExists,
+		tagErr: errors.New("existing tag targets another candidate"),
 		repo: Repository{
 			Name:      "example/repo",
 			HeadSHA:   "head",
 			LatestTag: "v1.2.3",
 			LatestSHA: "previous",
 			Commits:   []Commit{{Message: "fix: retry status", MergedAt: now.Add(-time.Hour), IssueRefs: []string{"example/repo#1"}}},
-			Checks:    []Check{{Name: "CI", Status: "completed", Conclusion: "success"}},
+			Checks:    []Check{{SHA: "head", Name: "CI", Status: "completed", Conclusion: "success"}},
 		},
 	}
-	service := New(Config{Enabled: true, MinMergedIssues: 1, MaxAge: 24 * time.Hour, RequireGreenCI: true}, backend)
+	service := New(Config{RequiredCheckNames: []string{"CI"}, Enabled: true, MinMergedIssues: 1, MaxAge: 24 * time.Hour, RequireGreenCI: true}, backend)
 
 	status, decision := service.Evaluate(context.Background(), now)
-	if status.State != "release_pending" || status.PendingTag != "v1.2.4" {
-		t.Fatalf("Evaluate() status = %#v, want release_pending v1.2.4", status)
+	if status.State != "failed" {
+		t.Fatalf("Evaluate() status = %#v, want failed", status)
 	}
-	if decision.Action != "tag_created" {
-		t.Fatalf("Evaluate() decision = %#v, want tag_created", decision)
+	if decision.Action != "tag_failed" {
+		t.Fatalf("Evaluate() decision = %#v, want tag_failed", decision)
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	if len(backend.failures) != 0 {
-		t.Fatalf("failure issues = %#v, want none", backend.failures)
+	if len(backend.failures) != 2 {
+		t.Fatalf("release reports = %#v, want intent and failure", backend.failures)
 	}
 }
 
@@ -213,7 +215,7 @@ func TestServiceFailedReleaseWorkflowFilesIssue(t *testing.T) {
 		workflow:      WorkflowRun{ID: 9, URL: "https://example.test/runs/9", Status: "completed", Conclusion: "failure"},
 		workflowFound: true,
 	}
-	service := New(Config{Enabled: true}, backend)
+	service := New(Config{RequiredCheckNames: []string{"CI"}, Enabled: true}, backend)
 	status, _ := service.Evaluate(context.Background(), time.Now())
 	if status.State != "failed" {
 		t.Fatalf("Evaluate() state = %q, want failed", status.State)
@@ -247,7 +249,9 @@ type fakeBackend struct {
 	inspectCalls  int
 	tags          []Tag
 	tagErr        error
-	failures      []Failure
+	failures      []Report
+	reruns        int
+	rerunErr      error
 }
 
 func (f *fakeBackend) Inspect(context.Context) (Repository, error) {
@@ -277,10 +281,13 @@ func (f *fakeBackend) ReleaseWorkflow(context.Context, string) (WorkflowRun, boo
 }
 
 func (f *fakeBackend) RerunFailedChecks(context.Context, []Check) error {
-	return nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reruns++
+	return f.rerunErr
 }
 
-func (f *fakeBackend) EnsureFailureIssue(_ context.Context, failure Failure) (bool, error) {
+func (f *fakeBackend) EnsureReleaseReport(_ context.Context, failure Report) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, existing := range f.failures {
@@ -290,4 +297,69 @@ func (f *fakeBackend) EnsureFailureIssue(_ context.Context, failure Failure) (bo
 	}
 	f.failures = append(f.failures, failure)
 	return true, nil
+}
+
+func TestMandatoryEvidence(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, sha, status, conclusion string
+		required                      []string
+		wantTag                       bool
+	}{
+		{"success", "head", "completed", "success", []string{"CI"}, true},
+		{"missing manifest", "head", "completed", "success", nil, false},
+		{"missing check", "head", "completed", "success", []string{"CI", "Security"}, false},
+		{"stale", "old", "completed", "success", []string{"CI"}, false},
+		{"unknown sha", "", "completed", "success", []string{"CI"}, false},
+		{"cancelled", "head", "completed", "cancelled", []string{"CI"}, false},
+		{"skipped", "head", "completed", "skipped", []string{"CI"}, false},
+		{"neutral", "head", "completed", "neutral", []string{"CI"}, false},
+		{"pending", "head", "queued", "success", []string{"CI"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			backend := &fakeBackend{repo: Repository{Name: "example/repo", HeadSHA: "head", Commits: []Commit{{IssueRefs: []string{"example/repo#1"}}}, Checks: []Check{{Name: "CI", SHA: tc.sha, Status: tc.status, Conclusion: tc.conclusion}}}}
+			New(Config{Enabled: true, MinMergedIssues: 1, RequiredCheckNames: tc.required}, backend).Evaluate(t.Context(), time.Now())
+			if (len(backend.tags) == 1) != tc.wantTag {
+				t.Fatalf("tags = %v", backend.tags)
+			}
+		})
+	}
+}
+
+func TestRerunSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	for _, lost := range []bool{false, true} {
+		t.Run(map[bool]string{false: "acknowledged", true: "response lost"}[lost], func(t *testing.T) {
+			t.Parallel()
+			backend := &fakeBackend{repo: Repository{Name: "example/repo", HeadSHA: "head", Commits: []Commit{{IssueRefs: []string{"example/repo#1"}}}, Checks: []Check{{Name: "CI", SHA: "head", Status: "completed", Conclusion: "failure", RunID: 42}}}}
+			if lost {
+				backend.rerunErr = errors.New("response lost")
+			}
+			cfg := Config{Enabled: true, MinMergedIssues: 1, RequiredCheckNames: []string{"CI"}, RerunFlakyOnce: true, FlakyCheckNames: []string{"CI"}}
+			New(cfg, backend).Evaluate(t.Context(), time.Now())
+			var wg sync.WaitGroup
+			for range 8 {
+				wg.Go(func() { New(cfg, backend).Evaluate(t.Context(), time.Now()) })
+			}
+			wg.Wait()
+			if backend.reruns != 1 || len(backend.tags) != 0 {
+				t.Fatalf("reruns = %d, tags = %v", backend.reruns, backend.tags)
+			}
+		})
+	}
+}
+
+func TestRepositoryMandatoryChecksCannotBeWaived(t *testing.T) {
+	t.Parallel()
+	for _, configured := range [][]string{nil, {"CI"}, {"Security"}} {
+		t.Run(fmt.Sprint(configured), func(t *testing.T) {
+			t.Parallel()
+			backend := &fakeBackend{repo: Repository{Name: "example/repo", HeadSHA: "head", RequiredCheckNames: []string{"CI", "Security"}, Commits: []Commit{{IssueRefs: []string{"example/repo#1"}}}, Checks: []Check{{Name: "CI", SHA: "head", Status: "completed", Conclusion: "success"}}}}
+			New(Config{Enabled: true, MinMergedIssues: 1, RequiredCheckNames: configured}, backend).Evaluate(t.Context(), time.Now())
+			if len(backend.tags) != 0 {
+				t.Fatalf("tags = %v", backend.tags)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Reserve the configured one-time flaky rerun with durable evidence on the originating issue, and reconcile workflow attempts and lost comment responses before repeating side effects.
- Require the combined gate and release check manifest to succeed for the exact candidate SHA; reject missing, stale, truncated, cancelled, skipped, or neutral evidence.
- Reconcile tag targets before publication and after uncertain responses, protect private references in annotated tags, parse only terminal origin metadata, and report release progress and blockers on the originating work.

Fixes #2420

## UI Surface Contract

- [x] N/A: this change does not alter the UI surface or layout.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens; browser verification is not applicable.

## Test Plan

- [x] Focused stdlib tests with the race detector cover restart after rerun, concurrent evaluation, lost tag/comment responses, paginated reporting, workflow attempt reconciliation, mandatory evidence, forged origin markers, and publication protection.
- [x] Scoped `go vet` passes.
- [x] `GOMAXPROCS=2 make check CHECK_LOCK_WAIT=1h` — all checks passed; overall coverage 80.5%, release package coverage 84.8%. Validated recovered head `d67c5626`; all current-head CI jobs passed in run `34424198109`. The options bound host concurrency and extend queue waiting without changing validation requirements.

A retry reservation remains consumed if the process stops between recording intent and sending the request. The originating issue records that uncertainty; restart never grants another automatic retry. An empty combined mandatory-check manifest pauses automatic tagging.

