### PR TITLE
perf(validation): preflight generated references

### DIFF
--- a/.detent/skills/eager-file-identity-snapshots.md
+++ b/.detent/skills/eager-file-identity-snapshots.md
@@ -1,0 +1,19 @@
+---
+name: eager-file-identity-snapshots
+description: Capture stable file identity when testing replacement across POSIX and Windows.
+when_to_use: Use when a Go replacement test compares os.FileInfo values across a rename and passes on POSIX but reports the same file on Windows.
+---
+
+- Inspect the active Go toolchain's Windows `os` implementation before treating
+  `os.FileInfo` from a pathname as a complete identity snapshot. Path-based
+  `os.Stat` can defer loading the volume and file index until `os.SameFile`.
+  Comparing after replacement can therefore resolve both snapshots to the new
+  destination, even though replacement succeeded.
+- Open the original file, call `file.Stat()`, and close the handle before the
+  mutation. Handle-based stat captures the identity eagerly; closing it avoids
+  imposing Windows open-handle replacement restrictions on the writer.
+- After replacement, stat the destination and compare identities. Also verify
+  the published content; identity alone does not establish content correctness.
+- Use this deterministic snapshot ordering instead of timestamp sleeps or
+  scheduler-sensitive reader/writer loops. Confirm the fixture rejects an
+  in-place rewrite, and run it on Windows as well as a POSIX platform.

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ security: security-gosec-determinism
 nilaway-audit:
 	$(NILAWAY) -include-pkgs=$(NILAWAY_INCLUDE_PKGS) ./...
 
-check: check-migrations
+check: check-migrations check-generated
 	@mkdir -p tmp
 	@common_dir="$$(git rev-parse --path-format=absolute --git-common-dir)" && \
 	go run ./tools/checklock -lock "$$common_dir/detent-validation.lock" -wait-timeout "$(CHECK_LOCK_WAIT)" -max-wait-timeout "$(CHECK_LOCK_MAX_WAIT)" -events tmp/validation-events.jsonl -- $(MAKE) check-unlocked

--- a/internal/config/configdoc/configdoc.go
+++ b/internal/config/configdoc/configdoc.go
@@ -92,13 +92,36 @@ func Generate(root string, check bool) error {
 		return nil
 	}
 
-	if err := os.WriteFile(docsPath, renderedDocs, 0o644); err != nil {
+	if err := writeGeneratedFile(docsPath, renderedDocs); err != nil {
 		return fmt.Errorf("write %s: %w", docsPath, err)
 	}
-	if err := os.WriteFile(referencePath, renderedReference, 0o644); err != nil {
+	if err := writeGeneratedFile(referencePath, renderedReference); err != nil {
 		return fmt.Errorf("write %s: %w", referencePath, err)
 	}
 	return nil
+}
+
+func writeGeneratedFile(path string, content []byte) (returnErr error) {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".configdoc-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if cleanupErr := os.Remove(temporaryPath); cleanupErr != nil && !errors.Is(cleanupErr, os.ErrNotExist) {
+			returnErr = errors.Join(returnErr, fmt.Errorf("remove temporary file: %w", cleanupErr))
+		}
+	}()
+	if err := temporary.Chmod(0o644); err != nil {
+		return errors.Join(err, temporary.Close())
+	}
+	if _, err := temporary.Write(content); err != nil {
+		return errors.Join(err, temporary.Close())
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
 }
 
 func Fields() ([]Field, error) {

--- a/internal/config/configdoc/configdoc.go
+++ b/internal/config/configdoc/configdoc.go
@@ -60,7 +60,10 @@ func Generate(root string, check bool) error {
 	if err != nil {
 		return err
 	}
+	return generateArtifacts(root, check, fields, nodes)
+}
 
+func generateArtifacts(root string, check bool, fields []fieldDetails, nodes []*schemaNode) error {
 	docsPath := filepath.Join(root, "docs", "config.md")
 	referencePath := filepath.Join(root, "config.reference.yaml")
 	currentDocs, err := os.ReadFile(docsPath)

--- a/internal/config/configdoc/configdoc_test.go
+++ b/internal/config/configdoc/configdoc_test.go
@@ -132,12 +132,93 @@ func TestConfigDocumentation(t *testing.T) {
 		}
 	})
 
