### PR TITLE
feat(merge): complete native queue support

### DIFF
--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -101,9 +101,9 @@ The queue path requires a nonempty checked PR head. Enqueue sends GitHub's
 the current PR head before adopting an existing entry, including after restart.
 The entry cache is scoped to that head, so a head change forces inspection.
 GitHub removal history also survives restart: an absent entry removed on the
-same head is deferred, not automatically re-enqueued after integration failure
-or cancellation. A newly checked head can retry. Missing removal identity
-fails closed; an operator can explicitly re-enqueue in GitHub, which Detent
+same head is routed to `Rework` with GitHub's removal reason, rather than
+automatically re-enqueued after integration failure or cancellation. A newly
+checked head can retry. Missing removal identity also routes to `Rework`; an operator can explicitly re-enqueue in GitHub, which Detent
 then observes. This preserves removal decisions without a local-only tombstone.
 Admission uses the repository queue's `maximumEntriesToBuild` as its window:
 when queue depth reaches that limit, further candidates wait without worker
@@ -203,3 +203,34 @@ Source-changing repairs and changed-base integrations are legitimate validation;
 the opportunity is avoiding PR-head refresh cycles through provider-owned
 integration, not accepting old-base green checks. The available evidence does
 not establish any duplicate CI rerun of identical integrated inputs.
+
+
+## Choosing and enabling a GitHub merge queue
+
+A merge queue validates integration groups against the latest target branch,
+reducing repeated PR head refreshes under strict up-to-date protection. The
+trade-off is additional merge-group CI and queue latency; required workflows
+must support `merge_group: checks_requested`. Repositories without a queue
+retain Detent's classic merge path.
+
+Detent reads the default branch's effective rulesets at project load and on
+workflow reconciliation/reload. A `merge_queue` rule enables native queue
+admission; PR inspection verifies the current target and queue entry. Discovery
+failures retain PR inspection and do not change repository settings.
+
+In GitHub repository **Settings → Rules → Rulesets**, create or edit an active
+branch ruleset targeting the merge branch and enable **Require merge queue**.
+Choose squash merging for this project and ensure every required check runs on
+the merge-group SHA. See GitHub's [merge queue setup documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
+The PR-required and security-audit exclusions above still apply.
+
+`detent doctor` recommends considering a queue when strict protection is enabled,
+no queue exists, and recorded merge cadence multiplied by median CI duration is
+at least 0.25 merges per CI run. It reads the last seven days of lane history,
+deduplicates PRs for the repository and target branch, and requires at least
+three merges and three measured CI durations. Cadence uses the interval between
+the first and last recorded merge. The recommendation reports the sample count,
+observed interval, merges/day, median CI minutes, and estimated overlap. CI
+durations and target branches are recorded with PR lane transitions; older
+history without these fields does not justify a recommendation. Doctor never
+mutates branch protection or rulesets.

--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -214,9 +214,14 @@ must support `merge_group: checks_requested`. Repositories without a queue
 retain Detent's classic merge path.
 
 Detent reads the default branch's effective rulesets at project load and on
-workflow reconciliation/reload. A `merge_queue` rule enables native queue
-admission; PR inspection verifies the current target and queue entry. Discovery
-failures retain PR inspection and do not change repository settings.
+actual workflow reload. Unchanged workflow reconciliation does not read policy.
+When PR inspection has no queue entry or GraphQL queue capability, it reads the
+PR repository and target branch's effective rules; policies are cached by that
+repository/branch pair for five minutes. This also supports delivery repositories
+that differ from the issue tracker. A `merge_queue` rule enables native queue
+admission. A failed initial discovery retains PR inspection; failed PR-level
+discovery defers admission until inspection succeeds. No repository settings
+are changed.
 
 In GitHub repository **Settings → Rules → Rulesets**, create or edit an active
 branch ruleset targeting the merge branch and enable **Require merge queue**.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -252,6 +252,7 @@ type doctorDeps struct {
 	httpDo               func(*http.Request) (*http.Response, error)
 	githubScopes         func(context.Context, string) ([]string, error)
 	githubReadiness      doctorGitHubReadinessFunc
+	githubBranchPolicy   func(context.Context, workflowconfig.Config, string) (ghconnector.BranchMergePolicy, error)
 	githubMergeSettings  func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryMergeSettings, error)
 	githubRepositoryInfo func(context.Context, workflowconfig.Config, string) (ghconnector.RepositoryInfo, error)
 	githubLabels         func(context.Context, workflowconfig.Config, string) ([]string, error)
@@ -1158,6 +1159,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.githubReadiness == nil {
 		d.githubReadiness = defaults.githubReadiness
 	}
+	if d.githubBranchPolicy == nil {
+		d.githubBranchPolicy = defaults.githubBranchPolicy
+	}
 	if d.githubMergeSettings == nil {
 		d.githubMergeSettings = defaults.githubMergeSettings
 	}
