### PR TITLE
fix(validation): preserve useful queue progress

### DIFF
--- a/tools/checklock/README.md
+++ b/tools/checklock/README.md
@@ -27,34 +27,46 @@ excess invocations fail explicitly instead of growing it without a bound.
 `-wait-timeout` (`CHECK_LOCK_WAIT` in Make, 15 minutes by default) bounds
 registration and waiting without progress. An observed change in valid owner
 identity (PID, hostname, acquisition time), or acquisition after an observed
-clear lock, renews that budget. Queue position
-improvement also renews it when the validation lock is not held. An unchanged
-live holder, unreadable owner metadata, periodic reports, and new arrivals do
-not renew the budget. Cancellations ahead of a waiter cannot extend a stalled
-holder's budget. Handoffs must be observed before the current budget expires;
-liveness alone does not prove that validation is progressing.
+clear lock, renews that budget. Forward queue movement also renews it, including
+cancellations ahead while an owner holds the gate. Fresh output activity from
+the same identified owner renews the budget without requiring a handoff. An
+unchanged holder, phase hints alone, unreadable metadata, periodic reports, and
+new arrivals do not renew it. Progress must be observed before the current
+budget expires; neither liveness nor output alone proves validation is healthy.
 
 `-max-wait-timeout` (`CHECK_LOCK_MAX_WAIT` in Make, 4 hours by default) bounds
-total registration and queue waiting even with repeated handoffs. This also
+total registration and queue waiting even with repeated handoffs, output, or
+queue advancement. This also
 bounds contention with older clients that do not honor FIFO. Both durations
 must be positive. The waiter retains its original ticket across renewals.
 Interrupt/termination signals and parent deadlines cancel waiting. Once
-validation starts, neither wait budget limits execution. Parent cancellation and termination signals
-stop the active command through the shared process-group helper. The wrapper
-retains the lock until command exit and process-group cleanup finish. The
-validation command controls its own active timeouts.
+validation starts, neither wait budget limits execution. Parent cancellation and
+termination signals stop the active command through the shared process-group
+helper. The wrapper retains the lock until command exit, output draining, and
+available process-group cleanup finish. Unix output draining has a five-second
+post-exit bound followed by descendant cleanup. Windows has no descendant
+cleanup, so output draining is not timed out: inherited output handles retain
+the gate until they close, including after leader exit or parent cancellation.
+The validation command controls its own active timeouts.
 
 Waiting diagnostics report queue position, queue size, elapsed wait, and the
-active owner's PID/acquisition time when available. They refresh when the queue
-or owner changes and at least every 30 seconds while polling the validation
-queue. Renewal messages identify the observed progress and both budgets. Expiration
+active owner's PID/acquisition time when available. Owner-bound `<lock>.activity`
+metadata adds a phase hint inferred from known command output, the latest
+activity timestamp, and output byte count. It stores no output body and is
+published atomically, at most once per second unless the phase changes. Metadata
+from another owner, malformed metadata, and future activity are ignored. Missing
+or unreadable activity is explicitly reported as unknown. Reports refresh when
+the queue, owner, or phase changes and at least every 30 seconds while polling. Renewal messages identify the observed progress and both budgets. Expiration
 messages distinguish no progress, the total cap, and parent cancellation or
-deadline expiry, and identify waiting before validation has started. Normal
+deadline expiry, identify waiting before validation has started, and explain
+that a retry joins the queue tail. Normal
 diagnostics omit repository paths and owner hostnames.
 
 Older checklock binaries still contend on the original exclusive validation
 lock, so exclusivity is preserved during rollout. FIFO ordering applies to
 invocations using this queue protocol; older polling binaries cannot honor it.
+Owners without activity metadata and silent owners retain the idle timeout;
+`CHECK_LOCK_WAIT=1h` remains available for a longer bounded wait during rollout.
 
 Validation:
 