+	t.Run("generation replaces complete artifacts", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		tests := []struct {
+			name string
+			path string
+			old  string
+			info os.FileInfo
+		}{
+			{name: "Markdown", path: filepath.Join(root, "docs", "config.md"), old: "prose\n" + beginMarker + "\nstale\n" + endMarker + "\n"},
+			{name: "YAML", path: filepath.Join(root, "config.reference.yaml"), old: "stale\n"},
+		}
+		for index := range tests {
+			test := &tests[index]
+			if err := os.WriteFile(test.path, []byte(test.old), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Stat(test.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.info = info
+		}
+		if err := Generate(root, false); err != nil {
+			t.Fatal(err)
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				info, err := os.Stat(test.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if os.SameFile(test.info, info) {
+					t.Error("generation rewrote the existing file instead of replacing it")
+				}
+				content, err := os.ReadFile(test.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(content) == test.old || len(content) == 0 {
+					t.Error("generation did not publish the new content")
+				}
+			})
+		}
+		if err := Generate(root, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	t.Run("generated artifacts are current", func(t *testing.T) {
 		root := filepath.Clean(filepath.Join("..", "..", ".."))
 		if err := Generate(root, true); err != nil {
 			t.Fatalf("Generate(check) error = %v", err)
 		}
 	})
+}
+
+func TestWriteGeneratedFileFailure(t *testing.T) {
+	for _, name := range []string{"missing parent", "directory destination"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "missing", "target")
+			wantEntries := 0
+			if name == "directory destination" {
+				path = filepath.Join(root, "target")
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				wantEntries = 1
+			}
+			if err := writeGeneratedFile(path, []byte("generated")); err == nil {
+				t.Fatal("writeGeneratedFile succeeded for an invalid destination")
+			}
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != wantEntries {
+				t.Fatalf("directory entries = %v, want %d entries without staging files", entries, wantEntries)
+			}
+			if wantEntries == 1 && (!entries[0].IsDir() || entries[0].Name() != "target") {
+				t.Fatal("failed replacement changed the existing destination")
+			}
+		})
+	}
 }
 
 func configSourceYAMLKeys(t *testing.T) map[string]struct{} {

--- a/internal/config/configdoc/configdoc_test.go
+++ b/internal/config/configdoc/configdoc_test.go
@@ -162,7 +162,7 @@ func TestConfigDocumentation(t *testing.T) {
 			}
 			test.info = info
 		}
-		if err := Generate(root, false); err != nil {
+		if err := generateArtifacts(root, false, fields, nodes); err != nil {
 			t.Fatal(err)
 		}
 		for _, test := range tests {
@@ -183,7 +183,7 @@ func TestConfigDocumentation(t *testing.T) {
 				}
 			})
 		}
