### PR TITLE
docs(agents): declare mechanism moratorium

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,23 @@ Concurrency, recovery, routing, multiple files, or a new endpoint alone do not
 justify higher effort. Preserve intentional operator exceptions. Configured
 complexity levels default to low; verify any approved exception against the
 runtime effort ceiling rather than raising broad defaults.
+
+## Mechanism moratorium
+
+Effective 2026-09-10 until the operator lifts it. Detent has grown a large set
+of interacting self-protection mechanisms (brakes, breakers, leases, parks,
+recovery sweeps, revocations, reconcilers). Their interactions are now the main
+source of incidents.
+
+- Do not add a new brake, breaker, lease, park, recovery path, revocation,
+  reason code, or reconciliation loop.
+- A fix for a misbehaving mechanism must remove or consolidate a mechanism, or
+  state in the PR why it cannot. "Add a guard for the new case" is not a fix.
+- Infrastructure failures (backend startup, protocol errors, workspace hooks)
+  are attributed to the instance, never to the issue.
+- The orchestrator is the only writer of tracker lane state; workers report
+  outcomes and never write lane labels.
+- Do not add configuration keys, CLI subcommands, or dashboard surfaces to work
+  around a mechanism. Fix the mechanism.
+- Machine-filed issues carry an origin stamp and a fingerprint; never file a
+  duplicate of an open issue, comment on it instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,26 @@ justify higher effort. Preserve intentional operator exceptions. Configured
 complexity levels default to low; verify any approved exception against the
 runtime effort ceiling rather than raising broad defaults.
 
+## Mechanism moratorium
+
+Effective 2026-09-10 until the operator lifts it. Detent has grown a large set
+of interacting self-protection mechanisms (brakes, breakers, leases, parks,
+recovery sweeps, revocations, reconcilers). Their interactions are now the main
+source of incidents.
+
+- Do not add a new brake, breaker, lease, park, recovery path, revocation,
+  reason code, or reconciliation loop.
+- A fix for a misbehaving mechanism must remove or consolidate a mechanism, or
+  state in the PR why it cannot. "Add a guard for the new case" is not a fix.
+- Infrastructure failures (backend startup, protocol errors, workspace hooks)
+  are attributed to the instance, never to the issue.
+- The orchestrator is the only writer of tracker lane state; workers report
+  outcomes and never write lane labels.
+- Do not add configuration keys, CLI subcommands, or dashboard surfaces to work
+  around a mechanism. Fix the mechanism.
+- Machine-filed issues carry an origin stamp and a fingerprint; never file a
+  duplicate of an open issue, comment on it instead.
+
 ## Validation
 
 - `make check` is the local pre-review gate.


### PR DESCRIPTION
## Summary

- Add a Mechanism moratorium section to `AGENTS.md` and `CLAUDE.md`: no new brakes, breakers, leases, parks, recovery paths, revocations, reason codes, or reconciliation loops; fixes must remove or consolidate a mechanism; infra failures attribute to the instance; the orchestrator is the sole lane writer; machine-filed issues carry origin and fingerprint.
- Operator decision from the 2026-09-10 audit. Companion issues: #2440 #2441 #2442 #2443 #2444.

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] Documentation-only change; no code paths touched.

https://claude.ai/code/session_01PK61Vw2Gr7EMRGtKohPXrw