--- a/tools/checklock/activity.go
+++ b/tools/checklock/activity.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+type validationActivity struct {
+	Owner instancelock.Owner `json:"owner"`
+	Phase string             `json:"phase"`
+	At    time.Time          `json:"at"`
+	Bytes int64              `json:"bytes"`
+}
+
+type validationActivityRecorder struct {
+	mu        sync.Mutex
+	path      string
+	activity  validationActivity
+	published time.Time
+	stderr    io.Writer
+}
+
+func newValidationActivityRecorder(path string, stderr io.Writer) *validationActivityRecorder {
+	r := &validationActivityRecorder{path: path + ".activity", stderr: stderr}
+	owner, err := instancelock.Inspect(path)
+	if err != nil || owner.MetadataError != nil || owner.Status != instancelock.StatusHeld {
+		fmt.Fprintln(stderr, "validation owner activity unavailable: cannot identify lock owner")
+		return r
+	}
+	r.activity = validationActivity{Owner: owner.Owner, Phase: "command", At: time.Now()}
+	r.publish()
+	return r
+}
+
+func (r *validationActivityRecorder) publish() {
+	data, err := json.Marshal(r.activity)
+	if err == nil {
+		err = os.WriteFile(r.path+".tmp", data, 0o600)
+	}
+	if err == nil {
+		err = os.Rename(r.path+".tmp", r.path)
+	}
+	if err != nil {
+		fmt.Fprintln(r.stderr, "validation owner activity unavailable: cannot publish activity")
+	}
+	r.published = time.Now()
+}
+
+func (r *validationActivityRecorder) observe(data []byte) {
+	if r.activity.Owner.PID == 0 || len(data) == 0 {
+		return
+	}
+	phase := r.activity.Phase
+	if phase == "command" {
+		phase = "running"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		for _, marker := range []struct{ command, phase string }{
+			{"go build ", "build"},
+			{"templ generate", "generate"},
+			{"golangci-lint", "lint"},
+			{"go vet ", "vet"},
+			{"nilaway", "nilaway"},
+			{"scripts/test-race-cover.sh", "tests"},
+			{"go run ./tools/covercheck", "coverage"},
+		} {
+			if strings.Contains(line, marker.command) {
+				phase = marker.phase
+			}
+		}
+	}
+	changed := phase != r.activity.Phase
+	r.activity.Phase = phase
+	r.activity.At = time.Now()
+	r.activity.Bytes += int64(len(data))
+	if changed || time.Since(r.published) >= time.Second {
+		r.publish()
+	}
+}
+
+type validationActivityWriter struct {
+	output   io.Writer
+	recorder *validationActivityRecorder
+}
+
+func (w validationActivityWriter) Write(data []byte) (int, error) {
+	w.recorder.mu.Lock()
+	defer w.recorder.mu.Unlock()
+	w.recorder.observe(data)
+	return w.output.Write(data)
+}
+
+func readValidationActivity(path string, owner instancelock.Inspection) (validationActivity, bool) {
+	if owner.Status != instancelock.StatusHeld || owner.MetadataError != nil {
+		return validationActivity{}, false
+	}
+	data, err := os.ReadFile(path + ".activity")
+	var activity validationActivity
+	if err != nil || json.Unmarshal(data, &activity) != nil || activity.Owner != owner.Owner || activity.At.Before(owner.Owner.StartedAt) || activity.At.After(time.Now()) {
+		return validationActivity{}, false
+	}
+	return activity, true
+}