-		if err := Generate(root, true); err != nil {
+		if err := generateArtifacts(root, true, fields, nodes); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/internal/config/configdoc/configdoc_test.go
+++ b/internal/config/configdoc/configdoc_test.go
@@ -1,6 +1,7 @@
 package configdoc
 
 import (
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -151,8 +152,12 @@ func TestConfigDocumentation(t *testing.T) {
 			if err := os.WriteFile(test.path, []byte(test.old), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			info, err := os.Stat(test.path)
+			file, err := os.Open(test.path)
 			if err != nil {
+				t.Fatal(err)
+			}
+			info, statErr := file.Stat()
+			if err := errors.Join(statErr, file.Close()); err != nil {
 				t.Fatal(err)
 			}
 			test.info = info

--- a/tools/checklock/makefile_test.go
+++ b/tools/checklock/makefile_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMakeCheckGeneratedPreflight(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Makefile requires POSIX shell commands")
+	}
+	if _, err := exec.LookPath("make"); err != nil {
+		t.Fatal(err)
+	}
+	makefile, err := os.ReadFile("../../Makefile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		stale     bool
+		change    bool
+		wantTrace string
+		wantError bool
+	}{
+		{"stale before admission", true, false, "migrations\ngenerated\n", true},
+		{"changed during admission", false, true, "migrations\ngenerated\nlock\nmigrations\ngenerated\n", true},
+		{"unchanged inputs", false, false, "migrations\ngenerated\nlock\nmigrations\ngenerated\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			write := func(name, content string, mode os.FileMode) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(content), mode); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write("Makefile", string(makefile), 0o600)
+			write(".golangci-version", "test", 0o600)
+			write("go.mod", "module fixture\n", 0o600)
+			write("input", "current", 0o600)
+			document := "current"
+			if tt.stale {
+				document = "stale"
+			}
+			write("reference", document, 0o600)
+			if tt.change {
+				write("change-at-admission", "", 0o600)
+			}
+			write("git", "#!/bin/sh\npwd\n", 0o700)
+			write("go", `#!/bin/sh
+set -eu
+case "$*" in
+  'run ./tools/migrationcheck')
+    echo migrations >> trace
+    ;;
+  'run ./internal/config/cmd/configdoc -root . -check')
+    echo generated >> trace
+    cmp input reference
+    ;;
+  'run ./tools/checklock '*)
+    echo lock >> trace
+    if [ -f change-at-admission ]; then
+      echo changed > input
+    fi
+    while [ "$1" != '--' ]; do shift; done
+    shift
+    exec "$@"
+    ;;
+  *) exit 99 ;;
+esac
+`, 0o700)
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("MAKEFLAGS", "")
+			t.Setenv("MFLAGS", "")
+			t.Setenv("MAKEOVERRIDES", "")
+			ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "make", "check", "VERSION=test", "COMMIT=test", "DATE=test", "GOLANGCI_LINT_VERSION=test", "MAKE=make -o build -o lint -o vet -o nilaway-audit -o test-race-cover")
+			cmd.Dir = dir
+			output, err := cmd.CombinedOutput()
+			if (err != nil) != tt.wantError {
+				t.Fatalf("make check error = %v, want error %v\n%s", err, tt.wantError, output)
+			}
+			trace, err := os.ReadFile(filepath.Join(dir, "trace"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(trace) != tt.wantTrace {
+				t.Errorf("trace = %q, want %q\n%s", trace, tt.wantTrace, output)
+			}
+			if got := strings.Contains(string(output), "All checks passed."); got == tt.wantError {
+				t.Errorf("success message = %v, want %v\n%s", got, !tt.wantError, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fail on stale generated configuration references before joining the shared validation queue, and check them again after acquiring the lock.
- Cover failed preflight, input drift during admission, and unchanged inputs with deterministic Makefile subprocess tests. FIFO admission, deadlines, and required validation checks remain unchanged.
- Publish generated references through staged file replacement so concurrent preflights cannot read files truncated by generation; cover replacement and failed-write cleanup.

Fixes #2427

## UI Surface Contract

- [x] N/A: this change has no UI surface or layout effects.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes require browser verification.

## Test Plan

- [x] Reproduced lock admission on stale input before the fix.
- [x] `go test -race ./internal/config/configdoc ./tools/checklock -count=1`
- [x] Reproduced in-place generated-file rewrites before the fix; replacement and cleanup regressions pass.
- [x] Final head `5a37ce6c`: `make check CHECK_LOCK_WAIT=1h` passed; 80.5% coverage and all package/file floors met. FIFO wait 3m14s; execution 7m39s. Source wait defaults are unchanged.
- [x] Replacement tests capture file identity from an open handle for Windows portability and reuse the existing schema to avoid redundant expensive builds.
- [x] Include a skill draft documenting portable file identity snapshots.

