### PR TITLE
fix(workspace): confirm exit after Windows PEB errors

### DIFF
--- a/internal/workspace/process_inspection.go
+++ b/internal/workspace/process_inspection.go
@@ -1,0 +1,34 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+func scratchProcessInspectionError(ctx context.Context, pid int, operation string, inspectionErr error, alive func(context.Context) (bool, error)) error {
+	ctx, cancel := context.WithTimeoutCause(ctx, 100*time.Millisecond, errors.New("process exit not confirmed within 100ms"))
+	defer cancel()
+	for {
+		if err := context.Cause(ctx); err != nil {
+			inspectionErr = errors.Join(inspectionErr, err)
+			break
+		}
+		running, err := alive(ctx)
+		if err != nil {
+			inspectionErr = errors.Join(inspectionErr, err)
+			break
+		}
+		if !running {
+			return nil
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
+	}
+	return fmt.Errorf("inspect worker %s for process %d: %w", operation, pid, inspectionErr)
+}

--- a/internal/workspace/process_inspection_test.go
+++ b/internal/workspace/process_inspection_test.go
@@ -1,0 +1,62 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestScratchProcessInspectionError(t *testing.T) {
+	inspectionErr := errors.New("cannot read process PEB")
+	observationErr := errors.New("cannot observe process")
+	for _, tt := range []struct {
+		name           string
+		exitAfter      time.Duration
+		observationErr error
+		deadline       time.Duration
+		wantErr        bool
+	}{
+		{name: "already exited"},
+		{name: "exits during teardown", exitAfter: 20 * time.Millisecond},
+		{name: "live inspection defect", exitAfter: time.Hour, wantErr: true},
+		{name: "unverifiable exit", observationErr: observationErr, wantErr: true},
+		{name: "cleanup deadline", exitAfter: time.Hour, deadline: 5 * time.Millisecond, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+				if tt.deadline != 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, tt.deadline)
+					defer cancel()
+				}
+				started := time.Now()
+				err := scratchProcessInspectionError(ctx, 2336, "directory", inspectionErr, func(context.Context) (bool, error) {
+					return time.Since(started) < tt.exitAfter, tt.observationErr
+				})
+				if (err != nil) != tt.wantErr {
+					t.Fatalf("inspection error = %v, want error %t", err, tt.wantErr)
+				}
+				if tt.wantErr && (!errors.Is(err, inspectionErr) || !strings.Contains(err.Error(), "directory for process 2336")) {
+					t.Fatalf("inspection diagnostic lost: %v", err)
+				}
+				if tt.observationErr != nil && !errors.Is(err, tt.observationErr) {
+					t.Fatalf("observation diagnostic lost: %v", err)
+				}
+				if got := errors.Is(err, context.DeadlineExceeded); got != (tt.deadline != 0) {
+					t.Fatalf("caller deadline error = %t, error = %v", got, err)
+				}
+				limit := 100 * time.Millisecond
+				if tt.deadline != 0 {
+					limit = tt.deadline
+				}
+				if elapsed := time.Since(started); elapsed > limit {
+					t.Fatalf("exit confirmation took %v, limit %v", elapsed, limit)
+				}
+			})
+		})
+	}
+}

--- a/internal/workspace/process_windows.go
+++ b/internal/workspace/process_windows.go
@@ -77,18 +77,29 @@ func windowsScratchProcessMatches(ctx context.Context, pid int, root string, own
 	if owner != "" && !strings.EqualFold(username, owner) {
 		return false, nil
 	}
+	alive := func(ctx context.Context) (bool, error) {
+		return windowsScratchProcessAlive(ctx, p.IsRunningWithContext)
+	}
 	environment, err := p.EnvironWithContext(ctx)
 	if err != nil {
-		return false, scratchProcessInspectionError(ctx, pid, "scratch ownership", err, p.IsRunningWithContext)
+		return false, scratchProcessInspectionError(ctx, pid, "scratch ownership", err, alive)
 	}
 	if workerScratchEnvironmentMatches(root, environment) {
 		return true, nil
 	}
 	cwd, err := p.CwdWithContext(ctx)
 	if err != nil {
-		return false, scratchProcessInspectionError(ctx, pid, "directory", err, p.IsRunningWithContext)
+		return false, scratchProcessInspectionError(ctx, pid, "directory", err, alive)
 	}
 	return filepath.IsAbs(cwd) && pathWithin(root, cwd), nil
+}
+
+func windowsScratchProcessAlive(ctx context.Context, observe func(context.Context) (bool, error)) (bool, error) {
+	alive, err := observe(ctx)
+	if errors.Is(err, process.ErrorProcessNotRunning) || errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return false, nil
+	}
+	return alive, err
 }
 
 func reapWorkspaceProcesses(ctx context.Context, path string, logger *slog.Logger) int {

--- a/internal/workspace/process_windows.go
+++ b/internal/workspace/process_windows.go
@@ -3,7 +3,6 @@ package workspace
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -80,22 +79,14 @@ func windowsScratchProcessMatches(ctx context.Context, pid int, root string, own
 	}
 	environment, err := p.EnvironWithContext(ctx)
 	if err != nil {
-		alive, aliveErr := p.IsRunningWithContext(ctx)
-		if aliveErr == nil && !alive {
-			return false, nil
-		}
-		return false, fmt.Errorf("inspect worker scratch ownership for process %d: %w", pid, err)
+		return false, scratchProcessInspectionError(ctx, pid, "scratch ownership", err, p.IsRunningWithContext)
 	}
 	if workerScratchEnvironmentMatches(root, environment) {
 		return true, nil
 	}
 	cwd, err := p.CwdWithContext(ctx)
 	if err != nil {
-		alive, aliveErr := p.IsRunningWithContext(ctx)
-		if aliveErr == nil && !alive {
-			return false, nil
-		}
-		return false, fmt.Errorf("inspect worker directory for process %d: %w", pid, err)
+		return false, scratchProcessInspectionError(ctx, pid, "directory", err, p.IsRunningWithContext)
 	}
 	return filepath.IsAbs(cwd) && pathWithin(root, cwd), nil
 }