--- a/tools/checklock/activity_test.go
+++ b/tools/checklock/activity_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/instancelock"
+)
+
+func TestValidationOwnerActivity(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct{ name, output, phase string }{
+		{"build", "go build -o tmp/detent ./cmd/detent\n", "build"},
+		{"tests", "bash scripts/test-race-cover.sh\n", "tests"},
+		{"generic", "some output\n", "running"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "gate.lock")
+			holder := acquireTestLock(t, path)
+			var output, diagnostics bytes.Buffer
+			recorder := newValidationActivityRecorder(path, &diagnostics)
+			writer := validationActivityWriter{output: &output, recorder: recorder}
+			if n, err := io.WriteString(writer, tt.output); err != nil || n != len(tt.output) || output.String() != tt.output {
+				t.Fatalf("output forwarding = %d, %v, %q", n, err, &output)
+			}
+			owner, err := instancelock.Inspect(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			activity, ok := readValidationActivity(path, owner)
+			if !ok || activity.Phase != tt.phase || activity.Bytes != int64(len(tt.output)) || diagnostics.Len() != 0 {
+				t.Fatalf("activity = %+v, known=%t, diagnostics=%s", activity, ok, &diagnostics)
+			}
+			if err := holder.Close(); err != nil {
+				t.Fatal(err)
+			}
+			acquireTestLock(t, path)
+			owner, err = instancelock.Inspect(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := readValidationActivity(path, owner); ok {
+				t.Fatal("previous owner's activity accepted")
+			}
+			if err := os.WriteFile(path+".activity", []byte("invalid"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := readValidationActivity(path, owner); ok {
+				t.Fatal("invalid activity accepted")
+			}
+		})
+	}
+}
+
+func TestValidationLongHeldOwner(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name            string
+		output, release bool
+		wantWait        time.Duration
+	}{
+		{"active owner retains ticket", true, true, 35*time.Minute + 700*time.Millisecond},
+		{"silent owner expires", false, false, 15*time.Minute + 300*time.Millisecond},
+		{"active owner respects total bound", true, false, 40*time.Minute + 800*time.Millisecond},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), 45*time.Minute)
+				defer cancel()
+				path := filepath.Join(t.TempDir(), "gate.lock")
+				holder := acquireTestLock(t, path)
+				recorder := newValidationActivityRecorder(path, io.Discard)
+				var older []validationWaiter
+				for range 5 {
+					w, err := registerValidationWaiter(t.Context(), path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() { w.lock.Close() })
+					older = append(older, w)
+				}
+				var diagnostics bytes.Buffer
+				started := time.Now()
+				calls := 0
+				var ticket string
+				lock, _, err := acquireValidationLockWithTimeouts(ctx, path, &diagnostics, 15*time.Minute, 40*time.Minute, func(ctx context.Context, path, name string) (int, int, error) {
+					if ticket != "" && ticket != name {
+						t.Fatal("waiter lost its ticket")
+					}
+					ticket = name
+					if calls > 0 {
+						time.Sleep(5 * time.Minute)
+						if tt.output {
+							recorder.observe([]byte("test output\n"))
+						}
+						if tt.output && calls <= 3 {
+							if err := older[calls-1].lock.Close(); err != nil {
+								t.Fatal(err)
+							}
+						}
+						if tt.release && calls == 7 {
+							for _, w := range older {
+								if err := w.lock.Close(); err != nil {
+									t.Fatal(err)
+								}
+							}
+							if err := holder.Close(); err != nil {
+								t.Fatal(err)
+							}
+						}
+					}
+					calls++
+					return validationPosition(ctx, path, name)
+				})
+				if elapsed := time.Since(started); elapsed != tt.wantWait {
+					t.Fatalf("waited %s, want %s", elapsed, tt.wantWait)
+				}
+				if tt.release {
+					if err != nil {
+						t.Fatalf("active owner lost progress: %v\n%s", err, &diagnostics)
+					}
+					defer lock.Close()
+					if time.Since(started) < 35*time.Minute {
+						t.Fatal("gate acquired before owner release")
+					}
+				} else {
+					if lock != nil || !errors.Is(err, context.DeadlineExceeded) {
+						t.Fatalf("timeout = %v, %v", lock, err)
+					}
+					if tt.output && !strings.Contains(err.Error(), "total queue wait limit") {
+						t.Fatal(err)
+					}
+					inspection, inspectErr := instancelock.Inspect(path)
+					if inspectErr != nil || inspection.Status != instancelock.StatusHeld {
+						t.Fatal("timeout released owner")
+					}
+					newer, registerErr := registerValidationWaiter(t.Context(), path)
+					if registerErr != nil {
+						t.Fatal(registerErr)
+					}
+					defer newer.lock.Close()
+					retry, registerErr := registerValidationWaiter(t.Context(), path)
+					if registerErr != nil {
+						t.Fatal(registerErr)
+					}
+					defer retry.lock.Close()
+					position, size, positionErr := validationPosition(t.Context(), path, retry.name)
+					if positionErr != nil || position != size || retry.name <= newer.name {
+						t.Fatalf("retry bypassed FIFO: %d/%d %v", position, size, positionErr)
+					}
+				}
+				if !strings.Contains(diagnostics.String(), "owner_phase_hint=") || (tt.output && !strings.Contains(diagnostics.String(), "reason=owner_output")) {
+					t.Fatalf("missing owner evidence: %s", &diagnostics)
+				}
+			})
+		})
+	}
+}
+
+func TestValidationActivityUnavailable(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"missing owner", "missing metadata", "unwritable metadata", "future activity"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "gate.lock")
+			if mode != "missing owner" {
+				acquireTestLock(t, path)
+			}
+			if mode == "unwritable metadata" {
+				if err := os.Mkdir(path+".activity.tmp", 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var diagnostics bytes.Buffer
+			if mode != "missing metadata" {
+				recorder := newValidationActivityRecorder(path, &diagnostics)
+				recorder.observe(nil)
+				if mode == "future activity" {
+					recorder.activity.At = time.Now().Add(time.Hour)
+					recorder.publish()
+				}
+			}
+			owner, err := instancelock.Inspect(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := readValidationActivity(path, owner); ok {
+				t.Fatal("unavailable activity accepted")
+			}
+			if (mode == "missing owner" || mode == "unwritable metadata") && !strings.Contains(diagnostics.String(), "activity unavailable") {
+				t.Fatalf("missing diagnostic: %s", &diagnostics)
+			}
+		})
+	}
+}

