### PR TITLE
fix(codex): isolate worker global instructions

### DIFF
--- a/.detent/skills/unprivileged-windows-profile-links.md
+++ b/.detent/skills/unprivileged-windows-profile-links.md
@@ -1,0 +1,12 @@
+---
+name: unprivileged-windows-profile-links
+description: Share files and directories in an isolated Windows profile without requiring symbolic-link privileges.
+when_to_use: A profile or workspace mirroring change works in elevated CI but fails for ordinary Windows accounts when os.Symlink requires Developer Mode or elevation.
+---
+
+- Keep symbolic links on platforms that support them without extra privileges. On Windows, use hard links for same-volume files and directory junctions for directories when shared identity is required.
+- Prefer native junction creation to introducing shell startup into a previously filesystem-only initialization path. Encode the mount-point reparse buffer with byte offsets and UTF-16 lengths, and use FSCTL_SET_REPARSE_POINT on a directory opened with OPEN_REPARSE_POINT and BACKUP_SEMANTICS.
+- Close the native handle on every path and remove only the newly created empty junction directory if initialization fails.
+- Hard links preserve file identity but do not follow atomic replacement of the source pathname. Refresh stale links during profile preparation and test that replacement explicitly.
+- Test shared identity with os.SameFile rather than requiring ModeSymlink or Readlink. Include repeated preparation, file replacement, directory access, and paths containing spaces and non-ASCII characters. Run junction tests on Windows; cross-compilation alone does not verify runtime behavior.
+- Filter reserved filenames using case-insensitive comparisons when exclusion must also hold on default macOS and Windows filesystems. Test the actual profile directory contents, including migration of older links.

--- a/internal/cli/codex_profile_junction_other.go
+++ b/internal/cli/codex_profile_junction_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package cli
+
+import "errors"
+
+func createCodexProfileJunction(string, string) error {
+	return errors.New("codex directory junctions require Windows")
+}

