### PR TITLE
fix(codex): normalize turn sandbox policy types

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -999,8 +999,8 @@
 #       repository: null
 #   # codex.thread_sandbox | type: string | default: "workspace-write" | required: No | validation: None
 #   thread_sandbox: "workspace-write"
-#   # codex.turn_sandbox_policy | type: mapping<string, value> | default: {} | required: No | validation: None
-#   turn_sandbox_policy: {}
+#   # codex.turn_sandbox_policy | type: mapping<string, value> | default: {"type":"workspaceWrite"} | required: No | validation: None
+#   turn_sandbox_policy: {"type":"workspaceWrite"}
 #   # codex.turn_timeout_ms | type: integer | default: 3600000 | required: No | validation: must be greater than 0
 #   turn_timeout_ms: 3600000
 #   # codex.read_timeout_ms | type: integer | default: 5000 | required: No | validation: must be greater than 0

--- a/docs/config.md
+++ b/docs/config.md
@@ -1061,7 +1061,7 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `codex.shell` | `string` | `platform default shell` | No | None |
 | `codex.stall_timeout_ms` | `integer` | `300000` | No | must be greater than or equal to 0 |
 | `codex.thread_sandbox` | `string` | `"workspace-write"` | No | None |
-| `codex.turn_sandbox_policy` | `mapping<string, value>` | `{}` | No | None |
+| `codex.turn_sandbox_policy` | `mapping<string, value>` | `{"type":"workspaceWrite"}` | No | None |
 | `codex.turn_timeout_ms` | `integer` | `3600000` | No | must be greater than 0 |
 | `deliverable` | `object` | `see child fields` | No | None |
 | `deliverable.kind` | `string` | `"pull_request"` | No | must be one of pull_request, artifact |

--- a/internal/cli/doctor_project_definition_test.go
+++ b/internal/cli/doctor_project_definition_test.go
@@ -147,3 +147,32 @@ func doctorProjectDefinitionConfig(t *testing.T, sourceRoot string) []byte {
 	}
 	return raw
 }