--- a/tools/checklock/main.go
+++ b/tools/checklock/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -105,12 +106,14 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	}
 	activity := newValidationActivityRecorder(*lockPath, stderr)
 	cmd := &exec.Cmd{
-		Path:      commandPath,
-		Args:      command,
-		Stdin:     stdin,
-		Stdout:    validationActivityWriter{output: stdout, recorder: activity},
-		Stderr:    validationActivityWriter{output: stderr, recorder: activity},
-		WaitDelay: 5 * time.Second,
+		Path:   commandPath,
+		Args:   command,
+		Stdin:  stdin,
+		Stdout: validationActivityWriter{output: stdout, recorder: activity},
+		Stderr: validationActivityWriter{output: stderr, recorder: activity},
+	}
+	if runtime.GOOS != "windows" {
+		cmd.WaitDelay = 5 * time.Second
 	}
 	runStarted := time.Now()
 	commandErr := runValidationCommand(ctx, cmd)

--- a/tools/checklock/main.go
+++ b/tools/checklock/main.go
@@ -31,7 +31,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	flags.SetOutput(stderr)
 
 	lockPath := flags.String("lock", "", "validation lock path")
-	waitTimeout := flags.Duration("wait-timeout", 15*time.Minute, "maximum wait without an owner handoff or unheld queue advancement")
+	waitTimeout := flags.Duration("wait-timeout", 15*time.Minute, "maximum wait without an owner handoff, output activity, or queue advancement")
 	maxWaitTimeout := flags.Duration("max-wait-timeout", 4*time.Hour, "maximum total registration and queue wait")
 	eventsPath := flags.String("events", "", "append local gate timing events as JSON lines")
 
@@ -103,12 +103,14 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		}
 		return 1
 	}
+	activity := newValidationActivityRecorder(*lockPath, stderr)
 	cmd := &exec.Cmd{
-		Path:   commandPath,
-		Args:   command,
-		Stdin:  stdin,
-		Stdout: stdout,
-		Stderr: stderr,
+		Path:      commandPath,
+		Args:      command,
+		Stdin:     stdin,
+		Stdout:    validationActivityWriter{output: stdout, recorder: activity},
+		Stderr:    validationActivityWriter{output: stderr, recorder: activity},
+		WaitDelay: 5 * time.Second,
 	}
 	runStarted := time.Now()
 	commandErr := runValidationCommand(ctx, cmd)