--- a/internal/workspace/process_windows_test.go
+++ b/internal/workspace/process_windows_test.go
@@ -1,0 +1,75 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+func TestWindowsScratchInspectionConfirmsProcessExit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestWindowsScratchInspectionHelper$")
+	cmd.Env = append(os.Environ(), "DETENT_WINDOWS_INSPECTION_HELPER=1", "GOCOVERDIR="+t.TempDir())
+	input, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input.Close()
+	output, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	if _, err := io.ReadFull(output, make([]byte, 1)); err != nil {
+		t.Fatalf("wait for readiness: %v", err)
+	}
+	p, err := process.NewProcessWithContext(ctx, int32(cmd.Process.Pid))
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspectionErr := errors.New("cannot read process PEB")
+	for _, exited := range []bool{false, true} {
+		if exited {
+			if err := input.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.Wait(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		err := scratchProcessInspectionError(ctx, cmd.Process.Pid, "directory", inspectionErr, p.IsRunningWithContext)
+		if exited && err != nil {
+			t.Fatalf("exited process inspection: %v", err)
+		}
+		if !exited && !errors.Is(err, inspectionErr) {
+			t.Fatalf("live process lost inspection error: %v", err)
+		}
+	}
+}
+
+func TestWindowsScratchInspectionHelper(t *testing.T) {
+	if os.Getenv("DETENT_WINDOWS_INSPECTION_HELPER") != "1" {
+		return
+	}
+	if _, err := os.Stdout.Write([]byte("r")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(io.Discard, os.Stdin); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/workspace/process_windows_test.go
+++ b/internal/workspace/process_windows_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -10,7 +11,38 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/v4/process"
+	"golang.org/x/sys/windows"
 )
+
+func TestWindowsScratchProcessAlive(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		alive     bool
+		err       error
+		wantAlive bool
+		wantErr   bool
+	}{
+		{name: "live", alive: true, wantAlive: true},
+		{name: "exited"},
+		{name: "not running", err: process.ErrorProcessNotRunning},
+		{name: "vanished pid", err: windows.ERROR_INVALID_PARAMETER},
+		{name: "wrapped vanished pid", err: fmt.Errorf("creation time: %w", windows.ERROR_INVALID_PARAMETER)},
+		{name: "access denied", err: windows.ERROR_ACCESS_DENIED, wantErr: true},
+		{name: "observation failed", err: errors.New("observation failed"), wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			alive, err := windowsScratchProcessAlive(t.Context(), func(context.Context) (bool, error) {
+				return tt.alive, tt.err
+			})
+			if alive != tt.wantAlive || (err != nil) != tt.wantErr {
+				t.Fatalf("alive = %t, error = %v, want %t, error %t", alive, err, tt.wantAlive, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, tt.err) {
+				t.Fatalf("observation error lost: %v", err)
+			}
+		})
+	}
+}
 
 func TestWindowsScratchInspectionConfirmsProcessExit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
@@ -52,7 +84,9 @@ func TestWindowsScratchInspectionConfirmsProcessExit(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		err := scratchProcessInspectionError(ctx, cmd.Process.Pid, "directory", inspectionErr, p.IsRunningWithContext)
+		err := scratchProcessInspectionError(ctx, cmd.Process.Pid, "directory", inspectionErr, func(ctx context.Context) (bool, error) {
+			return windowsScratchProcessAlive(ctx, p.IsRunningWithContext)
+		})
 		if exited && err != nil {
 			t.Fatalf("exited process inspection: %v", err)
 		}


### PR DESCRIPTION
## Summary

- After Windows worker ownership or directory inspection fails, allow a bounded 100 ms window to confirm that the same process exited. Treat recognized vanished-PID probe errors as confirmed exit. Retain the original error if the process stays alive or its state cannot be inspected; include observation failures in the diagnostic.
- Keep the outer cleanup deadline, ownership checks, identity checks, and termination behavior intact. Add deterministic tests for delayed exit, persistent failure, observation failure, and caller deadline, plus Windows vanished-PID error classification and real-process live/exited coverage. Retain escaped-descendant and unrelated-process lifecycle tests.
- The original CI log confirms PID 2336's PEB read failure but does not identify the process or record its exit state. The single-check policy rejects the controlled teardown sequence; this does not prove the historical PID's cause. Persistent inspection defects continue to fail visibly.

Fixes #2436

## UI Surface Contract

- [x] N/A — no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — no visual changes to primary operator screens.

## Test Plan

- [x] `make check` — passed; 80.5% overall coverage, 74.3% workspace coverage, package/file floors met. Final review-fix validation ran 7m53s after the shared-lock wait (`CHECK_LOCK_WAIT=60m`).
- [x] Focused workspace and CLI race tests, including scratch descendant cleanup and unrelated-process isolation.
- [x] Deterministic inspection policy tests repeated 20 times under the race detector; delayed-exit case fails with the old single-check policy.
- [x] Windows amd64 workspace test cross-build and `go vet`.
- [x] All current-head CI passed: [run 34430629875](https://github.com/digitaldrywood/detent/actions/runs/34430629875). Windows logs confirm the CLI routing fixture, deterministic inspection policy, vanished-PID classification, real-process exit confirmation, and escaped-descendant isolation tests all passed.