+
+func TestDoctorSandboxPolicySource(t *testing.T) {
+	t.Parallel()
+	for _, filename := range []string{"detent.yaml", "detent.local.yaml"} {
+		t.Run(filename, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			workflowPath := filepath.Join(dir, "WORKFLOW.md")
+			for name, body := range map[string]string{
+				"WORKFLOW.md": "Instructions.\n",
+				"detent.yaml": "schema: 1\ntracker:\n  kind: memory\n",
+			} {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			source := filepath.Join(dir, filename)
+			if err := os.WriteFile(source, []byte("schema: 1\ncodex:\n  turn_sandbox_policy: {type: invalid}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			deps := successfulDoctorDeps()
+			deps.loadWorkflow = workflowconfig.LoadWorkflow
+			checks := checkDoctorProject(t.Context(), globalconfig.Project{ID: "alpha", Workflow: workflowPath, Workdir: dir}, deps, RuntimeSecret{}, false)
+			if len(checks) == 0 || checks[0].Status != doctorFail || !strings.Contains(checks[0].Detail, source) || !strings.Contains(checks[0].Detail, "turn_sandbox_policy.type") {
+				t.Fatalf("checks = %#v, want invalid sandbox policy failure naming %s", checks, source)
+			}
+		})
+	}
+}

--- a/internal/codex/sandbox.go
+++ b/internal/codex/sandbox.go
@@ -36,30 +36,18 @@ func OptionsFromConfig(cfg config.CodexOptions) Options {
 }
 
 func turnSandboxPolicyForWorkspace(threadSandbox string, policy any, extraWritableRoots []string) any {
-	policyMap, ok := workspaceWriteSandboxPolicyMap(threadSandbox, policy)
-	if !ok {
-		return policy
-	}
-	if len(extraWritableRoots) == 0 {
-		return policy
-	}
-	return mergeSandboxWritableRoots(policyMap, extraWritableRoots)
-}
-
-func workspaceWriteSandboxPolicyMap(threadSandbox string, policy any) (map[string]any, bool) {
 	policyMap, ok := sandboxPolicyMap(policy)
 	if !ok {
-		return nil, false
+		return policy
 	}
-	policyKind := strings.TrimSpace(policyType(policyMap))
-	if isWorkspaceWriteSandboxName(policyKind) {
-		return policyMap, true
+	policyMap = config.NormalizeTurnSandboxPolicy(threadSandbox, policyMap)
+	if len(extraWritableRoots) > 0 && isWorkspaceWriteSandboxName(policyType(policyMap)) {
+		return mergeSandboxWritableRoots(policyMap, extraWritableRoots)
 	}
-	if policyKind != "" || !isWorkspaceWriteSandboxName(threadSandbox) {
-		return nil, false
+	if policy == nil {
+		return nil
 	}
-	policyMap["type"] = "workspaceWrite"
-	return policyMap, true
+	return policyMap
 }
 
 func sandboxPolicyMap(policy any) (map[string]any, bool) {

--- a/internal/codex/sandbox_test.go
+++ b/internal/codex/sandbox_test.go
@@ -1,6 +1,8 @@
 package codex
 
 import (
+	"fmt"
+	"maps"
 	"reflect"
 	"testing"
 	"time"
@@ -42,7 +44,7 @@ func TestTurnSandboxPolicyForWorkspaceMergesExtraWritableRoots(t *testing.T) {
 	}
 }
 
-func TestWorkspaceWriteSandboxPolicyMapSkipsExplicitNonWorkspacePolicy(t *testing.T) {
+func TestTurnSandboxPolicyPreservesExplicitNonWorkspacePolicy(t *testing.T) {
 	t.Parallel()
 
 	policy := map[string]any{
@@ -50,9 +52,9 @@ func TestWorkspaceWriteSandboxPolicyMapSkipsExplicitNonWorkspacePolicy(t *testin
 		"networkAccess": true,
 	}
 
-	got, ok := workspaceWriteSandboxPolicyMap("workspace-write", policy)
-	if ok {
-		t.Fatalf("workspaceWriteSandboxPolicyMap() = %#v, true; want false for explicit non-workspace policy", got)
+	got := turnSandboxPolicyForWorkspace("workspace-write", policy, []string{"/extra"})
+	if !reflect.DeepEqual(got, policy) {
+		t.Fatalf("turnSandboxPolicyForWorkspace() = %#v; want explicit non-workspace policy", got)
 	}
 	if policy["type"] != "dangerFullAccess" {
 		t.Fatalf("policy type = %#v, want dangerFullAccess", policy["type"])
@@ -105,5 +107,41 @@ func TestOptionsFromConfigClonesApprovalPolicy(t *testing.T) {
 	}
 	if options.StallTimeout != 1250*time.Millisecond {
 		t.Fatalf("StallTimeout = %v, want 1.25s", options.StallTimeout)
+	}
+}
+
+func TestTurnSandboxPolicyTypes(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct{ thread, kind string }{
+		{"workspace-write", "workspaceWrite"},
+		{"danger-full-access", "dangerFullAccess"},
+		{"read-only", "readOnly"},
+	} {
+		for _, explicit := range []bool{false, true} {
+			for _, roots := range [][]string{nil, {"/extra"}} {
+				t.Run(fmt.Sprintf("%s/explicit=%t/roots=%d", tt.thread, explicit, len(roots)), func(t *testing.T) {
+					t.Parallel()
+					policy := map[string]any{"networkAccess": false}
+					if explicit {
+						policy["type"] = tt.kind
+					}
+					original := maps.Clone(policy)
+					got, ok := turnSandboxPolicyForWorkspace(tt.thread, policy, roots).(map[string]any)
+					if !ok || got["type"] != tt.kind || got["networkAccess"] != false {
+						t.Fatalf("policy = %#v, want type %s and networkAccess false", got, tt.kind)
+					}
+					if tt.kind == "workspaceWrite" && len(roots) > 0 {
+						if !reflect.DeepEqual(got["writableRoots"], roots) {
+							t.Fatalf("roots = %#v, want %v", got["writableRoots"], roots)
+						}
+					} else if _, exists := got["writableRoots"]; exists {
+						t.Fatalf("unexpected writableRoots: %#v", got)
+					}
+					if !reflect.DeepEqual(policy, original) {
+						t.Fatalf("input mutated: %#v", policy)
+					}
+				})
+			}
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -635,6 +635,7 @@ type Codex struct {
 	TurnTimeoutMS                   int                          `yaml:"turn_timeout_ms"`
 	ReadTimeoutMS                   int                          `yaml:"read_timeout_ms"`
 	StallTimeoutMS                  int                          `yaml:"stall_timeout_ms"`
+	turnSandboxPolicyTypeInferred   bool
 }
 
 func (c Config) AgentBackendConfigs() []AgentBackend {
@@ -698,6 +699,10 @@ func CodexAgentBackend(codex Codex) AgentBackend {
 
 func mergedCodexAgentBackend(fallback Codex, backend AgentBackend) AgentBackend {
 	cfg := fallback
+	if fallback.turnSandboxPolicyTypeInferred {
+		cfg.TurnSandboxPolicy = maps.Clone(fallback.TurnSandboxPolicy)
+		delete(cfg.TurnSandboxPolicy, "type")
+	}
 	if strings.TrimSpace(backend.Command) != "" {
 		cfg.Command = strings.TrimSpace(backend.Command)
 	}
@@ -1853,6 +1858,9 @@ func (c *Config) normalize() {
 	}
 	c.Agent.Knowledge.Normalize()
 	c.Agents.normalize()
+	if _, explicit := c.Codex.TurnSandboxPolicy["type"]; !explicit && c.Codex.TurnSandboxPolicy != nil {
+		c.Codex.turnSandboxPolicyTypeInferred = true
+	}
 	c.Codex.TurnSandboxPolicy = NormalizeTurnSandboxPolicy(c.Codex.ThreadSandbox, c.Codex.TurnSandboxPolicy)
 	c.Codex.Shell = commandshell.Normalize(c.Codex.Shell)
 	c.Codex.ModelProvider = strings.TrimSpace(c.Codex.ModelProvider)
@@ -2565,7 +2573,8 @@ func validateSandboxPolicyNodes(node *yaml.Node) error {
 		return err
 	}
 	for i, backend := range source.Agents.Backends {
-		if backend.Kind != "" && backend.Kind != AgentBackendCodex {
+		kind := strings.ToLower(strings.TrimSpace(backend.Kind))
+		if kind != "" && kind != AgentBackendCodex {
 			continue
 		}
 		if err := validate(fmt.Sprintf("agents.backends[%d].options", i), backend.Options.Policy); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -676,7 +677,7 @@ func CodexAgentBackend(codex Codex) AgentBackend {
 		ApprovalPolicy:                  codex.ApprovalPolicy,
 		DeliverableElicitationAllowlist: append([]DeliverableElicitationRule(nil), codex.DeliverableElicitationAllowlist...),
 		ThreadSandbox:                   codex.ThreadSandbox,
-		TurnSandboxPolicy:               codex.TurnSandboxPolicy,
+		TurnSandboxPolicy:               NormalizeTurnSandboxPolicy(codex.ThreadSandbox, codex.TurnSandboxPolicy),
 		TurnTimeoutMS:                   codex.TurnTimeoutMS,
 		ReadTimeoutMS:                   codex.ReadTimeoutMS,
 		StallTimeoutMS:                  codex.StallTimeoutMS,
@@ -1217,7 +1218,7 @@ func ParseWorkflowOverlay(sharedRaw []byte, localRaw []byte, localPath string) (
 	}
 	localRoot, localPrompt, err := parseWorkflowDocument(localRaw)
 	if err != nil {
-		return Workflow{}, fmt.Errorf("parse local workflow overlay: %w", err)
+		return Workflow{}, fmt.Errorf("parse local workflow overlay %s: %w", localPath, err)
 	}
 
 	if sharedRoot == nil {
@@ -1268,6 +1269,9 @@ func parseWorkflowDocument(raw []byte) (*yaml.Node, []byte, error) {
 	}
 	if root.Kind != yaml.MappingNode {
 		return nil, nil, errors.New("workflow frontmatter must be a mapping")
+	}
+	if err := validateSandboxPolicyNodes(root); err != nil {
+		return nil, nil, err
 	}
 	return root, prompt, nil
 }
@@ -1849,6 +1853,7 @@ func (c *Config) normalize() {
 	}
 	c.Agent.Knowledge.Normalize()
 	c.Agents.normalize()
+	c.Codex.TurnSandboxPolicy = NormalizeTurnSandboxPolicy(c.Codex.ThreadSandbox, c.Codex.TurnSandboxPolicy)
 	c.Codex.Shell = commandshell.Normalize(c.Codex.Shell)
 	c.Codex.ModelProvider = strings.TrimSpace(c.Codex.ModelProvider)
 	c.Codex.ServiceTier = strings.TrimSpace(c.Codex.ServiceTier)
@@ -2491,7 +2496,89 @@ func (o *CodexOptions) normalize() {
 	o.DeliverableElicitationAllowlist = normalizeDeliverableElicitationRules(o.DeliverableElicitationAllowlist)
 }
 
+func NormalizeTurnSandboxPolicy(threadSandbox string, policy map[string]any) map[string]any {
+	if _, exists := policy["type"]; exists || policy == nil {
+		return policy
+	}
+	var kind string
+	switch strings.TrimSpace(threadSandbox) {
+	case "workspace-write":
+		kind = "workspaceWrite"
+	case "danger-full-access":
+		kind = "dangerFullAccess"
+	case "read-only":
+		kind = "readOnly"
+	default:
+		return policy
+	}
+	normalized := maps.Clone(policy)
+	normalized["type"] = kind
+	return normalized
+}
+
+func validateTurnSandboxPolicy(policy map[string]any) error {
+	value, exists := policy["type"]
+	if !exists {
+		return nil
+	}
+	switch value {
+	case "workspaceWrite", "dangerFullAccess", "readOnly", "externalSandbox":
+		return nil
+	default:
+		return fmt.Errorf("turn_sandbox_policy.type must be workspaceWrite, dangerFullAccess, readOnly, or externalSandbox; got %v", value)
+	}
+}
+
+func validateSandboxPolicyNodes(node *yaml.Node) error {
+	if node == nil {
+		return nil
+	}
+	type sandboxOptions struct {
+		Policy any `yaml:"turn_sandbox_policy"`
+	}
+	var source struct {
+		Codex  sandboxOptions `yaml:"codex"`
+		Agents struct {
+			Backends []struct {
+				Kind    string         `yaml:"kind"`
+				Options sandboxOptions `yaml:"options"`
+			} `yaml:"backends"`
+		} `yaml:"agents"`
+	}
+	if err := node.Decode(&source); err != nil {
+		return err
+	}
+	validate := func(path string, value any) error {
+		if value == nil {
+			return nil
+		}
+		policy, ok := value.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.turn_sandbox_policy must be an object such as {type: workspaceWrite, networkAccess: false}", path)
+		}
+		if err := validateTurnSandboxPolicy(policy); err != nil {
+			return fmt.Errorf("%s.%w", path, err)
+		}
+		return nil
+	}
+	if err := validate("codex", source.Codex.Policy); err != nil {
+		return err
+	}
+	for i, backend := range source.Agents.Backends {
+		if backend.Kind != "" && backend.Kind != AgentBackendCodex {
+			continue
+		}
+		if err := validate(fmt.Sprintf("agents.backends[%d].options", i), backend.Options.Policy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (o CodexOptions) validate(prefix string, problems *[]string) {
+	if err := validateTurnSandboxPolicy(o.TurnSandboxPolicy); err != nil {
+		*problems = append(*problems, prefix+"."+err.Error())
+	}
 	validateDeliverableElicitationRules(prefix+".deliverable_elicitation_allowlist", o.DeliverableElicitationAllowlist, problems)
 	if o.ModelProvider != "" && !validAgentIdentityLabel(o.ModelProvider) {
 		*problems = append(*problems, prefix+".model_provider must be a sanitized label containing only letters, numbers, dots, underscores, or hyphens")
@@ -2735,6 +2822,9 @@ func (b *Budget) validate(prefix string, problems *[]string) {
 }
 
 func (c *Codex) validate(problems *[]string) {
+	if err := validateTurnSandboxPolicy(c.TurnSandboxPolicy); err != nil {
+		*problems = append(*problems, "codex."+err.Error())
+	}
 	validateDeliverableElicitationRules("codex.deliverable_elicitation_allowlist", c.DeliverableElicitationAllowlist, problems)
 	if strings.TrimSpace(c.Command) == "" {
 		*problems = append(*problems, "codex.command is required")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4539,3 +4539,90 @@ func TestCheckpointIntervalConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadWorkflowSandboxPolicy(t *testing.T) {
+	t.Parallel()
+	for _, layout := range []string{"legacy", "split"} {
+		for _, overlay := range []bool{false, true} {
+			for _, tt := range []struct{ name, policy, kind, wantError string }{
+				{"partial", "{networkAccess: false}", "dangerFullAccess", ""},
+				{"explicit", "{type: readOnly}", "readOnly", ""},
+				{"external", "{type: externalSandbox}", "externalSandbox", ""},
+				{"invalid", "{type: workspace-write}", "", "turn_sandbox_policy.type"},
+				{"empty type", "{type: ''}", "", "turn_sandbox_policy.type"},
+				{"null type", "{type: null}", "", "turn_sandbox_policy.type"},
+				{"numeric type", "{type: 42}", "", "turn_sandbox_policy.type"},
+				{"list type", "{type: []}", "", "turn_sandbox_policy.type"},
+				{"string", "workspace-write", "", "must be an object"},
+			} {
+				t.Run(fmt.Sprintf("%s/overlay=%t/%s", layout, overlay, tt.name), func(t *testing.T) {
+					t.Parallel()
+					dir := t.TempDir()
+					workflowPath := filepath.Join(dir, "WORKFLOW.md")
+					basePath, localPath := workflowPath, LocalWorkflowPath(workflowPath)
+					wrap := func(body string) string { return "---\n" + body + "---\nInstructions.\n" }
+					if layout == "split" {
+						basePath, localPath = DefinitionPath(workflowPath), LocalDefinitionPath(workflowPath)
+						wrap = func(body string) string { return "schema: 1\n" + body }
+						if err := os.WriteFile(workflowPath, []byte("Instructions.\n"), 0o600); err != nil {
+							t.Fatal(err)
+						}
+					}
+					base := "tracker:\n  kind: memory\ncodex:\n  thread_sandbox: danger-full-access\n"
+					policy := "  turn_sandbox_policy: " + tt.policy + "\n"
+					offendingPath := basePath
+					if overlay {
+						offendingPath = localPath
+						if err := os.WriteFile(localPath, []byte(wrap("codex:\n"+policy)), 0o600); err != nil {
+							t.Fatal(err)
+						}
+					} else {
+						base += policy
+					}
+					if err := os.WriteFile(basePath, []byte(wrap(base)), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					workflow, err := LoadWorkflow(workflowPath)
+					if tt.wantError != "" {
+						if err == nil || !strings.Contains(err.Error(), tt.wantError) || !strings.Contains(err.Error(), offendingPath) {
+							t.Fatalf("LoadWorkflow() error = %v, want %q and %q", err, tt.wantError, offendingPath)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got := workflow.Config.Codex.TurnSandboxPolicy["type"]; got != tt.kind {
+						t.Fatalf("type = %v, want %s", got, tt.kind)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestBackendSandboxPolicy(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct{ name, policy, wantError string }{
+		{"partial", "{networkAccess: false}", ""},
+		{"invalid", "{type: invalid}", "turn_sandbox_policy.type"},
+		{"string", "workspace-write", "must be an object"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow, err := ParseWorkflow([]byte("---\ncodex:\n  thread_sandbox: danger-full-access\nagents:\n  backends:\n    - id: primary\n      kind: codex\n      options:\n        turn_sandbox_policy: " + tt.policy + "\n---\nInstructions.\n"))
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error = %v, want %s", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := workflow.Config.AgentBackendConfigs()[0].CodexOptions().TurnSandboxPolicy["type"]; got != "dangerFullAccess" {
+				t.Fatalf("type = %v, want dangerFullAccess", got)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4603,14 +4603,15 @@ func TestLoadWorkflowSandboxPolicy(t *testing.T) {
 
 func TestBackendSandboxPolicy(t *testing.T) {
 	t.Parallel()
-	for _, tt := range []struct{ name, policy, wantError string }{
-		{"partial", "{networkAccess: false}", ""},
-		{"invalid", "{type: invalid}", "turn_sandbox_policy.type"},
-		{"string", "workspace-write", "must be an object"},
+	for _, tt := range []struct{ name, kind, policy, wantError string }{
+		{"partial", "codex", "{networkAccess: false}", ""},
+		{"invalid", "codex", "{type: invalid}", "turn_sandbox_policy.type"},
+		{"normalized kind", "CODEX", "{type: invalid}", "turn_sandbox_policy.type"},
+		{"string", "codex", "workspace-write", "must be an object"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			workflow, err := ParseWorkflow([]byte("---\ncodex:\n  thread_sandbox: danger-full-access\nagents:\n  backends:\n    - id: primary\n      kind: codex\n      options:\n        turn_sandbox_policy: " + tt.policy + "\n---\nInstructions.\n"))
+			workflow, err := ParseWorkflow([]byte("---\ncodex:\n  thread_sandbox: danger-full-access\nagents:\n  backends:\n    - id: primary\n      kind: " + tt.kind + "\n      options:\n        turn_sandbox_policy: " + tt.policy + "\n---\nInstructions.\n"))
 			if tt.wantError != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
 					t.Fatalf("error = %v, want %s", err, tt.wantError)
@@ -4622,6 +4623,34 @@ func TestBackendSandboxPolicy(t *testing.T) {
 			}
 			if got := workflow.Config.AgentBackendConfigs()[0].CodexOptions().TurnSandboxPolicy["type"]; got != "dangerFullAccess" {
 				t.Fatalf("type = %v, want dangerFullAccess", got)
+			}
+		})
+	}
+}
+
+func TestBackendThreadSandboxOverridesInferredPolicy(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct{ name, thread, policy, want, globalKind string }{
+		{"inferred workspace", "workspace-write", "{networkAccess: false}", "readOnly", "workspaceWrite"},
+		{"inferred full access", "danger-full-access", "{networkAccess: false}", "readOnly", "dangerFullAccess"},
+		{"explicit workspace", "workspace-write", "{type: workspaceWrite, networkAccess: false}", "workspaceWrite", "workspaceWrite"},
+		{"explicit full access", "danger-full-access", "{type: dangerFullAccess, networkAccess: false}", "dangerFullAccess", "dangerFullAccess"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow, err := ParseWorkflow([]byte("---\ncodex:\n  thread_sandbox: " + tt.thread + "\n  turn_sandbox_policy: " + tt.policy + "\nagents:\n  backends:\n    - id: primary\n      kind: codex\n      options:\n        thread_sandbox: read-only\n---\nInstructions.\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			options := workflow.Config.AgentBackendConfigs()[0].CodexOptions()
+			if got := options.TurnSandboxPolicy["type"]; got != tt.want {
+				t.Fatalf("type = %v, want %s", got, tt.want)
+			}
+			if options.TurnSandboxPolicy["networkAccess"] != false {
+				t.Fatalf("policy = %#v, want networkAccess false", options.TurnSandboxPolicy)
+			}
+			if workflow.Config.Codex.TurnSandboxPolicy["type"] != tt.globalKind {
+				t.Fatal("global policy changed")
 			}
 		})
 	}

--- a/internal/config/project_definition.go
+++ b/internal/config/project_definition.go
@@ -331,6 +331,20 @@ func parseLegacyProjectDefinition(
 	shared projectWorkflowDocument,
 	local projectWorkflowDocument,
 ) (Workflow, error) {
+	for _, source := range []struct {
+		raw  []byte
+		path string
+	}{
+		{legacyWorkflowBytes(shared), sources.WorkflowPath},
+		{legacyWorkflowBytes(local), sources.LocalWorkflowPath},
+	} {
+		if source.path == sources.LocalWorkflowPath && !sources.HasLocalWorkflow {
+			continue
+		}
+		if _, _, err := parseWorkflowDocument(source.raw); err != nil {
+			return Workflow{}, fmt.Errorf("parse %s: %w", source.path, err)
+		}
+	}
 	sharedRaw := legacyWorkflowBytes(shared)
 	if !sources.HasLocalWorkflow {
 		return ParseWorkflow(sharedRaw)
@@ -441,6 +455,9 @@ func parseSchemaConfig(raw []byte, path string) (*yaml.Node, error) {
 			schema,
 			ProjectDefinitionSchema,
 		)
+	}
+	if err := validateSandboxPolicyNodes(root); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", displayDefinitionPath(path, "detent.yaml"), err)
 	}
 	root.Content = append(root.Content[:index], root.Content[index+2:]...)
 	return root, nil


### PR DESCRIPTION
## Summary

- Normalize partial Codex turn sandbox policies from the effective thread sandbox after backend overrides, including turns without extra writable roots. Preserve explicit types and only merge roots for workspace-write policies.
- Reject invalid policy types and string policies during config loading, with the offending base or overlay file in the error. Doctor uses the same validation.
- Add table-driven runtime, config, backend-option, and doctor regression tests; refresh the generated config reference.

Fixes #2440

## UI Surface Contract

- [x] N/A: no UI surface or layout changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Reproduced the missing-type failure with a regression test before implementation.
- [x] Focused sandbox, config loading, backend options, doctor, and explicit-versus-inferred policy inheritance tests.
- [x] `make generate` and config reference consistency tests.
- [x] `make check`