--- a/internal/cli/codex_profile_junction_windows.go
+++ b/internal/cli/codex_profile_junction_windows.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func createCodexProfileJunction(source string, destination string) error {
+	absolute, err := filepath.Abs(source)
+	if err != nil {
+		return err
+	}
+	target := `\??\` + strings.TrimPrefix(absolute, `\\?\`)
+	if strings.HasPrefix(absolute, `\\`) && !strings.HasPrefix(absolute, `\\?\`) {
+		target = `\??\UNC\` + strings.TrimPrefix(absolute, `\\`)
+	}
+	encoded, err := windows.UTF16FromString(target)
+	if err != nil {
+		return err
+	}
+	data := make([]byte, 16+len(encoded)*2+2)
+	if len(data) > windows.MAXIMUM_REPARSE_DATA_BUFFER_SIZE {
+		return fmt.Errorf("codex junction target is too long: %s", source)
+	}
+	binary.LittleEndian.PutUint32(data[0:4], windows.IO_REPARSE_TAG_MOUNT_POINT)
+	binary.LittleEndian.PutUint16(data[4:6], uint16(len(data)-8))
+	binary.LittleEndian.PutUint16(data[10:12], uint16((len(encoded)-1)*2))
+	binary.LittleEndian.PutUint16(data[12:14], uint16(len(encoded)*2))
+	for index, value := range encoded {
+		binary.LittleEndian.PutUint16(data[16+index*2:], value)
+	}
+	path, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	if err := os.Mkdir(destination, 0o700); err != nil {
+		return fmt.Errorf("create Codex junction directory: %w", err)
+	}
+	handle, err := windows.CreateFile(path, windows.GENERIC_WRITE, 0, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		return errors.Join(fmt.Errorf("open Codex junction directory: %w", err), os.Remove(destination))
+	}
+	var returned uint32
+	setErr := windows.DeviceIoControl(handle, windows.FSCTL_SET_REPARSE_POINT, &data[0], uint32(len(data)), nil, 0, &returned, nil)
+	closeErr := windows.CloseHandle(handle)
+	if setErr != nil {
+		return errors.Join(fmt.Errorf("set Codex junction target: %w", setErr), closeErr, os.Remove(destination))
+	}
+	return closeErr
+}

--- a/internal/cli/codex_service_profile.go
+++ b/internal/cli/codex_service_profile.go
@@ -90,8 +90,15 @@ func prepareWorkerCodexHome(sourceHome string, userHome string, isLaunchd bool) 
 	if err := ensureLaunchdCodexProfile(profileHome); err != nil {
 		return "", nil, err
 	}
-	for _, name := range []string{"AGENTS.md", "AGENTS.override.md"} {
-		path := filepath.Join(profileHome, name)
+	profileEntries, err := os.ReadDir(profileHome)
+	if err != nil {
+		return "", nil, fmt.Errorf("read worker Codex profile: %w", err)
+	}
+	for _, entry := range profileEntries {
+		if !codexInstructionFilename(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(profileHome, entry.Name())
 		local, err := removeManagedProfileLink(path)
 		if err != nil {
 			return "", nil, err
@@ -105,7 +112,7 @@ func prepareWorkerCodexHome(sourceHome string, userHome string, isLaunchd bool) 
 		return "", nil, fmt.Errorf("read Codex home %s: %w", sourceHome, err)
 	}
 	for _, entry := range entries {
-		if entry.Name() == "AGENTS.md" || entry.Name() == "AGENTS.override.md" ||
+		if codexInstructionFilename(entry.Name()) ||
 			entry.Name() == workerCodexProfileDir || entry.Name() == launchdCodexProfileDir ||
 			(isLaunchd && entry.Name() == "skills") {
 			continue
@@ -221,7 +228,15 @@ func rejectProtectedAgentSkills(userHome string) error {
 	return fmt.Errorf("launchd cannot access protected ~/.agents/skills links: %s", strings.Join(protected, ", "))
 }
 
+func codexInstructionFilename(name string) bool {
+	return strings.EqualFold(name, "AGENTS.md") || strings.EqualFold(name, "AGENTS.override.md")
+}
+
 func ensureProfileLink(source string, destination string) error {
+	if runtime.GOOS == "windows" {
+		return ensureWindowsCodexProfileLink(source, destination)
+	}
+
 	info, err := os.Lstat(destination)
 	if errors.Is(err, os.ErrNotExist) {
 		if err := os.Symlink(source, destination); err != nil {
@@ -315,4 +330,32 @@ func replaceCodexHomeAssignment(command string, profileHome string) string {
 	assignmentStart := match[0] + assignmentOffset
 	quotedProfile := "'" + strings.ReplaceAll(profileHome, "'", "'\\''") + "'"
 	return command[:assignmentStart] + "CODEX_HOME=" + quotedProfile + command[match[1]:]
+}
+
+func ensureWindowsCodexProfileLink(source string, destination string) error {
+	sourceInfo, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("inspect Codex profile source %s: %w", source, err)
+	}
+	destinationInfo, err := os.Stat(destination)
+	if err == nil {
+		if os.SameFile(sourceInfo, destinationInfo) {
+			return nil
+		}
+		if sourceInfo.IsDir() {
+			return fmt.Errorf("codex profile directory %s does not reference %s", destination, source)
+		}
+		if err := os.Remove(destination); err != nil {
+			return fmt.Errorf("refresh Codex profile link %s: %w", destination, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect Codex profile entry %s: %w", destination, err)
+	}
+	if !sourceInfo.IsDir() {
+		if err := os.Link(source, destination); err != nil {
+			return fmt.Errorf("hard-link Codex profile entry %s: %w", destination, err)
+		}
+		return nil
+	}
+	return createCodexProfileJunction(source, destination)
 }

--- a/internal/cli/codex_service_profile.go
+++ b/internal/cli/codex_service_profile.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	workerCodexProfileDir     = ".detent-worker"
 	launchdCodexProfileDir    = ".detent-launchd"
 	launchdCodexProfileMarker = ".detent-profile-v1"
 )
@@ -43,9 +44,7 @@ func prepareCodexCommandForService(
 	userHomeDir func() (string, error),
 ) (codexServiceCommand, error) {
 	prepared := codexServiceCommand{Command: command}
-	if goos != "darwin" || strings.TrimSpace(manager) != string(servicepkg.ManagerLaunchd) {
-		return prepared, nil
-	}
+	isLaunchd := goos == "darwin" && strings.TrimSpace(manager) == string(servicepkg.ManagerLaunchd)
 
 	credentialPath, err := codexCredentialPath(command, lookupEnv, userHomeDir)
 	if err != nil {
@@ -56,7 +55,7 @@ func prepareCodexCommandForService(
 		return codexServiceCommand{}, fmt.Errorf("resolve launchd user home: %w", err)
 	}
 	sourceHome := filepath.Dir(credentialPath)
-	profileHome, omittedSkills, err := prepareLaunchdCodexHome(sourceHome, home)
+	profileHome, omittedSkills, err := prepareWorkerCodexHome(sourceHome, home, isLaunchd)
 	if err != nil {
 		return codexServiceCommand{}, err
 	}
@@ -66,30 +65,49 @@ func prepareCodexCommandForService(
 	return prepared, nil
 }
 
-func prepareLaunchdCodexHome(sourceHome string, userHome string) (string, []string, error) {
+func prepareWorkerCodexHome(sourceHome string, userHome string, isLaunchd bool) (string, []string, error) {
 	launchdCodexProfileMu.Lock()
 	defer launchdCodexProfileMu.Unlock()
 
 	sourceHome = filepath.Clean(sourceHome)
 	userHome = filepath.Clean(userHome)
+	if err := os.MkdirAll(sourceHome, 0o700); err != nil {
+		return "", nil, fmt.Errorf("create Codex home %s: %w", sourceHome, err)
+	}
 	resolvedSource, err := filepath.EvalSymlinks(sourceHome)
 	if err != nil {
 		return "", nil, fmt.Errorf("resolve Codex home %s: %w", sourceHome, err)
 	}
-	if launchdProtectedPath(resolvedSource, userHome) {
+	if isLaunchd && launchdProtectedPath(resolvedSource, userHome) {
 		return "", nil, fmt.Errorf("codex home %s is in a macOS privacy-protected location", resolvedSource)
 	}
 
-	profileHome := filepath.Join(sourceHome, launchdCodexProfileDir)
+	profileDir := workerCodexProfileDir
+	if isLaunchd {
+		profileDir = launchdCodexProfileDir
+	}
+	profileHome := filepath.Join(sourceHome, profileDir)
 	if err := ensureLaunchdCodexProfile(profileHome); err != nil {
 		return "", nil, err
+	}
+	for _, name := range []string{"AGENTS.md", "AGENTS.override.md"} {
+		path := filepath.Join(profileHome, name)
+		local, err := removeManagedProfileLink(path)
+		if err != nil {
+			return "", nil, err
+		}
+		if local {
+			return "", nil, fmt.Errorf("worker Codex profile contains user instructions: %s", path)
+		}
 	}
 	entries, err := os.ReadDir(sourceHome)
 	if err != nil {
 		return "", nil, fmt.Errorf("read Codex home %s: %w", sourceHome, err)
 	}
 	for _, entry := range entries {
-		if entry.Name() == "skills" || entry.Name() == launchdCodexProfileDir {
+		if entry.Name() == "AGENTS.md" || entry.Name() == "AGENTS.override.md" ||
+			entry.Name() == workerCodexProfileDir || entry.Name() == launchdCodexProfileDir ||
+			(isLaunchd && entry.Name() == "skills") {
 			continue
 		}
 		if err := ensureProfileLink(
@@ -100,6 +118,9 @@ func prepareLaunchdCodexHome(sourceHome string, userHome string) (string, []stri
 		}
 	}
 
+	if !isLaunchd {
+		return profileHome, nil, nil
+	}
 	omittedSkills, err := syncLaunchdCodexSkills(sourceHome, profileHome, userHome)
 	if err != nil {
 		return "", nil, err

--- a/internal/cli/codex_service_profile_test.go
+++ b/internal/cli/codex_service_profile_test.go
@@ -121,32 +121,47 @@ func TestPrepareCodexCommandForServiceRewritesConfiguredHome(t *testing.T) {
 	}
 }
 
-func TestPrepareCodexCommandForServiceLeavesNonLaunchdCommandUnchanged(t *testing.T) {
+func TestPrepareCodexCommandForServiceIsolatesInstructions(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name    string
-		goos    string
-		manager string
-	}{
-		{name: "manual macOS", goos: "darwin", manager: string(servicepkg.ManagerManual)},
-		{name: "Linux service", goos: "linux", manager: string(servicepkg.ManagerLaunchd)},
-	}
-	for _, tt := range tests {
+	for _, tt := range []struct{ name, goos, manager string }{
+		{"manual macOS", "darwin", "manual"},
+		{"Linux service", "linux", "systemd"},
+		{"launchd", "darwin", "launchd"},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			prepared, err := prepareCodexCommandForService(
-				"codex app-server",
-				tt.goos,
-				tt.manager,
-				func(string) (string, bool) { return "", false },
-				func() (string, error) { return "", errors.New("must not resolve home") },
-			)
-			if err != nil {
-				t.Fatalf("prepareCodexCommandForService() error = %v", err)
+			home := t.TempDir()
+			source := filepath.Join(home, ".codex")
+			if err := os.MkdirAll(source, 0o700); err != nil {
+				t.Fatal(err)
 			}
-			if prepared.Command != "codex app-server" || len(prepared.Environment) != 0 {
-				t.Fatalf("prepared = %#v, want unchanged command", prepared)
+			for _, name := range []string{"AGENTS.md", "AGENTS.override.md", "auth.json", "config.toml"} {
+				if err := os.WriteFile(filepath.Join(source, name), []byte("Ask for confirmation before bulk changes"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			prepared, err := prepareCodexCommandForService("codex app-server", tt.goos, tt.manager,
+				func(string) (string, bool) { return "", false }, func() (string, error) { return home, nil })
+			if err != nil {
+				t.Fatal(err)
+			}
+			profile := prepared.Environment["CODEX_HOME"]
+			if profile == "" || profile == source {
+				t.Fatalf("worker CODEX_HOME = %q", profile)
+			}
+			for _, name := range []string{"AGENTS.md", "AGENTS.override.md"} {
+				if _, err := os.Stat(filepath.Join(profile, name)); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("worker sees %s: %v", name, err)
+				}
+				if _, err := os.Stat(filepath.Join(source, name)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, name := range []string{"auth.json", "config.toml"} {
+				target, err := os.Readlink(filepath.Join(profile, name))
+				if err != nil || target != filepath.Join(source, name) {
+					t.Fatalf("%s link = %q, %v", name, target, err)
+				}
 			}
 		})
 	}
@@ -214,5 +229,49 @@ func TestLaunchdProtectedSkillLinkResolvesSymlinkedParent(t *testing.T) {
 	}
 	if !protected {
 		t.Fatal("launchdProtectedSkillLink() = false, want true")
+	}
+}
+
+func TestPrepareWorkerCodexHomeExistingInstructions(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		link bool
+	}{{"legacy symlink", true}, {"local file", false}} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			home := t.TempDir()
+			source := filepath.Join(home, ".codex")
+			profile := filepath.Join(source, launchdCodexProfileDir)
+			if err := ensureLaunchdCodexProfile(profile); err != nil {
+				t.Fatal(err)
+			}
+			hostFile := filepath.Join(source, "AGENTS.md")
+			if err := os.WriteFile(hostFile, []byte("Ask for confirmation"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(profile, "AGENTS.md")
+			if tt.link {
+				if err := os.Symlink(hostFile, target); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(target, []byte("Local instructions"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, _, err := prepareWorkerCodexHome(source, home, true)
+			if tt.link {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Lstat(target); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("legacy link remains: %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), target) {
+				t.Fatalf("error = %v, want local instruction path", err)
+			}
+			if _, err := os.Stat(hostFile); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/internal/cli/codex_service_profile_test.go
+++ b/internal/cli/codex_service_profile_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -66,12 +68,17 @@ func TestPrepareCodexCommandForServiceCreatesLaunchdProfile(t *testing.T) {
 		filepath.Join(profileHome, "skills", ".system"),
 		filepath.Join(profileHome, "skills", "local"),
 	} {
-		info, err := os.Lstat(path)
+		info, err := os.Stat(path)
 		if err != nil {
 			t.Fatalf("Lstat(%q) error = %v", path, err)
 		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			t.Fatalf("%s is not a symlink", path)
+		relative, err := filepath.Rel(profileHome, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sourceInfo, err := os.Stat(filepath.Join(sourceHome, relative))
+		if err != nil || !os.SameFile(info, sourceInfo) {
+			t.Fatalf("%s does not share its source: %v", path, err)
 		}
 	}
 	if _, err := os.Lstat(filepath.Join(profileHome, "skills", "templui-pro")); !errors.Is(err, os.ErrNotExist) {
@@ -158,9 +165,13 @@ func TestPrepareCodexCommandForServiceIsolatesInstructions(t *testing.T) {
 				}
 			}
 			for _, name := range []string{"auth.json", "config.toml"} {
-				target, err := os.Readlink(filepath.Join(profile, name))
-				if err != nil || target != filepath.Join(source, name) {
-					t.Fatalf("%s link = %q, %v", name, target, err)
+				target, err := os.Stat(filepath.Join(profile, name))
+				if err != nil {
+					t.Fatal(err)
+				}
+				original, err := os.Stat(filepath.Join(source, name))
+				if err != nil || !os.SameFile(target, original) {
+					t.Fatalf("%s does not share its source: %v", name, err)
 				}
 			}
 		})
@@ -271,6 +282,86 @@ func TestPrepareWorkerCodexHomeExistingInstructions(t *testing.T) {
 			}
 			if _, err := os.Stat(hostFile); err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestPrepareWorkerCodexHomeInstructionCase(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"agents.md", "agents.override.md", "AgEnTs.Md"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := t.TempDir()
+			if err := os.WriteFile(filepath.Join(source, name), []byte("Ask for confirmation"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			profile, _, err := prepareWorkerCodexHome(source, t.TempDir(), false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entries, err := os.ReadDir(profile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, entry := range entries {
+				if codexInstructionFilename(entry.Name()) {
+					t.Fatalf("worker inherited %s", entry.Name())
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureWindowsCodexProfileLink(t *testing.T) {
+	t.Parallel()
+	for _, directory := range []bool{false, true} {
+		t.Run(fmt.Sprintf("directory=%t", directory), func(t *testing.T) {
+			t.Parallel()
+			if directory && runtime.GOOS != "windows" {
+				t.Skip("Windows junction support")
+			}
+			root := t.TempDir()
+			source := filepath.Join(root, "source & profile café")
+			destination := filepath.Join(root, "destination & profile")
+			if directory {
+				if err := os.Mkdir(source, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(source, []byte("credential fixture"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			for range 2 {
+				if err := ensureWindowsCodexProfileLink(source, destination); err != nil {
+					t.Fatal(err)
+				}
+				original, err := os.Stat(source)
+				if err != nil {
+					t.Fatal(err)
+				}
+				linked, err := os.Stat(destination)
+				if err != nil || !os.SameFile(original, linked) {
+					t.Fatalf("profile does not share source: %v", err)
+				}
+			}
+			if !directory {
+				replacement := filepath.Join(root, "replacement")
+				if err := os.WriteFile(replacement, []byte("refreshed credential"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Remove(source); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Rename(replacement, source); err != nil {
+					t.Fatal(err)
+				}
+				if err := ensureWindowsCodexProfileLink(source, destination); err != nil {
+					t.Fatal(err)
+				}
+				content, err := os.ReadFile(destination)
+				if err != nil || string(content) != "refreshed credential" {
+					t.Fatalf("refreshed profile = %q, %v", content, err)
+				}
 			}
 		})
 	}

--- a/internal/cli/doctor_codex_instructions.go
+++ b/internal/cli/doctor_codex_instructions.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+)
+
+func checkDoctorCodexInstructions(id string, cfg workflowconfig.Config, lookupEnv func(string) string) []doctorCheck {
+	var checks []doctorCheck
+	for _, backend := range cfg.AgentBackendConfigs() {
+		if backend.Kind != workflowconfig.AgentBackendCodex {
+			continue
+		}
+		check := doctorCheck{Name: "Project " + id + " Codex instructions " + backend.ID, Status: doctorOK}
+		lookup := os.LookupEnv
+		if lookupEnv != nil {
+			lookup = func(key string) (string, bool) { value := lookupEnv(key); return value, value != "" }
+		}
+		credential, err := codexCredentialPath(backend.Command, lookup, os.UserHomeDir)
+		if err != nil {
+			check.Status = doctorWarn
+			check.Detail = "cannot resolve Codex instruction home: " + err.Error()
+			checks = append(checks, check)
+			continue
+		}
+		var visible []string
+		for _, name := range []string{"AGENTS.override.md", "AGENTS.md"} {
+			path := filepath.Join(filepath.Dir(credential), name)
+			if _, err := os.Stat(path); err == nil {
+				visible = append(visible, path)
+			} else if !errors.Is(err, os.ErrNotExist) {
+				visible = append(visible, fmt.Sprintf("%s (inspection failed: %v)", path, err))
+			}
+		}
+		check.Detail = "no user-level Codex instruction files found; workers use an isolated Codex home"
+		if len(visible) > 0 {
+			check.Status = doctorWarn
+			check.Detail = "user-level instructions would be inherited without worker home isolation: " + strings.Join(visible, ", ")
+			check.Hint = "Detent excludes these files from worker Codex homes. Put unattended project guidance in repository AGENTS.md; restart older Detent instances to apply isolation."
+		}
+		checks = append(checks, check)
+	}
+	return checks
+}

--- a/internal/cli/doctor_codex_instructions_test.go
+++ b/internal/cli/doctor_codex_instructions_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+)
+
+func TestCheckDoctorCodexInstructions(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, file string
+		configured bool
+		want       doctorStatus
+	}{
+		{"absent", "", false, doctorOK},
+		{"global", "AGENTS.md", false, doctorWarn},
+		{"override", "AGENTS.override.md", false, doctorWarn},
+		{"command home", "AGENTS.md", true, doctorWarn},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			home := t.TempDir()
+			if tt.file != "" {
+				if err := os.WriteFile(filepath.Join(home, tt.file), []byte("Ask for confirmation"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			command := "codex app-server"
+			envHome := home
+			if tt.configured {
+				command = "env CODEX_HOME='" + home + "' codex app-server"
+				envHome = t.TempDir()
+			}
+			cfg := workflowconfig.Default()
+			cfg.Codex.Command = command
+			checks := checkDoctorCodexInstructions("test", cfg, func(key string) string {
+				if key == "CODEX_HOME" {
+					return envHome
+				}
+				return ""
+			})
+			if len(checks) != 1 || checks[0].Status != tt.want {
+				t.Fatalf("checks = %#v", checks)
+			}
+			if tt.file != "" && !strings.Contains(checks[0].Detail, filepath.Join(home, tt.file)) {
+				t.Fatalf("missing instruction path: %#v", checks[0])
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -401,6 +401,7 @@ func checkDoctorProjectWithProgress(
 	if workerGitHubCheck, ok := checkDoctorWorkerGitHubCredential(id, workflow.Config); ok {
 		checks = append(checks, workerGitHubCheck)
 	}
+	checks = append(checks, checkDoctorCodexInstructions(id, workflow.Config, deps.lookupEnv)...)
 	setDoctorCurrentCheck("Project " + id + " progress brake")
 	checks = append(checks, checkDoctorProgressBrake(id, workflow.Config))
 	checks = append(checks, checkDoctorTerminalAttemptRecovery(id, workflow.Config))

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1109,8 +1109,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "inherited spend breaker warns about billing ambiguity",
@@ -1118,8 +1118,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: omittedBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -1128,8 +1128,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
-			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
+			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
 		},
 		{
 			name: "all progress brakes disabled",
@@ -1137,8 +1137,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledProgressWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "billing_mode=subscription", "no effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "billing_mode=subscription", "no user-level Codex instruction files", "no effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -1146,8 +1146,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 	}
 
@@ -1155,7 +1155,14 @@ func TestCheckDoctorProjects(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			codexHome := t.TempDir()
 			got := checkDoctorProjects(context.Background(), globalconfig.Config{Projects: tt.projects}, doctorDeps{
+				lookupEnv: func(key string) string {
+					if key == "CODEX_HOME" {
+						return codexHome
+					}
+					return ""
+				},
 				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
 					return tt.workflow, tt.loadErr
 				},


### PR DESCRIPTION
## Summary

- Isolate Codex worker homes on all runtimes so operator `AGENTS.md` and `AGENTS.override.md` confirmation rules do not reach unattended workers. Preserve shared auth/config files and launchd skill filtering, and remove legacy instruction symlinks. Windows uses hard links and native directory junctions without requiring symbolic-link privileges; reserved instruction names are excluded case-insensitively.
- Add per-backend doctor warnings that name user-level instruction files and explain worker isolation.

Fixes #2449

## UI Surface Contract

- [x] N/A: no dashboard or layout changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Regression reproduced before the fix on manual macOS, Linux, and launchd profiles.
- [x] Focused table-driven tests cover instruction exclusion (including filename case), shared auth/config identity, stale hard-link refresh, legacy profile migration, and doctor warnings.
- [x] Windows test binary cross-compiles; native junction tests run in Windows CI.
- [x] Candidate skill captures unprivileged Windows profile-link testing.
- [x] `make check` — 80.5% coverage; package/file floors passed.