@@ -1234,6 +1238,7 @@ func defaultDoctorDeps() doctorDeps {
 		githubScopes:         defaultGitHubScopes,
 		githubReadiness:      ghconnector.CheckReadiness,
 		githubMergeSettings:  defaultDoctorGitHubMergeSettings,
+		githubBranchPolicy:   defaultDoctorGitHubBranchMergePolicy,
 		githubRepositoryInfo: defaultDoctorGitHubRepositoryInfo,
 		githubLabels:         defaultDoctorGitHubRepositoryLabels,
 		ghAuthToken:          defaultGHAuthToken,

--- a/internal/cli/doctor_merge_queue.go
+++ b/internal/cli/doctor_merge_queue.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+func defaultDoctorGitHubBranchMergePolicy(ctx context.Context, cfg workflowconfig.Config, repository string) (ghconnector.BranchMergePolicy, error) {
+	client, err := ghconnector.NewConnector(doctorGitHubConnectorConfig(cfg))
+	if err != nil {
+		return ghconnector.BranchMergePolicy{}, err
+	}
+	return client.RepositoryStrictMergePolicy(ctx, repository)
+}
+
+func checkDoctorMergeQueue(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, storePath string, deps doctorDeps) (check doctorCheck) {
+	check = doctorCheck{Name: "Project " + id + " merge queue recommendation", Status: doctorOK, Detail: "no measured strict-protection merge pressure"}
+	if strings.TrimSpace(storePath) == "" {
+		check.Detail = "no merge history recorded yet"
+		return check
+	}
+	deps = deps.withDefaults()
+	db, err := deps.openSQLiteReadOnly(ctx, storePath)
+	if err != nil {
+		check.Detail = "merge history unavailable: " + err.Error()
+		return check
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			check.Status = doctorWarn
+			check.Detail += "; close merge history: " + err.Error()
+		}
+	}()
+	for _, repository := range doctorGitHubRepositories(ctx, project, cfg, deps, projectSourceRoot(project, cfg)) {
+		policy, err := deps.githubBranchPolicy(ctx, cfg, repository)
+		if err != nil {
+			check.Status = doctorWarn
+			check.Detail = "branch protection could not be read: " + err.Error()
+			return check
+		}
+		if !policy.Strict || policy.MergeQueue {
+			continue
+		}
+		detail, err := doctorMergeQueueHistory(ctx, db, id, repository, policy.Branch, deps.now())
+		if err != nil {
+			check.Status = doctorWarn
+			check.Detail = "merge history could not be read: " + err.Error()
+			return check
+		}
+		if detail != "" {
+			check.Status = doctorWarn
+			check.Detail = detail
+			check.Hint = "Consider enabling GitHub's merge queue for this branch and running required checks on merge_group; detent doctor does not change repository settings."
+			return check
+		}
+	}
+	return check
+}
+
+func doctorMergeQueueHistory(ctx context.Context, db doctorTelemetryStore, projectID, repository, branch string, now time.Time) (string, error) {
+	const window = 7 * 24 * time.Hour
+	rows, err := db.QueryContext(ctx, `SELECT started_at, metadata_json FROM workflow_phase_events
+WHERE project_id = ? AND phase_type = 'lane' AND status = 'entered' AND reason = 'pull_request_merged'
+AND julianday(started_at) >= julianday(?) AND julianday(started_at) <= julianday(?)
+ORDER BY julianday(started_at), id`, projectID, now.Add(-window).Format(time.RFC3339Nano), now.Format(time.RFC3339Nano))
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	seen := map[int64]bool{}
+	durations := []int64{}
+	var first, last time.Time
+	for rows.Next() {
+		var rawAt, rawMetadata string
+		if err := rows.Scan(&rawAt, &rawMetadata); err != nil {
+			return "", err
+		}
+		var metadata struct {
+			PullRequest struct {
+				Repository        string `json:"repository"`
+				BaseRef           string `json:"base_ref"`
+				Number            int64  `json:"number"`
+				CIDurationSeconds int64  `json:"ci_duration_seconds"`
+			} `json:"pull_request"`
+		}
+		if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
+			return "", err
+		}
+		pr := metadata.PullRequest
+		if !strings.EqualFold(pr.Repository, repository) || pr.BaseRef != branch || pr.Number <= 0 || seen[pr.Number] {
+			continue
+		}
+		at, err := time.Parse(time.RFC3339Nano, rawAt)
+		if err != nil {
+			return "", err
+		}
+		seen[pr.Number] = true
+		if first.IsZero() {
+			first = at
+		}
+		last = at
+		if pr.CIDurationSeconds > 0 {
+			durations = append(durations, pr.CIDurationSeconds)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if len(seen) < 3 || len(durations) < 3 || !last.After(first) {
+		return "", nil
+	}
+	slices.Sort(durations)
+	median := float64(durations[len(durations)/2])
+	if len(durations)%2 == 0 {
+		median = (median + float64(durations[len(durations)/2-1])) / 2
+	}
+	cadence := float64(len(seen)-1) / last.Sub(first).Hours()
+	overlap := cadence * median / 3600
+	if overlap < 0.25 {
+		return "", nil
+	}
+	return fmt.Sprintf("%s branch %s requires up-to-date checks; %d distinct recorded merges over %.1fh (%.1f/day), median CI %.1f minutes from %d samples; %.2f merges per CI duration indicates likely head invalidation", repository, branch, len(seen), last.Sub(first).Hours(), cadence*24, median/60, len(durations), overlap), nil
+}

--- a/internal/cli/doctor_merge_queue_test.go
+++ b/internal/cli/doctor_merge_queue_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+func TestDoctorMergeQueueRecordedHistory(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name               string
+		strict, queue      bool
+		minutes            int
+		branch             string
+		wantRecommendation bool
+	}{
+		{name: "strict busy branch", strict: true, minutes: 22, branch: "main", wantRecommendation: true},
+		{name: "non strict busy branch", minutes: 22, branch: "main"},
+		{name: "existing queue", strict: true, queue: true, minutes: 22, branch: "main"},
+		{name: "fast CI", strict: true, minutes: 2, branch: "main"},
+		{name: "missing CI history", strict: true, branch: "main"},
+		{name: "different branch", strict: true, minutes: 22, branch: "release"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+			path := filepath.Join(t.TempDir(), "history.db")
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			_, err = db.ExecContext(t.Context(), `CREATE TABLE workflow_phase_events (id INTEGER PRIMARY KEY, project_id TEXT, phase_type TEXT, status TEXT, reason TEXT, started_at TEXT, metadata_json TEXT)`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for index := range 31 {
+				metadata := fmt.Sprintf(`{"pull_request":{"repository":"example/repo","base_ref":%q,"number":%d,"ci_duration_seconds":%d}}`, tt.branch, index+1, tt.minutes*60)
+				at := now.Add(-time.Duration(index) * 48 * time.Minute).Format(time.RFC3339Nano)
+				_, err = db.ExecContext(t.Context(), `INSERT INTO workflow_phase_events(project_id,phase_type,status,reason,started_at,metadata_json) VALUES ('alpha','lane','entered','pull_request_merged',?,?)`, at, metadata)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			cfg := workflowconfig.Config{}
+			cfg.Tracker.Repository = "example/repo"
+			got := checkDoctorMergeQueue(t.Context(), "alpha", globalconfig.Project{}, cfg, path, doctorDeps{
+				now:                func() time.Time { return now },
+				openSQLiteReadOnly: openDoctorSQLiteReadOnly,
+				githubBranchPolicy: func(context.Context, workflowconfig.Config, string) (ghconnector.BranchMergePolicy, error) {
+					return ghconnector.BranchMergePolicy{Branch: "main", Strict: tt.strict, MergeQueue: tt.queue}, nil
+				},
+			})
+			if (got.Status == doctorWarn) != tt.wantRecommendation {
+				t.Fatalf("check = %+v", got)
+			}
+			if tt.wantRecommendation {
+				for _, want := range []string{"31 distinct recorded merges", "30.0/day", "22.0 minutes", "0.46 merges per CI duration"} {
+					if !strings.Contains(got.Detail, want) {
+						t.Fatalf("detail %q missing %q", got.Detail, want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -457,6 +457,8 @@ func checkDoctorProjectWithProgress(
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) && workflow.Config.Deliverable.Kind == workflowconfig.DeliverablePullRequest {
 		setDoctorCurrentCheck("Project " + id + " repository merge policy")
 		checks = append(checks, checkDoctorRepositoryMergePolicy(ctx, id, project, workflow.Config, deps))
+		setDoctorCurrentCheck("Project " + id + " merge queue recommendation")
+		checks = append(checks, checkDoctorMergeQueue(ctx, id, project, workflow.Config, storePath, deps))
 	}
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceLabel {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -6234,7 +6234,7 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 	}{
 		{name: "GitHub readiness", current: "GitHub readiness", lastCompleted: "Project alpha skills"},
 		{name: "local workflow overlay", current: "local workflow overlay", lastCompleted: "Project alpha capabilities", blockOverlay: true},
-		{name: "dependency auto-unblock", current: "dependency auto-unblock", lastCompleted: "Project alpha repository merge policy", blockDependency: true},
+		{name: "dependency auto-unblock", current: "dependency auto-unblock", lastCompleted: "Project alpha merge queue recommendation", blockDependency: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -152,6 +152,7 @@ type PullRequestMergeQueue interface {
 type PullRequestMergeQueueStatus struct {
 	RemovalObserved   bool
 	RemovedHeadSHA    string
+	RemovalReason     string
 	Depth             int
 	AdmissionLimit    int
 	HeadSHA           string

--- a/internal/connector/github/branch_merge_policy.go
+++ b/internal/connector/github/branch_merge_policy.go
@@ -18,9 +18,8 @@ type BranchMergePolicy struct {
 }
 
 type branchMergePolicySnapshot struct {
-	Repository string
-	Policy     BranchMergePolicy
-	CheckedAt  time.Time
+	Policy    BranchMergePolicy
+	CheckedAt time.Time
 }
 
 func (c *Connector) RepositoryBranchMergePolicy(ctx context.Context, repository, branch string) (BranchMergePolicy, error) {
@@ -95,8 +94,32 @@ func (c *Connector) RefreshMergeQueuePolicy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.mu.Lock()
-	c.branchMergePolicy = branchMergePolicySnapshot{Repository: repository, Policy: policy, CheckedAt: c.now()}
-	c.mu.Unlock()
+	c.cacheBranchMergePolicy(repository, policy)
 	return nil
+}
+
+func (c *Connector) branchMergePolicy(ctx context.Context, repository, branch string) (BranchMergePolicy, error) {
+	key := strings.ToLower(repository) + "@" + branch
+	c.mu.RLock()
+	cached, ok := c.branchMergePolicies[key]
+	c.mu.RUnlock()
+	if ok && c.now().Sub(cached.CheckedAt) < 5*time.Minute {
+		return cached.Policy, nil
+	}
+	policy, err := c.RepositoryBranchMergePolicy(ctx, repository, branch)
+	if err != nil {
+		return BranchMergePolicy{}, err
+	}
+	c.cacheBranchMergePolicy(repository, policy)
+	return policy, nil
+}
+
+func (c *Connector) cacheBranchMergePolicy(repository string, policy BranchMergePolicy) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.branchMergePolicies == nil {
+		c.branchMergePolicies = make(map[string]branchMergePolicySnapshot)
+	}
+	key := strings.ToLower(repository) + "@" + policy.Branch
+	c.branchMergePolicies[key] = branchMergePolicySnapshot{Policy: policy, CheckedAt: c.now()}
 }

--- a/internal/connector/github/branch_merge_policy.go
+++ b/internal/connector/github/branch_merge_policy.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type BranchMergePolicy struct {
+	Branch         string
+	MergeQueue     bool
+	Strict         bool
+	AdmissionLimit int
+}
+
+type branchMergePolicySnapshot struct {
+	Repository string
+	Policy     BranchMergePolicy
+	CheckedAt  time.Time
+}
+
+func (c *Connector) RepositoryBranchMergePolicy(ctx context.Context, repository, branch string) (BranchMergePolicy, error) {
+	repo, ok := pullRequestRepoFromName(repository)
+	if !ok {
+		return BranchMergePolicy{}, fmt.Errorf("invalid GitHub repository %q", repository)
+	}
+	base := "/repos/" + repo.Owner + "/" + repo.Name
+	if branch == "" {
+		var info struct {
+			DefaultBranch string `json:"default_branch"`
+		}
+		if err := c.client.REST(ctx, http.MethodGet, base, nil, &info); err != nil {
+			return BranchMergePolicy{}, err
+		}
+		branch = strings.TrimSpace(info.DefaultBranch)
+	}
+	if branch == "" {
+		return BranchMergePolicy{}, errors.New("github repository has no default branch")
+	}
+	policy := BranchMergePolicy{Branch: branch}
+	for page := 1; ; page++ {
+		var rules []struct {
+			Type       string `json:"type"`
+			Parameters struct {
+				Strict     bool `json:"strict_required_status_checks_policy"`
+				MaxEntries int  `json:"max_entries_to_build"`
+			} `json:"parameters"`
+		}
+		path := fmt.Sprintf("%s/rules/branches/%s?per_page=100&page=%d", base, url.PathEscape(branch), page)
+		if err := c.client.REST(ctx, http.MethodGet, path, nil, &rules); err != nil {
+			return BranchMergePolicy{}, fmt.Errorf("read branch rules: %w", err)
+		}
+		for _, rule := range rules {
+			switch rule.Type {
+			case "merge_queue":
+				policy.MergeQueue = true
+				policy.AdmissionLimit = rule.Parameters.MaxEntries
+			case "required_status_checks":
+				policy.Strict = policy.Strict || rule.Parameters.Strict
+			}
+		}
+		if len(rules) < 100 {
+			break
+		}
+	}
+	return policy, nil
+}
+
+func (c *Connector) RepositoryStrictMergePolicy(ctx context.Context, repository string) (BranchMergePolicy, error) {
+	policy, err := c.RepositoryBranchMergePolicy(ctx, repository, "")
+	if err != nil {
+		return policy, err
+	}
+	var checks struct {
+		Strict bool `json:"strict"`
+	}
+	path := "/repos/" + repository + "/branches/" + url.PathEscape(policy.Branch) + "/protection/required_status_checks"
+	if err := c.client.REST(ctx, http.MethodGet, path, nil, &checks); err != nil && !errors.Is(err, ErrNotFound) {
+		return policy, fmt.Errorf("read strict branch protection: %w", err)
+	}
+	policy.Strict = policy.Strict || checks.Strict
+	return policy, nil
+}
+
+func (c *Connector) RefreshMergeQueuePolicy(ctx context.Context) error {
+	repository := pullRequestRepoName(c.repository)
+	if strings.Trim(repository, "/ ") == "" {
+		return nil
+	}
+	policy, err := c.RepositoryBranchMergePolicy(ctx, repository, "")
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.branchMergePolicy = branchMergePolicySnapshot{Repository: repository, Policy: policy, CheckedAt: c.now()}
+	c.mu.Unlock()
+	return nil
+}

--- a/internal/connector/github/branch_merge_policy_test.go
+++ b/internal/connector/github/branch_merge_policy_test.go
@@ -1,0 +1,116 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestRepositoryBranchMergePolicy(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		rules      string
+		protection string
+		wantQueue  bool
+		wantStrict bool
+		wantLimit  int
+		status     int
+		wantError  bool
+	}{
+		{name: "queue", rules: `[{"type":"merge_queue","parameters":{"max_entries_to_build":5}}]`, wantQueue: true, wantLimit: 5},
+		{name: "classic strict", rules: `[]`, protection: `{"strict":true}`, wantStrict: true},
+		{name: "ruleset strict", rules: `[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true}}]`, wantStrict: true},
+		{name: "unprotected", rules: `[]`},
+		{name: "unavailable rules", status: 500, wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("method = %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/example/repo":
+					fmt.Fprint(w, `{"default_branch":"release/stable"}`)
+				case "/repos/example/repo/rules/branches/release/stable":
+					if tt.status != 0 {
+						w.WriteHeader(tt.status)
+						return
+					}
+					fmt.Fprint(w, tt.rules)
+				case "/repos/example/repo/branches/release/stable/protection/required_status_checks":
+					if tt.protection == "" {
+						w.WriteHeader(http.StatusNotFound)
+						fmt.Fprint(w, `{"message":"Not Found"}`)
+						return
+					}
+					fmt.Fprint(w, tt.protection)
+				default:
+					t.Errorf("unexpected path %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+			c, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := c.RepositoryStrictMergePolicy(t.Context(), "example/repo")
+			if (err != nil) != tt.wantError {
+				t.Fatalf("error = %v", err)
+			}
+			if tt.wantError {
+				return
+			}
+			if got.Branch != "release/stable" || got.MergeQueue != tt.wantQueue || got.Strict != tt.wantStrict || got.AdmissionLimit != tt.wantLimit {
+				t.Fatalf("policy = %+v", got)
+			}
+		})
+	}
+}
+
+func TestRefreshMergeQueuePolicyTracksRuleChanges(t *testing.T) {
+	t.Parallel()
+	var enabled atomic.Bool
+	enabled.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/example/repo":
+			fmt.Fprint(w, `{"default_branch":"main"}`)
+		case "/repos/example/repo/rules/branches/main":
+			if enabled.Load() {
+				fmt.Fprint(w, `[{"type":"merge_queue","parameters":{"max_entries_to_build":4}}]`)
+			} else {
+				fmt.Fprint(w, `[]`)
+			}
+		case "/graphql":
+			fmt.Fprint(w, `{"data":{"repository":{"pullRequest":{"id":"PR_42","headRefOid":"head","baseRefName":"main"}}}}`)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	c, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []bool{true, false} {
+		enabled.Store(want)
+		if err := c.RefreshMergeQueuePolicy(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		number := 42
+		got, err := c.InspectPullRequestMergeQueue(t.Context(), connector.Issue{PRRepository: "example/repo", PRNumber: &number})
+		if err != nil || got.Available != want {
+			t.Fatalf("status=%+v error=%v", got, err)
+		}
+	}
+}

--- a/internal/connector/github/branch_merge_policy_test.go
+++ b/internal/connector/github/branch_merge_policy_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -112,5 +113,64 @@ func TestRefreshMergeQueuePolicyTracksRuleChanges(t *testing.T) {
 		if err != nil || got.Available != want {
 			t.Fatalf("status=%+v error=%v", got, err)
 		}
+	}
+}
+
+func TestInspectMergeQueueScopesPolicyToPullRequestTarget(t *testing.T) {
+	t.Parallel()
+	targets := []struct {
+		repository, branch string
+		queued             bool
+	}{
+		{repository: "example/delivery", branch: "release", queued: true},
+		{repository: "example/delivery", branch: "main"},
+		{repository: "example/other", branch: "release"},
+	}
+	var reads atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/graphql" {
+			var request struct {
+				Variables struct {
+					Number int `json:"number"`
+				} `json:"variables"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Error(err)
+				return
+			}
+			target := targets[request.Variables.Number-1]
+			fmt.Fprintf(w, `{"data":{"repository":{"pullRequest":{"id":"PR","headRefOid":"head","baseRefName":%q,"mergeQueue":null,"mergeQueueEntry":null}}}}`, target.branch)
+			return
+		}
+		reads.Add(1)
+		switch r.URL.Path {
+		case "/repos/example/delivery/rules/branches/release":
+			fmt.Fprint(w, `[{"type":"merge_queue","parameters":{"max_entries_to_build":4}}]`)
+		case "/repos/example/delivery/rules/branches/main", "/repos/example/other/rules/branches/release":
+			fmt.Fprint(w, `[]`)
+		default:
+			t.Errorf("unexpected policy read %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	c, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token", Repository: "example/tracker", GitHubStatusSource: GitHubStatusSourceLabel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, target := range targets {
+		t.Run(target.repository+"@"+target.branch, func(t *testing.T) {
+			number := index + 1
+			for range 2 {
+				got, err := c.InspectPullRequestMergeQueue(t.Context(), connector.Issue{PRRepository: target.repository, PRNumber: &number})
+				if err != nil || got.Available != target.queued {
+					t.Fatalf("status=%+v error=%v", got, err)
+				}
+			}
+		})
+	}
+	if reads.Load() != int64(len(targets)) {
+		t.Fatalf("policy reads=%d, want one per repository/branch", reads.Load())
 	}
 }

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -109,37 +109,37 @@ type Config struct {
 }
 
 type Connector struct {
-	branchMergePolicy  branchMergePolicySnapshot
-	client             *Client
-	statusSource       string
-	projectID          string
-	repository         pullRequestRepo
-	statusField        string
-	statusLabelPrefix  string
-	activeStates       []string
-	observedStates     []string
-	terminalStates     []string
-	stateMap           map[string]string
-	priorityMap        map[string]*int
-	requiredChecks     []string
-	unstartedThreshold time.Duration
-	dependencySource   string
-	dependencyCaps     map[string]nativeDependencyCapability
-	statusCache        *statusCache
-	issueFields        *issueFieldCache
-	projectCache       *projectCache
-	pullRequests       *pullRequestStatusCache
-	prHydration        *pullRequestHydrationCircuitBreaker
-	prHydrationCursor  map[string]string
-	prDiffFingerprints map[pullRequestDiffFingerprintCacheKey]string
-	triggerLabelDir    string
-	logger             *slog.Logger
-	now                func() time.Time
-	mu                 sync.RWMutex
-	writeMu            sync.Mutex
-	prerequisiteMu     sync.Mutex
-	instanceLogin      string
-	projectURL         string
+	branchMergePolicies map[string]branchMergePolicySnapshot
+	client              *Client
+	statusSource        string
+	projectID           string
+	repository          pullRequestRepo
+	statusField         string
+	statusLabelPrefix   string
+	activeStates        []string
+	observedStates      []string
+	terminalStates      []string
+	stateMap            map[string]string
+	priorityMap         map[string]*int
+	requiredChecks      []string
+	unstartedThreshold  time.Duration
+	dependencySource    string
+	dependencyCaps      map[string]nativeDependencyCapability
+	statusCache         *statusCache
+	issueFields         *issueFieldCache
+	projectCache        *projectCache
+	pullRequests        *pullRequestStatusCache
+	prHydration         *pullRequestHydrationCircuitBreaker
+	prHydrationCursor   map[string]string
+	prDiffFingerprints  map[pullRequestDiffFingerprintCacheKey]string
+	triggerLabelDir     string
+	logger              *slog.Logger
+	now                 func() time.Time
+	mu                  sync.RWMutex
+	writeMu             sync.Mutex
+	prerequisiteMu      sync.Mutex
+	instanceLogin       string
+	projectURL          string
 
 	publication             publication.Policy
 	publicationMu           sync.Mutex

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -109,6 +109,7 @@ type Config struct {
 }
 
 type Connector struct {
+	branchMergePolicy  branchMergePolicySnapshot
 	client             *Client
 	statusSource       string
 	projectID          string

--- a/internal/connector/github/merge_queue.go
+++ b/internal/connector/github/merge_queue.go
@@ -16,8 +16,9 @@ query DetentInspectPullRequestMergeQueue($owner: String!, $name: String!, $numbe
     pullRequest(number: $number) {
       id
       headRefOid
+      baseRefName
       timelineItems(last: 1, itemTypes: [REMOVED_FROM_MERGE_QUEUE_EVENT]) {
-        nodes { ... on RemovedFromMergeQueueEvent { beforeCommit { oid } } }
+        nodes { ... on RemovedFromMergeQueueEvent { beforeCommit { oid } reason } }
       }
       mergeQueue { url entries { totalCount } configuration { maximumEntriesToBuild } }
       mergeQueueEntry {
@@ -96,8 +97,10 @@ func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue conn
 			PullRequest *struct {
 				ID            string `json:"id"`
 				HeadRefOid    string `json:"headRefOid"`
+				BaseRefName   string `json:"baseRefName"`
 				TimelineItems struct {
 					Nodes []struct {
+						Reason       string `json:"reason"`
 						BeforeCommit struct {
 							OID string `json:"oid"`
 						} `json:"beforeCommit"`
@@ -132,12 +135,20 @@ func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue conn
 		Available:         pullRequest.MergeQueue != nil || pullRequest.MergeQueueEntry != nil,
 		PullRequestNodeID: strings.TrimSpace(pullRequest.ID),
 	}
+	c.mu.RLock()
+	policy := c.branchMergePolicy
+	c.mu.RUnlock()
+	if policy.Repository == pullRequestRepoName(repo) && policy.Policy.Branch == pullRequest.BaseRefName && c.now().Sub(policy.CheckedAt) < 5*time.Minute && policy.Policy.MergeQueue {
+		status.Available = true
+		status.AdmissionLimit = policy.Policy.AdmissionLimit
+	}
 	if pullRequest.MergeQueue != nil {
 		status.Depth = pullRequest.MergeQueue.Entries.TotalCount
 		status.AdmissionLimit = pullRequest.MergeQueue.Configuration.MaximumEntriesToBuild
 	}
 	if len(pullRequest.TimelineItems.Nodes) > 0 {
 		status.RemovalObserved = true
+		status.RemovalReason = strings.TrimSpace(pullRequest.TimelineItems.Nodes[0].Reason)
 		status.RemovedHeadSHA = strings.TrimSpace(pullRequest.TimelineItems.Nodes[0].BeforeCommit.OID)
 	}
 	status.Entry = connectorMergeQueueEntry(pullRequest.MergeQueueEntry)

--- a/internal/connector/github/merge_queue.go
+++ b/internal/connector/github/merge_queue.go
@@ -135,12 +135,13 @@ func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue conn
 		Available:         pullRequest.MergeQueue != nil || pullRequest.MergeQueueEntry != nil,
 		PullRequestNodeID: strings.TrimSpace(pullRequest.ID),
 	}
-	c.mu.RLock()
-	policy := c.branchMergePolicy
-	c.mu.RUnlock()
-	if policy.Repository == pullRequestRepoName(repo) && policy.Policy.Branch == pullRequest.BaseRefName && c.now().Sub(policy.CheckedAt) < 5*time.Minute && policy.Policy.MergeQueue {
-		status.Available = true
-		status.AdmissionLimit = policy.Policy.AdmissionLimit
+	if !status.Available && strings.TrimSpace(pullRequest.BaseRefName) != "" {
+		policy, err := c.branchMergePolicy(ctx, pullRequestRepoName(repo), pullRequest.BaseRefName)
+		if err != nil {
+			return connector.PullRequestMergeQueueStatus{}, fmt.Errorf("inspect github branch merge policy: %w", err)
+		}
+		status.Available = policy.MergeQueue
+		status.AdmissionLimit = policy.AdmissionLimit
 	}
 	if pullRequest.MergeQueue != nil {
 		status.Depth = pullRequest.MergeQueue.Entries.TotalCount

--- a/internal/connector/github/merge_queue_test.go
+++ b/internal/connector/github/merge_queue_test.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,24 +16,31 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		response  string
-		available bool
-		wantEntry *connector.PullRequestMergeQueueEntry
+		name        string
+		response    string
+		available   bool
+		wantRemoval string
+		wantEntry   *connector.PullRequestMergeQueueEntry
 	}{
 		{
 			name:      "detects merge queue policy",
-			response:  `{"data":{"repository":{"pullRequest":{"id":"PR_42","mergeStateStatus":"CLEAN","mergeQueue":{"url":"https://github.test/example/repo/queue/main","entries":{"totalCount":2},"configuration":{"maximumEntriesToBuild":3}},"mergeQueueEntry":null}}}}`,
+			response:  mergeQueueFixture(t, "queue_present.json"),
 			available: true,
 		},
 		{
 			name:      "falls back without merge queue policy",
-			response:  `{"data":{"repository":{"pullRequest":{"id":"PR_42","mergeStateStatus":"CLEAN","mergeQueue":null,"mergeQueueEntry":null}}}}`,
+			response:  mergeQueueFixture(t, "queue_absent.json"),
 			available: false,
 		},
 		{
+			name:        "rejected queue entry",
+			response:    mergeQueueFixture(t, "rejected_entry.json"),
+			available:   true,
+			wantRemoval: "Required check build failed",
+		},
+		{
 			name:      "recognizes existing queue entry",
-			response:  `{"data":{"repository":{"pullRequest":{"id":"PR_42","mergeStateStatus":"BLOCKED","mergeQueueEntry":{"headCommit":{"oid":"group-head"},"baseCommit":{"oid":"group-base"},"id":"MQE_42","state":"AWAITING_CHECKS","position":2,"estimatedTimeToMerge":420,"enqueuedAt":"2026-07-13T18:00:00Z","mergeQueue":{"url":"https://github.test/example/repo/queue/main","entries":{"totalCount":5}}}}}}}`,
+			response:  mergeQueueFixture(t, "queued_entry.json"),
 			available: true,
 			wantEntry: &connector.PullRequestMergeQueueEntry{
 				HeadSHA:                     "group-head",
@@ -64,6 +73,9 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 			}
 			if status.Available != tt.available || status.PullRequestNodeID != "PR_42" {
 				t.Fatalf("status = %#v, want available %t and node PR_42", status, tt.available)
+			}
+			if status.RemovalReason != tt.wantRemoval {
+				t.Fatalf("removal reason = %q, want %q", status.RemovalReason, tt.wantRemoval)
 			}
 			if !reflect.DeepEqual(status.Entry, tt.wantEntry) {
 				t.Fatalf("entry = %#v, want %#v", status.Entry, tt.wantEntry)
@@ -251,13 +263,22 @@ func TestConnectorMergeQueueHeadFence(t *testing.T) {
 
 func TestConnectorInspectChangedQueueHeadAllowsCleanup(t *testing.T) {
 	t.Parallel()
-	server := newGraphQLTestServer(t, []graphqlTestResponse{{body: `{"data":{"repository":{"pullRequest":{"id":"PR_42","headRefOid":"new-head","timelineItems":{"nodes":[{"beforeCommit":{"oid":"removed-head"}}]},"mergeQueueEntry":{"id":"MQE_42"}}}}}`}})
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{body: mergeQueueFixture(t, "removed_entry.json")}})
 	client := newGitHubTestConnector(t, server, Config{})
 	status, err := client.InspectPullRequestMergeQueue(context.Background(), connector.Issue{PRRepository: "example/repo", PullRequest: &connector.PullRequest{Number: 42, HeadSHA: "old-head"}})
-	if !status.RemovalObserved || status.RemovedHeadSHA != "removed-head" {
+	if !status.RemovalObserved || status.RemovedHeadSHA != "removed-head" || status.RemovalReason != "Required check build failed" {
 		t.Fatalf("removal = %#v, want removed-head", status)
 	}
 	if err != nil || status.HeadSHA != "new-head" || status.Entry == nil || status.Entry.ID != "MQE_42" {
 		t.Fatalf("status = %#v, error = %v; want current entry available for revocation", status, err)
 	}
+}
+
+func mergeQueueFixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "merge_queue", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/internal/connector/github/testdata/merge_queue/queue_absent.json
+++ b/internal/connector/github/testdata/merge_queue/queue_absent.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "PR_42",
+        "mergeStateStatus": "CLEAN",
+        "mergeQueue": null,
+        "mergeQueueEntry": null
+      }
+    }
+  }
+}

--- a/internal/connector/github/testdata/merge_queue/queue_present.json
+++ b/internal/connector/github/testdata/merge_queue/queue_present.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "PR_42",
+        "mergeStateStatus": "CLEAN",
+        "mergeQueue": {
+          "url": "https://github.test/example/repo/queue/main",
+          "entries": {
+            "totalCount": 2
+          },
+          "configuration": {
+            "maximumEntriesToBuild": 3
+          }
+        },
+        "mergeQueueEntry": null
+      }
+    }
+  }
+}

--- a/internal/connector/github/testdata/merge_queue/queued_entry.json
+++ b/internal/connector/github/testdata/merge_queue/queued_entry.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "PR_42",
+        "mergeStateStatus": "BLOCKED",
+        "mergeQueueEntry": {
+          "headCommit": {
+            "oid": "group-head"
+          },
+          "baseCommit": {
+            "oid": "group-base"
+          },
+          "id": "MQE_42",
+          "state": "AWAITING_CHECKS",
+          "position": 2,
+          "estimatedTimeToMerge": 420,
+          "enqueuedAt": "2026-07-13T18:00:00Z",
+          "mergeQueue": {
+            "url": "https://github.test/example/repo/queue/main",
+            "entries": {
+              "totalCount": 5
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/connector/github/testdata/merge_queue/rejected_entry.json
+++ b/internal/connector/github/testdata/merge_queue/rejected_entry.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "PR_42",
+        "mergeStateStatus": "CLEAN",
+        "mergeQueue": {
+          "url": "https://github.test/example/repo/queue/main",
+          "entries": {
+            "totalCount": 2
+          },
+          "configuration": {
+            "maximumEntriesToBuild": 3
+          }
+        },
+        "mergeQueueEntry": null,
+        "headRefOid": "removed-head",
+        "timelineItems": {
+          "nodes": [
+            {
+              "beforeCommit": {
+                "oid": "removed-head"
+              },
+              "reason": "Required check build failed"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/internal/connector/github/testdata/merge_queue/removed_entry.json
+++ b/internal/connector/github/testdata/merge_queue/removed_entry.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "PR_42",
+        "headRefOid": "new-head",
+        "timelineItems": {
+          "nodes": [
+            {
+              "beforeCommit": {
+                "oid": "removed-head"
+              },
+              "reason": "Required check build failed"
+            }
+          ]
+        },
+        "mergeQueueEntry": {
+          "id": "MQE_42"
+        }
+      }
+    }
+  }
+}

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -583,6 +583,14 @@ func (c *Connector) MergePullRequest(ctx context.Context, repository string, num
 	return c.github.MergePullRequest(ctx, repository, number, headSHA, mergeMethod)
 }
 
+func (c *Connector) RefreshMergeQueuePolicy(ctx context.Context) error {
+	refresher, ok := c.github.(interface{ RefreshMergeQueuePolicy(context.Context) error })
+	if !ok {
+		return nil
+	}
+	return refresher.RefreshMergeQueuePolicy(ctx)
+}
+
 func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue connector.Issue) (connector.PullRequestMergeQueueStatus, error) {
 	return c.github.InspectPullRequestMergeQueue(ctx, issue)
 }

--- a/internal/connector/githublocal/merge_queue_test.go
+++ b/internal/connector/githublocal/merge_queue_test.go
@@ -1,0 +1,47 @@
+package githublocal
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type mergeQueuePolicyBackend struct {
+	githubBackend
+	calls int
+	err   error
+}
+
+func (b *mergeQueuePolicyBackend) RefreshMergeQueuePolicy(context.Context) error {
+	b.calls++
+	return b.err
+}
+
+func TestRefreshMergeQueuePolicy(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{name: "success"},
+		{name: "provider failure", err: errors.New("rules unavailable")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			backend := &mergeQueuePolicyBackend{err: tt.err}
+			c := &Connector{github: backend}
+			if err := c.RefreshMergeQueuePolicy(t.Context()); !errors.Is(err, tt.err) {
+				t.Fatalf("error=%v", err)
+			}
+			if backend.calls != 1 {
+				t.Fatalf("calls=%d", backend.calls)
+			}
+		})
+	}
+	t.Run("backend without refresh capability", func(t *testing.T) {
+		c := &Connector{github: &recordingGitHubBackend{}}
+		if err := c.RefreshMergeQueuePolicy(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -114,6 +114,19 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 		}
 		if status.RemovalObserved && (strings.TrimSpace(status.RemovedHeadSHA) == "" || strings.TrimSpace(status.RemovedHeadSHA) == strings.TrimSpace(status.HeadSHA)) {
 			state.nativeMergeQueueDeferred[issueID] = struct{}{}
+			reason := strings.TrimSpace(status.RemovalReason)
+			if reason == "" {
+				reason = "GitHub removed the pull request from the merge queue without a reason"
+			}
+			if err := o.updateIssueState(ctx, state, candidate, autoPromoteReworkState, now, reason); err != nil {
+				o.logNativeMergeQueueFailure(candidate, "head_removed_from_queue", err)
+				continue
+			}
+			for index := range out {
+				if out[index].ID == issueID {
+					out[index].State = autoPromoteReworkState
+				}
+			}
 			o.logNativeMergeQueueFailure(candidate, "head_removed_from_queue", nil)
 			continue
 		}

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -1013,6 +1013,7 @@ type nativeMergeQueueConnector struct {
 	inspectedHead  string
 	admissionLimit *int
 	removedHeads   map[string]string
+	removalReason  string
 	dequeueErr     error
 	statusErr      error
 	inspections    int
@@ -1043,6 +1044,7 @@ func (c *nativeMergeQueueConnector) InspectPullRequestMergeQueue(_ context.Conte
 	}
 	status := connector.PullRequestMergeQueueStatus{Available: available, AdmissionLimit: limit, Depth: len(c.enqueued)}
 	status.RemovedHeadSHA, status.RemovalObserved = c.removedHeads[issue.ID]
+	status.RemovalReason = c.removalReason
 	if issue.PullRequest != nil {
 		status.HeadSHA = issue.PullRequest.HeadSHA
 	}
@@ -1237,6 +1239,9 @@ func TestNativeMergeQueueRemovalSurvivesRestart(t *testing.T) {
 				state := newState(cfg)
 				tracker.enqueued = nil
 				queued := orch.delegateNativeMergeQueueIssues(context.Background(), &state, issues, time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC))
+				if !tt.manualReenqueue && !tt.wantReenqueue && queued[1].State != autoPromoteReworkState {
+					t.Fatalf("removed queue issue state = %q, want Rework", queued[1].State)
+				}
 				if tt.manualReenqueue && (queued[1].PullRequest.MergeQueueEntry == nil || queued[1].PullRequest.MergeQueueEntry.ID != "operator-entry") {
 					t.Fatal("explicit provider entry not observed")
 				}
@@ -1269,6 +1274,45 @@ func TestNativeMergeQueueUnknownAdmissionLimit(t *testing.T) {
 			}
 			if candidates := orch.mergeWorkerDispatchCandidates(&state, queued, now); len(candidates) != 0 {
 				t.Fatalf("candidates = %v, want no worker fallback", candidates)
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueRejectionRecordsProviderReason(t *testing.T) {
+	t.Parallel()
+	for _, reason := range []string{"Required check build failed", ""} {
+		t.Run(reason, func(t *testing.T) {
+			t.Parallel()
+			issue := nativeMergeQueueTestIssue(990, "success")
+			issue.PullRequest.CIDurationSeconds = 1320
+			issue.PullRequest.BaseRef = "main"
+			tracker := &nativeMergeQueueConnector{removedHeads: map[string]string{issue.ID: issue.PullRequest.HeadSHA}, removalReason: reason, autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			recorder := &workflowMetricsRecorderSpy{}
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging", "Rework"}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workflowMetrics: recorder}
+			state := newState(cfg)
+			now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+			got := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			if got[0].State != "Rework" || len(tracker.enqueued) != 0 {
+				t.Fatalf("issues=%+v enqueue=%v", got, tracker.enqueued)
+			}
+			if len(recorder.events) != 2 {
+				t.Fatalf("events=%+v", recorder.events)
+			}
+			event := recorder.events[1]
+			if reason != "" && event.Reason != reason {
+				t.Fatalf("reason=%q", event.Reason)
+			}
+			if event.Reason == "" {
+				t.Fatal("missing rejection reason")
+			}
+			metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+			if !ok || metadata.PullRequest == nil || metadata.PullRequest.CIDurationSeconds != 1320 || metadata.PullRequest.BaseRef != "main" {
+				t.Fatalf("metadata=%s", event.MetadataJSON)
+			}
+			if len(orch.mergeWorkerDispatchCandidates(&state, got, now)) != 0 {
+				t.Fatal("rejection entered merge worker CI loop")
 			}
 		})
 	}

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -51,6 +51,8 @@ type workflowLaneMetadata struct {
 }
 
 type workflowLanePullRequestMetadata struct {
+	CIDurationSeconds    int64     `json:"ci_duration_seconds,omitempty"`
+	BaseRef              string    `json:"base_ref,omitempty"`
 	Repository           string    `json:"repository,omitempty"`
 	AssociationSource    string    `json:"association_source,omitempty"`
 	AssociationCheckedAt time.Time `json:"association_checked_at,omitzero"`
@@ -933,13 +935,15 @@ func workflowLaneMetadataHasAction(metadata workflowLaneMetadata, action string)
 
 func workflowLanePullRequestMetadataFromIssue(issue connector.Issue) *workflowLanePullRequestMetadata {
 	var metadata workflowLanePullRequestMetadata
-	metadata.Repository = issue.PRRepository
+	metadata.Repository = pullRequestRepository(issue)
 	metadata.AssociationSource = issue.PRSource
 	metadata.AssociationCheckedAt = issue.PRVerifiedAt
 	if number := workflowMetricsPRNumber(issue); number != nil && *number > 0 {
 		metadata.Number = *number
 	}
 	if issue.PullRequest != nil {
+		metadata.CIDurationSeconds = issue.PullRequest.CIDurationSeconds
+		metadata.BaseRef = issue.PullRequest.BaseRef
 		metadata.HeadSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
 		metadata.FailedChecks = autoPromoteCanonicalChecks(autoPromoteFailedChecksFromPullRequest(issue.PullRequest))
 	}

--- a/internal/project/merge_queue_test.go
+++ b/internal/project/merge_queue_test.go
@@ -1,0 +1,48 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+)
+
+type mergeQueuePolicyConnector struct {
+	connector.Connector
+	refreshes int
+	err       error
+}
+
+func (c *mergeQueuePolicyConnector) RefreshMergeQueuePolicy(context.Context) error {
+	c.refreshes++
+	return c.err
+}
+
+func TestBuildConnectorRefreshesMergeQueuePolicy(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{name: "available"},
+		{name: "discovery failure retains PR inspection", err: errors.New("rules unavailable")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &mergeQueuePolicyConnector{Connector: memory.New(memory.Config{}), err: tt.err}
+			factory := func(workflowconfig.Config) (connector.Connector, error) { return c, nil }
+			for range 2 {
+				got, err := buildConnector(t.Context(), workflowconfig.Config{}, factory)
+				if err != nil || got != c {
+					t.Fatalf("connector=%v error=%v", got, err)
+				}
+			}
+			if c.refreshes != 2 {
+				t.Fatalf("refreshes=%d, want load and reload", c.refreshes)
+			}
+		})
+	}
+}

--- a/internal/project/merge_queue_test.go
+++ b/internal/project/merge_queue_test.go
@@ -3,9 +3,12 @@ package project
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 )
@@ -44,5 +47,28 @@ func TestBuildConnectorRefreshesMergeQueuePolicy(t *testing.T) {
 				t.Fatalf("refreshes=%d, want load and reload", c.refreshes)
 			}
 		})
+	}
+}
+
+func TestUnchangedWorkflowReconciliationDoesNotRefreshMergePolicy(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	if err := os.WriteFile(path, []byte("---\ntracker:\n  kind: memory\n---\nWork.\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := globalconfig.Project{Workflow: path}
+	workflow, err := LoadWorkflowContext(t.Context(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &mergeQueuePolicyConnector{Connector: memory.New(memory.Config{})}
+	p := &Project{cfg: cfg, connector: c, workflowSource: WorkflowSourceStatus{Hash: workflow.SourceHash}}
+	for range 2 {
+		if err := p.reconcileWorkflow(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if c.refreshes != 0 {
+		t.Fatalf("refreshes=%d, want no reads for unchanged workflow", c.refreshes)
 	}
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -283,7 +283,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		}
 		connectorFactory = func(workflowconfig.Config) (connector.Connector, error) { return native, nil }
 	}
-	projectConnector, err := buildConnector(workflow.Config, connectorFactory)
+	projectConnector, err := buildConnector(context.Background(), workflow.Config, connectorFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		return nil, err
 	}
 	releaseCoordinator := releaseBuild.coordinator
-	projectRetroStore, productRetroStore, retroProductConnector, err := buildRetroIssueStores(workflow.Config, projectConnector, connectorFactory)
+	projectRetroStore, productRetroStore, retroProductConnector, err := buildRetroIssueStores(context.Background(), workflow.Config, projectConnector, connectorFactory)
 	if err != nil {
 		return nil, fmt.Errorf("create project retro: %w", err)
 	}
@@ -1414,7 +1414,9 @@ func (p *Project) reconcileWorkflow(ctx context.Context) error {
 	p.mu.Lock()
 	projectConfig := p.cfg
 	loadedHash := p.workflowSource.Hash
+	projectConnector := p.connector
 	p.mu.Unlock()
+	refreshMergeQueuePolicy(ctx, projectConnector)
 
 	workflow, err := LoadWorkflowContext(ctx, projectConfig)
 	now := time.Now().UTC()
@@ -1504,7 +1506,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		}
 	}
 
-	projectConnector, err := buildConnector(workflow.Config, connectorFactory)
+	projectConnector, err := buildConnector(ctx, workflow.Config, connectorFactory)
 	if err != nil {
 		return p.workflowReloadError("workflow reload connector failed", update.Path, err)
 	}
@@ -1519,7 +1521,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	}
 	releaseCoordinator := releaseBuild.coordinator
 
-	projectRetroStore, productRetroStore, retroProductConnector, err := buildRetroIssueStores(workflow.Config, projectConnector, connectorFactory)
+	projectRetroStore, productRetroStore, retroProductConnector, err := buildRetroIssueStores(ctx, workflow.Config, projectConnector, connectorFactory)
 	if err != nil {
 		return p.workflowReloadError("workflow reload retro connector failed", update.Path, err)
 	}
@@ -1982,6 +1984,7 @@ func projectSchedulerCandidate(project globalconfig.Project, workflow workflowco
 }
 
 func buildRetroIssueStores(
+	ctx context.Context,
 	cfg workflowconfig.Config,
 	projectConnector connector.Connector,
 	connectorFactory ConnectorFactory,
@@ -2007,7 +2010,7 @@ func buildRetroIssueStores(
 		}},
 		AllowPublicCrossProjectDetails: cfg.Retro.AllowPublicCrossProjectDetails,
 	}
-	productConnector, err := buildConnector(productConfig, connectorFactory)
+	productConnector, err := buildConnector(ctx, productConfig, connectorFactory)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -2176,7 +2179,7 @@ func resolveConnectorFactory(deps Dependencies) ConnectorFactory {
 	}
 }
 
-func buildConnector(cfg workflowconfig.Config, connectorFactory ConnectorFactory) (connector.Connector, error) {
+func buildConnector(ctx context.Context, cfg workflowconfig.Config, connectorFactory ConnectorFactory) (connector.Connector, error) {
 	projectConnector, err := connectorFactory(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("%w: create project connector: %w", ErrConnectorCreation, err)
@@ -2185,7 +2188,20 @@ func buildConnector(cfg workflowconfig.Config, connectorFactory ConnectorFactory
 		return nil, ErrMissingConnector
 	}
 
+	refreshMergeQueuePolicy(ctx, projectConnector)
 	return projectConnector, nil
+}
+
+func refreshMergeQueuePolicy(ctx context.Context, projectConnector connector.Connector) {
+	refresher, ok := projectConnector.(interface{ RefreshMergeQueuePolicy(context.Context) error })
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if err := refresher.RefreshMergeQueuePolicy(ctx); err != nil {
+		slog.Warn("refresh github branch merge policy failed; retaining pull request inspection", "error", err)
+	}
 }
 
 func closeConnector(projectConnector connector.Connector) error {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1414,9 +1414,7 @@ func (p *Project) reconcileWorkflow(ctx context.Context) error {
 	p.mu.Lock()
 	projectConfig := p.cfg
 	loadedHash := p.workflowSource.Hash
-	projectConnector := p.connector
 	p.mu.Unlock()
-	refreshMergeQueuePolicy(ctx, projectConnector)
 
 	workflow, err := LoadWorkflowContext(ctx, projectConfig)
 	now := time.Now().UTC()

--- a/internal/project/project_race_test.go
+++ b/internal/project/project_race_test.go
@@ -160,7 +160,7 @@ func TestBuildRetroIssueStoresRoutesProductRepository(t *testing.T) {
 	var repositories []string
 	var productPolicy publication.Policy
 
-	projectIssues, productIssues, created, err := buildRetroIssueStores(cfg, projectConnector, func(candidate workflowconfig.Config) (connector.Connector, error) {
+	projectIssues, productIssues, created, err := buildRetroIssueStores(t.Context(), cfg, projectConnector, func(candidate workflowconfig.Config) (connector.Connector, error) {
 		repositories = append(repositories, candidate.Tracker.Repository)
 		productPolicy = candidate.Tracker.Publication
 		return productConnector, nil


### PR DESCRIPTION
## Summary

- Detect effective GitHub merge-queue rules at project load, actual workflow reload, and PR inspection. Cache by the PR repository and base branch to support cross-repository delivery without idle policy polling. Preserve the classic merge path and PR-required/security-audit exclusions.
- Route queue removals to Rework with GitHub's reason, replacing indefinite same-head deferral. Queue admissions and waits continue through the existing worker-free path.
- Record observed PR CI durations and target branches in lane history. Doctor recommends a queue from strict protection, distinct recorded merges, and median CI; docs explain the trade-off and setup. No repository settings are changed.

Fixes #2443

## UI Surface Contract

- [x] N/A: no dashboard or layout changes.
- [x] No persistent top-of-screen messaging is added.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Focused table-driven tests for queue presence/absence, rule refresh, cross-repository/branch policy isolation, unchanged-workflow reconciliation, provider removal/restart, tracker forwarding, and recorded-history recommendations.
- [x] Provider response fixtures cover queue capability, existing entries, and removal history.
- [x] `make check`