--- a/tools/checklock/main_test.go
+++ b/tools/checklock/main_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -424,7 +425,118 @@ func TestValidationInheritedOutputHelper(t *testing.T) {
 	if _, err := io.ReadFull(output, make([]byte, len("ready\n"))); err != nil {
 		t.Fatal(err)
 	}
+	if release := os.Getenv("DETENT_CHECKLOCK_PARENT_RELEASE"); release != "" {
+		fmt.Fprintln(os.Stdout, os.Getpid())
+		for {
+			if _, err := os.Stat(release); err == nil {
+				break
+			} else if !errors.Is(err, os.ErrNotExist) {
+				t.Fatal(err)
+			}
+			if err := waitValidationPoll(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
 	os.Exit(0)
+}
+
+func TestRunWindowsRetainsInheritedOutputOwnership(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows retains inherited output until descendants exit")
+	}
+	for _, cancelParent := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cancel=%t", cancelParent), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+			defer cancel()
+			commandCtx, stop := context.WithCancel(ctx)
+			defer stop()
+			path := filepath.Join(t.TempDir(), "validation.lock")
+			criticalPath := filepath.Join(t.TempDir(), "critical.lock")
+			release := filepath.Join(t.TempDir(), "release")
+			t.Setenv("GOCOVERDIR", t.TempDir())
+			t.Setenv("DETENT_CHECKLOCK_PARENT_RELEASE", release)
+			reader, writer, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ready := newNotifyingWriter()
+			var stderr bytes.Buffer
+			done := make(chan struct{})
+			var code int
+			go func() {
+				code = run(commandCtx, []string{"-lock", path, "--", os.Args[0], "-test.run=^TestValidationInheritedOutputHelper$", "--", "checklock-inherited-output", criticalPath}, reader, ready, &stderr)
+				close(done)
+			}()
+			t.Cleanup(func() {
+				writer.Close()
+				stop()
+				select {
+				case <-done:
+				case <-time.After(validationIntegrationTimeout):
+					t.Error("validation did not stop after releasing descendant input")
+				}
+				reader.Close()
+			})
+			select {
+			case <-ready.notified:
+			case <-done:
+				t.Fatalf("parent exited before readiness: %d: %s", code, &stderr)
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			ready.mu.Lock()
+			pid, err := strconv.Atoi(strings.TrimSpace(ready.data.String()))
+			ready.mu.Unlock()
+			if err != nil {
+				t.Fatal(err)
+			}
+			parent, err := os.FindProcess(pid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer parent.Release()
+			if err := os.WriteFile(release, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := parent.Wait(); err != nil {
+				t.Fatal(err)
+			}
+			if cancelParent {
+				stop()
+			}
+			select {
+			case <-done:
+				t.Fatalf("gate released while descendant retained output: %d: %s", code, &stderr)
+			case <-time.After(10 * time.Second):
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			for _, heldPath := range []string{path, criticalPath} {
+				inspection, err := instancelock.Inspect(heldPath)
+				if err != nil || inspection.Status != instancelock.StatusHeld {
+					t.Fatalf("descendant ownership lost: %+v, %v", inspection, err)
+				}
+			}
+			if _, err := writer.Write([]byte{1}); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-done:
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			wantCode := 0
+			if cancelParent {
+				wantCode = 1
+			}
+			if code != wantCode {
+				t.Fatalf("released descendant: code=%d want=%d stderr=%s", code, wantCode, &stderr)
+			}
+			acquireTestLock(t, path)
+			acquireTestLock(t, criticalPath)
+		})
+	}
 }
 
 func TestRunRetainsWaitAcrossHandoffs(t *testing.T) {

--- a/tools/checklock/main_test.go
+++ b/tools/checklock/main_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -371,6 +373,58 @@ func TestValidationCancellationHelper(t *testing.T) {
 	if _, err := io.ReadFull(os.Stdin, make([]byte, 1)); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestRunBoundsInheritedOutputDrain(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("process group cleanup is Unix-specific")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), validationIntegrationTimeout)
+	defer cancel()
+	path := filepath.Join(t.TempDir(), "validation.lock")
+	criticalPath := filepath.Join(t.TempDir(), "critical.lock")
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+	var stderr bytes.Buffer
+	code := run(ctx, []string{
+		"-lock", path, "--", "env", "GOCOVERDIR=" + t.TempDir(), os.Args[0], "-test.run=^TestValidationInheritedOutputHelper$",
+		"--", "checklock-inherited-output", criticalPath,
+	}, reader, io.Discard, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), exec.ErrWaitDelay.Error()) || ctx.Err() != nil {
+		t.Fatalf("inherited output drain = %d, context=%v, stderr=%s", code, ctx.Err(), &stderr)
+	}
+	acquireTestLock(t, path)
+	acquireTestLock(t, criticalPath)
+}
+
+func TestValidationInheritedOutputHelper(t *testing.T) {
+	if len(os.Args) < 3 || os.Args[len(os.Args)-2] != "checklock-inherited-output" {
+		t.Skip("helper process")
+	}
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestValidationCancellationHelper$", "--", "checklock-cancel-child", os.Args[len(os.Args)-1])
+	coverageDir := filepath.Join(os.Getenv("GOCOVERDIR"), "child")
+	if err := os.Mkdir(coverageDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cmd.Env = append(os.Environ(), "GOCOVERDIR="+coverageDir)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	output, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(output, make([]byte, len("ready\n"))); err != nil {
+		t.Fatal(err)
+	}
+	os.Exit(0)
 }
 
 func TestRunRetainsWaitAcrossHandoffs(t *testing.T) {

--- a/tools/checklock/queue.go
+++ b/tools/checklock/queue.go
@@ -39,6 +39,7 @@ func acquireValidationLockWithTimeouts(ctx context.Context, path string, stderr 
 	lastPosition := 0
 	var lastOwner instancelock.Owner
 	var lastOwnerStatus instancelock.Status
+	lastActivity := started
 	waiter, err := registerValidationWaiter(ctx, path)
 	if err != nil {
 		return nil, false, fmt.Errorf("register validation waiter after %s: %w", time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
@@ -55,10 +56,10 @@ func acquireValidationLockWithTimeouts(ctx context.Context, path string, stderr 
 	for ctx := ctx; ; {
 		position, size, err := lookupPosition(ctx, path, waiter.name)
 		if err != nil {
-			return nil, waited, fmt.Errorf("wait for validation queue after %s: %w", time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
+			return nil, waited, fmt.Errorf("wait for validation queue after %s (last_position=%d; retry joins queue tail): %w", time.Since(started).Round(time.Millisecond), lastPosition, errors.Join(err, context.Cause(ctx)))
 		}
 		if err := ctx.Err(); err != nil {
-			return nil, waited, fmt.Errorf("validation queue wait ended (position=%d queued=%d waited=%s; validation has not started): %w", position, size, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
+			return nil, waited, fmt.Errorf("validation queue wait ended (position=%d queued=%d waited=%s; validation has not started; retry joins queue tail): %w", position, size, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
 		}
 		if position == 1 {
 			lock, err := instancelock.Acquire(path)
@@ -73,44 +74,65 @@ func acquireValidationLockWithTimeouts(ctx context.Context, path string, stderr 
 		if err != nil {
 			return nil, waited, err
 		}
+		activity, activityKnown := readValidationActivity(path, owner)
 		progress := ""
 		if owner.Status == instancelock.StatusHeld && owner.MetadataError == nil {
 			if (!lastOwner.StartedAt.IsZero() && owner.Owner != lastOwner) || (lastPosition > 0 && lastOwnerStatus != instancelock.StatusHeld) {
 				progress = "owner_handoff"
 			}
-			lastOwner = owner.Owner
 		} else if owner.Status != instancelock.StatusHeld && lastPosition > position {
 			progress = "queue_advanced_without_owner"
+		}
+		if progress == "" && lastPosition > position && owner.Status == instancelock.StatusHeld {
+			progress = "queue_advanced"
+		}
+		if progress == "" && activityKnown && activity.Bytes > 0 && activity.At.After(lastActivity) && owner.Owner == lastOwner {
+			progress = "owner_output"
+		}
+		if activityKnown {
+			lastActivity = activity.At
+		}
+		if owner.MetadataError == nil {
+			lastOwner = owner.Owner
 		}
 		lastPosition = position
 		lastOwnerStatus = owner.Status
 		if err := ctx.Err(); err != nil {
-			return nil, waited, fmt.Errorf("validation queue wait ended (position=%d queued=%d waited=%s; validation has not started): %w", position, size, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
+			return nil, waited, fmt.Errorf("validation queue wait ended (position=%d queued=%d waited=%s; validation has not started; retry joins queue tail): %w", position, size, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
 		}
 		if progress != "" {
 			cancel()
 			ctx, cancel = validationIdleContext(maxCtx, idleTimeout)
 			lastProgress = time.Now()
-			fmt.Fprintf(stderr, "validation queue progress: reason=%s position=%d waited=%s; renewing idle wait budget=%s (total limit=%s)\n", progress, position, time.Since(started).Round(time.Millisecond), idleTimeout, maxTimeout)
+			if progress != "owner_output" || time.Since(lastReport) >= 30*time.Second {
+				fmt.Fprintf(stderr, "validation queue progress: reason=%s position=%d waited=%s; renewing idle wait budget=%s (total limit=%s)\n", progress, position, time.Since(started).Round(time.Millisecond), idleTimeout, maxTimeout)
+			}
 		}
 		diagnostic := fmt.Sprintf("position=%d queued=%d owner=%s", position, size, owner.Status)
 		if owner.Status == instancelock.StatusHeld && owner.MetadataError == nil {
 			diagnostic += fmt.Sprintf(" owner_pid=%d owner_since=%s", owner.Owner.PID, owner.Owner.StartedAt.Format(time.RFC3339Nano))
 		}
-		if diagnostic != lastDiagnostic || time.Since(lastReport) >= 30*time.Second {
+		reportKey := diagnostic
+		if activityKnown {
+			reportKey += activity.Phase
+			diagnostic += fmt.Sprintf(" owner_phase_hint=%s owner_activity_at=%s owner_output_bytes=%d", activity.Phase, activity.At.Format(time.RFC3339Nano), activity.Bytes)
+		} else {
+			diagnostic += " owner_activity=unknown"
+		}
+		if reportKey != lastDiagnostic || time.Since(lastReport) >= 30*time.Second {
 			fmt.Fprintf(stderr, "validation gate waiting: %s waited=%s idle=%s idle_limit=%s total_limit=%s\n", diagnostic, time.Since(started).Round(time.Millisecond), time.Since(lastProgress).Round(time.Millisecond), idleTimeout, maxTimeout)
-			lastDiagnostic = diagnostic
+			lastDiagnostic = reportKey
 			lastReport = time.Now()
 		}
 		waited = true
 		if err := waitValidationPoll(ctx); err != nil {
-			return nil, waited, fmt.Errorf("validation queue wait ended (%s waited=%s; validation has not started): %w", diagnostic, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
+			return nil, waited, fmt.Errorf("validation queue wait ended (%s waited=%s; validation has not started; retry joins queue tail): %w", diagnostic, time.Since(started).Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
 		}
 	}
 }
 
 func validationIdleContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeoutCause(ctx, timeout, fmt.Errorf("no validation owner handoff or unheld queue advancement for %s: %w", timeout, context.DeadlineExceeded))
+	return context.WithTimeoutCause(ctx, timeout, fmt.Errorf("no validation owner handoff, output activity, or queue advancement for %s: %w", timeout, context.DeadlineExceeded))
 }
 
 func registerValidationWaiter(ctx context.Context, path string) (validationWaiter, error) {

--- a/tools/checklock/queue_test.go
+++ b/tools/checklock/queue_test.go
@@ -527,8 +527,9 @@ func TestValidationQueueWaitBudgets(t *testing.T) {
 		wantReason string
 	}{
 		{name: "owner starts after queueing", activity: "owner starts", maxWait: time.Minute, wantWait: 1500 * time.Millisecond, wantReason: "no validation owner handoff"},
+		{name: "owner output appears", activity: "output appears", maxWait: time.Minute, wantWait: 1500 * time.Millisecond, wantReason: "no validation owner handoff"},
 		{name: "live stalled holder", maxWait: time.Minute, wantWait: time.Second, wantReason: "no validation owner handoff"},
-		{name: "queue advancement does not renew stalled holder", activity: "cancel older", maxWait: time.Minute, wantWait: time.Second, wantReason: "no validation owner handoff"},
+		{name: "queue advancement renews held owner wait", activity: "cancel older", maxWait: time.Minute, wantWait: 1500 * time.Millisecond, wantReason: "no validation owner handoff"},
 		{name: "new arrivals do not renew wait", activity: "new waiter", maxWait: time.Minute, wantWait: time.Second, wantReason: "no validation owner handoff"},
 		{name: "handoffs stop at total bound", activity: "handoff", maxWait: 2 * time.Second, wantWait: 2 * time.Second, wantReason: "total queue wait limit reached"},
 		{name: "cancellation after handoff", activity: "cancel", maxWait: time.Minute, wantWait: time.Second, wantReason: "context canceled"},
@@ -560,6 +561,11 @@ func TestValidationQueueWaitBudgets(t *testing.T) {
 						case "owner starts":
 							if calls == 1 {
 								holder = acquireTestLock(t, path)
+							}
+						case "output appears":
+							if calls == 1 {
+								recorder := newValidationActivityRecorder(path, io.Discard)
+								recorder.observe([]byte("test output\n"))
 							}
 						case "handoff", "cancel":
 							if err := holder.Close(); err != nil {
@@ -594,7 +600,7 @@ func TestValidationQueueWaitBudgets(t *testing.T) {
 				if (tt.activity == "handoff" || tt.activity == "cancel" || tt.activity == "owner starts") && !strings.Contains(stderr.String(), "reason=owner_handoff") {
 					t.Fatalf("missing renewal reason: %s", &stderr)
 				}
-				if tt.activity != "handoff" && tt.activity != "cancel" && tt.activity != "owner starts" && strings.Contains(stderr.String(), "renewing") {
+				if tt.activity != "handoff" && tt.activity != "cancel" && tt.activity != "owner starts" && tt.activity != "cancel older" && tt.activity != "output appears" && strings.Contains(stderr.String(), "renewing") {
 					t.Fatalf("non-progress renewed wait: %s", &stderr)
 				}
 				inspection, err := instancelock.Inspect(path)


### PR DESCRIPTION
## Summary

- Preserve a validation waiter's FIFO ticket when the queue advances under a held owner or fresh owner output demonstrates activity. Keep the idle timeout for silent waits, the absolute total-wait bound, and exclusive gate execution.
- Report owner-bound phase hints, activity timestamps, and output byte counts without copying command output. Ignore metadata from previous owners and report unavailable activity explicitly. Timeout diagnostics explain that retrying joins the queue tail.
- Bound post-exit output draining on Unix before process-group cleanup. On Windows, retain the gate until inherited output handles close because descendant cleanup is unavailable.

Phase hints and output do not prove health. Silent owners and older wrappers without activity metadata retain the idle limit; no owner is interrupted when a waiter expires.

Fixes #2425

## UI Surface Contract

- [x] N/A: this change affects command-line validation only.
- [x] No persistent UI messaging is added.
- [x] No primary operator screen changes; browser verification is not applicable.

## Test Plan

- [x] Original implementation fails the deterministic long-held-owner regression despite forward queue movement; the fix retains the ticket through a 35-minute hold.
- [x] Stdlib tests cover silent-owner expiration, total bounds despite output, late/unavailable/stale metadata, FIFO timeout/retry ordering, and inherited-pipe cleanup.
- [x] Focused race tests pass.
- [x] `GOTOOLCHAIN=go1.26.6 make CHECK_LOCK_WAIT=1h check` — passed; 79.8% overall coverage, 89.8% for checklock, all configured floors met.


- [x] Recovery full gate passed on e48324ee in 8m10s after 11m59s queued; Windows regression covers normal and canceled parent exit.
