### PR TITLE
feat(intake): stamp and deduplicate machine issues

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -305,7 +305,9 @@ the operator explicitly accepts that setting for this customer/project.
    Apps should grant Issue Fields organization read for issue-field mode,
    repository label access for label mode, Issues repository read/write when
    status moves or comments are enabled, Pull requests read/checks read for PR
-   gates, and selected repository access.
+   gates, and selected repository access. Machine issue filing additionally
+   requires Contents repository read/write to create and update fingerprint
+   records on the target repository’s `detent-schedule-coordination` branch.
 
 3. **Confirm Codex is installed and signed in.** Detent dispatches agents
    through the Codex app-server. Verify:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,11 @@ repository label access for label mode. Issue-field writes use the issue field
 values API and require issue or pull request repository write permission plus
 push access to the repository. Label mode uses repository label reads/writes and
 issue label updates. If Kanban integration mode is enabled in a release that
-supports it, comment submission also requires issue/PR comment write.
+supports it, comment submission also requires issue/PR comment write. Machine
+issue filing also requires Contents repository read/write: fingerprint
+publication records use the existing GitHub-ref coordinator on the target
+repository’s `detent-schedule-coordination` branch. If coordination fails,
+Detent returns the error without creating an uncoordinated issue.
 
 2. Choose the GitHub status source.
 

--- a/docs/scheduled-routines.md
+++ b/docs/scheduled-routines.md
@@ -38,11 +38,20 @@ configured maximum clock skew before takeover, so failover is bounded without
 allowing clock drift to create two active holders. Changing ownership backend
 settings requires a Detent restart.
 
-Issue fingerprints use durable records on the same branch. A creator reserves
+Scheduled operation markers use durable records on the configured branch. A creator reserves
 the fingerprint before posting and records the resulting issue. If a create
 response becomes uncertain, successors reconcile the marker and do not issue a
 second POST. `detent doctor` fails when scheduled operations lack ownership,
 the backend is unreachable, or no active owner is renewing the project lease.
+
+Machine issue fingerprints additionally use the same publication coordinator
+on the target repository's `detent-schedule-coordination` branch, with a
+repository-and-fingerprint key shared by every connector and instance. This
+publication coordination applies to worker and doctor filings as well as
+scheduled sources, even when schedule ownership is disabled. The credential
+needs Contents read/write on the target repository. Failure to coordinate
+returns an error without an issue POST. Matching open issues receive occurrence
+comments; closed issues allow a new publication. This adds no daily cap.
 
 ## Alert and Scheduled Intake
 

--- a/internal/cli/doctor_self_improvement.go
+++ b/internal/cli/doctor_self_improvement.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -19,6 +20,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector/factory"
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 	"github.com/digitaldrywood/detent/internal/lessons"
 	"github.com/digitaldrywood/detent/internal/store"
 )
@@ -447,15 +449,23 @@ func createDoctorWorkflowImprovementProposalIssues(
 		if err != nil {
 			return nil, err
 		}
+		if reused && !issue.Closed {
+			body := issueorigin.Stamp(proposal.IssueBody, issueorigin.Origin{Kind: "doctor", Source: time.Now().UTC().Format(time.RFC3339Nano), Fingerprint: issueorigin.Fingerprint(proposal.IssueMarker)})
+			if err := projectConnector.CreateComment(ctx, issue.ID, issueorigin.Occurrence(body)); err != nil {
+				return nil, err
+			}
+		}
 		if !reused {
 			issue, err = projectConnector.CreateIssue(ctx, connector.IssueDraft{
 				Title: proposal.Title,
-				Body:  proposal.IssueBody,
+				Body:  issueorigin.Stamp(proposal.IssueBody, issueorigin.Origin{Kind: "doctor", Source: time.Now().UTC().Format(time.RFC3339Nano), Fingerprint: issueorigin.Fingerprint(proposal.IssueMarker)}),
 			})
 			if err != nil {
 				return nil, err
 			}
-			if err := deps.proposalLaneWriter(ctx, projectID, cfg, projectConnector, issue, doctorWorkflowProposalBacklogState); errors.Is(err, connector.ErrStateUpdateBlocked) {
+			if issue.PublicationReused {
+				reused = true
+			} else if err := deps.proposalLaneWriter(ctx, projectID, cfg, projectConnector, issue, doctorWorkflowProposalBacklogState); errors.Is(err, connector.ErrStateUpdateBlocked) {
 				slog.Default().Debug("skip blocked self-improvement proposal state update", "issue_id", issue.ID, "target_state", doctorWorkflowProposalBacklogState, "error", err)
 			} else if err != nil {
 				return nil, err
@@ -572,7 +582,7 @@ func doctorWorkflowExistingProposalIssue(ctx context.Context, projectConnector d
 		return connector.Issue{}, false, err
 	}
 	for _, issue := range issues {
-		if strings.Contains(issue.Description, proposal.IssueMarker) {
+		if !issue.Closed && strings.Contains(issue.Description, proposal.IssueMarker) {
 			return issue, true, nil
 		}
 	}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/coordination"
 	"github.com/digitaldrywood/detent/internal/intake"
 	"github.com/digitaldrywood/detent/internal/publication"
 )
@@ -109,6 +110,7 @@ type Config struct {
 }
 
 type Connector struct {
+	machineIssueStore   coordination.Store
 	branchMergePolicies map[string]branchMergePolicySnapshot
 	client              *Client
 	statusSource        string

--- a/internal/connector/github/intake.go
+++ b/internal/connector/github/intake.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 )
 
 const intakeIssueSearchPageSize = 100
@@ -35,7 +36,7 @@ func (c *Connector) FindIntakeIssue(ctx context.Context, marker string) (intake.
 			return intake.Issue{}, false, fmt.Errorf("find github intake issue: %w", err)
 		}
 		for _, item := range response.Items {
-			if item.PullRequest != nil || item.Body == nil || !strings.Contains(*item.Body, marker) {
+			if item.PullRequest != nil || item.Body == nil || strings.EqualFold(item.State, "closed") || !strings.Contains(*item.Body, marker) {
 				continue
 			}
 			ref := issueRef{Owner: c.repository.Owner, Name: c.repository.Name, Number: item.Number}
@@ -61,7 +62,7 @@ func (c *Connector) CreateIntakeIssue(ctx context.Context, draft intake.IssueDra
 	if err != nil {
 		return intake.Issue{}, err
 	}
-	if !c.usesLabelStatus() && !c.usesIssueFieldStatus() {
+	if !issue.PublicationReused && !c.usesLabelStatus() && !c.usesIssueFieldStatus() {
 		if err := c.addIntakeIssueToProject(ctx, issue.ID); err != nil {
 			return intakeIssue(issue), err
 		}
@@ -77,6 +78,11 @@ func (c *Connector) UpdateIntakeIssue(ctx context.Context, issueID string, draft
 	if !ok {
 		return intake.Issue{}, ErrStatusUpdateFailed
 	}
+	previous, err := c.fetchRESTIssue(ctx, ref)
+	if err != nil {
+		return intake.Issue{}, err
+	}
+	draft.Body = issueorigin.Preserve(draft.Body, previous.Body)
 	repository := ref.Owner + "/" + ref.Name
 	payload := map[string]any{
 		"title": c.protectPublicationText(ctx, repository, strings.TrimSpace(draft.Title)),
@@ -148,7 +154,7 @@ func (c *Connector) addIntakeIssueToProject(ctx context.Context, issueID string)
 func restIntakeIssueSearchPath(repo pullRequestRepo, marker string, page int) string {
 	token := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(marker), "<!--"), "-->"))
 	values := url.Values{}
-	values.Set("q", "repo:"+repo.Owner+"/"+repo.Name+" is:issue in:body \""+token+"\"")
+	values.Set("q", "repo:"+repo.Owner+"/"+repo.Name+" is:issue is:open in:body \""+token+"\"")
 	values.Set("per_page", strconv.Itoa(intakeIssueSearchPageSize))
 	values.Set("page", strconv.Itoa(page))
 	return "/search/issues?" + values.Encode()
@@ -171,5 +177,6 @@ func intakeIssue(issue connector.Issue) intake.Issue {
 		URL:        strings.TrimSpace(issue.URL),
 		Body:       issue.Description,
 		Closed:     issue.Closed,
+		Reused:     issue.PublicationReused,
 	}
 }

--- a/internal/connector/github/intake_test.go
+++ b/internal/connector/github/intake_test.go
@@ -42,7 +42,7 @@ func TestConnectorFindIntakeIssueSearchesDurableMarker(t *testing.T) {
 func TestConnectorUpdateIntakeIssuePatchesContentAndAddsLabels(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{method: http.MethodGet, body: `{"node_id":"I_42","number":42,"body":"original body","state":"open"}`},
 		{
 			method: http.MethodPatch,
 			path:   "/repos/example/repo/issues/42",
@@ -69,11 +69,11 @@ func TestConnectorUpdateIntakeIssuePatchesContentAndAddsLabels(t *testing.T) {
 		t.Fatalf("issue = %#v", issue)
 	}
 	requests := server.requests()
-	patchBody := requests[0]["body"].(map[string]any)
+	patchBody := requests[1]["body"].(map[string]any)
 	if patchBody["title"] != "Updated alert" || patchBody["body"] != "updated body" {
 		t.Fatalf("patch body = %#v", patchBody)
 	}
-	labels := requests[1]["body"].(map[string]any)["labels"].([]any)
+	labels := requests[2]["body"].(map[string]any)["labels"].([]any)
 	if len(labels) != 1 || labels[0] != "bug" {
 		t.Fatalf("labels = %#v, want [bug]", labels)
 	}
@@ -82,7 +82,7 @@ func TestConnectorUpdateIntakeIssuePatchesContentAndAddsLabels(t *testing.T) {
 func TestConnectorUpdateIssueBodyPatchesOnlyBody(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{method: http.MethodGet, body: `{"node_id":"I_42","number":42,"body":"original body","state":"open"}`}, {
 		method: http.MethodPatch,
 		path:   "/repos/example/repo/issues/42",
 		body:   `{"node_id":"I_42","number":42,"title":"Existing title","body":"updated body","state":"open","html_url":"https://github.com/example/repo/issues/42"}`,
@@ -93,7 +93,7 @@ func TestConnectorUpdateIssueBodyPatchesOnlyBody(t *testing.T) {
 	if err := connector.UpdateIssueBody(context.Background(), "I_42", "updated body"); err != nil {
 		t.Fatalf("UpdateIssueBody() error = %v", err)
 	}
-	body := server.requests()[0]["body"].(map[string]any)
+	body := server.requests()[1]["body"].(map[string]any)
 	if len(body) != 1 || body["body"] != "updated body" {
 		t.Fatalf("patch body = %#v, want only updated body", body)
 	}

--- a/internal/connector/github/issue_origin.go
+++ b/internal/connector/github/issue_origin.go
@@ -4,10 +4,89 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/coordination"
+	"github.com/digitaldrywood/detent/internal/intake"
 	"github.com/digitaldrywood/detent/internal/issueorigin"
+	"github.com/digitaldrywood/detent/internal/scheduleowner"
 )
+
+func (c *Connector) createMachineIssue(ctx context.Context, draft connector.IssueDraft, fingerprint string) (connector.Issue, error) {
+	repository := strings.ToLower(c.repository.Owner + "/" + c.repository.Name)
+	config := (scheduleowner.Config{Enabled: true, Key: repository}).Normalized(repository, "")
+	store := c.machineIssueStore
+	if store == nil {
+		var err error
+		store, err = coordination.NewGitHubRefStore(coordination.GitHubRefConfig{
+			Repository: repository, Branch: config.Branch, Client: c.client,
+		})
+		if err != nil {
+			return connector.Issue{}, err
+		}
+	}
+	coordinator, err := scheduleowner.NewIssueCoordinator(config, store, scheduleowner.Dependencies{})
+	if err != nil {
+		return connector.Issue{}, err
+	}
+	backend := &fingerprintIssueBackend{connector: c, fingerprint: fingerprint}
+	_, created, err := coordinator.EnsureRecurring(ctx, "machine:"+fingerprint, intake.IssueDraft{
+		Title: draft.Title, Body: draft.Body, Labels: draft.Labels,
+	}, backend)
+	if err != nil {
+		return connector.Issue{}, err
+	}
+	backend.issue.PublicationReused = !created
+	return backend.issue, nil
+}
+
+type fingerprintIssueBackend struct {
+	connector   *Connector
+	fingerprint string
+	issue       connector.Issue
+}
+
+func (b *fingerprintIssueBackend) FindIntakeIssue(ctx context.Context, _ string) (intake.Issue, bool, error) {
+	issue, found, err := b.connector.findOpenFingerprint(ctx, b.fingerprint)
+	if found {
+		b.issue = issue
+	}
+	return intake.Issue{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL, Body: issue.Description}, found, err
+}
+
+func (b *fingerprintIssueBackend) CreateIntakeIssue(ctx context.Context, draft intake.IssueDraft) (intake.Issue, error) {
+	issue, err := b.connector.createIssue(ctx, connector.IssueDraft{Title: draft.Title, Body: draft.Body, Labels: draft.Labels}, draft.Title, draft.Body)
+	b.issue = issue
+	return intake.Issue{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL, Body: issue.Description}, err
+}
+
+func (b *fingerprintIssueBackend) IntakeIssueClosed(ctx context.Context, id string) (bool, error) {
+	issue, found, err := b.FindIntakeIssue(ctx, b.fingerprint)
+	if err != nil {
+		return false, err
+	}
+	if found && issue.ID == id {
+		return false, nil
+	}
+	ref, ok, err := b.connector.issueRefForID(ctx, id, graphQLQueryIssueLookup)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, ErrStatusUpdateFailed
+	}
+	node, err := b.connector.fetchRESTIssue(ctx, ref)
+	if err != nil {
+		return false, err
+	}
+	b.issue = b.connector.buildLabelIssue(node, b.connector.labelStatusFromLabels(node.Labels))
+	return strings.EqualFold(node.State, "closed"), nil
+}
+
+func (b *fingerprintIssueBackend) CreateComment(ctx context.Context, id, body string) error {
+	return b.connector.CreateComment(ctx, id, body)
+}
 
 func (c *Connector) findOpenFingerprint(ctx context.Context, fingerprint string) (connector.Issue, bool, error) {
 	for page := 1; ; page++ {

--- a/internal/connector/github/issue_origin.go
+++ b/internal/connector/github/issue_origin.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+)
+
+func (c *Connector) findOpenFingerprint(ctx context.Context, fingerprint string) (connector.Issue, bool, error) {
+	for page := 1; ; page++ {
+		var issues []restIssue
+		path := fmt.Sprintf("/repos/%s/%s/issues?state=open&per_page=100&page=%d", c.repository.Owner, c.repository.Name, page)
+		if err := c.client.REST(ctx, http.MethodGet, path, nil, &issues); err != nil {
+			return connector.Issue{}, false, fmt.Errorf("find open issue fingerprint: %w", err)
+		}
+		for _, issue := range issues {
+			if issue.PullRequest != nil || issue.Body == nil || issue.State == "closed" {
+				continue
+			}
+			origin, ok := issueorigin.Parse(*issue.Body)
+			if !ok || origin.Fingerprint != fingerprint {
+				continue
+			}
+			ref := issueRef{Owner: c.repository.Owner, Name: c.repository.Name, Number: issue.Number}
+			node := githubIssueNodeFromREST(ref, issue)
+			c.cacheIssueRef(node)
+			return c.buildLabelIssue(node, c.labelStatusFromLabels(node.Labels)), true, nil
+		}
+		if len(issues) < 100 {
+			return connector.Issue{}, false, nil
+		}
+	}
+}

--- a/internal/connector/github/issue_origin_test.go
+++ b/internal/connector/github/issue_origin_test.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+)
+
+func TestMachineIssueDuplicate(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, existing, state string
+		reused                bool
+	}{
+		{"same fingerprint", issueorigin.Stamp("Original", issueorigin.Origin{Kind: "routine", Instance: "one", Source: "run-1", Fingerprint: "disk"}), "open", true},
+		{"legacy audit", "<!-- detent-audit-fp:disk -->", "open", true},
+		{"different fingerprint", issueorigin.Stamp("Other", issueorigin.Origin{Kind: "audit", Fingerprint: "network"}), "open", false},
+		{"closed issue", issueorigin.Stamp("Closed", issueorigin.Origin{Kind: "worker", Fingerprint: "disk"}), "closed", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := issueorigin.Stamp("New occurrence", issueorigin.Origin{Kind: "worker", Instance: "two", Source: "attempt-2", Fingerprint: "disk"})
+			path := "/repos/example/repo/issues"
+			response := fmt.Sprintf(`{"node_id":"I_43","number":43,"body":%q,"state":"open"}`, body)
+			if tt.reused {
+				path = "/repos/example/repo/issues/42/comments"
+				response = `{"node_id":"IC_1"}`
+			}
+			server := newGraphQLTestServer(t, []graphqlTestResponse{
+				{method: http.MethodGet, body: fmt.Sprintf(`[{"node_id":"I_42","number":42,"body":%q,"state":%q}]`, tt.existing, tt.state)},
+				{method: http.MethodPost, path: path, body: response},
+			})
+			c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			issue, err := c.CreateIssue(t.Context(), connector.IssueDraft{Title: "Disk space", Body: body})
+			if err != nil || issue.PublicationReused != tt.reused {
+				t.Fatalf("CreateIssue() = %+v, %v", issue, err)
+			}
+			requests := server.requests()
+			posted := requests[1]["body"].(map[string]any)["body"].(string)
+			if tt.reused && (!strings.Contains(posted, "New machine occurrence") || issue.Description != tt.existing) {
+				t.Fatalf("duplicate replaced body or lost occurrence: %+v %s", issue, posted)
+			}
+		})
+	}
+}
+
+func TestSeptemberEightDiskOccurrences(t *testing.T) {
+	t.Parallel()
+	fixtures := []struct {
+		number    int
+		title, at string
+	}{
+		{2364, "Restore disk capacity for Detent worker validation", "2026-09-08T22:45:23Z"},
+		{2365, "operator: restore validation host disk capacity", "2026-09-08T22:46:49Z"},
+		{2366, "Restore free disk capacity for Detent validation", "2026-09-08T22:52:31Z"},
+		{2367, "Free host disk space for Detent validation", "2026-09-08T22:53:18Z"},
+	}
+	var responses []graphqlTestResponse
+	original := issueorigin.Stamp(fixtures[0].title, issueorigin.Origin{Kind: "worker", Instance: "validation-host", Source: fixtures[0].at, Fingerprint: "validation-host-disk-capacity"})
+	for index := range fixtures {
+		if index == 0 {
+			responses = append(responses,
+				graphqlTestResponse{method: http.MethodGet, body: `[]`},
+				graphqlTestResponse{method: http.MethodPost, path: "/repos/example/repo/issues", body: fmt.Sprintf(`{"node_id":"I_2364","number":2364,"state":"open","body":%q}`, original)},
+			)
+		} else {
+			responses = append(responses,
+				graphqlTestResponse{method: http.MethodGet, body: fmt.Sprintf(`[{"node_id":"I_2364","number":2364,"state":"open","body":%q}]`, original)},
+				graphqlTestResponse{method: http.MethodPost, path: "/repos/example/repo/issues/2364/comments", body: `{"node_id":"IC_occurrence"}`},
+			)
+		}
+	}
+	server := newGraphQLTestServer(t, responses)
+	c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+	for index, fixture := range fixtures {
+		body := issueorigin.Stamp(fixture.title, issueorigin.Origin{Kind: "worker", Instance: "validation-host", Source: fixture.at, Fingerprint: "validation-host-disk-capacity"})
+		issue, err := c.CreateIssue(t.Context(), connector.IssueDraft{Title: fixture.title, Body: body})
+		if err != nil || issue.ID != "I_2364" || issue.PublicationReused != (index > 0) {
+			t.Fatalf("occurrence #%d = %+v, %v", fixture.number, issue, err)
+		}
+	}
+}
+
+func TestMachineOriginSurvivesBodyUpdates(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"body", "intake"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			original := issueorigin.Stamp("Original", issueorigin.Origin{Kind: "routine", Instance: "first-instance", Source: "first-run", Fingerprint: "problem"})
+			server := newGraphQLTestServer(t, []graphqlTestResponse{
+				{method: http.MethodGet, body: fmt.Sprintf(`{"node_id":"I_42","number":42,"state":"open","body":%q}`, original)},
+				{method: http.MethodPatch, path: "/repos/example/repo/issues/42", body: `{"node_id":"I_42","number":42,"state":"open","body":"updated"}`},
+			})
+			c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			c.projectCache.SetIssueRef("I_42", issueRef{Owner: "example", Name: "repo", Number: 42})
+			var err error
+			if mode == "body" {
+				err = c.UpdateIssueBody(t.Context(), "I_42", "Updated")
+			} else {
+				_, err = c.UpdateIntakeIssue(t.Context(), "I_42", intake.IssueDraft{Title: "Updated", Body: "Updated"})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := server.requests()[1]["body"].(map[string]any)["body"].(string)
+			origin, ok := issueorigin.Parse(body)
+			if !ok || origin.Instance != "first-instance" || origin.Source != "first-run" || origin.Fingerprint != "problem" {
+				t.Fatalf("updated origin = %+v", origin)
+			}
+		})
+	}
+}

--- a/internal/connector/github/issue_origin_test.go
+++ b/internal/connector/github/issue_origin_test.go
@@ -1,12 +1,18 @@
 package github
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/coordination"
 	"github.com/digitaldrywood/detent/internal/intake"
 	"github.com/digitaldrywood/detent/internal/issueorigin"
 )
@@ -36,6 +42,7 @@ func TestMachineIssueDuplicate(t *testing.T) {
 				{method: http.MethodPost, path: path, body: response},
 			})
 			c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			c.machineIssueStore = &machineTestStore{records: map[string]coordination.Record{}}
 			issue, err := c.CreateIssue(t.Context(), connector.IssueDraft{Title: "Disk space", Body: body})
 			if err != nil || issue.PublicationReused != tt.reused {
 				t.Fatalf("CreateIssue() = %+v, %v", issue, err)
@@ -77,6 +84,7 @@ func TestSeptemberEightDiskOccurrences(t *testing.T) {
 	}
 	server := newGraphQLTestServer(t, responses)
 	c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+	c.machineIssueStore = &machineTestStore{records: map[string]coordination.Record{}}
 	for index, fixture := range fixtures {
 		body := issueorigin.Stamp(fixture.title, issueorigin.Origin{Kind: "worker", Instance: "validation-host", Source: fixture.at, Fingerprint: "validation-host-disk-capacity"})
 		issue, err := c.CreateIssue(t.Context(), connector.IssueDraft{Title: fixture.title, Body: body})
@@ -97,6 +105,7 @@ func TestMachineOriginSurvivesBodyUpdates(t *testing.T) {
 				{method: http.MethodPatch, path: "/repos/example/repo/issues/42", body: `{"node_id":"I_42","number":42,"state":"open","body":"updated"}`},
 			})
 			c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			c.machineIssueStore = &machineTestStore{records: map[string]coordination.Record{}}
 			c.projectCache.SetIssueRef("I_42", issueRef{Owner: "example", Name: "repo", Number: 42})
 			var err error
 			if mode == "body" {
@@ -111,6 +120,125 @@ func TestMachineOriginSurvivesBodyUpdates(t *testing.T) {
 			origin, ok := issueorigin.Parse(body)
 			if !ok || origin.Instance != "first-instance" || origin.Source != "first-run" || origin.Fingerprint != "problem" {
 				t.Fatalf("updated origin = %+v", origin)
+			}
+		})
+	}
+}
+
+type machineTestStore struct {
+	mu      sync.Mutex
+	records map[string]coordination.Record
+}
+
+func (s *machineTestStore) Get(_ context.Context, key string) (coordination.Record, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[key]
+	return record, ok, nil
+}
+
+func (s *machineTestStore) CompareAndSwap(_ context.Context, key, version string, value []byte) (coordination.Record, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous := s.records[key]
+	if previous.Version != version {
+		return previous, false, nil
+	}
+	record := coordination.Record{Value: append([]byte(nil), value...), Version: version + "x", ModifiedAt: time.Now()}
+	s.records[key] = record
+	return record, true, nil
+}
+
+func TestMachineIssueSeparateConnectors(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	var body string
+	creates, comments := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			if body == "" {
+				fmt.Fprint(w, `[]`)
+				return
+			}
+			fmt.Fprintf(w, `[{"node_id":"I_1","number":1,"state":"open","body":%q}]`, body)
+		case strings.HasSuffix(r.URL.Path, "/comments"):
+			comments++
+			fmt.Fprint(w, `{"node_id":"IC_1"}`)
+		default:
+			var draft struct{ Body string }
+			if err := json.NewDecoder(r.Body).Decode(&draft); err != nil {
+				t.Error(err)
+			}
+			body = draft.Body
+			creates++
+			fmt.Fprintf(w, `{"node_id":"I_1","number":1,"state":"open","body":%q}`, body)
+		}
+	}))
+	defer server.Close()
+	store := &machineTestStore{records: map[string]coordination.Record{}}
+	results := make(chan error, 2)
+	reused := make(chan bool, 2)
+	for _, kind := range []string{"worker", "routine"} {
+		c, err := NewConnector(Config{Endpoint: server.URL, APIKey: "token", Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.machineIssueStore = store
+		go func() {
+			issue, err := c.CreateIssue(t.Context(), connector.IssueDraft{Title: "Disk", Body: issueorigin.Stamp(kind, issueorigin.Origin{Kind: kind, Fingerprint: "disk"})})
+			if err == nil && issue.ID != "I_1" {
+				err = fmt.Errorf("issue ID = %q", issue.ID)
+			}
+			reused <- issue.PublicationReused
+			results <- err
+		}()
+	}
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if first, second := <-reused, <-reused; first == second {
+		t.Fatalf("reused = %v, %v", first, second)
+	}
+	if creates != 1 || comments != 1 {
+		t.Fatalf("creates=%d comments=%d", creates, comments)
+	}
+}
+
+func TestMachineIssueCoordinationFailure(t *testing.T) {
+	t.Parallel()
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: `{"errors":[{"message":"coordination access denied"}]}`},
+	})
+	c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+	_, err := c.CreateIssue(t.Context(), connector.IssueDraft{Title: "Disk", Body: issueorigin.Stamp("Disk", issueorigin.Origin{Kind: "worker", Fingerprint: "disk"})})
+	if err == nil {
+		t.Fatal("expected coordination failure")
+	}
+	if len(server.requests()) != 1 {
+		t.Fatalf("requests=%v", server.requests())
+	}
+}
+
+func TestMachineIssueListingAbsenceIsNotClosure(t *testing.T) {
+	t.Parallel()
+	for _, state := range []string{"open", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			server := newGraphQLTestServer(t, []graphqlTestResponse{
+				{method: http.MethodGet, body: `[]`},
+				{method: http.MethodGet, path: "/repos/example/repo/issues/1", body: fmt.Sprintf(`{"node_id":"I_1","number":1,"state":%q,"body":"original"}`, state)},
+			})
+			c := newGitHubTestConnector(t, server, Config{Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel})
+			c.projectCache.SetIssueRef("I_1", issueRef{Owner: "example", Name: "repo", Number: 1})
+			backend := &fingerprintIssueBackend{connector: c, fingerprint: "disk"}
+			closed, err := backend.IntakeIssueClosed(t.Context(), "I_1")
+			if err != nil || closed != (state == "closed") {
+				t.Fatalf("closed=%v err=%v", closed, err)
 			}
 		})
 	}

--- a/internal/connector/github/issue_write.go
+++ b/internal/connector/github/issue_write.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 )
 
 func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
@@ -70,6 +71,11 @@ func (c *Connector) UpdateIssueBody(ctx context.Context, issueID string, body st
 	if !ok {
 		return ErrStatusUpdateFailed
 	}
+	previous, err := c.fetchRESTIssue(ctx, ref)
+	if err != nil {
+		return err
+	}
+	body = issueorigin.Preserve(body, previous.Body)
 	repository := ref.Owner + "/" + ref.Name
 	body = c.protectPublicationText(ctx, repository, body)
 	var response restIssue
@@ -96,6 +102,21 @@ func (c *Connector) CreateIssue(ctx context.Context, draft connector.IssueDraft)
 	}
 
 	body := c.protectPublicationText(ctx, repository, strings.TrimSpace(draft.Body))
+	if origin, machine := issueorigin.Parse(body); machine {
+		c.writeMu.Lock()
+		defer c.writeMu.Unlock()
+		existing, found, err := c.findOpenFingerprint(ctx, origin.Fingerprint)
+		if err != nil {
+			return connector.Issue{}, err
+		}
+		if found {
+			if err := c.CreateComment(ctx, existing.ID, issueorigin.Occurrence(body)); err != nil {
+				return connector.Issue{}, err
+			}
+			existing.PublicationReused = true
+			return existing, nil
+		}
+	}
 	labels := normalizedIssueDraftLabels(draft.Labels)
 	payload := map[string]any{
 		"title": title,

--- a/internal/connector/github/issue_write.go
+++ b/internal/connector/github/issue_write.go
@@ -103,20 +103,13 @@ func (c *Connector) CreateIssue(ctx context.Context, draft connector.IssueDraft)
 
 	body := c.protectPublicationText(ctx, repository, strings.TrimSpace(draft.Body))
 	if origin, machine := issueorigin.Parse(body); machine {
-		c.writeMu.Lock()
-		defer c.writeMu.Unlock()
-		existing, found, err := c.findOpenFingerprint(ctx, origin.Fingerprint)
-		if err != nil {
-			return connector.Issue{}, err
-		}
-		if found {
-			if err := c.CreateComment(ctx, existing.ID, issueorigin.Occurrence(body)); err != nil {
-				return connector.Issue{}, err
-			}
-			existing.PublicationReused = true
-			return existing, nil
-		}
+		draft.Title, draft.Body = title, body
+		return c.createMachineIssue(ctx, draft, origin.Fingerprint)
 	}
+	return c.createIssue(ctx, draft, title, body)
+}
+
+func (c *Connector) createIssue(ctx context.Context, draft connector.IssueDraft, title, body string) (connector.Issue, error) {
 	labels := normalizedIssueDraftLabels(draft.Labels)
 	payload := map[string]any{
 		"title": title,

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -39,6 +39,7 @@ func (a AuthorAssociation) Valid() bool {
 }
 
 type Issue struct {
+	PublicationReused bool                 `json:"-" yaml:"-"`
 	ID                string               `json:"id,omitempty" yaml:"id,omitempty"`
 	Identifier        string               `json:"identifier,omitempty" yaml:"identifier,omitempty"`
 	Number            int                  `json:"number,omitempty" yaml:"number,omitempty"`

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 )
 
 const (
@@ -304,6 +305,26 @@ func (c *Connector) CreateIssue(_ context.Context, draft connector.IssueDraft) (
 	defer c.mu.Unlock()
 
 	now := c.now().UTC()
+	if origin, machine := issueorigin.Parse(draft.Body); machine {
+		for index := range c.issues {
+			existing := &c.issues[index]
+			previous, ok := issueorigin.Parse(existing.Description)
+			if existing.Closed || !ok || previous.Fingerprint != origin.Fingerprint {
+				continue
+			}
+			body := issueorigin.Occurrence(draft.Body)
+			existing.Comments = append(existing.Comments, connector.IssueComment{
+				ID: memoryCommentID(*existing, len(existing.Comments)+1), Backend: connector.BackendMemory.String(),
+				Body: body, AuthorLogin: "memory", AuthorAuthorized: true, CreatedAt: &now,
+				Local: true, TargetType: connector.IssueCommentTargetIssue,
+			})
+			existing.UpdatedAt = &now
+			c.send(Event{Kind: EventKindComment, IssueID: existing.ID, Body: body})
+			result := cloneIssue(*existing)
+			result.PublicationReused = true
+			return result, nil
+		}
+	}
 	issueID := "issue-" + strconv.Itoa(len(c.issues)+1)
 	issue := connector.NewIssue()
 	issue.ID = issueID
@@ -324,7 +345,7 @@ func (c *Connector) FindIntakeIssue(_ context.Context, marker string) (intake.Is
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	for _, issue := range c.issues {
-		if strings.Contains(issue.Description, marker) {
+		if !issue.Closed && strings.Contains(issue.Description, marker) {
 			return memoryIntakeIssue(issue), true, nil
 		}
 	}
@@ -584,6 +605,7 @@ func memoryIntakeIssue(issue connector.Issue) intake.Issue {
 		URL:        issue.URL,
 		Body:       issue.Description,
 		Closed:     issue.Closed,
+		Reused:     issue.PublicationReused,
 	}
 }
 

--- a/internal/connector/memory/memory_test.go
+++ b/internal/connector/memory/memory_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 )
 
 func TestConnectorFetchesConfiguredIssues(t *testing.T) {
@@ -525,4 +527,39 @@ func issueIDs(issues []connector.Issue) []string {
 		ids = append(ids, issue.ID)
 	}
 	return ids
+}
+
+func TestMachineIssueFingerprint(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, fingerprint string
+		closed, reused    bool
+	}{
+		{"repeat", "disk", false, true},
+		{"different", "network", false, false},
+		{"closed", "disk", true, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(Config{Stateful: true})
+			original, err := c.CreateIntakeIssue(t.Context(), intake.IssueDraft{Title: "Original", Body: issueorigin.Stamp("Original", issueorigin.Origin{Kind: "worker", Fingerprint: "disk"})})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.closed {
+				if err := c.CloseIssue(t.Context(), original.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			result, err := c.CreateIntakeIssue(t.Context(), intake.IssueDraft{Title: "Occurrence", Body: issueorigin.Stamp("Occurrence", issueorigin.Origin{Kind: "routine", Fingerprint: tt.fingerprint})})
+			if err != nil || result.Reused != tt.reused {
+				t.Fatalf("result=%+v err=%v", result, err)
+			}
+			if tt.reused && (len(c.issues) != 1 || len(c.issues[0].Comments) != 1 || result.Body != original.Body) {
+				t.Fatalf("issues=%+v", c.issues)
+			}
+			if !tt.reused && len(c.issues) != 2 {
+				t.Fatalf("issues=%+v", c.issues)
+			}
+		})
+	}
 }

--- a/internal/intake/intake.go
+++ b/internal/intake/intake.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/robfig/cron/v3"
 
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 	"github.com/digitaldrywood/detent/internal/schedulehealth"
 )
 
@@ -38,6 +39,7 @@ type Event struct {
 }
 
 type Issue struct {
+	Reused     bool   `json:"-"`
 	ID         string `json:"id,omitempty"`
 	Identifier string `json:"identifier,omitempty"`
 	Number     int    `json:"number,omitempty"`
@@ -121,7 +123,6 @@ type Manager struct {
 	scannerFactory ScannerFactory
 	logger         *slog.Logger
 	now            func() time.Time
-	issues         map[string]Issue
 	updates        chan struct{}
 	projectID      string
 	scheduleRuns   schedulehealth.Recorder
@@ -152,7 +153,6 @@ func New(cfg Config, store IssueStore, deps Dependencies) (*Manager, error) {
 		scannerFactory: scannerFactory,
 		logger:         logger,
 		now:            now,
-		issues:         map[string]Issue{},
 		updates:        make(chan struct{}, 1),
 		projectID:      strings.TrimSpace(deps.ProjectID),
 		scheduleRuns:   deps.ScheduleRuns,
@@ -415,19 +415,17 @@ func (m *Manager) process(ctx context.Context, source Source, store IssueStore, 
 		Body:   appendMarker(render(source.Creates.Body, fields), marker),
 		Labels: append([]string(nil), source.Creates.Labels...),
 	}
+	draft.Body = issueorigin.Stamp(draft.Body, issueorigin.Origin{Kind: "audit", Source: source.Name + "/" + m.now().UTC().Format(time.RFC3339Nano), Fingerprint: fingerprint})
 	pendingDraft := draft
 	pendingDraft.Body = appendMarker(draft.Body, pendingStateMarker)
 
 	m.processMu.Lock()
 	defer m.processMu.Unlock()
-	if cached, ok := m.issues[marker]; ok {
-		return m.updateExisting(ctx, source, store, marker, cached, draft, pendingDraft, result)
-	}
 	issue, found, err := store.FindIntakeIssue(ctx, marker)
 	if err != nil {
 		return result, fmt.Errorf("find intake issue: %w", err)
 	}
-	if found {
+	if found && !issue.Closed {
 		return m.updateExisting(ctx, source, store, marker, issue, draft, pendingDraft, result)
 	}
 	created := true
@@ -439,9 +437,11 @@ func (m *Manager) process(ctx context.Context, source Source, store IssueStore, 
 	if err != nil {
 		return result, fmt.Errorf("create intake issue: %w", err)
 	}
-	m.issues[marker] = issue
 	result.Issue = issue
-	result.Created = created
+	result.Created = created && !issue.Reused
+	if issue.Reused {
+		return result, nil
+	}
 	if err := store.SetIntakeIssueState(ctx, issue.ID, source.Creates.Status); err != nil {
 		return result, fmt.Errorf("set intake issue %s state: %w", issue.Identifier, err)
 	}
@@ -449,7 +449,6 @@ func (m *Manager) process(ctx context.Context, source Source, store IssueStore, 
 	if err != nil {
 		return result, fmt.Errorf("complete intake issue %s state handoff: %w", issue.Identifier, err)
 	}
-	m.issues[marker] = issue
 	result.Issue = issue
 	return result, nil
 }
@@ -464,12 +463,16 @@ func (m *Manager) updateExisting(
 	pendingDraft IssueDraft,
 	result Result,
 ) (Result, error) {
+	if !strings.Contains(issue.Body, pendingStateMarker) && !issue.Closed {
+		result.Issue = issue
+		return result, CommentOccurrence(ctx, store, issue.ID, draft.Body)
+	}
+	draft.Body = issueorigin.Preserve(draft.Body, issue.Body)
 	if strings.Contains(issue.Body, pendingStateMarker) {
 		updated, err := store.UpdateIntakeIssue(ctx, issue.ID, pendingDraft)
 		if err != nil {
 			return result, fmt.Errorf("update pending intake issue %s: %w", issue.Identifier, err)
 		}
-		m.issues[marker] = updated
 		result.Issue = updated
 		if err := store.SetIntakeIssueState(ctx, issue.ID, source.Creates.Status); err != nil {
 			return result, fmt.Errorf("set intake issue %s state: %w", issue.Identifier, err)
@@ -479,7 +482,6 @@ func (m *Manager) updateExisting(
 	if err != nil {
 		return result, fmt.Errorf("update intake issue %s: %w", issue.Identifier, err)
 	}
-	m.issues[marker] = updated
 	result.Issue = updated
 	return result, nil
 }

--- a/internal/intake/intake_test.go
+++ b/internal/intake/intake_test.go
@@ -46,11 +46,11 @@ func TestManagerCreatesThenUpdatesDeduplicatedWebhookIssue(t *testing.T) {
 	if second.Created || !second.Matched || second.Issue.ID != "issue-1" {
 		t.Fatalf("second result = %#v", second)
 	}
-	if len(store.created) != 1 || len(store.updated) != 2 {
-		t.Fatalf("create/update counts = %d/%d, want 1/2", len(store.created), len(store.updated))
+	if len(store.created) != 1 || len(store.updated) != 1 || len(store.comments) != 1 {
+		t.Fatalf("create/update counts = %d/%d, want 1/1", len(store.created), len(store.updated))
 	}
-	if store.updated[1].Title != "[alerts] Database still unavailable" {
-		t.Fatalf("updated title = %q", store.updated[1].Title)
+	if !strings.Contains(store.comments[0], "Replica also failed") {
+		t.Fatalf("comment = %q", store.comments[0])
 	}
 	if len(store.states) != 1 {
 		t.Fatalf("state writes = %#v, recurring event reset starting state", store.states)
@@ -93,8 +93,8 @@ func TestManagerUpdatesDurableFingerprintMatch(t *testing.T) {
 	if result.Created || result.Issue.ID != "existing" {
 		t.Fatalf("result = %#v, want existing issue update", result)
 	}
-	if len(store.updated) != 1 || len(store.states) != 0 {
-		t.Fatalf("updates/states = %d/%d, want 1/0", len(store.updated), len(store.states))
+	if len(store.updated) != 0 || len(store.comments) != 1 || len(store.states) != 0 {
+		t.Fatalf("updates/states = %d/%d, want 0/0", len(store.updated), len(store.states))
 	}
 }
 
@@ -238,6 +238,7 @@ type fakeIssueStore struct {
 	findCalls   int
 	created     []IssueDraft
 	updated     []IssueDraft
+	comments    []string
 	states      []string
 	stateErrors []error
 }
@@ -249,12 +250,14 @@ func (s *fakeIssueStore) FindIntakeIssue(context.Context, string) (Issue, bool, 
 
 func (s *fakeIssueStore) CreateIntakeIssue(_ context.Context, draft IssueDraft) (Issue, error) {
 	s.created = append(s.created, draft)
-	return Issue{ID: "issue-1", Identifier: "example/repo#1", Number: 1, Body: draft.Body}, nil
+	s.found = Issue{ID: "issue-1", Identifier: "example/repo#1", Number: 1, Body: draft.Body}
+	return s.found, nil
 }
 
 func (s *fakeIssueStore) UpdateIntakeIssue(_ context.Context, issueID string, draft IssueDraft) (Issue, error) {
 	s.updated = append(s.updated, draft)
-	return Issue{ID: issueID, Identifier: "example/repo#1", Number: 1, Body: draft.Body}, nil
+	s.found = Issue{ID: issueID, Identifier: "example/repo#1", Number: 1, Body: draft.Body}
+	return s.found, nil
 }
 
 func (s *fakeIssueStore) SetIntakeIssueState(_ context.Context, issueID string, state string) error {
@@ -283,4 +286,9 @@ type fakeScanner struct {
 
 func (s fakeScanner) Scan(context.Context) ([]Event, error) {
 	return append([]Event(nil), s.events...), nil
+}
+
+func (s *fakeIssueStore) CreateComment(_ context.Context, _, body string) error {
+	s.comments = append(s.comments, body)
+	return nil
 }

--- a/internal/intake/occurrence.go
+++ b/internal/intake/occurrence.go
@@ -1,0 +1,20 @@
+package intake
+
+import (
+	"context"
+	"errors"
+
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+)
+
+type OccurrenceCommenter interface {
+	CreateComment(context.Context, string, string) error
+}
+
+func CommentOccurrence(ctx context.Context, store any, issueID, body string) error {
+	commenter, ok := store.(OccurrenceCommenter)
+	if !ok {
+		return errors.New("issue store cannot comment on duplicate occurrences")
+	}
+	return commenter.CreateComment(ctx, issueID, issueorigin.Occurrence(body))
+}

--- a/internal/intake/occurrence_test.go
+++ b/internal/intake/occurrence_test.go
@@ -1,0 +1,58 @@
+package intake
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type occurrenceStore struct {
+	*fakeIssueStore
+	comments []string
+	err      error
+}
+
+func (s *occurrenceStore) CreateComment(_ context.Context, _, body string) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.comments = append(s.comments, body)
+	return nil
+}
+
+func TestIntakeDuplicateComments(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		fail bool
+	}{{"repeat", false}, {"comment failure", true}} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			store := &occurrenceStore{fakeIssueStore: &fakeIssueStore{}}
+			manager := newWebhookManager(t, store, "")
+			payload := []byte(`{"summary":"Disk full","fingerprint":"disk"}`)
+			first, err := manager.IngestWebhook(t.Context(), "alerts", payload)
+			if err != nil || !first.Created {
+				t.Fatalf("first = %+v, %v", first, err)
+			}
+			if tt.fail {
+				store.err = errors.New("comment unavailable")
+			}
+			second, err := manager.IngestWebhook(t.Context(), "alerts", payload)
+			if (err != nil) != tt.fail || second.Created || len(store.created) != 1 || len(store.updated) != 1 || len(store.states) != 1 {
+				t.Fatalf("second = %+v, %v; creates=%d updates=%d states=%d", second, err, len(store.created), len(store.updated), len(store.states))
+			}
+			if !tt.fail && (len(store.comments) != 1 || !strings.Contains(store.comments[0], "New machine occurrence")) {
+				t.Fatalf("comments = %v", store.comments)
+			}
+		})
+	}
+}
+
+func TestOccurrenceRequiresCommentSupport(t *testing.T) {
+	t.Parallel()
+	if err := CommentOccurrence(t.Context(), nil, "issue", "body"); err == nil {
+		t.Fatal("missing comment support accepted")
+	}
+}

--- a/internal/issueorigin/origin.go
+++ b/internal/issueorigin/origin.go
@@ -1,0 +1,96 @@
+package issueorigin
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Origin struct {
+	Kind        string `yaml:"origin_kind"`
+	Instance    string `yaml:"instance_identity"`
+	Source      string `yaml:"source_ref"`
+	Fingerprint string `yaml:"fingerprint"`
+}
+
+var block = regexp.MustCompile("(?m)^```detent-origin\\s*\\n([\\s\\S]*?)^```[ \\t]*$")
+var audit = regexp.MustCompile(`<!--\s*detent-audit-fp[:=\s]+([^\s>]+)\s*-->`)
+
+func Parse(body string) (Origin, bool) {
+	for _, match := range block.FindAllStringSubmatch(body, -1) {
+		var origin Origin
+		if yaml.Unmarshal([]byte(match[1]), &origin) == nil && validKind(origin.Kind) && strings.TrimSpace(origin.Fingerprint) != "" {
+			return origin, true
+		}
+	}
+	if match := audit.FindStringSubmatch(body); len(match) > 1 {
+		return Origin{Kind: "audit", Fingerprint: match[1]}, true
+	}
+	return Origin{}, false
+}
+
+func validKind(kind string) bool {
+	switch kind {
+	case "routine", "lesson", "worker", "doctor", "audit":
+		return true
+	default:
+		return false
+	}
+}
+
+func Instance() string {
+	host, err := os.Hostname()
+	if err != nil {
+		host = "localhost"
+	}
+	return fmt.Sprintf("%s/%d", host, os.Getpid())
+}
+
+func Fingerprint(problem string) string {
+	digest := sha256.Sum256([]byte(strings.Join(strings.Fields(strings.ToLower(problem)), " ")))
+	return hex.EncodeToString(digest[:])
+}
+
+func Stamp(body string, origin Origin) string {
+	if origin.Fingerprint == "" {
+		if existing, ok := Parse(body); ok {
+			origin.Fingerprint = existing.Fingerprint
+		}
+	}
+	return stamp(body, origin)
+}
+
+func stamp(body string, origin Origin) string {
+	if origin.Instance == "" {
+		origin.Instance = Instance()
+	}
+	encoded, err := yaml.Marshal(origin)
+	if err != nil {
+		return body
+	}
+	body = strings.TrimSpace(block.ReplaceAllString(body, ""))
+	return body + "\n\n```detent-origin\n" + string(encoded) + "```"
+}
+
+func Preserve(body, previous string) string {
+	if origin, ok := Parse(previous); ok {
+		return stamp(block.ReplaceAllString(body, ""), origin)
+	}
+	return body
+}
+
+func Marker(body string) string {
+	if origin, ok := Parse(body); ok {
+		return origin.Kind
+	}
+	return "operator"
+}
+
+func Occurrence(body string) string {
+	return "## New machine occurrence\n\n" + strings.TrimSpace(body)
+}

--- a/internal/issueorigin/origin_test.go
+++ b/internal/issueorigin/origin_test.go
@@ -1,0 +1,58 @@
+package issueorigin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOrigin(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"routine", "lesson", "worker", "doctor", "audit"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			want := Origin{Kind: kind, Instance: "instance-1", Source: "run-2", Fingerprint: "problem"}
+			body := Stamp("Finding", want)
+			got, ok := Parse(body)
+			if !ok || got != want || Marker(body) != kind {
+				t.Fatalf("Parse() = %+v, %v; marker = %s", got, ok, Marker(body))
+			}
+			if got := Preserve("Updated", body); !strings.Contains(got, "Updated") || !strings.Contains(got, "instance-1") {
+				t.Fatalf("Preserve() = %s", got)
+			}
+			if got := Stamp(body, want); got != body {
+				t.Fatalf("Stamp is not idempotent: %s", got)
+			}
+		})
+	}
+}
+
+func TestLegacyAndInvalidOrigins(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct{ name, body, kind, fingerprint string }{
+		{"operator", "An operator request", "operator", ""},
+		{"legacy colon", "<!-- detent-audit-fp:disk-capacity -->", "audit", "disk-capacity"},
+		{"legacy equals", "<!-- detent-audit-fp=disk-capacity -->", "audit", "disk-capacity"},
+		{"invalid", "```detent-origin\norigin_kind: unknown\nfingerprint: x\n```", "operator", ""},
+		{"missing fingerprint", "```detent-origin\norigin_kind: routine\n```", "operator", ""},
+		{"malformed", "```detent-origin\n[\n```", "operator", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			origin, _ := Parse(tt.body)
+			if origin.Fingerprint != tt.fingerprint || Marker(tt.body) != tt.kind {
+				t.Fatalf("origin = %+v, marker = %s", origin, Marker(tt.body))
+			}
+		})
+	}
+	if Fingerprint("  Disk CAPACITY ") != Fingerprint("disk capacity") || Fingerprint("disk capacity") == Fingerprint("network") {
+		t.Fatal("fingerprint normalization failed")
+	}
+	body := Stamp("<!-- detent-audit-fp:legacy -->", Origin{Kind: "worker", Source: "attempt"})
+	origin, ok := Parse(body)
+	if !ok || origin.Instance == "" || origin.Fingerprint != "legacy" {
+		t.Fatalf("legacy stamp = %+v", origin)
+	}
+	if Preserve("updated", "operator body") != "updated" || !strings.Contains(Occurrence(body), "New machine occurrence") {
+		t.Fatal("body preservation or occurrence failed")
+	}
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -857,6 +857,7 @@ func (o *Orchestrator) dispatchIssueWithMergeControl(
 		ForgeRetry:          cloneForgeRetry(queuedRetry.ForgeRetry),
 	}
 	o.attachHumanQuestionTool(&request)
+	o.attachMachineIssueTool(&request)
 	if source, ok := o.scheduling.(interface{ RunExecution(string) runpkg.Execution }); ok {
 		request.Execution = source.RunExecution(issue.ID)
 	}

--- a/internal/orchestrator/machine_issue.go
+++ b/internal/orchestrator/machine_issue.go
@@ -1,0 +1,60 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+func (o *Orchestrator) attachMachineIssueTool(request *RunRequest) {
+	backend, ok := o.connector.(intake.IssueStore)
+	if !ok {
+		return
+	}
+	previous := request.AgentToolHandler
+	source := strconv.FormatInt(request.WorkAttemptID, 10)
+	request.AgentTools = append(request.AgentTools, runner.AgentTool{
+		Name:        "file_machine_issue",
+		Description: "File a machine-discovered follow-up in this repository's Backlog, or comment on an open issue with the same fingerprint. Use a stable problem key shared across occurrences, excluding attempt IDs, wording variations and timestamps. Inspect existing issues for their fingerprint first.",
+		InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false,"required":["title","body","fingerprint"],"properties":{"title":{"type":"string","minLength":1},"body":{"type":"string","minLength":1},"fingerprint":{"type":"string","minLength":1}}}`),
+	})
+	request.AgentToolHandler = func(ctx context.Context, call runner.AgentToolCall) (runner.AgentToolResult, error) {
+		if call.Name != "file_machine_issue" {
+			if previous != nil {
+				return previous(ctx, call)
+			}
+			return runner.AgentToolResult{Content: "unsupported tool"}, nil
+		}
+		var input struct {
+			Title       string `json:"title"`
+			Body        string `json:"body"`
+			Fingerprint string `json:"fingerprint"`
+		}
+		decoder := json.NewDecoder(strings.NewReader(string(call.Arguments)))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&input); err != nil {
+			return runner.AgentToolResult{Content: err.Error()}, nil
+		}
+		if err := decoder.Decode(new(any)); !errors.Is(err, io.EOF) || strings.TrimSpace(input.Title) == "" || strings.TrimSpace(input.Body) == "" || strings.TrimSpace(input.Fingerprint) == "" {
+			return runner.AgentToolResult{Content: "one request with title, body and fingerprint is required"}, nil
+		}
+		body := issueorigin.Stamp(input.Body, issueorigin.Origin{Kind: "worker", Source: source, Fingerprint: strings.TrimSpace(input.Fingerprint)})
+		issue, err := backend.CreateIntakeIssue(ctx, intake.IssueDraft{Title: input.Title, Body: body})
+		if err != nil {
+			return runner.AgentToolResult{Content: err.Error()}, nil
+		}
+		if !issue.Reused {
+			if err := backend.SetIntakeIssueState(ctx, issue.ID, "Backlog"); err != nil {
+				return runner.AgentToolResult{Content: err.Error()}, nil
+			}
+		}
+		return runner.AgentToolResult{Success: true, Content: issue.Identifier + " " + issue.URL}, nil
+	}
+}

--- a/internal/orchestrator/machine_issue_test.go
+++ b/internal/orchestrator/machine_issue_test.go
@@ -1,0 +1,100 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+type machineIssueTracker struct {
+	*memory.Connector
+	draft               intake.IssueDraft
+	reused              bool
+	createErr, stateErr error
+	states              int
+}
+
+func (s *machineIssueTracker) CreateIntakeIssue(_ context.Context, draft intake.IssueDraft) (intake.Issue, error) {
+	s.draft = draft
+	return intake.Issue{ID: "issue", Identifier: "example/repo#1", Reused: s.reused}, s.createErr
+}
+
+func (s *machineIssueTracker) SetIntakeIssueState(_ context.Context, _, state string) error {
+	if state != "Backlog" {
+		return errors.New("wrong state")
+	}
+	s.states++
+	return s.stateErr
+}
+
+func TestMachineIssueTool(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, arguments                        string
+		reused, createFail, stateFail, success bool
+		states                                 int
+	}{
+		{"create", `{"title":"Disk","body":"Evidence","fingerprint":"disk"}`, false, false, false, true, 1},
+		{"supplied provenance", "{\"title\":\"Disk\",\"body\":\"Evidence\\n\\n```detent-origin\\norigin_kind: audit\\ninstance_identity: supplied\\nsource_ref: supplied\\nfingerprint: other\\n```\",\"fingerprint\":\"disk\"}", false, false, false, true, 1},
+		{"reuse", `{"title":"Disk","body":"Evidence","fingerprint":"disk"}`, true, false, false, true, 0},
+		{"create failure", `{"title":"Disk","body":"Evidence","fingerprint":"disk"}`, false, true, false, false, 0},
+		{"state failure", `{"title":"Disk","body":"Evidence","fingerprint":"disk"}`, false, false, true, false, 1},
+		{"missing", `{}`, false, false, false, false, 0},
+		{"unknown field", `{"extra":1}`, false, false, false, false, 0},
+		{"trailing", `{} {}`, false, false, false, false, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tracker := &machineIssueTracker{Connector: memory.New(memory.Config{}), reused: tt.reused}
+			if tt.createFail {
+				tracker.createErr = errors.New("create failed")
+			}
+			if tt.stateFail {
+				tracker.stateErr = errors.New("state failed")
+			}
+			o := &Orchestrator{connector: tracker}
+			request := RunRequest{WorkAttemptID: 5187}
+			o.attachMachineIssueTool(&request)
+			result, err := request.AgentToolHandler(t.Context(), runner.AgentToolCall{Name: "file_machine_issue", Arguments: json.RawMessage(tt.arguments)})
+			if err != nil || result.Success != tt.success || tracker.states != tt.states {
+				t.Fatalf("result = %+v, error = %v, states = %d", result, err, tracker.states)
+			}
+			if tt.success {
+				origin, ok := issueorigin.Parse(tracker.draft.Body)
+				if !ok || origin.Kind != "worker" || origin.Source != "5187" || origin.Instance == "" || origin.Fingerprint != "disk" {
+					t.Fatalf("origin = %+v", origin)
+				}
+			}
+		})
+	}
+}
+
+func TestMachineIssueToolDelegates(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{}
+	request := RunRequest{}
+	o.attachMachineIssueTool(&request)
+	if len(request.AgentTools) != 0 {
+		t.Fatal("tool attached without backend")
+	}
+	o.connector = &machineIssueTracker{Connector: memory.New(memory.Config{})}
+	o.attachMachineIssueTool(&request)
+	result, err := request.AgentToolHandler(t.Context(), runner.AgentToolCall{Name: "other"})
+	if err != nil || result.Success {
+		t.Fatalf("unsupported = %+v, %v", result, err)
+	}
+	request.AgentToolHandler = func(context.Context, runner.AgentToolCall) (runner.AgentToolResult, error) {
+		return runner.AgentToolResult{Success: true, Content: "previous"}, nil
+	}
+	o.attachMachineIssueTool(&request)
+	result, err = request.AgentToolHandler(t.Context(), runner.AgentToolCall{Name: "other"})
+	if err != nil || result.Content != "previous" {
+		t.Fatalf("delegation = %+v, %v", result, err)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1832,12 +1832,39 @@ type coordinatedIntakeIssueStore struct {
 	coordinator *scheduleowner.IssueCoordinator
 }
 
+func (s coordinatedIntakeIssueStore) CreateComment(ctx context.Context, issueID, body string) error {
+	commenter, ok := s.IssueStore.(intake.OccurrenceCommenter)
+	if !ok {
+		return connector.ErrNotImplemented
+	}
+	return commenter.CreateComment(ctx, issueID, body)
+}
+
 func (s coordinatedIntakeIssueStore) EnsureIntakeIssue(
 	ctx context.Context,
 	marker string,
 	draft intake.IssueDraft,
 ) (intake.Issue, bool, error) {
-	return s.coordinator.Ensure(ctx, marker, draft, s.IssueStore)
+	return s.coordinator.EnsureRecurring(ctx, marker, draft, s)
+}
+
+func (s coordinatedIntakeIssueStore) IntakeIssueClosed(ctx context.Context, issueID string) (bool, error) {
+	reader, ok := s.IssueStore.(interface {
+		FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error)
+	})
+	if !ok {
+		return false, connector.ErrNotImplemented
+	}
+	issues, err := reader.FetchIssueStatesByIDs(ctx, []string{issueID})
+	if err != nil {
+		return false, err
+	}
+	for _, issue := range issues {
+		if issue.ID == issueID {
+			return issue.Closed, nil
+		}
+	}
+	return false, nil
 }
 
 func coordinatedIntakeStore(projectConnector connector.Connector, coordinator *scheduleowner.IssueCoordinator, writers ...func(context.Context, string, string) error) intake.IssueStore {
@@ -1862,6 +1889,14 @@ func routineIssueStore(projectConnector connector.Connector) routine.IssueStore 
 type coordinatedRoutineStore struct {
 	routine.IssueStore
 	coordinator *scheduleowner.IssueCoordinator
+}
+
+func (s coordinatedRoutineStore) CreateComment(ctx context.Context, issueID, body string) error {
+	commenter, ok := s.IssueStore.(intake.OccurrenceCommenter)
+	if !ok {
+		return connector.ErrNotImplemented
+	}
+	return commenter.CreateComment(ctx, issueID, body)
 }
 
 func (s coordinatedRoutineStore) EnsureRoutineIssue(

--- a/internal/project/scheduled_lanes.go
+++ b/internal/project/scheduled_lanes.go
@@ -19,6 +19,24 @@ func (s intakeLaneStore) SetIntakeIssueState(ctx context.Context, issueID, targe
 	return s.write(ctx, issueID, target)
 }
 
+func (s intakeLaneStore) CreateComment(ctx context.Context, issueID, body string) error {
+	commenter, ok := s.IssueStore.(intake.OccurrenceCommenter)
+	if !ok {
+		return connector.ErrNotImplemented
+	}
+	return commenter.CreateComment(ctx, issueID, body)
+}
+
+func (s intakeLaneStore) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) ([]connector.Issue, error) {
+	reader, ok := s.IssueStore.(interface {
+		FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error)
+	})
+	if !ok {
+		return nil, connector.ErrNotImplemented
+	}
+	return reader.FetchIssueStatesByIDs(ctx, issueIDs)
+}
+
 type routineLaneStore struct {
 	routine.IssueStore
 	write func(context.Context, string, string) error
@@ -26,6 +44,14 @@ type routineLaneStore struct {
 
 func (s routineLaneStore) SetIntakeIssueState(ctx context.Context, issueID, target string) error {
 	return s.write(ctx, issueID, target)
+}
+
+func (s routineLaneStore) CreateComment(ctx context.Context, issueID, body string) error {
+	commenter, ok := s.IssueStore.(intake.OccurrenceCommenter)
+	if !ok {
+		return connector.ErrNotImplemented
+	}
+	return commenter.CreateComment(ctx, issueID, body)
 }
 
 func scheduledLaneWriter(owner func() *orchestrator.Orchestrator, tracker connector.Connector, reason string) func(context.Context, string, string) error {

--- a/internal/project/scheduled_lanes_test.go
+++ b/internal/project/scheduled_lanes_test.go
@@ -1,0 +1,76 @@
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/scheduleowner"
+)
+
+func TestScheduledLaneStoresPreserveOccurrences(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"intake", "lesson", "routine", "coordinated intake", "coordinated routine"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			tracker := memory.New(memory.Config{Stateful: true})
+			issue, err := tracker.CreateIssue(t.Context(), connector.IssueDraft{Title: "Original", Body: "Original body"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := tracker.UpdateIssueState(t.Context(), issue.ID, "Todo"); err != nil {
+				t.Fatal(err)
+			}
+			writes := 0
+			write := func(ctx context.Context, id, target string) error {
+				writes++
+				return tracker.UpdateIssueState(ctx, id, target)
+			}
+			var store interface {
+				SetIntakeIssueState(context.Context, string, string) error
+			}
+			switch kind {
+			case "intake", "lesson":
+				store = intakeLaneStore{IssueStore: tracker, write: write}
+			case "routine":
+				store = routineLaneStore{IssueStore: tracker, write: write}
+			case "coordinated intake":
+				store = coordinatedIntakeStore(tracker, &scheduleowner.IssueCoordinator{}, write)
+			case "coordinated routine":
+				store = coordinatedRoutineIssueStore(tracker, &scheduleowner.IssueCoordinator{}, write)
+			}
+			if err := intake.CommentOccurrence(t.Context(), store, issue.ID, "New occurrence"); err != nil {
+				t.Fatal(err)
+			}
+			issues, err := tracker.FetchIssueStatesByIDs(t.Context(), []string{issue.ID})
+			if err != nil || len(issues) != 1 {
+				t.Fatalf("issues = %+v, error = %v", issues, err)
+			}
+			got := issues[0]
+			if writes != 0 || got.State != "Todo" || got.Description != "Original body" || len(got.Comments) != 1 {
+				t.Fatalf("occurrence changed issue or lane: issue = %+v, writes = %d", got, writes)
+			}
+			if err := store.SetIntakeIssueState(t.Context(), issue.ID, "Backlog"); err != nil || writes != 1 {
+				t.Fatalf("lane delegation: error = %v, writes = %d", err, writes)
+			}
+			reader, ok := store.(interface {
+				IntakeIssueClosed(context.Context, string) (bool, error)
+			})
+			if !ok {
+				return
+			}
+			for _, closed := range []bool{false, true} {
+				if closed {
+					if err := tracker.CloseIssue(t.Context(), issue.ID); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if got, err := reader.IntakeIssueClosed(t.Context(), issue.ID); err != nil || got != closed {
+					t.Fatalf("closed = %v, error = %v, want %v", got, err, closed)
+				}
+			}
+		})
+	}
+}

--- a/internal/retro/manager.go
+++ b/internal/retro/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/robfig/cron/v3"
 
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 	"github.com/digitaldrywood/detent/internal/workflowmetrics"
 )
 
@@ -69,7 +70,6 @@ type Manager struct {
 	now       func() time.Time
 	triggers  chan string
 	updates   chan struct{}
-	issues    map[string]intake.Issue
 }
 
 func New(settings Settings, store TelemetryStore, logger *slog.Logger, now func() time.Time) (*Manager, error) {
@@ -85,7 +85,6 @@ func New(settings Settings, store TelemetryStore, logger *slog.Logger, now func(
 		now:      now,
 		triggers: make(chan string, 1),
 		updates:  make(chan struct{}, 1),
-		issues:   map[string]intake.Issue{},
 	}
 	if err := manager.Update(settings); err != nil {
 		return nil, err
@@ -112,7 +111,6 @@ func (m *Manager) Update(settings Settings) error {
 	m.mu.Lock()
 	m.settings = settings
 	m.mu.Unlock()
-	m.issues = map[string]intake.Issue{}
 	m.signalUpdate()
 	return nil
 }
@@ -236,7 +234,7 @@ func (m *Manager) RunOnce(ctx context.Context, trigger string) (Result, error) {
 		if finding.Scope == ScopeProduct {
 			issueStore = settings.ProductIssues
 		}
-		outcome, err := m.upsertFinding(ctx, issueStore, settings, finding, remaining > 0)
+		outcome, err := m.upsertFinding(ctx, issueStore, settings, finding, remaining > 0, startedAt)
 		if outcome.created {
 			result.Filed++
 			remaining--
@@ -259,64 +257,62 @@ type upsertOutcome struct {
 	capped  bool
 }
 
-func (m *Manager) upsertFinding(ctx context.Context, issueStore intake.IssueStore, settings Settings, finding Finding, allowCreate bool) (upsertOutcome, error) {
+func (m *Manager) upsertFinding(ctx context.Context, issueStore intake.IssueStore, settings Settings, finding Finding, allowCreate bool, startedAt time.Time) (upsertOutcome, error) {
 	fingerprint := Fingerprint(settings.ProjectID, finding)
 	marker := "<!-- detent-retro fingerprint=" + fingerprint + " -->"
 	draft := intake.IssueDraft{
 		Title:  "[retro] " + finding.Title,
-		Body:   findingIssueBody(settings.ProjectID, finding, marker),
+		Body:   issueorigin.Stamp(findingIssueBody(settings.ProjectID, finding, marker), issueorigin.Origin{Kind: "lesson", Source: settings.ProjectID + "/" + startedAt.Format(time.RFC3339Nano), Fingerprint: fingerprint}),
 		Labels: append([]string(nil), settings.Config.Labels...),
 	}
 	pendingDraft := draft
 	pendingDraft.Body = draft.Body + "\n\n" + pendingStateMarker
-	cacheKey := finding.Scope + "\x00" + marker
-	issue, found := m.issues[cacheKey]
-	if !found {
-		var err error
-		issue, found, err = issueStore.FindIntakeIssue(ctx, marker)
-		if err != nil {
-			return upsertOutcome{}, err
-		}
+	issue, found, err := issueStore.FindIntakeIssue(ctx, marker)
+	if err != nil {
+		return upsertOutcome{}, err
 	}
-	if found {
+	if found && !issue.Closed {
+		if !strings.Contains(issue.Body, pendingStateMarker) {
+			err := intake.CommentOccurrence(ctx, issueStore, issue.ID, draft.Body)
+			return upsertOutcome{updated: err == nil}, err
+		}
+		draft.Body = issueorigin.Preserve(draft.Body, issue.Body)
 		if strings.Contains(issue.Body, pendingStateMarker) {
-			updated, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, pendingDraft)
+			_, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, pendingDraft)
 			if err != nil {
 				return upsertOutcome{}, err
 			}
-			m.issues[cacheKey] = updated
 			if err := issueStore.SetIntakeIssueState(ctx, issue.ID, settings.Config.TargetState); err != nil {
 				return upsertOutcome{}, err
 			}
 		}
 		draft.Body = preserveFindingOutcome(draft.Body, issue.Body)
 		if strings.TrimSpace(issue.Body) == strings.TrimSpace(draft.Body) {
-			m.issues[cacheKey] = issue
 			return upsertOutcome{}, nil
 		}
-		updated, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, draft)
+		_, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, draft)
 		if err != nil {
 			return upsertOutcome{}, err
 		}
-		m.issues[cacheKey] = updated
 		return upsertOutcome{updated: true}, nil
 	}
 	if !allowCreate {
 		return upsertOutcome{capped: true}, nil
 	}
-	issue, err := issueStore.CreateIntakeIssue(ctx, pendingDraft)
+	issue, err = issueStore.CreateIntakeIssue(ctx, pendingDraft)
 	if err != nil {
 		return upsertOutcome{}, err
 	}
-	m.issues[cacheKey] = issue
+	if issue.Reused {
+		return upsertOutcome{updated: true}, nil
+	}
 	if err := issueStore.SetIntakeIssueState(ctx, issue.ID, settings.Config.TargetState); err != nil {
 		return upsertOutcome{created: true}, err
 	}
-	updated, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, draft)
+	_, err = issueStore.UpdateIntakeIssue(ctx, issue.ID, draft)
 	if err != nil {
 		return upsertOutcome{created: true}, err
 	}
-	m.issues[cacheKey] = updated
 	return upsertOutcome{created: true}, nil
 }
 

--- a/internal/retro/manager_test.go
+++ b/internal/retro/manager_test.go
@@ -50,10 +50,19 @@ func TestManagerRoutesAndDeduplicatesRecurringFindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunOnce(second) error = %v", err)
 	}
-	if second.Filed != 0 || second.Updated != 1 {
-		t.Fatalf("RunOnce(second) = %#v, want only the recurring finding updated", second)
+	if second.Filed != 0 || second.Updated != 2 {
+		t.Fatalf("RunOnce(second) = %#v, want occurrence comments for both findings", second)
 	}
-	assertSingleRetroIssue(t, projectIssues, PatternInvalidWorkpadStatus, "occurrences: 3")
+	assertSingleRetroIssue(t, projectIssues, PatternInvalidWorkpadStatus, "occurrences: 2")
+	issues, err := projectIssues.FetchIssuesByStates(t.Context(), []string{"Backlog"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	comments, err := projectIssues.FetchIssueComments(t.Context(), issues[0])
+	if err != nil || len(comments) != 1 || !strings.Contains(comments[0].Body, "occurrences: 3") {
+		t.Fatalf("occurrence comments = %+v, %v", comments, err)
+	}
+
 	assertSingleRetroIssue(t, productIssues, PatternCompletedRedispatch, "classification: product")
 }
 
@@ -104,8 +113,8 @@ func TestManagerPreservesReviewedOutcomeOnRecurrence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunOnce(second) error = %v", err)
 	}
-	if result.Updated != 1 {
-		t.Fatalf("RunOnce(second).Updated = %d, want only recurring evidence updated", result.Updated)
+	if result.Updated != 2 {
+		t.Fatalf("RunOnce(second).Updated = %d, want occurrence comments for both findings", result.Updated)
 	}
 	assertSingleRetroIssue(t, projectIssues, PatternInvalidWorkpadStatus, "- status: accepted")
 }

--- a/internal/routine/manager.go
+++ b/internal/routine/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 	routinemodel "github.com/digitaldrywood/detent/internal/routine/model"
 	"github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/schedulehealth"
@@ -328,10 +329,10 @@ func (m *Manager) runOnce(ctx context.Context, settings Settings, definition con
 	if proposalErr != nil {
 		return result, proposalErr
 	}
-	return m.fileProposals(ctx, settings, definition, proposals)
+	return m.fileProposals(ctx, settings, definition, proposals, startedAt)
 }
 
-func (m *Manager) fileProposals(ctx context.Context, settings Settings, definition config.Routine, proposals []Proposal) (Result, error) {
+func (m *Manager) fileProposals(ctx context.Context, settings Settings, definition config.Routine, proposals []Proposal, startedAt time.Time) (Result, error) {
 	result := Result{Proposed: len(proposals)}
 	if len(proposals) == 0 {
 		return result, nil
@@ -367,7 +368,7 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 	if err := m.store.CloseRoutineIssues(ctx, settings.ProjectID, definition.Name, closedIssueIDs); err != nil {
 		return result, fmt.Errorf("close filed routine issues: %w", err)
 	}
-	openMarkers := map[string]struct{}{}
+	openMarkers := map[string]string{}
 	openFindings := len(filedIssueSet)
 	scopeMarker := routineScopeMarker(settings.ProjectID, definition.Name)
 	for _, issue := range issues {
@@ -387,7 +388,7 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		for _, proposal := range proposals {
 			marker := proposalMarker(settings.ProjectID, definition.Name, proposal.DedupKey)
 			if strings.Contains(issue.Description, marker) {
-				openMarkers[marker] = struct{}{}
+				openMarkers[marker] = issue.ID
 			}
 		}
 	}
@@ -401,7 +402,12 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 			continue
 		}
 		marker := proposalMarker(settings.ProjectID, definition.Name, proposal.DedupKey)
-		if _, ok := openMarkers[marker]; ok {
+		if issueID, ok := openMarkers[marker]; ok {
+			body := issueorigin.Stamp(proposal.Body, issueorigin.Origin{Kind: "routine", Source: definition.Name + "/" + startedAt.Format(time.RFC3339Nano), Fingerprint: proposal.DedupKey})
+			if err := intake.CommentOccurrence(ctx, settings.Issues, issueID, body); err != nil {
+				runErr = errors.Join(runErr, err)
+				continue
+			}
 			result.Deduplicated++
 			continue
 		}
@@ -415,6 +421,11 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 			break
 		}
 		if found && !existing.Closed {
+			body := issueorigin.Stamp(proposal.Body, issueorigin.Origin{Kind: "routine", Source: definition.Name + "/" + startedAt.Format(time.RFC3339Nano), Fingerprint: proposal.DedupKey})
+			if err := intake.CommentOccurrence(ctx, settings.Issues, existing.ID, body); err != nil {
+				runErr = errors.Join(runErr, err)
+				continue
+			}
 			record := IssueRecord{ID: existing.ID, Identifier: existing.Identifier, URL: existing.URL}
 			if strings.TrimSpace(record.ID) != "" {
 				if _, ok := filedIssueSet[strings.TrimSpace(record.ID)]; !ok {
@@ -428,7 +439,7 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 			} else {
 				openFindings++
 			}
-			openMarkers[marker] = struct{}{}
+			openMarkers[marker] = existing.ID
 			result.Deduplicated++
 			continue
 		}
@@ -440,11 +451,11 @@ func (m *Manager) fileProposals(ctx context.Context, settings Settings, definiti
 		labels := proposalLabels(definition, proposal)
 		issue, created, createErr := createRoutineIssue(ctx, settings.Issues, marker, intake.IssueDraft{
 			Title:  proposal.Title,
-			Body:   scopeMarker + "\n" + marker + "\n\n" + proposal.Body,
+			Body:   issueorigin.Stamp(scopeMarker+"\n"+marker+"\n\n"+proposal.Body, issueorigin.Origin{Kind: "routine", Source: definition.Name + "/" + startedAt.Format(time.RFC3339Nano), Fingerprint: proposal.DedupKey}),
 			Labels: labels,
 		})
 		openFindings++
-		openMarkers[marker] = struct{}{}
+		openMarkers[marker] = issue.ID
 		record := IssueRecord{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL}
 		if strings.TrimSpace(record.ID) != "" {
 			if !created {
@@ -503,7 +514,7 @@ func createRoutineIssue(
 		return creator.EnsureIntakeIssue(ctx, marker, draft)
 	}
 	issue, err := store.CreateIntakeIssue(ctx, draft)
-	return issue, true, err
+	return issue, !issue.Reused, err
 }
 
 func (m *Manager) nextScheduled(ctx context.Context) (time.Time, string, bool, error) {
@@ -561,7 +572,7 @@ func Due(schedule string, lastRun time.Time, now time.Time) (bool, error) {
 func proposalTool() runner.AgentTool {
 	return runner.AgentTool{
 		Name:        ProposalToolName,
-		Description: "Record one actionable maintenance issue proposal for Detent to validate, deduplicate, and file after the routine finishes.",
+		Description: "Record one actionable maintenance issue proposal for Detent to validate, deduplicate, and file after the routine finishes. The dedup_key is a repository-wide problem fingerprint, shared across origin kinds; reuse existing detent-origin or detent-audit-fp fingerprints and exclude timestamps or wording variations.",
 		InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false,"required":["dedup_key","title","body"],"properties":{"dedup_key":{"type":"string","minLength":1,"maxLength":256},"title":{"type":"string","minLength":1,"maxLength":256},"body":{"type":"string","minLength":1,"maxLength":262144},"labels":{"type":"array","items":{"type":"string","minLength":1},"uniqueItems":true}}}`),
 	}
 }

--- a/internal/routine/manager_test.go
+++ b/internal/routine/manager_test.go
@@ -708,3 +708,5 @@ func (s *fakeIssueStore) SetIntakeIssueState(_ context.Context, _ string, state 
 	s.states = append(s.states, state)
 	return s.stateErr
 }
+
+func (s *fakeIssueStore) CreateComment(context.Context, string, string) error { return nil }

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -673,7 +673,8 @@ func appendFollowupsBlock(prompt string, cfg config.Followups) string {
 
 	const block = `## Out-of-scope discoveries
 
-When this run surfaces a meaningful problem or improvement unrelated to the current issue, file a separate tracker issue instead of expanding the current issue's scope.
+When this run surfaces a meaningful problem or improvement unrelated to the current issue, use the file_machine_issue tool to file a follow-up. Never bypass it with gh issue create or a direct tracker creation tool. If unavailable, record the finding on the assigned issue for orchestrator intake.
+- Search open issues in the same repository first. Reuse their detent-origin fingerprint or legacy detent-audit-fp fingerprint when the underlying problem is the same. Supply a stable problem key, excluding title wording, timestamps and attempt IDs. Use a key describing the affected subsystem and underlying problem. The tool stamps the instance and attempt, comments on an open match, and creates only when no match exists.
 - Place the follow-up issue in the project's Backlog state through the configured status source.
 - Include a fenced ` + "`detent-agent`" + ` block with ` + "`schema: 1`" + ` and a best-guess ` + "`effort`" + ` chosen from the project's effort rubric.
 - If the configured status source cannot be set from this session, file the issue without a state and say so in the final handoff.`

--- a/internal/scheduleowner/issue.go
+++ b/internal/scheduleowner/issue.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/coordination"
 	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 )
 
 const (
@@ -144,7 +145,8 @@ func (c *IssueCoordinator) ensure(
 					return c.createReserved(ctx, key, marker, draft, backend, reserved, reservationToken, issueClosed)
 				}
 			}
-			return effect.Issue, false, nil
+			issue, err := commentExistingOccurrence(ctx, backend, effect.Issue, draft)
+			return issue, false, err
 		case effectReserved:
 			if c.now().Before(record.ModifiedAt.Add(c.config.LeaseTTL() + c.config.MaxClockSkew())) {
 				if err := c.wait(ctx, c.config.RetryInterval()); err != nil {
@@ -217,6 +219,10 @@ func (c *IssueCoordinator) createReserved(
 		return intake.Issue{}, false, fmt.Errorf("reconcile coordinated issue before create: %w", err)
 	}
 	if found && (issueClosed == nil || !issue.Closed) {
+		issue, err = commentExistingOccurrence(ctx, backend, issue, draft)
+		if err != nil {
+			return intake.Issue{}, false, err
+		}
 		completed, completeErr := c.completeDurably(ctx, key, token, issue)
 		return completed, false, completeErr
 	}
@@ -232,7 +238,7 @@ func (c *IssueCoordinator) createReserved(
 		return intake.Issue{}, false, errors.Join(ErrIssueCreateUncertain, createErr, findErr)
 	}
 	completed, err := c.completeDurably(ctx, key, token, issue)
-	return completed, true, err
+	return completed, !issue.Reused, err
 }
 
 func (c *IssueCoordinator) completeDurably(ctx context.Context, key string, token string, issue intake.Issue) (intake.Issue, error) {
@@ -301,4 +307,15 @@ func decodeEffect(value []byte) (effectState, error) {
 		return effectState{}, ErrIssueCreateUncertain
 	}
 	return effect, nil
+}
+
+func commentExistingOccurrence(ctx context.Context, backend IssueBackend, issue intake.Issue, draft intake.IssueDraft) (intake.Issue, error) {
+	if _, ok := issueorigin.Parse(draft.Body); !ok {
+		return issue, nil
+	}
+	if err := intake.CommentOccurrence(ctx, backend, issue.ID, draft.Body); err != nil {
+		return issue, err
+	}
+	issue.Reused = true
+	return issue, nil
 }

--- a/internal/scheduleowner/issue.go
+++ b/internal/scheduleowner/issue.go
@@ -168,6 +168,10 @@ func (c *IssueCoordinator) ensure(
 				return intake.Issue{}, false, fmt.Errorf("reconcile coordinated issue: %w", findErr)
 			}
 			if exists && (issueClosed == nil || !issue.Closed) {
+				issue, err = commentExistingOccurrence(ctx, backend, issue, draft)
+				if err != nil {
+					return intake.Issue{}, false, err
+				}
 				completed, completeErr := c.completeDurably(ctx, key, effect.Token, issue)
 				return completed, false, completeErr
 			}

--- a/internal/scheduleowner/issue_occurrence_test.go
+++ b/internal/scheduleowner/issue_occurrence_test.go
@@ -2,8 +2,10 @@ package scheduleowner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/intake"
 	"github.com/digitaldrywood/detent/internal/issueorigin"
@@ -44,6 +46,33 @@ func TestCoordinatedOccurrence(t *testing.T) {
 			issue, err := commentExistingOccurrence(t.Context(), backend, intake.Issue{ID: "issue"}, draft)
 			if (err != nil) != tt.failure || backend.comments != tt.comments || issue.Reused != (tt.machine && !tt.failure) {
 				t.Fatalf("issue = %+v, error = %v, comments = %d", issue, err, backend.comments)
+			}
+		})
+	}
+}
+
+func TestCoordinatedOccurrenceDuringPublication(t *testing.T) {
+	t.Parallel()
+	for _, state := range []string{effectCreating, effectComplete} {
+		t.Run(state, func(t *testing.T) {
+			clock := newTestClock(time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC))
+			store := newMemoryCoordinationStore(clock.Now)
+			config := testConfig()
+			marker := "machine:disk"
+			existing := intake.Issue{ID: "issue-1", Body: "original"}
+			value, err := json.Marshal(effectState{Schema: effectSchema, Status: state, Token: "creator", Issue: existing})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := store.CompareAndSwap(t.Context(), effectPath(config.Key, marker), "", value); err != nil {
+				t.Fatal(err)
+			}
+			underlying := &blockingIssueBackend{marker: marker, issue: existing}
+			backend := &occurrenceBackend{IssueBackend: underlying}
+			coordinator := newTestIssueCoordinator(t, config, "second", store, clock)
+			issue, created, err := coordinator.Ensure(t.Context(), marker, intake.IssueDraft{Body: issueorigin.Stamp("again", issueorigin.Origin{Kind: "worker", Fingerprint: "disk"})}, backend)
+			if err != nil || created || !issue.Reused || backend.comments != 1 || underlying.CreateCount() != 0 {
+				t.Fatalf("issue=%+v created=%v err=%v comments=%d", issue, created, err, backend.comments)
 			}
 		})
 	}

--- a/internal/scheduleowner/issue_occurrence_test.go
+++ b/internal/scheduleowner/issue_occurrence_test.go
@@ -1,0 +1,50 @@
+package scheduleowner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+)
+
+type occurrenceBackend struct {
+	IssueBackend
+	comments int
+	err      error
+}
+
+func (b *occurrenceBackend) CreateComment(context.Context, string, string) error {
+	b.comments++
+	return b.err
+}
+
+func TestCoordinatedOccurrence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name             string
+		machine, failure bool
+		comments         int
+	}{
+		{"machine", true, false, 1},
+		{"failure", true, true, 1},
+		{"legacy coordination", false, false, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			backend := &occurrenceBackend{}
+			if tt.failure {
+				backend.err = errors.New("comment failed")
+			}
+			draft := intake.IssueDraft{Body: "body"}
+			if tt.machine {
+				draft.Body = issueorigin.Stamp(draft.Body, issueorigin.Origin{Kind: "routine", Fingerprint: "problem"})
+			}
+			issue, err := commentExistingOccurrence(t.Context(), backend, intake.Issue{ID: "issue"}, draft)
+			if (err != nil) != tt.failure || backend.comments != tt.comments || issue.Reused != (tt.machine && !tt.failure) {
+				t.Fatalf("issue = %+v, error = %v, comments = %d", issue, err, backend.comments)
+			}
+		})
+	}
+}

--- a/internal/web/intake_test.go
+++ b/internal/web/intake_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
-func TestIntakeWebhookCreatesAndUpdatesWithoutResettingPromotedState(t *testing.T) {
+func TestIntakeWebhookCommentsWithoutResettingPromotedState(t *testing.T) {
 	t.Parallel()
 
 	server, connector, refresher := newIntakeWebhookServer(t, "level:error")
@@ -33,6 +33,7 @@ func TestIntakeWebhookCreatesAndUpdatesWithoutResettingPromotedState(t *testing.
 	if len(issues) != 1 || issues[0].State != "Backlog" {
 		t.Fatalf("issues = %#v, want one Backlog issue", issues)
 	}
+	originalBody := issues[0].Description
 	if err := connector.UpdateIssueState(context.Background(), issues[0].ID, "Todo"); err != nil {
 		t.Fatalf("UpdateIssueState() error = %v", err)
 	}
@@ -47,8 +48,11 @@ func TestIntakeWebhookCreatesAndUpdatesWithoutResettingPromotedState(t *testing.
 	if err != nil {
 		t.Fatalf("FetchCandidateIssues() error = %v", err)
 	}
-	if len(issues) != 1 || issues[0].State != "Todo" || issues[0].Title != "[alerts] Database still down" {
-		t.Fatalf("updated issues = %#v, want one promoted updated issue", issues)
+	if len(issues) != 1 || issues[0].State != "Todo" || issues[0].Title != "[alerts] Database down" || issues[0].Description != originalBody {
+		t.Fatalf("updated issues = %#v, want the original promoted issue", issues)
+	}
+	if len(issues[0].Comments) != 1 || !strings.Contains(issues[0].Comments[0].Body, "Replica failed") || !strings.Contains(issues[0].Comments[0].Body, "detent-origin") {
+		t.Fatalf("occurrence comments = %+v", issues[0].Comments)
 	}
 	if refresher.targetCalls != 2 {
 		t.Fatalf("target refresh calls = %d, want 2", refresher.targetCalls)

--- a/internal/web/templates/board.templ
+++ b/internal/web/templates/board.templ
@@ -667,6 +667,13 @@ templ boardCardView2(card boardCardView) {
 						@primitives.TrackerReferenceLinkIsolated(card.MetaRight, card.PRURL, "flex-none max-w-full break-all tabular-nums")
 					</span>
 				}
+				<span class="text-dim" data-board-creation-origin={ card.CreationOrigin }>
+					if card.CreationOrigin == "operator" {
+						<span>Operator</span>
+					} else {
+						<span>{ "Machine · " + card.CreationOrigin }</span>
+					}
+				</span>
 			</div>
 		</div>
 		<span class="hidden" data-board-card-state>{ card.State }</span>

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -978,6 +978,7 @@ type boardCardView struct {
 	State             string
 	Origin            string
 	OriginDetail      string
+	CreationOrigin    string
 	AuthorDetail      string
 	Signals           []boardCardSignal
 	ExtraKind         primitives.Kind
@@ -1497,6 +1498,10 @@ func boardCardViewFromCard(data DashboardData, lane projectKanbanLane, card proj
 	view.BlockerSummary = card.BlockerSummary
 	view.ParkSummary, view.ParkDetail = boardCardParkSummary(card.ParkSummary)
 	view.ProgressSummary, view.ProgressDetail, view.ProgressKind = boardCardCompletionProgress(card.CompletionProgress)
+	view.CreationOrigin = card.CreationOrigin
+	if view.CreationOrigin == "" {
+		view.CreationOrigin = "operator"
+	}
 	view.OriginDetail = boardCardOriginDetail(card.Origin, card.OriginActor)
 	view.AuthorDetail = boardCardAuthorDetail(card.AuthorID, card.OriginActor)
 	if card.BlockedReason == "" && card.BlockedRecoveryAction == "" && card.BlockedRecoveryReason == "" {

--- a/internal/web/templates/board_templ.go
+++ b/internal/web/templates/board_templ.go
@@ -1859,180 +1859,221 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "</div></div><span class=\"hidden\" data-board-card-state>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "<span class=\"text-dim\" data-board-creation-origin=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var88 string
-		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(card.State)
+		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(card.CreationOrigin)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 672, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 670, Col: 75}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var89 = []any{boardCardTitleClass(card)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var89...)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		if card.CreationOrigin == "operator" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "<span>Operator</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "<span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var89 string
+			templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs("Machine · " + card.CreationOrigin)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 674, Col: 49}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "</span></div></div><span class=\"hidden\" data-board-card-state>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var90 string
-		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var89).String())
+		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(card.State)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 679, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "\" data-board-card-title>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var91 string
-		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(card.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 673, Col: 77}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
+		var templ_7745c5c3_Var91 = []any{boardCardTitleClass(card)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var91...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "<div class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var92 string
+		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var91).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "\" data-board-card-title>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var93 string
+		templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(card.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 680, Col: 77}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(card.Signals) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "<div class=\"grid min-w-0 gap-1\" data-board-card-signals>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "<div class=\"grid min-w-0 gap-1\" data-board-card-signals>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, signal := range card.Signals {
-				var templ_7745c5c3_Var92 = []any{"min-w-0 truncate text-2xs " + boardExtraTextClass(signal.Kind)}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var92...)
+				var templ_7745c5c3_Var94 = []any{"min-w-0 truncate text-2xs " + boardExtraTextClass(signal.Kind)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var94...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var93 string
-				templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var92).String())
+				var templ_7745c5c3_Var95 string
+				templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var94).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "\" data-board-card-signal>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "\" data-board-card-signal>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var94 string
-				templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(signal.Text)
+				var templ_7745c5c3_Var96 string
+				templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(signal.Text)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 677, Col: 120}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 684, Col: 120}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.DispatchStatus != "" {
-			var templ_7745c5c3_Var95 = []any{"min-w-0 break-words text-2xs " + boardExtraTextClass(card.ExtraKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var95...)
+			var templ_7745c5c3_Var97 = []any{"min-w-0 break-words text-2xs " + boardExtraTextClass(card.ExtraKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var97...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "<div class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var96 string
-			templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var95).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "\" data-board-dispatch-evidence>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var97 string
-			templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 683, Col: 20}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if card.AgeFooter != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "<div class=\"flex min-w-0 items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var98 string
-			templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
+			templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var97).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 687, Col: 150}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "\" data-board-card-age-footer><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\" data-board-dispatch-evidence>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var99 string
-			templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
+			templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 689, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 690, Col: 20}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "<div class=\"min-w-0 grid-cols-1 gap-1.5 border-t border-line/70 pt-1.5\" data-board-card-content=\"comfy\" data-board-card-details><div class=\"flex min-w-0 flex-wrap items-center gap-1 font-mono text-2xs font-medium text-sec\" data-board-card-priority-details>")
+		if card.AgeFooter != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "<div class=\"flex min-w-0 items-center justify-between gap-2 border-t border-line/70 pt-1.5 font-mono text-2xs text-sec\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var100 string
+			templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooterTitle)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 694, Col: 150}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "\" data-board-card-age-footer><span class=\"min-w-0 truncate\">In lane</span> <span class=\"flex-none whitespace-nowrap tabular-nums\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var101 string
+			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(card.AgeFooter)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 696, Col: 75}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "</span></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "<div class=\"min-w-0 grid-cols-1 gap-1.5 border-t border-line/70 pt-1.5\" data-board-card-content=\"comfy\" data-board-card-details><div class=\"flex min-w-0 flex-wrap items-center gap-1 font-mono text-2xs font-medium text-sec\" data-board-card-priority-details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2043,158 +2084,158 @@ func boardCardView2(card boardCardView) templ.Component {
 			}
 		}
 		if card.PriorityBadge != "" {
-			var templ_7745c5c3_Var100 = []any{boardPriorityBadgeClass(card)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var100...)
+			var templ_7745c5c3_Var102 = []any{boardPriorityBadgeClass(card)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var102...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "<span id=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var101 string
-			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 699, Col: 35}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "\" class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var102 string
-			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var100).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "\" tabindex=\"0\" role=\"img\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "<span id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var103 string
-			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs("Priority: " + card.PriorityBadge)
+			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 703, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 706, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "\" data-board-priority data-board-priority-top=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "\" class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var104 string
-			templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(card.PriorityTop))
+			templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var102).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 705, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "\" data-help-trigger data-help-scope=\"dispatch-priority\" data-help-term=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "\" tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var105 string
-			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
+			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs("Priority: " + card.PriorityBadge)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 708, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 710, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "\" data-help-title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "\" data-board-priority data-board-priority-top=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var106 string
-			templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityTitle)
+			templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(card.PriorityTop))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 709, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 712, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "\" data-help-description=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "\" data-help-trigger data-help-scope=\"dispatch-priority\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var107 string
-			templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityDetail)
+			templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-priority")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 710, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 715, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "\" onclick=\"event.stopPropagation()\"><span class=\"min-w-0 truncate\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "\" data-help-title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var108 string
-			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityBadge)
+			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityTitle)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 712, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 716, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "</span></span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if card.MoveDisabledText != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "<span class=\"flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, "\" data-help-description=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var109 string
-			templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 715, Col: 122}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 717, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "\" data-kanban-move-disabled-label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "\" onclick=\"event.stopPropagation()\"><span class=\"min-w-0 truncate\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var110 string
-			templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs(card.PriorityBadge)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 715, Col: 181}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 719, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var110))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 190, "</span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else if card.Done {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 191, "<span class=\"text-ok\" role=\"img\" aria-label=\"done\">✓</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "</span></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 192, "</div>")
+		if card.MoveDisabledText != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "<span class=\"flex-none rounded-chip border border-line px-1.5 py-0.5 text-2xs text-dim\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var111 string
+			templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledText)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 722, Col: 122}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "\" data-kanban-move-disabled-label>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var112 string
+			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveDisabledLabel)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 722, Col: 181}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if card.Done {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "<span class=\"text-ok\" role=\"img\" aria-label=\"done\">✓</span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2205,38 +2246,38 @@ func boardCardView2(card boardCardView) templ.Component {
 			}
 		}
 		if card.MergeLaneStatus != "" {
-			var templ_7745c5c3_Var111 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.MergeLaneKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var111...)
+			var templ_7745c5c3_Var113 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.MergeLaneKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var113...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 193, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var112 string
-			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var111).String())
+			var templ_7745c5c3_Var114 string
+			templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var113).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 194, "\" data-board-card-merge-lane data-board-card-expanded title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "\" data-board-card-merge-lane data-board-card-expanded title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var113 string
-			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
+			var templ_7745c5c3_Var115 string
+			templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 724, Col: 179}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 731, Col: 179}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 195, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2244,39 +2285,39 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 196, "<span class=\"line-clamp-2 min-w-0 font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "<span class=\"line-clamp-2 min-w-0 font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var114 string
-			templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneStatus)
+			var templ_7745c5c3_Var116 string
+			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneStatus)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 726, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 733, Col: 74}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 197, "</span> <span class=\"min-w-0 truncate font-mono\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var115 string
-			templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 727, Col: 68}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "</span> <span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 198, "</span></div>")
+			var templ_7745c5c3_Var117 string
+			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(card.MergeLaneDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 734, Col: 68}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.OriginDetail != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 199, "<div class=\"flex items-center gap-1.5 text-2xs text-info\" data-board-card-origin data-board-card-expanded>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "<div class=\"flex items-center gap-1.5 text-2xs text-info\" data-board-card-origin data-board-card-expanded>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2284,27 +2325,27 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 200, "<span class=\"min-w-0 truncate font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "<span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var116 string
-			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(card.OriginDetail)
+			var templ_7745c5c3_Var118 string
+			templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(card.OriginDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 733, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 740, Col: 65}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 201, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.DispatchStatus == "" && card.ExtraText != "" && (!card.RuntimeBadge || card.ExtraText != "agent working") {
 			if card.ExtraChip {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 202, "<div class=\"min-w-0 line-clamp-2\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, "<div class=\"min-w-0 line-clamp-2\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -2312,30 +2353,30 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 203, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				var templ_7745c5c3_Var117 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var117...)
+				var templ_7745c5c3_Var119 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ExtraKind)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var119...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 204, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var118 string
-				templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var117).String())
+				var templ_7745c5c3_Var120 string
+				templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var119).String())
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var120))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, "\" data-board-card-expanded>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "\" data-board-card-expanded>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -2343,71 +2384,71 @@ func boardCardView2(card boardCardView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 206, "<span class=\"line-clamp-2 min-w-0\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, "<span class=\"line-clamp-2 min-w-0\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var119 string
-				templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
+				var templ_7745c5c3_Var121 string
+				templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(card.ExtraText)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 744, Col: 57}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 751, Col: 57}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 207, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
 		if card.Work.SyncKey != "synced" {
-			var templ_7745c5c3_Var120 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.Work.SyncKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var120...)
+			var templ_7745c5c3_Var122 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.Work.SyncKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var122...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 208, "<div class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var121 string
-			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var120).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 209, "\" data-board-card-sync=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var122 string
-			templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(card.Work.SyncKey)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 749, Col: 139}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 210, "\" data-board-card-expanded title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var123 string
-			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(card.Work.SyncTitle)
+			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var122).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 749, Col: 194}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 211, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "\" data-board-card-sync=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var124 string
+			templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(card.Work.SyncKey)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 756, Col: 139}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "\" data-board-card-expanded title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var125 string
+			templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(card.Work.SyncTitle)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 756, Col: 194}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 216, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2415,147 +2456,147 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 212, "<span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var124 string
-			templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs("GitHub " + card.Work.Sync)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 751, Col: 39}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 213, "</span></div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if card.BlockerSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 214, "<div class=\"line-clamp-2 min-w-0 break-words text-2xs text-sec\" data-board-card-blockers data-board-card-expanded><span class=\"text-dim\">Blocker refs</span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var125 string
-			templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(card.BlockerSummary)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 756, Col: 69}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 215, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if card.ParkSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 216, "<div id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "<span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var126 string
-			templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
+			templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs("GitHub " + card.Work.Sync)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 761, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 758, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 217, "\" class=\"min-w-0 truncate font-mono text-2xs text-sec\" tabindex=\"0\" role=\"img\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "</span></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if card.BlockerSummary != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "<div class=\"line-clamp-2 min-w-0 break-words text-2xs text-sec\" data-board-card-blockers data-board-card-expanded><span class=\"text-dim\">Blocker refs</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var127 string
-			templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs("Park history: " + card.ParkDetail)
+			templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(card.BlockerSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 765, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 763, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 218, "\" data-board-card-park-summary data-board-card-expanded data-help-trigger data-help-scope=\"park-history\" data-help-term=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if card.ParkSummary != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 221, "<div id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var128 string
 			templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 770, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 768, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 219, "\" data-help-title=\"Park history\" data-help-description=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 222, "\" class=\"min-w-0 truncate font-mono text-2xs text-sec\" tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var129 string
-			templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkDetail)
+			templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs("Park history: " + card.ParkDetail)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 772, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 772, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 220, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 223, "\" data-board-card-park-summary data-board-card-expanded data-help-trigger data-help-scope=\"park-history\" data-help-term=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var130 string
-			templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkSummary)
+			templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-park-summary")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 773, Col: 23}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 777, Col: 50}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var130))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 221, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 224, "\" data-help-title=\"Park history\" data-help-description=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		}
-		if card.ProgressSummary != "" {
-			var templ_7745c5c3_Var131 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ProgressKind)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var131...)
+			var templ_7745c5c3_Var131 string
+			templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 779, Col: 44}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 222, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 225, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var132 string
-			templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var131).String())
+			templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(card.ParkSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 780, Col: 23}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var132))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 223, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 226, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var133 string
-			templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressDetail)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 776, Col: 125}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
+		}
+		if card.ProgressSummary != "" {
+			var templ_7745c5c3_Var133 = []any{"flex items-center gap-1.5 text-2xs " + boardExtraTextClass(card.ProgressKind)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var133...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 224, "\" data-board-card-progress data-board-card-expanded>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 227, "<div class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var134 string
+			templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var133).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 228, "\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var135 string
+			templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 783, Col: 125}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 229, "\" data-board-card-progress data-board-card-expanded>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2563,158 +2604,158 @@ func boardCardView2(card boardCardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 225, "<span class=\"min-w-0 truncate font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 230, "<span class=\"min-w-0 truncate font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var134 string
-			templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressSummary)
+			var templ_7745c5c3_Var136 string
+			templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(card.ProgressSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 778, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 785, Col: 68}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 226, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 231, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if card.AuthorDetail != "" || len(card.Labels) > 0 || card.Effort != "" || card.Activity != "" || card.PRStatus != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 227, "<div class=\"grid min-w-0 gap-1.5 text-2xs text-sec\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 232, "<div class=\"grid min-w-0 gap-1.5 text-2xs text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if card.AuthorDetail != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 228, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-author><span class=\"flex-none text-dim\">Filed by</span> <span class=\"min-w-0 truncate font-mono text-text\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var135 string
-				templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(card.AuthorDetail)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 786, Col: 77}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 229, "</span></div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if len(card.Labels) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 230, "<div class=\"line-clamp-2 min-w-0\" data-board-card-labels>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				for _, label := range card.Labels {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 231, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var136 string
-					templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(label)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 792, Col: 87}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 232, "</span>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 233, "</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if card.Effort != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 234, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 233, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-author><span class=\"flex-none text-dim\">Filed by</span> <span class=\"min-w-0 truncate font-mono text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var137 string
-				templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
+				templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(card.AuthorDetail)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 799, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 793, Col: 77}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 235, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 234, "</span></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if len(card.Labels) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 235, "<div class=\"line-clamp-2 min-w-0\" data-board-card-labels>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				for _, label := range card.Labels {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 236, "<span class=\"max-w-full truncate rounded-chip bg-surface px-1.5 py-0.5\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var138 string
+					templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 799, Col: 87}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 237, "</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 238, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if card.Effort != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 239, "<div class=\"flex min-w-0 items-center gap-1.5\" data-board-card-effort><span class=\"text-dim\">Effort</span> <span class=\"truncate font-mono text-text\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var139 string
+				templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(card.Effort)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 806, Col: 63}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 240, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if card.Activity != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 236, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var138 string
-				templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 803, Col: 119}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 237, "</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if card.PRStatus != "" {
-				var templ_7745c5c3_Var139 = []any{"line-clamp-2 max-w-full rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var139...)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 238, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 241, "<div class=\"line-clamp-2 min-w-0\" data-board-card-activity><span class=\"text-dim\">Activity</span> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var140 string
-				templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var139).String())
+				templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(card.Activity)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 810, Col: 119}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 239, "\" data-board-card-pr-status>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var141 string
-				templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 806, Col: 154}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var141))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 240, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 242, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 241, "</div>")
+			if card.PRStatus != "" {
+				var templ_7745c5c3_Var141 = []any{"line-clamp-2 max-w-full rounded-chip border px-1.5 py-0.5 font-mono " + card.PRStatusClass}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var141...)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 243, "<div class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var142 string
+				templ_7745c5c3_Var142, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var141).String())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var142))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 244, "\" data-board-card-pr-status>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var143 string
+				templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRStatus)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 813, Col: 154}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 245, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 246, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 242, "<div class=\"flex flex-col gap-1.5 border-t border-line/70 pt-1.5\" data-ai-debug-card-action>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 247, "<div class=\"flex flex-col gap-1.5 border-t border-line/70 pt-1.5\" data-ai-debug-card-action>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2722,7 +2763,7 @@ func boardCardView2(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 243, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 248, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2732,7 +2773,7 @@ func boardCardView2(card boardCardView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 244, "</article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 249, "</article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2756,74 +2797,74 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var142 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var142 == nil {
-			templ_7745c5c3_Var142 = templ.NopComponent
+		templ_7745c5c3_Var144 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var144 == nil {
+			templ_7745c5c3_Var144 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 245, "<div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 250, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var143 string
-		templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
+		var templ_7745c5c3_Var145 string
+		templ_7745c5c3_Var145, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-badge")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 822, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 829, Col: 36}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var145))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 246, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 251, "\" class=\"flex min-w-0 items-center gap-1.5 text-2xs text-ok\" data-board-runtime-badge data-board-card-expanded")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.RuntimeSummary != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 247, " tabindex=\"0\" role=\"img\" aria-label=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var144 string
-			templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 829, Col: 55}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 248, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var145 string
-			templ_7745c5c3_Var145, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 832, Col: 52}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var145))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 249, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 252, " tabindex=\"0\" role=\"img\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var146 string
-			templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
+			templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs("Agent runtime: " + card.RuntimeSummary)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 834, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 836, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 250, "\" onclick=\"event.stopPropagation()\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 253, "\" data-help-trigger data-help-scope=\"runtime-identity\" data-help-term=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var147 string
+			templ_7745c5c3_Var147, templ_7745c5c3_Err = templ.JoinStringErrs(card.DomID + "-runtime-identity")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 839, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var147))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 254, "\" data-help-title=\"Agent runtime\" data-help-description=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var148 string
+			templ_7745c5c3_Var148, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeDetail)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 841, Col: 45}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var148))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 255, "\" onclick=\"event.stopPropagation()\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 251, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 256, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2831,33 +2872,33 @@ func boardRuntimeBadge(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 252, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 257, "<span class=\"min-w-0 truncate font-mono\"><span class=\"runtime-badge-cozy\" data-runtime-density=\"cozy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var147 string
-		templ_7745c5c3_Var147, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
+		var templ_7745c5c3_Var149 string
+		templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeCozyText)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 840, Col: 86}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 847, Col: 86}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var147))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 253, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var149))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var148 string
-		templ_7745c5c3_Var148, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 841, Col: 89}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var148))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 258, "</span> <span class=\"runtime-badge-comfy\" data-runtime-density=\"comfy\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 254, "</span></span></div>")
+		var templ_7745c5c3_Var150 string
+		templ_7745c5c3_Var150, templ_7745c5c3_Err = templ.JoinStringErrs(card.RuntimeComfyText)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 848, Col: 89}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var150))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 259, "</span></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2881,87 +2922,87 @@ func boardKanbanDragMoveForm(card boardCardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var149 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var149 == nil {
-			templ_7745c5c3_Var149 = templ.NopComponent
+		templ_7745c5c3_Var151 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var151 == nil {
+			templ_7745c5c3_Var151 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 255, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var150 string
-		templ_7745c5c3_Var150, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 849, Col: 61}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var150))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 256, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var151 string
-		templ_7745c5c3_Var151, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 850, Col: 65}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var151))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 257, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 260, "<form class=\"hidden\" hx-post=\"/api/v1/kanban/move\" hx-target=\"#snapshot\" hx-swap=\"morph:innerHTML\" data-kanban-drag-move-form><input type=\"hidden\" name=\"kanban_drag\" value=\"true\"> <input type=\"hidden\" name=\"kanban_board\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var152 string
-		templ_7745c5c3_Var152, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+		templ_7745c5c3_Var152, templ_7745c5c3_Err = templ.JoinStringErrs(card.Scope)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 851, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 856, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var152))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 258, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 261, "\"> <input type=\"hidden\" name=\"project_id\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var153 string
-		templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+		templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs(card.MoveProject)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 852, Col: 69}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 857, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var153))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 259, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 262, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var154 string
+		templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 858, Col: 59}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var154))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 263, "\"> <input type=\"hidden\" name=\"current_state\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var155 string
+		templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(card.CurrentState)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 859, Col: 69}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var155))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 264, "\"> <input type=\"hidden\" name=\"target_state\" value=\"\" data-kanban-drag-target-state> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if card.PRNumber != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 260, "<input type=\"hidden\" name=\"pr_number\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 265, "<input type=\"hidden\" name=\"pr_number\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var154 string
-			templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
+			var templ_7745c5c3_Var156 string
+			templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(card.PRNumber)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 855, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 862, Col: 62}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var154))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var156))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 261, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 266, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 262, "</form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 267, "</form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2988,74 +3029,74 @@ func boardLanePicker(view boardView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var155 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var155 == nil {
-			templ_7745c5c3_Var155 = templ.NopComponent
+		templ_7745c5c3_Var157 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var157 == nil {
+			templ_7745c5c3_Var157 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 263, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-work-board-only data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var156 string
-		templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 866, Col: 85}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var156))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 264, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var157 string
-		templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 870, Col: 44}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var157))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 265, "\" aria-label=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 268, "<details id=\"board-lane-picker\" class=\"relative col-span-3 justify-self-start md:col-span-1\" data-board-lane-picker data-work-board-only data-preserve-details=\"board-lane-picker\"><summary class=\"flex min-h-11 cursor-pointer list-none items-center gap-1.5 rounded-chip border border-line px-2.5 py-1 text-2xs text-sec hover:text-text [&::-webkit-details-marker]:hidden md:min-h-0\">Lanes <span data-board-lane-count class=\"tabular-nums\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var158 string
-		templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
+		templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneCountLabel(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 871, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 873, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var158))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 266, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if view.HiddenCards == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 267, " hidden")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 268, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 269, "</span> <span class=\"rounded-chip bg-warn/15 px-1.5 py-0.5 font-mono text-warn\" data-board-hidden-card-count title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var159 string
-		templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
+		templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 873, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 877, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var159))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 269, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 270, "\" aria-label=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var160 string
+		templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardSummary(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 878, Col: 49}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var160))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 271, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if view.HiddenCards == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 272, " hidden")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 273, ">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var161 string
+		templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneHiddenCardBadgeLabel(view))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 880, Col: 41}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var161))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 274, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3063,7 +3104,7 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 270, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 275, "</summary><div class=\"absolute left-0 top-full z-40 mt-1 flex max-h-[calc(100vh-10rem)] w-[calc(100vw-2.5rem)] flex-col gap-1 overflow-y-auto rounded-card border border-line bg-elev p-1.5 md:left-auto md:right-0 md:max-h-none md:w-80 md:overflow-visible\"><div class=\"flex items-center justify-between gap-2 border-b border-line px-1 pb-1.5\"><span class=\"text-2xs font-medium uppercase text-sec\">Visibility</span> <button type=\"button\" class=\"inline-flex min-h-11 items-center gap-1.5 rounded-chip border border-line px-2 text-2xs font-medium text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:min-h-7\" data-board-lane-reset-all aria-label=\"Reset all lanes to Auto\" title=\"Reset all lanes to Auto\" disabled aria-disabled=\"true\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3071,264 +3112,264 @@ func boardLanePicker(view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 271, "<span>Reset all</span></button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 276, "<span>Reset all</span></button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, lane := range view.Lanes {
-			var templ_7745c5c3_Var160 = []any{boardLaneVisibilityRowClass(lane)}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var160...)
+			var templ_7745c5c3_Var162 = []any{boardLaneVisibilityRowClass(lane)}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var162...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 272, "<div class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var161 string
-			templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var160).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var161))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 273, "\" data-board-lane-row=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var162 string
-			templ_7745c5c3_Var162, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 893, Col: 86}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var162))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 274, "\" data-board-lane-card-count=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 277, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var163 string
-			templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
+			templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var162).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 893, Col: 146}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var163))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 275, "\" data-board-lane-hidden-populated=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 278, "\" data-board-lane-row=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var164 string
-			templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
+			templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 893, Col: 229}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 900, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var164))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 276, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 279, "\" data-board-lane-card-count=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var165 string
-			templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
+			templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(lane.CardCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 895, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 900, Col: 146}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var165))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 277, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 280, "\" data-board-lane-hidden-populated=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var166 string
-			templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
+			templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(boardLaneHiddenPopulated(lane)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 896, Col: 111}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 900, Col: 229}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var166))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 278, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 281, "\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 flex-1 truncate font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var167 string
-			templ_7745c5c3_Var167, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			templ_7745c5c3_Var167, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 899, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 902, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var167))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 279, "\" data-board-lane-visibility-status>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 282, "</span> <span class=\"rounded-chip bg-surface px-1.5 py-0.5 font-mono text-2xs text-sec tabular-nums\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var168 string
-			templ_7745c5c3_Var168, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
+			templ_7745c5c3_Var168, templ_7745c5c3_Err = templ.JoinStringErrs(lane.Count)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 899, Col: 174}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 903, Col: 111}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var168))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 280, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 283, "</span></div><div class=\"grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5\"><span class=\"min-w-0 truncate text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var169 string
-			templ_7745c5c3_Var169, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var169, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 902, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 906, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var169))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 281, "\" data-board-lane-visibility-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 284, "\" data-board-lane-visibility-status>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var170 string
-			templ_7745c5c3_Var170, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var170, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusLabel(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 903, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 906, Col: 174}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var170))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 282, "\" data-board-lane-visibility-effective=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 285, "</span> <select class=\"h-11 rounded-chip border border-line bg-surface px-2 text-2xs text-text outline-none focus:border-accent md:h-7\" data-board-lane-visibility=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var171 string
-			templ_7745c5c3_Var171, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
+			templ_7745c5c3_Var171, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 904, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 909, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var171))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 283, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 286, "\" data-board-lane-visibility-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var172 string
-			templ_7745c5c3_Var172, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
+			templ_7745c5c3_Var172, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 905, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 910, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var172))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 284, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 287, "\" data-board-lane-visibility-effective=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var173 string
-			templ_7745c5c3_Var173, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
+			templ_7745c5c3_Var173, templ_7745c5c3_Err = templ.JoinStringErrs(boardBoolAttr(lane.DefaultVisible))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 906, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 911, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var173))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 285, "\"><option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 288, "\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var174 string
-			templ_7745c5c3_Var174, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
+			templ_7745c5c3_Var174, templ_7745c5c3_Err = templ.JoinStringErrs("Visibility for " + lane.Title + " lane")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 908, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 912, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var174))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 286, "\" selected>Auto</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 289, "\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var175 string
-			templ_7745c5c3_Var175, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
+			templ_7745c5c3_Var175, templ_7745c5c3_Err = templ.JoinStringErrs(boardLaneVisibilityStatusTitle(lane))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 909, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 913, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var175))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 287, "\">Show</option> <option value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 290, "\"><option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var176 string
-			templ_7745c5c3_Var176, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
+			templ_7745c5c3_Var176, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityAuto))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 910, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 915, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var176))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 288, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 291, "\" selected>Auto</option> <option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var177 string
-			templ_7745c5c3_Var177, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var177, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityShow))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 915, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 916, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var177))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 289, "\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 292, "\">Show</option> <option value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var178 string
-			templ_7745c5c3_Var178, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			templ_7745c5c3_Var178, templ_7745c5c3_Err = templ.JoinStringErrs(string(boardLaneVisibilityHide))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 916, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 917, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var178))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 290, "\" aria-label=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 293, "\">Hide</option></select> <button type=\"button\" class=\"inline-flex size-11 items-center justify-center rounded-chip border border-line text-sec hover:border-accent hover:text-accent disabled:pointer-events-none disabled:opacity-40 md:size-7\" data-board-lane-reset=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var179 string
-			templ_7745c5c3_Var179, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			templ_7745c5c3_Var179, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 917, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 922, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var179))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 291, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 294, "\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var180 string
+			templ_7745c5c3_Var180, templ_7745c5c3_Err = templ.JoinStringErrs(lane.LaneID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 923, Col: 26}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var180))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 295, "\" aria-label=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var181 string
+			templ_7745c5c3_Var181, templ_7745c5c3_Err = templ.JoinStringErrs("Reset " + lane.Title + " lane to Auto")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 924, Col: 59}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var181))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 296, "\" title=\"Reset lane to Auto\" disabled aria-disabled=\"true\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -3336,12 +3377,12 @@ func boardLanePicker(view boardView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 292, "</button></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 297, "</button></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 293, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 298, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3365,12 +3406,12 @@ func boardLaneScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var180 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var180 == nil {
-			templ_7745c5c3_Var180 = templ.NopComponent
+		templ_7745c5c3_Var182 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var182 == nil {
+			templ_7745c5c3_Var182 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 294, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 299, "<script>\n\t\t(function () {\n\t\t\tvar storagePrefix = \"detent.ui.board.lanes.v2.\";\n\t\t\tvar legacyStoragePrefix = \"detent.ui.board.lanes.\";\n\t\t\tvar storageVersion = 1;\n\t\t\tvar stateAuto = \"auto\";\n\t\t\tvar stateShow = \"show\";\n\t\t\tvar stateHide = \"hide\";\n\t\t\tvar pickerOpen = false;\n\t\t\tvar activeLaneID = \"\";\n\t\t\tvar lanePositionFrame = 0;\n\n\t\t\tfunction visibilityStorage() {\n\t\t\t\ttry {\n\t\t\t\t\treturn window.localStorage;\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction storageKey(root) {\n\t\t\t\treturn storagePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction legacyStorageKey(root) {\n\t\t\t\treturn legacyStoragePrefix + (root.getAttribute(\"data-board-key\") || \"fleet\");\n\t\t\t}\n\t\t\tfunction emptyPrefs() {\n\t\t\t\treturn { show: new Set(), hide: new Set() };\n\t\t\t}\n\t\t\tfunction laneIDSet(ids) {\n\t\t\t\tvar out = new Set();\n\t\t\t\tif (!Array.isArray(ids)) return out;\n\t\t\t\tids.forEach(function (id) {\n\t\t\t\t\tif (typeof id === \"string\" && id.trim() !== \"\") out.add(id);\n\t\t\t\t});\n\t\t\t\treturn out;\n\t\t\t}\n\t\t\tfunction normalizedPrefs(showIDs, hideIDs) {\n\t\t\t\tvar prefs = emptyPrefs();\n\t\t\t\tlaneIDSet(showIDs).forEach(function (id) {\n\t\t\t\t\tprefs.show.add(id);\n\t\t\t\t});\n\t\t\t\tlaneIDSet(hideIDs).forEach(function (id) {\n\t\t\t\t\tif (!prefs.show.has(id)) prefs.hide.add(id);\n\t\t\t\t});\n\t\t\t\treturn prefs;\n\t\t\t}\n\t\t\tfunction discardLegacyPrefs(root, store) {\n\t\t\t\tvar legacy = legacyStorageKey(root);\n\t\t\t\ttry {\n\t\t\t\t\tif (legacy !== storageKey(root)) store.removeItem(legacy);\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction readPrefs(root) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return emptyPrefs();\n\t\t\t\tdiscardLegacyPrefs(root, store);\n\t\t\t\tvar raw = \"\";\n\t\t\t\ttry {\n\t\t\t\t\traw = store.getItem(storageKey(root));\n\t\t\t\t} catch (err) {\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t\tif (!raw) return emptyPrefs();\n\t\t\t\ttry {\n\t\t\t\t\tvar parsed = JSON.parse(raw);\n\t\t\t\t\tif (!parsed || parsed.v !== storageVersion) {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t\t} catch (err) {}\n\t\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t\t}\n\t\t\t\t\treturn normalizedPrefs(parsed.show, parsed.hide);\n\t\t\t\t} catch (err) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn emptyPrefs();\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction writePrefs(root, prefs) {\n\t\t\t\tvar store = visibilityStorage();\n\t\t\t\tif (!store) return;\n\t\t\t\tvar show = Array.from(prefs.show).filter(Boolean).sort();\n\t\t\t\tvar hide = Array.from(prefs.hide).filter(function (id) {\n\t\t\t\t\treturn Boolean(id) && !prefs.show.has(id);\n\t\t\t\t}).sort();\n\t\t\t\tif (show.length === 0 && hide.length === 0) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tstore.removeItem(storageKey(root));\n\t\t\t\t\t} catch (err) {}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttry {\n\t\t\t\t\tstore.setItem(storageKey(root), JSON.stringify({ v: storageVersion, show: show, hide: hide }));\n\t\t\t\t} catch (err) {}\n\t\t\t}\n\t\t\tfunction prefsHaveOverrides(prefs) {\n\t\t\t\treturn prefs.show.size > 0 || prefs.hide.size > 0;\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction boardLanesRoot(scope) {\n\t\t\t\tif (scope instanceof Element && scope.matches(\"[data-board-lanes]\")) return scope;\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\") return scope.querySelector(\"[data-board-lanes]\");\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction findByData(scope, attr, value) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar nodes = root.querySelectorAll(\"[\" + attr + \"]\");\n\t\t\t\tfor (var i = 0; i < nodes.length; i += 1) {\n\t\t\t\t\tif (nodes[i].getAttribute(attr) === value) return nodes[i];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneID(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane\") || \"\";\n\t\t\t}\n\t\t\tfunction laneDefaultVisible(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-default\") === \"true\";\n\t\t\t}\n\t\t\tfunction laneCardCount(lane) {\n\t\t\t\tvar parsed = Number.parseInt(lane.getAttribute(\"data-board-lane-card-count\") || \"0\", 10);\n\t\t\t\tif (!Number.isFinite(parsed) || parsed < 0) return 0;\n\t\t\t\treturn parsed;\n\t\t\t}\n\t\t\tfunction laneTitle(lane) {\n\t\t\t\treturn lane.getAttribute(\"data-board-lane-title\") || \"lane\";\n\t\t\t}\n\t\t\tfunction visibleBoardLanes(root) {\n\t\t\t\treturn Array.from(root.querySelectorAll(\"[data-board-lane]\")).filter(function (lane) {\n\t\t\t\t\treturn lane.getAttribute(\"data-lane-hidden\") !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction lanePositionIndex(root, lanes, preferredID) {\n\t\t\t\tif (lanes.length === 0) return -1;\n\t\t\t\tif (preferredID) {\n\t\t\t\t\tvar preferred = lanes.findIndex(function (lane) {\n\t\t\t\t\t\treturn laneID(lane) === preferredID;\n\t\t\t\t\t});\n\t\t\t\t\tif (preferred >= 0) return preferred;\n\t\t\t\t}\n\t\t\t\tif (!root.isConnected) return 0;\n\t\t\t\tvar rootRect = root.getBoundingClientRect();\n\t\t\t\tvar center = rootRect.left + root.clientWidth / 2;\n\t\t\t\tvar nearest = 0;\n\t\t\t\tvar nearestDistance = Number.POSITIVE_INFINITY;\n\t\t\t\tlanes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar distance = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (distance < nearestDistance) {\n\t\t\t\t\t\tnearest = index;\n\t\t\t\t\t\tnearestDistance = distance;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn nearest;\n\t\t\t}\n\t\t\tfunction updateLanePosition(scope, root, preferredID) {\n\t\t\t\tvar lanes = visibleBoardLanes(root);\n\t\t\t\tvar index = lanePositionIndex(root, lanes, preferredID);\n\t\t\t\tvar current = index < 0 ? 0 : index + 1;\n\t\t\t\tvar position = queryRoot(scope).querySelector(\"[data-board-lane-position]\");\n\t\t\t\tif (position) {\n\t\t\t\t\tvar currentNode = position.querySelector(\"[data-board-lane-position-current]\");\n\t\t\t\t\tvar totalNode = position.querySelector(\"[data-board-lane-position-total]\");\n\t\t\t\t\tif (currentNode) currentNode.textContent = String(current);\n\t\t\t\t\tif (totalNode) totalNode.textContent = String(lanes.length);\n\t\t\t\t\tposition.setAttribute(\"aria-label\", \"Lane \" + current + \" of \" + lanes.length);\n\t\t\t\t}\n\t\t\t\tif (root.isConnected && index >= 0) activeLaneID = laneID(lanes[index]);\n\t\t\t}\n\t\t\tfunction scheduleLanePosition(root) {\n\t\t\t\tif (!root || !root.isConnected) return;\n\t\t\t\twindow.cancelAnimationFrame(lanePositionFrame);\n\t\t\t\tlanePositionFrame = window.requestAnimationFrame(function () {\n\t\t\t\t\tupdateLanePosition(document, root, \"\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction formatNumber(value) {\n\t\t\t\treturn new Intl.NumberFormat(\"en-US\").format(value);\n\t\t\t}\n\t\t\tfunction cardCountLabel(count, singular, plural) {\n\t\t\t\treturn formatNumber(count) + \" \" + (count === 1 ? singular : plural);\n\t\t\t}\n\t\t\tfunction laneOverrideState(lane, prefs) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tif (prefs.show.has(id)) return stateShow;\n\t\t\t\tif (prefs.hide.has(id)) return stateHide;\n\t\t\t\treturn stateAuto;\n\t\t\t}\n\t\t\tfunction laneVisible(lane, state) {\n\t\t\t\tif (state === stateShow) return true;\n\t\t\t\tif (state === stateHide) return false;\n\t\t\t\treturn laneDefaultVisible(lane);\n\t\t\t}\n\t\t\tfunction stateLabel(lane, state, visible) {\n\t\t\t\tvar label = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\tlabel = \"Always shown\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\tlabel = \"Always hidden\";\n\t\t\t\t} else {\n\t\t\t\t\tlabel = visible ? \"Auto shown\" : \"Auto hidden\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn label + \" - \" + cardCountLabel(laneCardCount(lane), \"hidden card\", \"hidden cards\");\n\t\t\t\t}\n\t\t\t\treturn label;\n\t\t\t}\n\t\t\tfunction stateTitle(lane, state, visible) {\n\t\t\t\tvar title = \"\";\n\t\t\t\tif (state === stateShow) {\n\t\t\t\t\ttitle = \"Always show is saved for this lane.\";\n\t\t\t\t} else if (state === stateHide) {\n\t\t\t\t\ttitle = \"Always hide is saved for this lane.\";\n\t\t\t\t} else {\n\t\t\t\t\ttitle = \"Auto follows the board default.\";\n\t\t\t\t}\n\t\t\t\tif (!visible && laneCardCount(lane) > 0) {\n\t\t\t\t\treturn title + \" \" + cardCountLabel(laneCardCount(lane), \"card is\", \"cards are\") + \" hidden while this lane is off.\";\n\t\t\t\t}\n\t\t\t\treturn title;\n\t\t\t}\n\t\t\tfunction hiddenLaneSummary(lanes) {\n\t\t\t\tif (lanes.length === 0) return \"All populated lanes are visible.\";\n\t\t\t\tif (lanes.length === 1) {\n\t\t\t\t\tvar lane = lanes[0];\n\t\t\t\t\treturn cardCountLabel(lane.count, \"hidden card\", \"hidden cards\") + \" in \" + lane.title + \".\";\n\t\t\t\t}\n\t\t\t\tvar total = lanes.reduce(function (sum, lane) {\n\t\t\t\t\treturn sum + lane.count;\n\t\t\t\t}, 0);\n\t\t\t\tvar labels = lanes.map(function (lane) {\n\t\t\t\t\treturn lane.title + \" (\" + formatNumber(lane.count) + \")\";\n\t\t\t\t}).join(\", \");\n\t\t\t\treturn cardCountLabel(total, \"hidden card\", \"hidden cards\") + \" across \" + cardCountLabel(lanes.length, \"lane\", \"lanes\") + \": \" + labels + \".\";\n\t\t\t}\n\t\t\tfunction setResetDisabled(button, disabled) {\n\t\t\t\tif (!(button instanceof HTMLButtonElement)) return;\n\t\t\t\tbutton.disabled = disabled;\n\t\t\t\tbutton.setAttribute(\"aria-disabled\", disabled ? \"true\" : \"false\");\n\t\t\t}\n\t\t\tfunction updateLaneControls(scope, lane, state, visible) {\n\t\t\t\tvar id = laneID(lane);\n\t\t\t\tvar row = findByData(scope, \"data-board-lane-row\", id);\n\t\t\t\tvar hiddenPopulated = !visible && laneCardCount(lane) > 0;\n\t\t\t\tif (row instanceof HTMLElement) {\n\t\t\t\t\trow.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\trow.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\trow.dataset.boardLaneHiddenPopulated = hiddenPopulated ? \"true\" : \"false\";\n\t\t\t\t\trow.classList.toggle(\"border-warn/45\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"bg-warn/10\", hiddenPopulated);\n\t\t\t\t\trow.classList.toggle(\"border-transparent\", !hiddenPopulated);\n\t\t\t\t\tvar status = row.querySelector(\"[data-board-lane-visibility-status]\");\n\t\t\t\t\tif (status) {\n\t\t\t\t\t\tstatus.textContent = stateLabel(lane, state, visible);\n\t\t\t\t\t\tstatus.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tvar select = findByData(scope, \"data-board-lane-visibility\", id);\n\t\t\t\tif (select instanceof HTMLSelectElement) {\n\t\t\t\t\tselect.value = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityState = state;\n\t\t\t\t\tselect.dataset.boardLaneVisibilityEffective = visible ? \"visible\" : \"hidden\";\n\t\t\t\t\tselect.setAttribute(\"title\", stateTitle(lane, state, visible));\n\t\t\t\t}\n\t\t\t\tsetResetDisabled(findByData(scope, \"data-board-lane-reset\", id), state === stateAuto);\n\t\t\t}\n\t\t\tfunction updateHiddenCardBadge(scope, hiddenCards, hiddenLanes) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar badge = root.querySelector(\"[data-board-hidden-card-count]\");\n\t\t\t\tif (!badge) return;\n\t\t\t\tvar summary = hiddenLaneSummary(hiddenLanes);\n\t\t\t\tbadge.hidden = hiddenCards === 0;\n\t\t\t\tbadge.textContent = hiddenCards > 0 ? formatNumber(hiddenCards) + \" hidden\" : \"\";\n\t\t\t\tbadge.setAttribute(\"title\", summary);\n\t\t\t\tbadge.setAttribute(\"aria-label\", summary);\n\t\t\t}\n\t\t\tfunction updateResetAll(scope, prefs) {\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-board-lane-reset-all]\").forEach(function (button) {\n\t\t\t\t\tsetResetDisabled(button, !prefsHaveOverrides(prefs));\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTo(scope) {\n\t\t\t\tvar root = boardLanesRoot(scope);\n\t\t\t\tif (!root) return false;\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tvar total = 0;\n\t\t\t\tvar visible = 0;\n\t\t\t\tvar hiddenCards = 0;\n\t\t\t\tvar hiddenLanes = [];\n\t\t\t\troot.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\ttotal += 1;\n\t\t\t\t\tvar state = laneOverrideState(lane, prefs);\n\t\t\t\t\tvar show = laneVisible(lane, state);\n\t\t\t\t\tvar cards = laneCardCount(lane);\n\t\t\t\t\tlane.setAttribute(\"data-lane-hidden\", show ? \"false\" : \"true\");\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-visibility-state\", state);\n\t\t\t\t\tlane.setAttribute(\"data-board-lane-pinned\", state === stateAuto ? \"false\" : \"true\");\n\t\t\t\t\tif (show) {\n\t\t\t\t\t\tvisible += 1;\n\t\t\t\t\t} else if (cards > 0) {\n\t\t\t\t\t\thiddenCards += cards;\n\t\t\t\t\t\thiddenLanes.push({ title: laneTitle(lane), count: cards });\n\t\t\t\t\t}\n\t\t\t\t\tupdateLaneControls(scope, lane, state, show);\n\t\t\t\t});\n\t\t\t\tvar count = queryRoot(scope).querySelector(\"[data-board-lane-count]\");\n\t\t\t\tif (count) count.textContent = visible + \"/\" + total;\n\t\t\t\tupdateHiddenCardBadge(scope, hiddenCards, hiddenLanes);\n\t\t\t\tupdateResetAll(scope, prefs);\n\t\t\t\tvar picker = queryRoot(scope).querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && pickerOpen) picker.setAttribute(\"open\", \"\");\n\t\t\t\tupdateLanePosition(scope, root, activeLaneID);\n\t\t\t\tif (root.isConnected) scheduleLanePosition(root);\n\t\t\t\tif (typeof window.__detentBoardKanbanDragAdjustSnapshot === \"function\") {\n\t\t\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot(scope);\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction apply() {\n\t\t\t\tapplyTo(document);\n\t\t\t}\n\t\t\tfunction adjustedBoardHTML(html) {\n\t\t\t\tif (typeof html !== \"string\" || html.indexOf(\"data-board-lanes\") < 0) return \"\";\n\t\t\t\tvar template = document.createElement(\"template\");\n\t\t\t\ttemplate.innerHTML = html;\n\t\t\t\tif (!applyTo(template.content)) return \"\";\n\t\t\t\treturn template.innerHTML;\n\t\t\t}\n\t\t\tfunction snapshotSwapTarget(event) {\n\t\t\t\tvar target = event.detail && event.detail.target;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction applyBeforeSwap(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tif (!snapshotSwapTarget(event) || typeof detail.serverResponse !== \"string\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.serverResponse);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tdetail.serverResponse = adjusted;\n\t\t\t}\n\t\t\tfunction applyBeforeSSEMessage(event) {\n\t\t\t\tvar detail = event.detail || {};\n\t\t\t\tvar target = detail.elt;\n\t\t\t\tif (!(target instanceof Element)) target = event.target;\n\t\t\t\tif (!(target instanceof Element) || target.id !== \"snapshot\") return;\n\t\t\t\tif (!window.htmx || typeof window.htmx.swap !== \"function\") return;\n\t\t\t\tvar adjusted = adjustedBoardHTML(detail.data);\n\t\t\t\tif (!adjusted) return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\twindow.htmx.swap(target, adjusted, { swapStyle: target.getAttribute(\"hx-swap\") || \"innerHTML\" }, { contextElement: target });\n\t\t\t}\n\t\t\tfunction setLaneState(root, id, state) {\n\t\t\t\tvar prefs = readPrefs(root);\n\t\t\t\tprefs.show.delete(id);\n\t\t\t\tprefs.hide.delete(id);\n\t\t\t\tif (state === stateShow) prefs.show.add(id);\n\t\t\t\tif (state === stateHide) prefs.hide.add(id);\n\t\t\t\twritePrefs(root, prefs);\n\t\t\t\tapply();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar select = target ? target.closest(\"[data-board-lane-visibility]\") : null;\n\t\t\t\tif (!(select instanceof HTMLSelectElement)) return;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tif (!root) return;\n\t\t\t\tvar state = select.value;\n\t\t\t\tif (state !== stateShow && state !== stateHide) state = stateAuto;\n\t\t\t\tsetLaneState(root, select.getAttribute(\"data-board-lane-visibility\") || \"\", state);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"toggle\", function (event) {\n\t\t\t\tvar picker = event.target;\n\t\t\t\tif (picker instanceof Element && picker.hasAttribute(\"data-board-lane-picker\")) {\n\t\t\t\t\tpickerOpen = picker.open;\n\t\t\t\t}\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar target = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar root = document.querySelector(\"[data-board-lanes]\");\n\t\t\t\tvar reset = target ? target.closest(\"[data-board-lane-reset]\") : null;\n\t\t\t\tif (reset instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tsetLaneState(root, reset.value || reset.getAttribute(\"data-board-lane-reset\") || \"\", stateAuto);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar resetAll = target ? target.closest(\"[data-board-lane-reset-all]\") : null;\n\t\t\t\tif (resetAll instanceof HTMLButtonElement && root) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\twritePrefs(root, emptyPrefs());\n\t\t\t\t\tapply();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open && !picker.contains(event.target)) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key !== \"Escape\") return;\n\t\t\t\tvar picker = document.querySelector(\"[data-board-lane-picker]\");\n\t\t\t\tif (picker && picker.open) {\n\t\t\t\t\tpicker.removeAttribute(\"open\");\n\t\t\t\t\tpickerOpen = false;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeSwap\", applyBeforeSwap);\n\t\t\tdocument.addEventListener(\"htmx:sseBeforeMessage\", applyBeforeSSEMessage);\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", apply);\n\t\t\tdocument.addEventListener(\"DOMContentLoaded\", apply);\n\t\t\tdocument.addEventListener(\"scroll\", function (event) {\n\t\t\t\tvar root = event.target instanceof Element && event.target.matches(\"[data-board-lanes]\") ? event.target : null;\n\t\t\t\tif (root) scheduleLanePosition(root);\n\t\t\t}, true);\n\t\t\twindow.addEventListener(\"resize\", function () {\n\t\t\t\tscheduleLanePosition(document.querySelector(\"[data-board-lanes]\"));\n\t\t\t});\n\t\t\twindow.addEventListener(\"storage\", function (event) {\n\t\t\t\tif (event.key && event.key.indexOf(storagePrefix) === 0) apply();\n\t\t\t});\n\t\t\tapply();\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3401,12 +3442,12 @@ func boardKanbanDragScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var181 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var181 == nil {
-			templ_7745c5c3_Var181 = templ.NopComponent
+		templ_7745c5c3_Var183 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var183 == nil {
+			templ_7745c5c3_Var183 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 295, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction connectionAllowsMoves() {\n\t\t\t\treturn document.documentElement.getAttribute(\"data-detent-connection\") === \"connected\";\n\t\t\t}\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar pressedElement = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar pressedCard = pressedElement ? pressedElement.closest(\"[data-kanban-card]\") : null;\n\t\t\t\tif (pressedCard && !connectionAllowsMoves()) {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(\"Moves are disabled while the board reconnects. Reload if the connection does not recover.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (pressedCard && pressedCard.dataset.kanbanMoveDisabled === \"true\") {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(pressedCard.dataset.kanbanMoveDisabledReason || \"This card cannot be moved.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar card = pressedCard && pressedCard.dataset.kanbanAction === \"move\" ? pressedCard : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (!connectionAllowsMoves()) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\tfeedback(\"Move cancelled because the board connection was lost.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"detent:connectionChange\", function (event) {\n\t\t\t\tif (!event.detail || event.detail.state === \"connected\") return;\n\t\t\t\tif (active) cancelDrag();\n\t\t\t\telse clearPending();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 300, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentBoardKanbanDragHandlersRegistered) return;\n\t\t\twindow.__detentBoardKanbanDragHandlersRegistered = true;\n\t\t\tvar DRAG_THRESHOLD_PX = 6;\n\t\t\tvar TOUCH_MOVE_TOLERANCE_PX = 10;\n\t\t\tvar TOUCH_LONG_PRESS_MS = 450;\n\t\t\tvar TOUCH_EDGE_ZONE_PX = 56;\n\t\t\tvar TOUCH_EDGE_ADVANCE_MS = 500;\n\t\t\t// Real mouse clicks travel a few pixels between press and release,\n\t\t\t// so distance alone cannot separate a click from a drag. A short\n\t\t\t// gesture released back over the source lane is a click: finish the\n\t\t\t// drag without swallowing the click so the detail sheet still opens.\n\t\t\tvar CLICK_GESTURE_MS = 250;\n\t\t\tvar draggedIssueID = \"\";\n\t\t\tvar draggedAllowedTargetKeys = [];\n\t\t\tvar pending = null;\n\t\t\tvar active = null;\n\t\t\tvar recentTouchStart = null;\n\t\t\tfunction connectionAllowsMoves() {\n\t\t\t\treturn document.documentElement.getAttribute(\"data-detent-connection\") === \"connected\";\n\t\t\t}\n\t\t\tfunction clearPending() {\n\t\t\t\tif (pending && pending.longPressTimer) window.clearTimeout(pending.longPressTimer);\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t}\n\t\t\tfunction touchWithIdentifier(touches, identifier) {\n\t\t\t\tif (!touches || identifier === null || identifier === undefined) return null;\n\t\t\t\tfor (var index = 0; index < touches.length; index += 1) {\n\t\t\t\t\tif (touches[index].identifier === identifier) return touches[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction recentTouchIdentifier(card, event) {\n\t\t\t\tif (event.pointerType !== \"touch\" || !recentTouchStart) return null;\n\t\t\t\tif (Date.now() - recentTouchStart.startedAt >= 100) return null;\n\t\t\t\tif (!(recentTouchStart.target instanceof Node) || !card.contains(recentTouchStart.target)) return null;\n\t\t\t\treturn recentTouchStart.identifier;\n\t\t\t}\n\t\t\tfunction feedback(message, kind) {\n\t\t\t\tvar target = document.getElementById(\"board-feedback\");\n\t\t\t\tif (!target) return;\n\t\t\t\tvar text = String(message || \"\").trim();\n\t\t\t\ttarget.className = \"flex flex-none items-center gap-2 px-5 pt-3.5 text-xs \" + (kind === \"error\" ? \"text-err\" : \"text-sec\");\n\t\t\t\ttarget.textContent = text;\n\t\t\t\ttarget.hidden = text === \"\";\n\t\t\t}\n\t\t\tfunction queryRoot(scope) {\n\t\t\t\tif (scope && typeof scope.querySelector === \"function\" && typeof scope.querySelectorAll === \"function\") return scope;\n\t\t\t\treturn document;\n\t\t\t}\n\t\t\tfunction draggedCard(scope) {\n\t\t\t\tif (!draggedIssueID || !window.CSS || typeof CSS.escape !== \"function\") return null;\n\t\t\t\treturn queryRoot(scope).querySelector(\"[data-kanban-card][data-kanban-issue-id='\" + CSS.escape(draggedIssueID) + \"']\");\n\t\t\t}\n\t\t\tfunction cardByIssueID(scope, issueID) {\n\t\t\t\tvar cards = queryRoot(scope).querySelectorAll(\"[data-kanban-card][data-kanban-issue-id]\");\n\t\t\t\tfor (var index = 0; index < cards.length; index += 1) {\n\t\t\t\t\tif (cards[index].dataset.kanbanIssueId === issueID) return cards[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction laneByState(scope, state) {\n\t\t\t\tvar lanes = queryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\");\n\t\t\t\tfor (var index = 0; index < lanes.length; index += 1) {\n\t\t\t\t\tif (lanes[index].dataset.kanbanDropState === state) return lanes[index];\n\t\t\t\t}\n\t\t\t\treturn null;\n\t\t\t}\n\t\t\tfunction cardContainer(lane) {\n\t\t\t\treturn lane instanceof HTMLElement ? lane.querySelector(\"[data-kanban-card-container]\") : null;\n\t\t\t}\n\t\t\tfunction updateEmptyLine(container) {\n\t\t\t\tif (!(container instanceof HTMLElement)) return;\n\t\t\t\tvar emptyLine = container.querySelector(\"[data-kanban-empty-line]\");\n\t\t\t\tif (emptyLine instanceof HTMLElement) emptyLine.hidden = Boolean(container.querySelector(\"[data-kanban-card]\"));\n\t\t\t}\n\t\t\tfunction placeCardInLane(card, state, scope) {\n\t\t\t\tvar lane = laneByState(scope, state);\n\t\t\t\tvar container = cardContainer(lane);\n\t\t\t\tif (!(card instanceof HTMLElement) || !(lane instanceof HTMLElement) || !(container instanceof HTMLElement)) return null;\n\t\t\t\tvar previousContainer = card.parentElement;\n\t\t\t\tcontainer.appendChild(card);\n\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\tupdateEmptyLine(previousContainer);\n\t\t\t\tupdateEmptyLine(container);\n\t\t\t\treturn lane;\n\t\t\t}\n\t\t\tfunction copyPendingMove(source, target) {\n\t\t\t\t[\n\t\t\t\t\t\"kanbanPendingMove\",\n\t\t\t\t\t\"kanbanPendingOrigin\",\n\t\t\t\t\t\"kanbanPendingSeq\",\n\t\t\t\t\t\"kanbanPendingTargetWasHidden\"\n\t\t\t\t].forEach(function (key) {\n\t\t\t\t\tif (source.dataset[key] === undefined) {\n\t\t\t\t\t\tdelete target.dataset[key];\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttarget.dataset[key] = source.dataset[key];\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction clearPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement)) return;\n\t\t\t\tdelete card.dataset.kanbanPendingMove;\n\t\t\t\tdelete card.dataset.kanbanPendingOrigin;\n\t\t\t\tdelete card.dataset.kanbanPendingSeq;\n\t\t\t\tdelete card.dataset.kanbanPendingTargetWasHidden;\n\t\t\t}\n\t\t\tfunction pendingMoveSuperseded(liveCard, serverCard) {\n\t\t\t\tvar targetState = liveCard.dataset.kanbanPendingMove || \"\";\n\t\t\t\tif ((serverCard.dataset.kanbanCurrentState || \"\") === targetState) return true;\n\t\t\t\tvar pendingSeq = Number.parseInt(liveCard.dataset.kanbanPendingSeq || \"\", 10);\n\t\t\t\tvar serverSeq = Number.parseInt(serverCard.dataset.kanbanDataSeq || \"\", 10);\n\t\t\t\treturn Number.isFinite(pendingSeq) && Number.isFinite(serverSeq) && serverSeq > pendingSeq;\n\t\t\t}\n\t\t\tfunction applyPendingMoveState(scope) {\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar applied = false;\n\t\t\t\tdocument.querySelectorAll(\"#snapshot [data-kanban-card][data-kanban-pending-move]\").forEach(function (liveCard) {\n\t\t\t\t\tif (!(liveCard instanceof HTMLElement)) return;\n\t\t\t\t\tvar issueID = liveCard.dataset.kanbanIssueId || \"\";\n\t\t\t\t\tvar serverCard = cardByIssueID(root, issueID);\n\t\t\t\t\tif (!(serverCard instanceof HTMLElement)) return;\n\t\t\t\t\tif (pendingMoveSuperseded(liveCard, serverCard)) {\n\t\t\t\t\t\tif (serverCard === liveCard) clearPendingMove(serverCard);\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcopyPendingMove(liveCard, serverCard);\n\t\t\t\t\tif (placeCardInLane(serverCard, liveCard.dataset.kanbanPendingMove || \"\", root)) applied = true;\n\t\t\t\t});\n\t\t\t\treturn applied;\n\t\t\t}\n\t\t\tfunction targetKeysFromValue(value) {\n\t\t\t\treturn String(value || \"\").split(/\\s+/).filter(Boolean);\n\t\t\t}\n\t\t\tfunction allowedTargetKeys(card) {\n\t\t\t\tif (card instanceof HTMLElement) {\n\t\t\t\t\tvar keys = targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\");\n\t\t\t\t\tif (keys.length > 0) return keys;\n\t\t\t\t}\n\t\t\t\treturn draggedAllowedTargetKeys.slice();\n\t\t\t}\n\t\t\tfunction laneAllowed(card, lane) {\n\t\t\t\tif (!(lane instanceof HTMLElement)) return false;\n\t\t\t\tvar key = lane.dataset.kanbanDropKey || \"\";\n\t\t\t\treturn key !== \"\" && allowedTargetKeys(card).includes(key);\n\t\t\t}\n\t\t\tfunction setDropTargetState(card, scope) {\n\t\t\t\tvar sourceLane = card instanceof HTMLElement ? card.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t\tqueryRoot(scope).querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden === undefined) {\n\t\t\t\t\t\tlane.dataset.kanbanDropWasHidden = lane.dataset.laneHidden || \"false\";\n\t\t\t\t\t}\n\t\t\t\t\tlane.dataset.laneHidden = \"false\";\n\t\t\t\t\tif (lane === sourceLane) {\n\t\t\t\t\t\t// The origin lane is not a transition target, but styling\n\t\t\t\t\t\t// it blocked reads as an error; mark it as the source so\n\t\t\t\t\t\t// the operator can see where the card came from.\n\t\t\t\t\t\tlane.dataset.kanbanDropSource = \"true\";\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tvar allowed = laneAllowed(card, lane);\n\t\t\t\t\tlane.dataset.kanbanDropAllowed = allowed ? \"true\" : \"false\";\n\t\t\t\t\tlane.setAttribute(\"aria-disabled\", allowed ? \"false\" : \"true\");\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyActiveDragState(scope) {\n\t\t\t\tif (!draggedIssueID || draggedAllowedTargetKeys.length === 0) return false;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar card = draggedCard(root);\n\t\t\t\tif (card instanceof HTMLElement) card.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, root);\n\t\t\t\tapplyTouchDragStyles(card, root);\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction applyDragState(scope) {\n\t\t\t\tvar pendingApplied = applyPendingMoveState(scope);\n\t\t\t\treturn applyActiveDragState(scope) || pendingApplied;\n\t\t\t}\n\t\t\twindow.__detentBoardKanbanDragAdjustSnapshot = applyDragState;\n\t\t\tfunction clearDropTargetState() {\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-drop-state]\").forEach(function (lane) {\n\t\t\t\t\tif (!(lane instanceof HTMLElement)) return;\n\t\t\t\t\tif (lane.dataset.kanbanDropWasHidden !== undefined) {\n\t\t\t\t\t\tlane.dataset.laneHidden = lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t\tdelete lane.dataset.kanbanDropWasHidden;\n\t\t\t\t\t}\n\t\t\t\t\tdelete lane.dataset.kanbanDropAllowed;\n\t\t\t\t\tdelete lane.dataset.kanbanDropSource;\n\t\t\t\t\tlane.removeAttribute(\"aria-disabled\");\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-kanban-card][data-kanban-dragging='true']\").forEach(function (card) {\n\t\t\t\t\tif (card instanceof HTMLElement) delete card.dataset.kanbanDragging;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction responseMessage(response) {\n\t\t\t\tif (!response) return \"\";\n\t\t\t\tvar doc = new DOMParser().parseFromString(response, \"text/html\");\n\t\t\t\treturn (doc.body.textContent || \"\").trim();\n\t\t\t}\n\t\t\tfunction buildGhost(card, rect) {\n\t\t\t\tvar ghost = card.cloneNode(true);\n\t\t\t\tghost.removeAttribute(\"id\");\n\t\t\t\tghost.querySelectorAll(\"[id]\").forEach(function (node) {\n\t\t\t\t\tnode.removeAttribute(\"id\");\n\t\t\t\t});\n\t\t\t\tvar form = ghost.querySelector(\"[data-kanban-drag-move-form]\");\n\t\t\t\tif (form) form.remove();\n\t\t\t\tdelete ghost.dataset.kanbanDragging;\n\t\t\t\tvar origin = document.createElement(\"div\");\n\t\t\t\torigin.className = \"mb-1.5 flex items-center gap-1.5 border-b border-line pb-1.5 font-mono text-2xs font-medium text-accent\";\n\t\t\t\torigin.textContent = \"From \" + (card.dataset.kanbanCurrentState || \"current lane\");\n\t\t\t\tghost.insertBefore(origin, ghost.firstChild);\n\t\t\t\tghost.setAttribute(\"aria-hidden\", \"true\");\n\t\t\t\tghost.style.position = \"fixed\";\n\t\t\t\tghost.style.left = \"0\";\n\t\t\t\tghost.style.top = \"0\";\n\t\t\t\tghost.style.margin = \"0\";\n\t\t\t\tghost.style.width = rect.width + \"px\";\n\t\t\t\tghost.style.height = rect.height + \"px\";\n\t\t\t\tghost.style.pointerEvents = \"none\";\n\t\t\t\tghost.style.zIndex = \"1000\";\n\t\t\t\tghost.style.opacity = \"0.9\";\n\t\t\t\tghost.style.boxShadow = \"0 12px 32px rgba(0, 0, 0, 0.35)\";\n\t\t\t\tghost.style.willChange = \"transform\";\n\t\t\t\tdocument.body.appendChild(ghost);\n\t\t\t\treturn ghost;\n\t\t\t}\n\t\t\tfunction moveGhost(ghost, x, y, offsetX, offsetY) {\n\t\t\t\tghost.style.transform = \"translate(\" + Math.round(x - offsetX) + \"px, \" + Math.round(y - offsetY) + \"px)\";\n\t\t\t}\n\t\t\tfunction laneFromPoint(x, y) {\n\t\t\t\tvar hit = document.elementFromPoint(x, y);\n\t\t\t\treturn hit instanceof Element ? hit.closest(\"[data-kanban-drop-state]\") : null;\n\t\t\t}\n\t\t\tfunction applyTouchStyle(element, styles) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || !(element instanceof HTMLElement) || !element.isConnected) return;\n\t\t\t\tif (!active.touchStyles.has(element)) {\n\t\t\t\t\tvar original = {};\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\toriginal[property] = element.style[property];\n\t\t\t\t\t});\n\t\t\t\t\tactive.touchStyles.set(element, original);\n\t\t\t\t}\n\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyTouchDragStyles(card, scope) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar root = queryRoot(scope);\n\t\t\t\tvar lanes = root.querySelector(\"[data-board-lanes]\");\n\t\t\t\tapplyTouchStyle(lanes, { touchAction: \"none\", scrollSnapType: \"none\" });\n\t\t\t\tapplyTouchStyle(card, {\n\t\t\t\t\ttouchAction: \"none\",\n\t\t\t\t\toutline: \"2px solid var(--color-accent)\",\n\t\t\t\t\toutlineOffset: \"2px\"\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction restoreTouchDragStyles() {\n\t\t\t\tif (!active || !active.touchStyles) return;\n\t\t\t\tactive.touchStyles.forEach(function (styles, element) {\n\t\t\t\t\tObject.keys(styles).forEach(function (property) {\n\t\t\t\t\t\telement.style[property] = styles[property];\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t\tactive.touchStyles.clear();\n\t\t\t}\n\t\t\t// Native drags auto-scrolled the lane strip at the viewport edges;\n\t\t\t// pointer drags must do it themselves. Scrolls only while the\n\t\t\t// pointer moves, which is enough to reach off-screen lanes.\n\t\t\tfunction autoScrollLanes(x) {\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tif (x < rect.left + 48) {\n\t\t\t\t\tlanes.scrollLeft -= 16;\n\t\t\t\t} else if (x > rect.right - 48) {\n\t\t\t\t\tlanes.scrollLeft += 16;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction visibleDropLanes(lanes) {\n\t\t\t\treturn Array.from(lanes.querySelectorAll(\"[data-kanban-drop-state]\")).filter(function (lane) {\n\t\t\t\t\treturn lane instanceof HTMLElement && lane.dataset.laneHidden !== \"true\";\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction closestLaneIndex(lanes, laneNodes) {\n\t\t\t\tvar center = lanes.getBoundingClientRect().left + lanes.clientWidth / 2;\n\t\t\t\tvar closest = 0;\n\t\t\t\tvar distance = Infinity;\n\t\t\t\tlaneNodes.forEach(function (lane, index) {\n\t\t\t\t\tvar rect = lane.getBoundingClientRect();\n\t\t\t\t\tvar candidate = Math.abs(rect.left + rect.width / 2 - center);\n\t\t\t\t\tif (candidate < distance) {\n\t\t\t\t\t\tdistance = candidate;\n\t\t\t\t\t\tclosest = index;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn closest;\n\t\t\t}\n\t\t\tfunction advanceTouchLane(direction) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\" || active.edgeDirection !== direction) return;\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar laneNodes = visibleDropLanes(lanes);\n\t\t\t\tif (laneNodes.length === 0) return;\n\t\t\t\tvar current = closestLaneIndex(lanes, laneNodes);\n\t\t\t\tvar target = Math.max(0, Math.min(laneNodes.length - 1, current + direction));\n\t\t\t\tif (target !== current) {\n\t\t\t\t\tlaneNodes[target].scrollIntoView({ behavior: \"smooth\", block: \"nearest\", inline: \"start\" });\n\t\t\t\t}\n\t\t\t\tif (active && active.edgeDirection === direction && target !== current) {\n\t\t\t\t\tactive.edgeTimer = window.setTimeout(function () {\n\t\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction updateTouchEdgeAdvance(x) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar lanes = document.getElementById(\"board-lanes\");\n\t\t\t\tif (!lanes) return;\n\t\t\t\tvar rect = lanes.getBoundingClientRect();\n\t\t\t\tvar direction = x < rect.left + TOUCH_EDGE_ZONE_PX ? -1 : (x > rect.right - TOUCH_EDGE_ZONE_PX ? 1 : 0);\n\t\t\t\tif (direction === active.edgeDirection) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeDirection = direction;\n\t\t\t\tactive.edgeTimer = direction === 0 ? null : window.setTimeout(function () {\n\t\t\t\t\tadvanceTouchLane(direction);\n\t\t\t\t}, TOUCH_EDGE_ADVANCE_MS);\n\t\t\t}\n\t\t\tfunction stopTouchEdgeAdvance() {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (active.edgeTimer) window.clearTimeout(active.edgeTimer);\n\t\t\t\tactive.edgeTimer = null;\n\t\t\t\tactive.edgeDirection = 0;\n\t\t\t}\n\t\t\tfunction suppressNextClick() {\n\t\t\t\tvar until = Date.now() + 400;\n\t\t\t\tdocument.addEventListener(\"click\", function suppress(event) {\n\t\t\t\t\tdocument.removeEventListener(\"click\", suppress, true);\n\t\t\t\t\tif (Date.now() > until) return;\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t}, true);\n\t\t\t}\n\t\t\tfunction beginDrag(event) {\n\t\t\t\tvar press = pending;\n\t\t\t\tif (!press) return;\n\t\t\t\tif (press.longPressTimer) window.clearTimeout(press.longPressTimer);\n\t\t\t\tdraggedIssueID = press.issueID;\n\t\t\t\tdraggedAllowedTargetKeys = press.targets;\n\t\t\t\tvar card = draggedCard(document) || press.card;\n\t\t\t\tactive = {\n\t\t\t\t\tpointerId: press.pointerId,\n\t\t\t\t\tpointerType: press.pointerType,\n\t\t\t\t\ttouchIdentifier: press.touchIdentifier,\n\t\t\t\t\toffsetX: press.startX - press.rect.left,\n\t\t\t\t\toffsetY: press.startY - press.rect.top,\n\t\t\t\t\tghost: buildGhost(card, press.rect),\n\t\t\t\t\tlastLaneBlocked: false,\n\t\t\t\t\tstartedAt: press.startedAt,\n\t\t\t\t\tcaptureElement: press.card,\n\t\t\t\t\ttouchStyles: new Map(),\n\t\t\t\t\tedgeDirection: 0,\n\t\t\t\t\tedgeTimer: null\n\t\t\t\t};\n\t\t\t\tpending = null;\n\t\t\t\trecentTouchStart = null;\n\t\t\t\tif (active.pointerType === \"touch\" && typeof active.captureElement.setPointerCapture === \"function\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tactive.captureElement.setPointerCapture(active.pointerId);\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tcard.dataset.kanbanDragging = \"true\";\n\t\t\t\tsetDropTargetState(card, document);\n\t\t\t\tapplyTouchDragStyles(card, document);\n\t\t\t\tfeedback(\"Moving \" + (card.dataset.kanbanCurrentState || \"card\") + \".\");\n\t\t\t\tmoveGhost(active.ghost, event.clientX, event.clientY, active.offsetX, active.offsetY);\n\t\t\t}\n\t\t\tfunction finishDrag(keepClick) {\n\t\t\t\tif (active) {\n\t\t\t\t\tstopTouchEdgeAdvance();\n\t\t\t\t\trestoreTouchDragStyles();\n\t\t\t\t\tif (active.ghost) active.ghost.remove();\n\t\t\t\t\tif (active.captureElement && typeof active.captureElement.releasePointerCapture === \"function\") {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tif (active.captureElement.hasPointerCapture(active.pointerId)) active.captureElement.releasePointerCapture(active.pointerId);\n\t\t\t\t\t\t} catch (_) {}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tclearPending();\n\t\t\t\tactive = null;\n\t\t\t\tdraggedIssueID = \"\";\n\t\t\t\tdraggedAllowedTargetKeys = [];\n\t\t\t\tclearDropTargetState();\n\t\t\t\t// A drag ends with the pointer still over a card, so the release\n\t\t\t\t// also fires a click; swallow it or the detail sheet opens.\n\t\t\t\tif (!keepClick) suppressNextClick();\n\t\t\t}\n\t\t\tfunction cancelDrag(keepClick) {\n\t\t\t\tif (!active) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tfinishDrag(keepClick);\n\t\t\t\tfeedback(\"Move cancelled.\", \"error\");\n\t\t\t}\n\t\t\tfunction rollbackPendingMove(card) {\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar targetLane = card.closest(\"[data-kanban-drop-state]\");\n\t\t\t\tvar targetWasHidden = card.dataset.kanbanPendingTargetWasHidden === \"true\";\n\t\t\t\tvar originState = card.dataset.kanbanPendingOrigin || \"\";\n\t\t\t\tclearPendingMove(card);\n\t\t\t\tplaceCardInLane(card, originState, document);\n\t\t\t\tif (targetLane instanceof HTMLElement) {\n\t\t\t\t\ttargetLane.dataset.laneHidden = targetWasHidden ? \"true\" : \"false\";\n\t\t\t\t\tupdateEmptyLine(cardContainer(targetLane));\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction moveDragTo(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tmoveGhost(active.ghost, x, y, active.offsetX, active.offsetY);\n\t\t\t\tif (active.pointerType === \"touch\") {\n\t\t\t\t\tupdateTouchEdgeAdvance(x);\n\t\t\t\t} else {\n\t\t\t\t\tautoScrollLanes(x);\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tvar blocked = lane instanceof HTMLElement && lane.dataset.kanbanDropSource !== \"true\" && !laneAllowed(card, lane);\n\t\t\t\tif (blocked && !active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t} else if (!blocked && active.lastLaneBlocked) {\n\t\t\t\t\tfeedback(\"Moving \" + ((card && card.dataset.kanbanCurrentState) || \"card\") + \".\");\n\t\t\t\t}\n\t\t\t\tactive.lastLaneBlocked = blocked;\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerdown\", function (event) {\n\t\t\t\tif (active || event.button !== 0 || event.isPrimary === false) return;\n\t\t\t\tvar pressedElement = event.target instanceof Element ? event.target : null;\n\t\t\t\tvar pressedCard = pressedElement ? pressedElement.closest(\"[data-kanban-card]\") : null;\n\t\t\t\tif (pressedCard && !connectionAllowsMoves()) {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(\"Moves are disabled while the board reconnects. Reload if the connection does not recover.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (pressedCard && pressedCard.dataset.kanbanMoveDisabled === \"true\") {\n\t\t\t\t\tif (pressedElement.closest(\"a, button, input, select, textarea, summary, label, [data-help-trigger]\")) return;\n\t\t\t\t\tfeedback(pressedCard.dataset.kanbanMoveDisabledReason || \"This card cannot be moved.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar card = pressedCard && pressedCard.dataset.kanbanAction === \"move\" ? pressedCard : null;\n\t\t\t\tif (!card) return;\n\t\t\t\tif (card.dataset.kanbanPendingMove) return;\n\t\t\t\tvar issueID = card.dataset.kanbanIssueId || \"\";\n\t\t\t\tif (!issueID) return;\n\t\t\t\tpending = {\n\t\t\t\t\tpointerId: event.pointerId,\n\t\t\t\t\tpointerType: event.pointerType,\n\t\t\t\t\ttouchIdentifier: recentTouchIdentifier(card, event),\n\t\t\t\t\tcard: card,\n\t\t\t\t\tissueID: issueID,\n\t\t\t\t\ttargets: targetKeysFromValue(card.dataset.kanbanAllowedTargets || \"\"),\n\t\t\t\t\trect: card.getBoundingClientRect(),\n\t\t\t\t\tstartX: event.clientX,\n\t\t\t\t\tstartY: event.clientY,\n\t\t\t\t\tlastX: event.clientX,\n\t\t\t\t\tlastY: event.clientY,\n\t\t\t\t\tstartedAt: Date.now(),\n\t\t\t\t\tlongPressTimer: null\n\t\t\t\t};\n\t\t\t\tif (event.pointerType === \"touch\") {\n\t\t\t\t\tvar pointerId = event.pointerId;\n\t\t\t\t\tpending.longPressTimer = window.setTimeout(function () {\n\t\t\t\t\t\tif (!pending || pending.pointerId !== pointerId) return;\n\t\t\t\t\t\tbeginDrag({ clientX: pending.lastX, clientY: pending.lastY });\n\t\t\t\t\t}, TOUCH_LONG_PRESS_MS);\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchstart\", function (event) {\n\t\t\t\tif (active || !event.changedTouches || event.changedTouches.length === 0) return;\n\t\t\t\tvar touch = event.changedTouches[0];\n\t\t\t\trecentTouchStart = {\n\t\t\t\t\tidentifier: touch.identifier,\n\t\t\t\t\ttarget: event.target,\n\t\t\t\t\tstartedAt: Date.now()\n\t\t\t\t};\n\t\t\t\tif (pending && pending.pointerType === \"touch\" && event.target instanceof Node && pending.card.contains(event.target)) {\n\t\t\t\t\tpending.touchIdentifier = touch.identifier;\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointermove\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tif (pending.pointerType === \"touch\") {\n\t\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) >= TOUCH_MOVE_TOLERANCE_PX) {\n\t\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tpending.lastX = event.clientX;\n\t\t\t\t\t\tpending.lastY = event.clientY;\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\t// A missed pointerup (released outside the window) must not\n\t\t\t\t\t// leave a stale press that turns a later hover into a drag.\n\t\t\t\t\tif (event.buttons === 0) {\n\t\t\t\t\t\tclearPending();\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tif (Math.hypot(event.clientX - pending.startX, event.clientY - pending.startY) < DRAG_THRESHOLD_PX) return;\n\t\t\t\t\tbeginDrag(event);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tif (active.pointerType !== \"touch\" && event.buttons === 0) {\n\t\t\t\t\t// The release happened outside the window, so no click is\n\t\t\t\t\t// coming — cancelling must not arm the click suppressor or\n\t\t\t\t\t// it would eat the next real click after recovery.\n\t\t\t\t\tcancelDrag(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tevent.preventDefault();\n\t\t\t\tmoveDragTo(event.clientX, event.clientY);\n\t\t\t}, { passive: false });\n\t\t\tfunction dropAt(x, y) {\n\t\t\t\tif (!active) return;\n\t\t\t\tif (!connectionAllowsMoves()) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\tfeedback(\"Move cancelled because the board connection was lost.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar lane = laneFromPoint(x, y);\n\t\t\t\tvar card = draggedCard(document);\n\t\t\t\tif (!(lane instanceof HTMLElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (lane.dataset.kanbanDropSource === \"true\") {\n\t\t\t\t\tif (Date.now() - active.startedAt < CLICK_GESTURE_MS) {\n\t\t\t\t\t\tfinishDrag(true);\n\t\t\t\t\t\tfeedback(\"\");\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!laneAllowed(card, lane)) {\n\t\t\t\t\tfinishDrag();\n\t\t\t\t\tfeedback(\"Move blocked by transition policy.\", \"error\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar form = card ? card.querySelector(\"[data-kanban-drag-move-form]\") : null;\n\t\t\t\tvar targetState = form ? form.querySelector(\"[data-kanban-drag-target-state]\") : null;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !(targetState instanceof HTMLInputElement)) {\n\t\t\t\t\tcancelDrag();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\ttargetState.value = lane.dataset.kanbanDropState || \"\";\n\t\t\t\tcard.dataset.kanbanPendingMove = targetState.value;\n\t\t\t\tcard.dataset.kanbanPendingOrigin = card.dataset.kanbanCurrentState || \"\";\n\t\t\t\tif (card.dataset.kanbanDataSeq) card.dataset.kanbanPendingSeq = card.dataset.kanbanDataSeq;\n\t\t\t\tcard.dataset.kanbanPendingTargetWasHidden = lane.dataset.kanbanDropWasHidden || lane.dataset.laneHidden || \"false\";\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tfinishDrag();\n\t\t\t\tplaceCardInLane(card, targetState.value, document);\n\t\t\t\tform.requestSubmit();\n\t\t\t}\n\t\t\tdocument.addEventListener(\"pointerup\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || event.pointerId !== active.pointerId) return;\n\t\t\t\tdropAt(event.clientX, event.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"pointercancel\", function (event) {\n\t\t\t\tif (pending && event.pointerId === pending.pointerId) {\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (active && event.pointerId === active.pointerId && active.pointerType !== \"touch\") cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchmove\", function (event) {\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tevent.preventDefault();\n\t\t\t\tvar touch = touchWithIdentifier(event.touches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 1) touch = event.touches[0];\n\t\t\t\tif (touch) moveDragTo(touch.clientX, touch.clientY);\n\t\t\t}, { passive: false });\n\t\t\tdocument.addEventListener(\"touchend\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (!touch && active.touchIdentifier === null && event.touches && event.touches.length === 0) touch = event.changedTouches && event.changedTouches[0];\n\t\t\t\tif (touch) dropAt(touch.clientX, touch.clientY);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"touchcancel\", function (event) {\n\t\t\t\tif (pending && pending.pointerType === \"touch\") {\n\t\t\t\t\tvar pendingTouch = touchWithIdentifier(event.changedTouches, pending.touchIdentifier);\n\t\t\t\t\tif (!pendingTouch && !(pending.touchIdentifier === null && event.touches && event.touches.length === 0)) return;\n\t\t\t\t\tclearPending();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (!active || active.pointerType !== \"touch\") return;\n\t\t\t\tvar touch = touchWithIdentifier(event.changedTouches, active.touchIdentifier);\n\t\t\t\tif (touch || (active.touchIdentifier === null && event.touches && event.touches.length === 0)) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"contextmenu\", function (event) {\n\t\t\t\tvar touchPress = pending && pending.pointerType === \"touch\";\n\t\t\t\tvar touchDrag = active && active.pointerType === \"touch\";\n\t\t\t\tif ((touchPress || touchDrag) && event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\" && active) cancelDrag();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"detent:connectionChange\", function (event) {\n\t\t\t\tif (!event.detail || event.detail.state === \"connected\") return;\n\t\t\t\tif (active) cancelDrag();\n\t\t\t\telse clearPending();\n\t\t\t});\n\t\t\twindow.addEventListener(\"blur\", function () {\n\t\t\t\tif (active) cancelDrag();\n\t\t\t});\n\t\t\t// Native HTML5 drags stay disabled inside cards (links, images):\n\t\t\t// they would start a compositor drag session that steals the pointer.\n\t\t\tdocument.addEventListener(\"dragstart\", function (event) {\n\t\t\t\tif (event.target instanceof Element && event.target.closest(\"[data-kanban-card]\")) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function () {\n\t\t\t\tapplyDragState(document);\n\t\t\t});\n\t\t\tfunction handleMoveError(event) {\n\t\t\t\tvar form = event.detail && event.detail.elt;\n\t\t\t\tif (!(form instanceof HTMLFormElement) || !form.matches(\"[data-kanban-drag-move-form]\")) return;\n\t\t\t\tvar issueIDInput = form.querySelector(\"input[name='issue_id']\");\n\t\t\t\tvar issueID = issueIDInput instanceof HTMLInputElement ? issueIDInput.value : \"\";\n\t\t\t\tvar card = form.closest(\"[data-kanban-card][data-kanban-pending-move]\");\n\t\t\t\tif (!(card instanceof HTMLElement) || !card.isConnected) card = cardByIssueID(document, issueID);\n\t\t\t\trollbackPendingMove(card);\n\t\t\t\tvar response = event.detail.xhr ? event.detail.xhr.responseText : \"\";\n\t\t\t\tfeedback(responseMessage(response) || \"Move failed.\", \"error\");\n\t\t\t}\n\t\t\tdocument.body.addEventListener(\"htmx:responseError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:sendError\", handleMoveError);\n\t\t\tdocument.body.addEventListener(\"htmx:timeout\", handleMoveError);\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -3432,61 +3473,61 @@ func boardScopeSelect(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var182 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var182 == nil {
-			templ_7745c5c3_Var182 = templ.NopComponent
+		templ_7745c5c3_Var184 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var184 == nil {
+			templ_7745c5c3_Var184 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 296, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 301, "<details class=\"group/scope relative min-w-0\"><summary class=\"flex min-w-0 cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1 text-xs text-sec hover:text-text [&::-webkit-details-marker]:hidden\"><span class=\"min-w-0 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var183 string
-		templ_7745c5c3_Var183, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
+		var templ_7745c5c3_Var185 string
+		templ_7745c5c3_Var185, templ_7745c5c3_Err = templ.JoinStringErrs(boardScopeLabel(data))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2038, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2045, Col: 57}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var183))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var185))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 297, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 302, "</span> <span aria-hidden=\"true\">▾</span></summary><div class=\"absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5\"><a href=\"/\" class=\"rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">All projects</a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, project := range appShellProjects(DashboardShellDataFromDashboard(data)) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 298, "<a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 303, "<a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var184 templ.SafeURL
-			templ_7745c5c3_Var184, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
+			var templ_7745c5c3_Var186 templ.SafeURL
+			templ_7745c5c3_Var186, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2044, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2051, Col: 41}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var184))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 299, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var186))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var185 string
-			templ_7745c5c3_Var185, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2044, Col: 133}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var185))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 304, "\" class=\"truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 300, "</a>")
+			var templ_7745c5c3_Var187 string
+			templ_7745c5c3_Var187, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 2051, Col: 133}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var187))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 305, "</a>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 301, "</div></details>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 306, "</div></details>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/creation_origin_test.go
+++ b/internal/web/templates/creation_origin_test.go
@@ -1,0 +1,37 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestCreationOriginCards(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"operator", "routine", "lesson", "worker", "doctor", "audit"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			body := strings.Repeat("Description ", 30)
+			if kind != "operator" {
+				body = issueorigin.Stamp(body, issueorigin.Origin{Kind: kind, Instance: "instance", Source: "run", Fingerprint: "problem"})
+			}
+			data := DashboardData{}
+			card := projectKanbanCardForIssue(data, telemetry.Issue{ID: "I_1", Identifier: "example/repo#1", Title: "Finding", Description: body}, "Backlog", time.Time{}, time.Now())
+			view := boardCardViewFromCard(data, projectKanbanLane{}, card, false, "", "")
+			if view.CreationOrigin != kind || workItemDataAttributes(view.Work, "board")["data-work-origin"] != kind {
+				t.Fatalf("origin = %s, metadata = %+v", view.CreationOrigin, view.Work)
+			}
+			var out bytes.Buffer
+			if err := boardCardView2(view).Render(t.Context(), &out); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), `data-board-creation-origin="`+kind+`"`) {
+				t.Fatalf("origin marker missing: %s", out.String())
+			}
+		})
+	}
+}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -17,6 +17,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/dispatchpriority"
 	"github.com/digitaldrywood/detent/internal/efficiency"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
 	"github.com/digitaldrywood/detent/internal/observability"
 	"github.com/digitaldrywood/detent/internal/projectcolor"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
@@ -625,6 +626,7 @@ type projectKanbanLane struct {
 }
 
 type projectKanbanCard struct {
+	CreationOrigin        string
 	IssueNumber           string
 	Identity              string
 	Identifier            string
@@ -3183,6 +3185,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		ProjectColor:          projectColorForID(issue.ProjectID, data.Projects),
 		Title:                 issueTitle(issue),
 		Description:           issueDescriptionPreview(issue),
+		CreationOrigin:        issueorigin.Marker(issue.Description),
 		URL:                   strings.TrimSpace(issue.URL),
 		PullRequestLabel:      projectKanbanPullRequestLabel(issue),
 		TimeInStage:           prPipelineAge(stageAt, now),

--- a/internal/web/templates/work.templ
+++ b/internal/web/templates/work.templ
@@ -18,6 +18,14 @@ templ workToolbar(data DashboardData, view boardView) {
 				<span class="rounded-chip bg-accent/15 px-1.5 py-0.5 font-mono text-2xs text-accent" data-work-filter-count hidden>0</span>
 			</summary>
 			<div class="absolute right-0 top-full z-40 mt-1 grid max-h-[calc(100vh-8rem)] w-[min(28rem,calc(100vw-2.5rem))] gap-3 overflow-y-auto rounded-card border border-line bg-elev p-3 shadow-lg">
+				@workFilterGroup("Origin", "origin", []workFilterOption{
+					{Value: "operator", Label: "Operator"},
+					{Value: "routine", Label: "Machine · routine"},
+					{Value: "lesson", Label: "Machine · lesson"},
+					{Value: "worker", Label: "Machine · worker"},
+					{Value: "doctor", Label: "Machine · doctor"},
+					{Value: "audit", Label: "Machine · audit"},
+				})
 				@workFilterGroup("State", "state", workStateFilterOptions(view))
 				@workFilterGroup("Readiness", "readiness", []workFilterOption{
 					{Value: "ready", Label: "Ready"},
@@ -226,7 +234,7 @@ templ workViewScript() {
 		(function () {
 			if (window.__detentWorkViewRegistered) return;
 			window.__detentWorkViewRegistered = true;
-			var filterNames = ["state", "readiness", "priority", "project", "sync"];
+			var filterNames = ["state", "readiness", "priority", "project", "sync", "origin"];
 			var bulkSelection = new Set();
 			var state = null;
 			function surface() {

--- a/internal/web/templates/work_data.go
+++ b/internal/web/templates/work_data.go
@@ -12,6 +12,7 @@ import (
 )
 
 type workItemMetadata struct {
+	CreationOrigin   string
 	Key              string
 	Identity         string
 	Search           string
@@ -93,6 +94,7 @@ func workItemMetadataFromCard(data DashboardData, card projectKanbanCard, view b
 		pullRequestTitle = view.PRStatus
 	}
 	metadata := workItemMetadata{
+		CreationOrigin:   view.CreationOrigin,
 		Key:              boardCardScopedSlug(view.Project, view.Identity),
 		Identity:         view.Identity,
 		State:            card.Stage,
@@ -317,6 +319,7 @@ func workItemDataAttributes(meta workItemMetadata, representation string) templ.
 		"data-work-machine":        meta.MachineKey,
 		"data-work-pr":             meta.PullRequestKey,
 		"data-work-sync":           meta.SyncKey,
+		"data-work-origin":         meta.CreationOrigin,
 		"data-work-updated":        strconv.FormatInt(meta.UpdatedUnix, 10),
 		"data-work-search":         meta.Search,
 	}

--- a/internal/web/templates/work_templ.go
+++ b/internal/web/templates/work_templ.go
@@ -52,6 +52,17 @@ func workToolbar(data DashboardData, view boardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = workFilterGroup("Origin", "origin", []workFilterOption{
+			{Value: "operator", Label: "Operator"},
+			{Value: "routine", Label: "Machine · routine"},
+			{Value: "lesson", Label: "Machine · lesson"},
+			{Value: "worker", Label: "Machine · worker"},
+			{Value: "doctor", Label: "Machine · doctor"},
+			{Value: "audit", Label: "Machine · audit"},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = workFilterGroup("State", "state", workStateFilterOptions(view)).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -100,7 +111,7 @@ func workToolbar(data DashboardData, view boardView) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(len(view.Items)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 48, Col: 91}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 56, Col: 91}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -135,7 +146,7 @@ func workToolbar(data DashboardData, view boardView) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(workHealthTitle(data))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 62, Col: 231}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 70, Col: 231}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -156,7 +167,7 @@ func workToolbar(data DashboardData, view boardView) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(refreshFreshnessSummary(data.Snapshot))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 64, Col: 75}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 72, Col: 75}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -174,7 +185,7 @@ func workToolbar(data DashboardData, view boardView) templ.Component {
 			var templ_7745c5c3_Var8 templ.SafeURL
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(workNewIssueURL(data)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 77, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 85, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -221,7 +232,7 @@ func workFilterGroup(label string, name string, options []workFilterOption) temp
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 84, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 92, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -239,7 +250,7 @@ func workFilterGroup(label string, name string, options []workFilterOption) temp
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(option.Value)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 88, Col: 77}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 96, Col: 77}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -252,7 +263,7 @@ func workFilterGroup(label string, name string, options []workFilterOption) temp
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 88, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 96, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -265,7 +276,7 @@ func workFilterGroup(label string, name string, options []workFilterOption) temp
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(option.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 89, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 97, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -283,7 +294,7 @@ func workFilterGroup(label string, name string, options []workFilterOption) temp
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(option.Count))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 91, Col: 76}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 99, Col: 76}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -335,7 +346,7 @@ func workList(view boardView) templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(len(view.Items)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 102, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 110, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -348,7 +359,7 @@ func workList(view boardView) templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(len(view.Items)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 109, Col: 113}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 117, Col: 113}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -410,7 +421,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs("work-row-" + item.Meta.Key)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 139, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 147, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -435,7 +446,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(item.Card.Project)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 145, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 153, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -448,7 +459,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(item.Card.Number)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 146, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 154, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -461,7 +472,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("Select " + item.Card.Number)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 148, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 156, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -474,7 +485,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs("Select " + item.Card.Number)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 149, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 157, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -487,7 +498,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.Key)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 150, Col: 78}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 158, Col: 78}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -508,7 +519,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(item.Card.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 154, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 162, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -526,7 +537,7 @@ func workListRow(item workItemView) templ.Component {
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(item.Card.Project)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 156, Col: 101}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 164, Col: 101}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -552,7 +563,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.State)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 161, Col: 75}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 169, Col: 75}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -565,7 +576,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(item.Card.PriorityDetail)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 163, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 171, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
@@ -578,7 +589,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var29 string
 		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.Priority)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 163, Col: 112}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 171, Col: 112}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
@@ -613,7 +624,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var32 string
 		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.ReadinessDetail)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 164, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 172, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 		if templ_7745c5c3_Err != nil {
@@ -626,7 +637,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.Readiness)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 165, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 173, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
@@ -644,7 +655,7 @@ func workListRow(item workItemView) templ.Component {
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(workBlockerLabel(item.Meta.BlockerCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 167, Col: 95}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 175, Col: 95}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
@@ -657,7 +668,7 @@ func workListRow(item workItemView) templ.Component {
 			var templ_7745c5c3_Var35 string
 			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs("· " + strconv.Itoa(item.Meta.BlockerCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 167, Col: 144}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 175, Col: 144}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 			if templ_7745c5c3_Err != nil {
@@ -675,7 +686,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.LeaseTitle)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 170, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 178, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
@@ -688,7 +699,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var37 string
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.Machine)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 171, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 179, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
@@ -706,7 +717,7 @@ func workListRow(item workItemView) templ.Component {
 			var templ_7745c5c3_Var38 string
 			templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.LeaseAge)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 173, Col: 85}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 181, Col: 85}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 			if templ_7745c5c3_Err != nil {
@@ -724,7 +735,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.PullRequestTitle)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 176, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 184, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
@@ -743,7 +754,7 @@ func workListRow(item workItemView) templ.Component {
 			var templ_7745c5c3_Var40 string
 			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.PullRequest)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 180, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 188, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
@@ -779,7 +790,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var43 string
 		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.SyncTitle)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 183, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 191, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
@@ -792,7 +803,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.SyncKey)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 183, Col: 131}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 191, Col: 131}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
@@ -813,7 +824,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var45 string
 		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.Sync)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 185, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 193, Col: 25}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 		if templ_7745c5c3_Err != nil {
@@ -826,7 +837,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var46 string
 		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.UpdatedTitle + "; " + item.Meta.StageAgeTitle)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 187, Col: 127}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 195, Col: 127}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
@@ -839,7 +850,7 @@ func workListRow(item workItemView) templ.Component {
 		var templ_7745c5c3_Var47 string
 		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(item.Meta.Updated)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 188, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 196, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 		if templ_7745c5c3_Err != nil {
@@ -857,7 +868,7 @@ func workListRow(item workItemView) templ.Component {
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs("· " + item.Meta.StageAge)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 190, Col: 84}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 198, Col: 84}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
@@ -943,7 +954,7 @@ func workStateList(message string) templ.Component {
 		var templ_7745c5c3_Var51 string
 		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 220, Col: 155}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/work.templ`, Line: 228, Col: 155}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 		if templ_7745c5c3_Err != nil {
@@ -978,7 +989,7 @@ func workViewScript() templ.Component {
 			templ_7745c5c3_Var52 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentWorkViewRegistered) return;\n\t\t\twindow.__detentWorkViewRegistered = true;\n\t\t\tvar filterNames = [\"state\", \"readiness\", \"priority\", \"project\", \"sync\"];\n\t\t\tvar bulkSelection = new Set();\n\t\t\tvar state = null;\n\t\t\tfunction surface() {\n\t\t\t\treturn document.querySelector(\"[data-work-surface]\");\n\t\t\t}\n\t\t\tfunction settledSnapshot(event) {\n\t\t\t\tvar detailTarget = event.detail && event.detail.target;\n\t\t\t\tvar target = detailTarget instanceof Element ? detailTarget : event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction storageKey(kind) {\n\t\t\t\tvar root = surface();\n\t\t\t\treturn \"detent.ui.work.\" + kind + \".v1.\" + (root ? root.dataset.workKey : \"fleet\");\n\t\t\t}\n\t\t\tfunction storedJSON(key) {\n\t\t\t\ttry {\n\t\t\t\t\treturn JSON.parse(window.localStorage.getItem(key) || \"null\");\n\t\t\t\t} catch (_) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction readState() {\n\t\t\t\tvar url = new URL(window.location.href);\n\t\t\t\tvar saved = storedJSON(storageKey(\"query\")) || {};\n\t\t\t\tvar viewInURL = url.searchParams.has(\"view\");\n\t\t\t\tvar hasQuery = [\"q\", \"state\", \"readiness\", \"priority\", \"project\", \"sync\", \"sort\"].some(function (name) {\n\t\t\t\t\treturn url.searchParams.has(name);\n\t\t\t\t});\n\t\t\t\tvar mode = url.searchParams.get(\"view\");\n\t\t\t\tif (mode !== \"board\" && mode !== \"list\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tmode = window.localStorage.getItem(storageKey(\"view\"));\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tif (mode !== \"list\") mode = \"board\";\n\t\t\t\tvar next = {\n\t\t\t\t\tmode: mode,\n                    page: Math.max(1, Math.min(1000000, parseInt(url.searchParams.get(\"page\"), 10) || 1)),\n\t\t\t\t\tviewInURL: viewInURL || mode === \"list\",\n\t\t\t\t\tq: hasQuery ? (url.searchParams.get(\"q\") || \"\") : (saved.q || \"\"),\n\t\t\t\t\tsort: hasQuery ? (url.searchParams.get(\"sort\") || \"priority\") : (saved.sort || \"priority\"),\n\t\t\t\t\tfocus: url.searchParams.get(\"focus\") || \"\",\n\t\t\t\t\tissue: url.searchParams.get(\"issue\") || \"\",\n\t\t\t\t\tissueProject: url.searchParams.get(\"issue_project\") || \"\",\n\t\t\t\t\tfilters: {}\n\t\t\t\t};\n\t\t\t\tfilterNames.forEach(function (name) {\n\t\t\t\t\tnext.filters[name] = hasQuery ? url.searchParams.getAll(name).map(function (value) { return value.toLowerCase(); }) : (Array.isArray(saved[name]) ? saved[name] : []);\n\t\t\t\t});\n\t\t\t\treturn next;\n\t\t\t}\n\t\t\tfunction storeState() {\n\t\t\t\ttry {\n\t\t\t\t\twindow.localStorage.setItem(storageKey(\"view\"), state.mode);\n\t\t\t\t\tvar saved = { q: state.q, sort: state.sort };\n\t\t\t\t\tfilterNames.forEach(function (name) { saved[name] = state.filters[name]; });\n\t\t\t\t\twindow.localStorage.setItem(storageKey(\"query\"), JSON.stringify(saved));\n\t\t\t\t} catch (_) {}\n\t\t\t}\n\t\t\tfunction updateURL() {\n\t\t\t\tvar url = new URL(window.location.href);\n\t\t\t\tif (state.viewInURL || state.mode === \"list\") url.searchParams.set(\"view\", state.mode);\n\t\t\t\telse url.searchParams.delete(\"view\");\n\t\t\t\tif (state.page > 1) url.searchParams.set(\"page\", String(state.page));\n                else url.searchParams.delete(\"page\");\n\t\t\t\tif (state.q) url.searchParams.set(\"q\", state.q);\n\t\t\t\telse url.searchParams.delete(\"q\");\n\t\t\t\tif (state.sort && state.sort !== \"priority\") url.searchParams.set(\"sort\", state.sort);\n\t\t\t\telse url.searchParams.delete(\"sort\");\n\t\t\t\tfilterNames.forEach(function (name) {\n\t\t\t\t\turl.searchParams.delete(name);\n\t\t\t\t\tstate.filters[name].forEach(function (value) { url.searchParams.append(name, value); });\n\t\t\t\t});\n\t\t\t\tif (state.focus) url.searchParams.set(\"focus\", state.focus);\n\t\t\t\telse url.searchParams.delete(\"focus\");\n\t\t\t\tif (state.issue) url.searchParams.set(\"issue\", state.issue);\n\t\t\t\telse url.searchParams.delete(\"issue\");\n\t\t\t\tif (state.issueProject) url.searchParams.set(\"issue_project\", state.issueProject);\n\t\t\t\telse url.searchParams.delete(\"issue_project\");\n\t\t\t\twindow.history.replaceState(null, \"\", url);\n\t\t\t\tstoreState();\n\t\t\t}\n\t\t\tfunction matches(item) {\n\t\t\t\tif (state.q && !(item.dataset.workSearch || \"\").includes(state.q.toLowerCase())) return false;\n\t\t\t\tfor (var index = 0; index < filterNames.length; index += 1) {\n\t\t\t\t\tvar name = filterNames[index];\n\t\t\t\t\tvar selected = state.filters[name];\n\t\t\t\t\tif (selected.length > 0 && !selected.includes(item.dataset[\"work\" + name.charAt(0).toUpperCase() + name.slice(1)] || \"\")) return false;\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction activeItems() {\n\t\t\t\treturn Array.from(document.querySelectorAll('[data-work-item][data-work-representation=\"' + state.mode + '\"]')).filter(function (item) {\n\t\t\t\t\treturn !item.hidden;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction sortList() {\n\t\t\t\tvar body = document.querySelector(\"[data-work-list-body]\");\n\t\t\t\tif (!body) return;\n\t\t\t\tvar rows = Array.from(body.querySelectorAll('[data-work-item][data-work-representation=\"list\"]'));\n\t\t\t\trows.sort(function (left, right) {\n\t\t\t\t\tvar comparison = 0;\n\t\t\t\t\tif (state.sort === \"updated\") comparison = Number(right.dataset.workUpdated || 0) - Number(left.dataset.workUpdated || 0);\n\t\t\t\t\telse if (state.sort === \"state\") comparison = (left.dataset.workState || \"\").localeCompare(right.dataset.workState || \"\");\n\t\t\t\t\telse if (state.sort === \"identifier\") comparison = (left.dataset.workIdentity || \"\").localeCompare(right.dataset.workIdentity || \"\", undefined, { numeric: true });\n\t\t\t\t\telse comparison = Number(left.dataset.workPriorityRank || 5) - Number(right.dataset.workPriorityRank || 5);\n\t\t\t\t\tif (comparison !== 0) return comparison;\n\t\t\t\t\treturn (left.dataset.workIdentity || \"\").localeCompare(right.dataset.workIdentity || \"\", undefined, { numeric: true });\n\t\t\t\t});\n\t\t\t\trows.forEach(function (row) { body.appendChild(row); });\n\t\t\t}\n\t\t\tfunction filtersActive() {\n\t\t\t\treturn Boolean(state.q) || filterNames.some(function (name) { return state.filters[name].length > 0; });\n\t\t\t}\n\t\t\tfunction applyLaneCounts() {\n\t\t\t\tdocument.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\tvar cards = Array.from(lane.querySelectorAll('[data-work-item][data-work-representation=\"board\"]'));\n\t\t\t\t\tvar visible = cards.filter(function (card) { return !card.hidden; }).length;\n\t\t\t\t\tvar count = lane.querySelector(\"[data-work-lane-count]\");\n\t\t\t\t\tif (count) count.textContent = filtersActive() ? visible + \"/\" + cards.length : count.dataset.workLaneLabel;\n\t\t\t\t\tvar empty = lane.querySelector(\"[data-work-filter-empty]\");\n\t\t\t\t\tif (empty) empty.hidden = !filtersActive() || visible > 0 || cards.length === 0;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyBulk() {\n\t\t\t\tvar visible = activeItems().filter(function (item) { return item.dataset.workRepresentation === \"list\"; });\n\t\t\t\tdocument.querySelectorAll(\"[data-work-bulk-checkbox]\").forEach(function (checkbox) {\n\t\t\t\t\tcheckbox.checked = bulkSelection.has(checkbox.value);\n\t\t\t\t\tvar row = checkbox.closest(\"[data-work-item]\");\n\t\t\t\t\tif (row) row.dataset.workSelected = checkbox.checked ? \"true\" : \"false\";\n\t\t\t\t});\n\t\t\t\tvar all = document.querySelector(\"[data-work-bulk-all]\");\n\t\t\t\tif (all) {\n\t\t\t\t\tvar selectedVisible = visible.filter(function (item) { return bulkSelection.has(item.dataset.workKey); }).length;\n\t\t\t\t\tall.checked = visible.length > 0 && selectedVisible === visible.length;\n\t\t\t\t\tall.indeterminate = selectedVisible > 0 && selectedVisible < visible.length;\n\t\t\t\t}\n\t\t\t\tvar bar = document.querySelector(\"[data-work-bulk-bar]\");\n\t\t\t\tvar count = document.querySelector(\"[data-work-bulk-count]\");\n\t\t\t\tif (count) count.textContent = bulkSelection.size + \" selected\";\n\t\t\t\tif (bar) {\n\t\t\t\t\tbar.hidden = bulkSelection.size === 0;\n\t\t\t\t\tbar.classList.toggle(\"hidden\", bulkSelection.size === 0);\n\t\t\t\t\tbar.classList.toggle(\"flex\", bulkSelection.size > 0);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction applyControls() {\n\t\t\t\tdocument.documentElement.dataset.workView = state.mode;\n\t\t\t\tdocument.querySelectorAll(\"[data-work-view-panel]\").forEach(function (panel) {\n\t\t\t\t\tpanel.hidden = panel.dataset.workViewPanel !== state.mode;\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"button[data-work-view]\").forEach(function (button) {\n\t\t\t\t\tvar active = button.dataset.workView === state.mode;\n\t\t\t\t\tbutton.setAttribute(\"aria-pressed\", active ? \"true\" : \"false\");\n\t\t\t\t\tbutton.classList.toggle(\"bg-elev\", active);\n\t\t\t\t\tbutton.classList.toggle(\"text-text\", active);\n\t\t\t\t\tbutton.classList.toggle(\"text-sec\", !active);\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-work-board-only]\").forEach(function (node) { node.hidden = state.mode !== \"board\"; });\n\t\t\t\tdocument.querySelectorAll(\"[data-work-list-only]\").forEach(function (node) { node.hidden = state.mode !== \"list\"; });\n\t\t\t\tvar search = document.querySelector(\"[data-work-search-input]\");\n\t\t\t\tif (search && search.value !== state.q) search.value = state.q;\n\t\t\t\tvar sort = document.querySelector(\"[data-work-sort]\");\n\t\t\t\tif (sort) sort.value = state.sort;\n\t\t\t\tdocument.querySelectorAll(\"[data-work-filter]\").forEach(function (checkbox) {\n\t\t\t\t\tcheckbox.checked = state.filters[checkbox.dataset.workFilter].includes(checkbox.value.toLowerCase());\n\t\t\t\t});\n\t\t\t\tvar count = filterNames.reduce(function (total, name) { return total + state.filters[name].length; }, state.q ? 1 : 0);\n\t\t\t\tvar badge = document.querySelector(\"[data-work-filter-count]\");\n\t\t\t\tif (badge) {\n\t\t\t\t\tbadge.textContent = String(count);\n\t\t\t\t\tbadge.hidden = count === 0;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction applyItems() {\n\t\t\t\tsortList();\n                var rows = Array.from(document.querySelectorAll('[data-work-item][data-work-representation=\"list\"]')).filter(matches);\n                var pages = Math.max(1, Math.ceil(rows.length / 50));\n                state.page = Math.min(state.page, pages);\n                var pageKeys = new Set(rows.slice((state.page - 1) * 50, state.page * 50).map(function (row) { return row.dataset.workKey; }));\n                document.querySelectorAll(\"[data-work-item]\").forEach(function (item) {\n\t\t\t\t\titem.hidden = item.dataset.workRepresentation === \"list\" ? !pageKeys.has(item.dataset.workKey) : !matches(item);\n\t\t\t\t});\n                document.querySelectorAll(\"[data-work-page-step]\").forEach(function (button) { button.disabled = Number(button.dataset.workPageStep) < 0 ? state.page <= 1 : state.page >= pages; });\n                var pageSummary = document.querySelector(\"[data-work-page-summary]\");\n                if (pageSummary) pageSummary.textContent = \"Page \" + state.page + \" of \" + pages;\n\t\t\t\tapplyLaneCounts();\n\t\t\t\tvar visible = activeItems();\n\t\t\t\tvar summary = visible.length + (visible.length === 1 ? \" issue\" : \" issues\");\n\t\t\t\tdocument.querySelectorAll(\"[data-work-result-count], [data-work-list-summary]\").forEach(function (node) { node.textContent = summary; });\n\t\t\t\tvar empty = document.querySelector(\"[data-work-list-empty]\");\n\t\t\t\tif (empty) empty.hidden = visible.length > 0 || state.mode !== \"list\";\n\t\t\t\tapplyBulk();\n\t\t\t}\n\t\t\tfunction applyState(restoreFocus) {\n\t\t\t\tif (!surface()) return;\n\t\t\t\tapplyControls();\n\t\t\t\tapplyItems();\n\t\t\t\tupdateURL();\n\t\t\t\tif (restoreFocus && state.focus) {\n\t\t\t\t\tvar target = activeItems().find(function (item) { return item.dataset.workKey === state.focus; });\n\t\t\t\t\tif (target) target.focus({ preventScroll: true });\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction setSelection(item) {\n\t\t\t\tstate.issue = item ? (item.dataset.workIdentity || \"\") : \"\";\n\t\t\t\tstate.issueProject = item ? (item.dataset.workProject || \"\") : \"\";\n\t\t\t\tupdateURL();\n\t\t\t}\n\t\t\tfunction restoreSelection() {\n\t\t\t\tif (!state.issue) return;\n\t\t\t\tvar host = document.getElementById(\"detail-sheet-host\");\n\t\t\t\tif (host && host.querySelector(\"[data-detail-sheet]\")) return;\n\t\t\t\tvar target = activeItems().find(function (item) {\n\t\t\t\t\treturn item.dataset.workIdentity === state.issue && (!state.issueProject || item.dataset.workProject === state.issueProject.toLowerCase());\n\t\t\t\t});\n\t\t\t\tif (target) window.requestAnimationFrame(function () { target.click(); });\n\t\t\t}\n\t\t\tstate = readState();\n\t\t\tapplyState(Boolean(state.focus));\n\t\t\trestoreSelection();\n\t\t\tdocument.addEventListener(\"input\", function (event) {\n\t\t\t\tvar search = event.target.closest(\"[data-work-search-input]\");\n\t\t\t\tif (!search) return;\n\t\t\t\tstate.q = search.value.trim();\n                state.page = 1;\n\t\t\t\tapplyState(false);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar sort = event.target.closest(\"[data-work-sort]\");\n\t\t\t\tif (sort) {\n\t\t\t\t\tstate.sort = sort.value;\n                    state.page = 1;\n\t\t\t\t\tapplyState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar checkbox = event.target.closest(\"[data-work-bulk-checkbox]\");\n\t\t\t\tif (checkbox) {\n\t\t\t\t\tif (checkbox.checked) bulkSelection.add(checkbox.value);\n\t\t\t\t\telse bulkSelection.delete(checkbox.value);\n\t\t\t\t\tapplyBulk();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-work-bulk-all]\")) {\n\t\t\t\t\tvar checked = event.target.checked;\n\t\t\t\t\tactiveItems().forEach(function (item) {\n\t\t\t\t\t\tif (checked) bulkSelection.add(item.dataset.workKey);\n\t\t\t\t\t\telse bulkSelection.delete(item.dataset.workKey);\n\t\t\t\t\t});\n\t\t\t\t\tapplyBulk();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar pageButton = event.target.closest(\"[data-work-page-step]\");\n                if (pageButton) {\n                    state.page = Math.max(1, state.page + Number(pageButton.dataset.workPageStep));\n                    applyState(false);\n                    return;\n                }\n                var filter = event.target.closest(\"[data-work-filter]\");\n\t\t\t\tif (filter) {\n\t\t\t\t\tstate.page = 1;\n                    var name = filter.dataset.workFilter;\n\t\t\t\t\tvar value = filter.value.toLowerCase();\n\t\t\t\t\tvar selected = state.filters[name];\n\t\t\t\t\tstate.filters[name] = selected.includes(value) ? selected.filter(function (item) { return item !== value; }) : selected.concat(value);\n\t\t\t\t\tapplyState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar view = event.target.closest(\"button[data-work-view]\");\n\t\t\t\tif (view) {\n\t\t\t\t\tvar focused = document.activeElement && document.activeElement.closest ? document.activeElement.closest(\"[data-work-item]\") : null;\n\t\t\t\t\tif (focused) state.focus = focused.dataset.workKey || state.focus;\n\t\t\t\t\tstate.mode = view.dataset.workView;\n\t\t\t\t\tstate.viewInURL = true;\n\t\t\t\t\tapplyState(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-work-clear-filters]\")) {\n\t\t\t\t\tstate.q = \"\";\n                    state.page = 1;\n\t\t\t\t\tfilterNames.forEach(function (name) { state.filters[name] = []; });\n\t\t\t\t\tapplyState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-work-bulk-clear]\")) {\n\t\t\t\t\tbulkSelection.clear();\n\t\t\t\t\tapplyBulk();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-sheet-close]\")) setSelection(null);\n\t\t\t\tvar item = event.target.closest(\"[data-work-item]\");\n\t\t\t\tif (item && !event.target.closest(\"a, button, input, select, label, [data-work-bulk]\")) setSelection(item);\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"focusin\", function (event) {\n\t\t\t\tvar item = event.target.closest(\"[data-work-item]\");\n\t\t\t\tif (!item || item.dataset.workRepresentation !== state.mode) return;\n\t\t\t\tstate.focus = item.dataset.workKey || \"\";\n\t\t\t\tupdateURL();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\") {\n\t\t\t\t\tsetSelection(null);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar formControl = event.target.closest(\"input, select, textarea\");\n\t\t\t\tif (event.key === \"/\" && !formControl) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tvar search = document.querySelector(\"[data-work-search-input]\");\n\t\t\t\t\tif (search) search.focus();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar current = event.target.closest(\"[data-work-item]\");\n\t\t\t\tif (!current || current.dataset.workRepresentation !== state.mode) return;\n\t\t\t\tif (event.key === \"Enter\") {\n\t\t\t\t\tvar interactive = event.target.closest(\"a, button, input, select, textarea, label, [data-work-bulk]\");\n\t\t\t\t\tif (interactive && interactive !== current) return;\n\t\t\t\t\tsetSelection(current);\n\t\t\t\t\tif (!current.matches('[role=\"button\"]')) {\n\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t\tcurrent.click();\n\t\t\t\t\t}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar items = activeItems();\n\t\t\t\tvar index = items.indexOf(current);\n\t\t\t\tvar next = index;\n\t\t\t\tif (event.key === \"ArrowDown\" || event.key === \"j\") next = Math.min(items.length - 1, index + 1);\n\t\t\t\telse if (event.key === \"ArrowUp\" || event.key === \"k\") next = Math.max(0, index - 1);\n\t\t\t\telse if (event.key === \"Home\") next = 0;\n\t\t\t\telse if (event.key === \"End\") next = items.length - 1;\n\t\t\t\telse return;\n\t\t\t\tif (items[next]) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\titems[next].focus();\n\t\t\t\t\titems[next].scrollIntoView({ block: \"nearest\", inline: \"nearest\" });\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeRequest\", function (event) {\n\t\t\t\tvar trigger = event.detail && event.detail.elt;\n\t\t\t\tif (trigger instanceof Element && trigger.matches(\"[data-detail-sheet-trigger][data-work-item]\")) setSelection(trigger);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"kanbanActionSucceeded\", function () { setSelection(null); });\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function (event) {\n\t\t\t\tif (!settledSnapshot(event)) return;\n\t\t\t\tapplyState(false);\n\t\t\t\trestoreSelection();\n\t\t\t});\n\t\t\twindow.addEventListener(\"popstate\", function () {\n\t\t\t\tstate = readState();\n\t\t\t\tapplyState(Boolean(state.focus));\n\t\t\t\trestoreSelection();\n\t\t\t});\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<script>\n\t\t(function () {\n\t\t\tif (window.__detentWorkViewRegistered) return;\n\t\t\twindow.__detentWorkViewRegistered = true;\n\t\t\tvar filterNames = [\"state\", \"readiness\", \"priority\", \"project\", \"sync\", \"origin\"];\n\t\t\tvar bulkSelection = new Set();\n\t\t\tvar state = null;\n\t\t\tfunction surface() {\n\t\t\t\treturn document.querySelector(\"[data-work-surface]\");\n\t\t\t}\n\t\t\tfunction settledSnapshot(event) {\n\t\t\t\tvar detailTarget = event.detail && event.detail.target;\n\t\t\t\tvar target = detailTarget instanceof Element ? detailTarget : event.target;\n\t\t\t\tif (!(target instanceof Element)) return false;\n\t\t\t\treturn target.id === \"snapshot\" || Boolean(target.closest(\"#snapshot\"));\n\t\t\t}\n\t\t\tfunction storageKey(kind) {\n\t\t\t\tvar root = surface();\n\t\t\t\treturn \"detent.ui.work.\" + kind + \".v1.\" + (root ? root.dataset.workKey : \"fleet\");\n\t\t\t}\n\t\t\tfunction storedJSON(key) {\n\t\t\t\ttry {\n\t\t\t\t\treturn JSON.parse(window.localStorage.getItem(key) || \"null\");\n\t\t\t\t} catch (_) {\n\t\t\t\t\treturn null;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction readState() {\n\t\t\t\tvar url = new URL(window.location.href);\n\t\t\t\tvar saved = storedJSON(storageKey(\"query\")) || {};\n\t\t\t\tvar viewInURL = url.searchParams.has(\"view\");\n\t\t\t\tvar hasQuery = [\"q\", \"state\", \"readiness\", \"priority\", \"project\", \"sync\", \"sort\"].some(function (name) {\n\t\t\t\t\treturn url.searchParams.has(name);\n\t\t\t\t});\n\t\t\t\tvar mode = url.searchParams.get(\"view\");\n\t\t\t\tif (mode !== \"board\" && mode !== \"list\") {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tmode = window.localStorage.getItem(storageKey(\"view\"));\n\t\t\t\t\t} catch (_) {}\n\t\t\t\t}\n\t\t\t\tif (mode !== \"list\") mode = \"board\";\n\t\t\t\tvar next = {\n\t\t\t\t\tmode: mode,\n                    page: Math.max(1, Math.min(1000000, parseInt(url.searchParams.get(\"page\"), 10) || 1)),\n\t\t\t\t\tviewInURL: viewInURL || mode === \"list\",\n\t\t\t\t\tq: hasQuery ? (url.searchParams.get(\"q\") || \"\") : (saved.q || \"\"),\n\t\t\t\t\tsort: hasQuery ? (url.searchParams.get(\"sort\") || \"priority\") : (saved.sort || \"priority\"),\n\t\t\t\t\tfocus: url.searchParams.get(\"focus\") || \"\",\n\t\t\t\t\tissue: url.searchParams.get(\"issue\") || \"\",\n\t\t\t\t\tissueProject: url.searchParams.get(\"issue_project\") || \"\",\n\t\t\t\t\tfilters: {}\n\t\t\t\t};\n\t\t\t\tfilterNames.forEach(function (name) {\n\t\t\t\t\tnext.filters[name] = hasQuery ? url.searchParams.getAll(name).map(function (value) { return value.toLowerCase(); }) : (Array.isArray(saved[name]) ? saved[name] : []);\n\t\t\t\t});\n\t\t\t\treturn next;\n\t\t\t}\n\t\t\tfunction storeState() {\n\t\t\t\ttry {\n\t\t\t\t\twindow.localStorage.setItem(storageKey(\"view\"), state.mode);\n\t\t\t\t\tvar saved = { q: state.q, sort: state.sort };\n\t\t\t\t\tfilterNames.forEach(function (name) { saved[name] = state.filters[name]; });\n\t\t\t\t\twindow.localStorage.setItem(storageKey(\"query\"), JSON.stringify(saved));\n\t\t\t\t} catch (_) {}\n\t\t\t}\n\t\t\tfunction updateURL() {\n\t\t\t\tvar url = new URL(window.location.href);\n\t\t\t\tif (state.viewInURL || state.mode === \"list\") url.searchParams.set(\"view\", state.mode);\n\t\t\t\telse url.searchParams.delete(\"view\");\n\t\t\t\tif (state.page > 1) url.searchParams.set(\"page\", String(state.page));\n                else url.searchParams.delete(\"page\");\n\t\t\t\tif (state.q) url.searchParams.set(\"q\", state.q);\n\t\t\t\telse url.searchParams.delete(\"q\");\n\t\t\t\tif (state.sort && state.sort !== \"priority\") url.searchParams.set(\"sort\", state.sort);\n\t\t\t\telse url.searchParams.delete(\"sort\");\n\t\t\t\tfilterNames.forEach(function (name) {\n\t\t\t\t\turl.searchParams.delete(name);\n\t\t\t\t\tstate.filters[name].forEach(function (value) { url.searchParams.append(name, value); });\n\t\t\t\t});\n\t\t\t\tif (state.focus) url.searchParams.set(\"focus\", state.focus);\n\t\t\t\telse url.searchParams.delete(\"focus\");\n\t\t\t\tif (state.issue) url.searchParams.set(\"issue\", state.issue);\n\t\t\t\telse url.searchParams.delete(\"issue\");\n\t\t\t\tif (state.issueProject) url.searchParams.set(\"issue_project\", state.issueProject);\n\t\t\t\telse url.searchParams.delete(\"issue_project\");\n\t\t\t\twindow.history.replaceState(null, \"\", url);\n\t\t\t\tstoreState();\n\t\t\t}\n\t\t\tfunction matches(item) {\n\t\t\t\tif (state.q && !(item.dataset.workSearch || \"\").includes(state.q.toLowerCase())) return false;\n\t\t\t\tfor (var index = 0; index < filterNames.length; index += 1) {\n\t\t\t\t\tvar name = filterNames[index];\n\t\t\t\t\tvar selected = state.filters[name];\n\t\t\t\t\tif (selected.length > 0 && !selected.includes(item.dataset[\"work\" + name.charAt(0).toUpperCase() + name.slice(1)] || \"\")) return false;\n\t\t\t\t}\n\t\t\t\treturn true;\n\t\t\t}\n\t\t\tfunction activeItems() {\n\t\t\t\treturn Array.from(document.querySelectorAll('[data-work-item][data-work-representation=\"' + state.mode + '\"]')).filter(function (item) {\n\t\t\t\t\treturn !item.hidden;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction sortList() {\n\t\t\t\tvar body = document.querySelector(\"[data-work-list-body]\");\n\t\t\t\tif (!body) return;\n\t\t\t\tvar rows = Array.from(body.querySelectorAll('[data-work-item][data-work-representation=\"list\"]'));\n\t\t\t\trows.sort(function (left, right) {\n\t\t\t\t\tvar comparison = 0;\n\t\t\t\t\tif (state.sort === \"updated\") comparison = Number(right.dataset.workUpdated || 0) - Number(left.dataset.workUpdated || 0);\n\t\t\t\t\telse if (state.sort === \"state\") comparison = (left.dataset.workState || \"\").localeCompare(right.dataset.workState || \"\");\n\t\t\t\t\telse if (state.sort === \"identifier\") comparison = (left.dataset.workIdentity || \"\").localeCompare(right.dataset.workIdentity || \"\", undefined, { numeric: true });\n\t\t\t\t\telse comparison = Number(left.dataset.workPriorityRank || 5) - Number(right.dataset.workPriorityRank || 5);\n\t\t\t\t\tif (comparison !== 0) return comparison;\n\t\t\t\t\treturn (left.dataset.workIdentity || \"\").localeCompare(right.dataset.workIdentity || \"\", undefined, { numeric: true });\n\t\t\t\t});\n\t\t\t\trows.forEach(function (row) { body.appendChild(row); });\n\t\t\t}\n\t\t\tfunction filtersActive() {\n\t\t\t\treturn Boolean(state.q) || filterNames.some(function (name) { return state.filters[name].length > 0; });\n\t\t\t}\n\t\t\tfunction applyLaneCounts() {\n\t\t\t\tdocument.querySelectorAll(\"[data-board-lane]\").forEach(function (lane) {\n\t\t\t\t\tvar cards = Array.from(lane.querySelectorAll('[data-work-item][data-work-representation=\"board\"]'));\n\t\t\t\t\tvar visible = cards.filter(function (card) { return !card.hidden; }).length;\n\t\t\t\t\tvar count = lane.querySelector(\"[data-work-lane-count]\");\n\t\t\t\t\tif (count) count.textContent = filtersActive() ? visible + \"/\" + cards.length : count.dataset.workLaneLabel;\n\t\t\t\t\tvar empty = lane.querySelector(\"[data-work-filter-empty]\");\n\t\t\t\t\tif (empty) empty.hidden = !filtersActive() || visible > 0 || cards.length === 0;\n\t\t\t\t});\n\t\t\t}\n\t\t\tfunction applyBulk() {\n\t\t\t\tvar visible = activeItems().filter(function (item) { return item.dataset.workRepresentation === \"list\"; });\n\t\t\t\tdocument.querySelectorAll(\"[data-work-bulk-checkbox]\").forEach(function (checkbox) {\n\t\t\t\t\tcheckbox.checked = bulkSelection.has(checkbox.value);\n\t\t\t\t\tvar row = checkbox.closest(\"[data-work-item]\");\n\t\t\t\t\tif (row) row.dataset.workSelected = checkbox.checked ? \"true\" : \"false\";\n\t\t\t\t});\n\t\t\t\tvar all = document.querySelector(\"[data-work-bulk-all]\");\n\t\t\t\tif (all) {\n\t\t\t\t\tvar selectedVisible = visible.filter(function (item) { return bulkSelection.has(item.dataset.workKey); }).length;\n\t\t\t\t\tall.checked = visible.length > 0 && selectedVisible === visible.length;\n\t\t\t\t\tall.indeterminate = selectedVisible > 0 && selectedVisible < visible.length;\n\t\t\t\t}\n\t\t\t\tvar bar = document.querySelector(\"[data-work-bulk-bar]\");\n\t\t\t\tvar count = document.querySelector(\"[data-work-bulk-count]\");\n\t\t\t\tif (count) count.textContent = bulkSelection.size + \" selected\";\n\t\t\t\tif (bar) {\n\t\t\t\t\tbar.hidden = bulkSelection.size === 0;\n\t\t\t\t\tbar.classList.toggle(\"hidden\", bulkSelection.size === 0);\n\t\t\t\t\tbar.classList.toggle(\"flex\", bulkSelection.size > 0);\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction applyControls() {\n\t\t\t\tdocument.documentElement.dataset.workView = state.mode;\n\t\t\t\tdocument.querySelectorAll(\"[data-work-view-panel]\").forEach(function (panel) {\n\t\t\t\t\tpanel.hidden = panel.dataset.workViewPanel !== state.mode;\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"button[data-work-view]\").forEach(function (button) {\n\t\t\t\t\tvar active = button.dataset.workView === state.mode;\n\t\t\t\t\tbutton.setAttribute(\"aria-pressed\", active ? \"true\" : \"false\");\n\t\t\t\t\tbutton.classList.toggle(\"bg-elev\", active);\n\t\t\t\t\tbutton.classList.toggle(\"text-text\", active);\n\t\t\t\t\tbutton.classList.toggle(\"text-sec\", !active);\n\t\t\t\t});\n\t\t\t\tdocument.querySelectorAll(\"[data-work-board-only]\").forEach(function (node) { node.hidden = state.mode !== \"board\"; });\n\t\t\t\tdocument.querySelectorAll(\"[data-work-list-only]\").forEach(function (node) { node.hidden = state.mode !== \"list\"; });\n\t\t\t\tvar search = document.querySelector(\"[data-work-search-input]\");\n\t\t\t\tif (search && search.value !== state.q) search.value = state.q;\n\t\t\t\tvar sort = document.querySelector(\"[data-work-sort]\");\n\t\t\t\tif (sort) sort.value = state.sort;\n\t\t\t\tdocument.querySelectorAll(\"[data-work-filter]\").forEach(function (checkbox) {\n\t\t\t\t\tcheckbox.checked = state.filters[checkbox.dataset.workFilter].includes(checkbox.value.toLowerCase());\n\t\t\t\t});\n\t\t\t\tvar count = filterNames.reduce(function (total, name) { return total + state.filters[name].length; }, state.q ? 1 : 0);\n\t\t\t\tvar badge = document.querySelector(\"[data-work-filter-count]\");\n\t\t\t\tif (badge) {\n\t\t\t\t\tbadge.textContent = String(count);\n\t\t\t\t\tbadge.hidden = count === 0;\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction applyItems() {\n\t\t\t\tsortList();\n                var rows = Array.from(document.querySelectorAll('[data-work-item][data-work-representation=\"list\"]')).filter(matches);\n                var pages = Math.max(1, Math.ceil(rows.length / 50));\n                state.page = Math.min(state.page, pages);\n                var pageKeys = new Set(rows.slice((state.page - 1) * 50, state.page * 50).map(function (row) { return row.dataset.workKey; }));\n                document.querySelectorAll(\"[data-work-item]\").forEach(function (item) {\n\t\t\t\t\titem.hidden = item.dataset.workRepresentation === \"list\" ? !pageKeys.has(item.dataset.workKey) : !matches(item);\n\t\t\t\t});\n                document.querySelectorAll(\"[data-work-page-step]\").forEach(function (button) { button.disabled = Number(button.dataset.workPageStep) < 0 ? state.page <= 1 : state.page >= pages; });\n                var pageSummary = document.querySelector(\"[data-work-page-summary]\");\n                if (pageSummary) pageSummary.textContent = \"Page \" + state.page + \" of \" + pages;\n\t\t\t\tapplyLaneCounts();\n\t\t\t\tvar visible = activeItems();\n\t\t\t\tvar summary = visible.length + (visible.length === 1 ? \" issue\" : \" issues\");\n\t\t\t\tdocument.querySelectorAll(\"[data-work-result-count], [data-work-list-summary]\").forEach(function (node) { node.textContent = summary; });\n\t\t\t\tvar empty = document.querySelector(\"[data-work-list-empty]\");\n\t\t\t\tif (empty) empty.hidden = visible.length > 0 || state.mode !== \"list\";\n\t\t\t\tapplyBulk();\n\t\t\t}\n\t\t\tfunction applyState(restoreFocus) {\n\t\t\t\tif (!surface()) return;\n\t\t\t\tapplyControls();\n\t\t\t\tapplyItems();\n\t\t\t\tupdateURL();\n\t\t\t\tif (restoreFocus && state.focus) {\n\t\t\t\t\tvar target = activeItems().find(function (item) { return item.dataset.workKey === state.focus; });\n\t\t\t\t\tif (target) target.focus({ preventScroll: true });\n\t\t\t\t}\n\t\t\t}\n\t\t\tfunction setSelection(item) {\n\t\t\t\tstate.issue = item ? (item.dataset.workIdentity || \"\") : \"\";\n\t\t\t\tstate.issueProject = item ? (item.dataset.workProject || \"\") : \"\";\n\t\t\t\tupdateURL();\n\t\t\t}\n\t\t\tfunction restoreSelection() {\n\t\t\t\tif (!state.issue) return;\n\t\t\t\tvar host = document.getElementById(\"detail-sheet-host\");\n\t\t\t\tif (host && host.querySelector(\"[data-detail-sheet]\")) return;\n\t\t\t\tvar target = activeItems().find(function (item) {\n\t\t\t\t\treturn item.dataset.workIdentity === state.issue && (!state.issueProject || item.dataset.workProject === state.issueProject.toLowerCase());\n\t\t\t\t});\n\t\t\t\tif (target) window.requestAnimationFrame(function () { target.click(); });\n\t\t\t}\n\t\t\tstate = readState();\n\t\t\tapplyState(Boolean(state.focus));\n\t\t\trestoreSelection();\n\t\t\tdocument.addEventListener(\"input\", function (event) {\n\t\t\t\tvar search = event.target.closest(\"[data-work-search-input]\");\n\t\t\t\tif (!search) return;\n\t\t\t\tstate.q = search.value.trim();\n                state.page = 1;\n\t\t\t\tapplyState(false);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar sort = event.target.closest(\"[data-work-sort]\");\n\t\t\t\tif (sort) {\n\t\t\t\t\tstate.sort = sort.value;\n                    state.page = 1;\n\t\t\t\t\tapplyState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar checkbox = event.target.closest(\"[data-work-bulk-checkbox]\");\n\t\t\t\tif (checkbox) {\n\t\t\t\t\tif (checkbox.checked) bulkSelection.add(checkbox.value);\n\t\t\t\t\telse bulkSelection.delete(checkbox.value);\n\t\t\t\t\tapplyBulk();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-work-bulk-all]\")) {\n\t\t\t\t\tvar checked = event.target.checked;\n\t\t\t\t\tactiveItems().forEach(function (item) {\n\t\t\t\t\t\tif (checked) bulkSelection.add(item.dataset.workKey);\n\t\t\t\t\t\telse bulkSelection.delete(item.dataset.workKey);\n\t\t\t\t\t});\n\t\t\t\t\tapplyBulk();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar pageButton = event.target.closest(\"[data-work-page-step]\");\n                if (pageButton) {\n                    state.page = Math.max(1, state.page + Number(pageButton.dataset.workPageStep));\n                    applyState(false);\n                    return;\n                }\n                var filter = event.target.closest(\"[data-work-filter]\");\n\t\t\t\tif (filter) {\n\t\t\t\t\tstate.page = 1;\n                    var name = filter.dataset.workFilter;\n\t\t\t\t\tvar value = filter.value.toLowerCase();\n\t\t\t\t\tvar selected = state.filters[name];\n\t\t\t\t\tstate.filters[name] = selected.includes(value) ? selected.filter(function (item) { return item !== value; }) : selected.concat(value);\n\t\t\t\t\tapplyState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar view = event.target.closest(\"button[data-work-view]\");\n\t\t\t\tif (view) {\n\t\t\t\t\tvar focused = document.activeElement && document.activeElement.closest ? document.activeElement.closest(\"[data-work-item]\") : null;\n\t\t\t\t\tif (focused) state.focus = focused.dataset.workKey || state.focus;\n\t\t\t\t\tstate.mode = view.dataset.workView;\n\t\t\t\t\tstate.viewInURL = true;\n\t\t\t\t\tapplyState(true);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-work-clear-filters]\")) {\n\t\t\t\t\tstate.q = \"\";\n                    state.page = 1;\n\t\t\t\t\tfilterNames.forEach(function (name) { state.filters[name] = []; });\n\t\t\t\t\tapplyState(false);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-work-bulk-clear]\")) {\n\t\t\t\t\tbulkSelection.clear();\n\t\t\t\t\tapplyBulk();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-sheet-close]\")) setSelection(null);\n\t\t\t\tvar item = event.target.closest(\"[data-work-item]\");\n\t\t\t\tif (item && !event.target.closest(\"a, button, input, select, label, [data-work-bulk]\")) setSelection(item);\n\t\t\t}, true);\n\t\t\tdocument.addEventListener(\"focusin\", function (event) {\n\t\t\t\tvar item = event.target.closest(\"[data-work-item]\");\n\t\t\t\tif (!item || item.dataset.workRepresentation !== state.mode) return;\n\t\t\t\tstate.focus = item.dataset.workKey || \"\";\n\t\t\t\tupdateURL();\n\t\t\t});\n\t\t\tdocument.addEventListener(\"keydown\", function (event) {\n\t\t\t\tif (event.key === \"Escape\") {\n\t\t\t\t\tsetSelection(null);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar formControl = event.target.closest(\"input, select, textarea\");\n\t\t\t\tif (event.key === \"/\" && !formControl) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tvar search = document.querySelector(\"[data-work-search-input]\");\n\t\t\t\t\tif (search) search.focus();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar current = event.target.closest(\"[data-work-item]\");\n\t\t\t\tif (!current || current.dataset.workRepresentation !== state.mode) return;\n\t\t\t\tif (event.key === \"Enter\") {\n\t\t\t\t\tvar interactive = event.target.closest(\"a, button, input, select, textarea, label, [data-work-bulk]\");\n\t\t\t\t\tif (interactive && interactive !== current) return;\n\t\t\t\t\tsetSelection(current);\n\t\t\t\t\tif (!current.matches('[role=\"button\"]')) {\n\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t\tcurrent.click();\n\t\t\t\t\t}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar items = activeItems();\n\t\t\t\tvar index = items.indexOf(current);\n\t\t\t\tvar next = index;\n\t\t\t\tif (event.key === \"ArrowDown\" || event.key === \"j\") next = Math.min(items.length - 1, index + 1);\n\t\t\t\telse if (event.key === \"ArrowUp\" || event.key === \"k\") next = Math.max(0, index - 1);\n\t\t\t\telse if (event.key === \"Home\") next = 0;\n\t\t\t\telse if (event.key === \"End\") next = items.length - 1;\n\t\t\t\telse return;\n\t\t\t\tif (items[next]) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\titems[next].focus();\n\t\t\t\t\titems[next].scrollIntoView({ block: \"nearest\", inline: \"nearest\" });\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeRequest\", function (event) {\n\t\t\t\tvar trigger = event.detail && event.detail.elt;\n\t\t\t\tif (trigger instanceof Element && trigger.matches(\"[data-detail-sheet-trigger][data-work-item]\")) setSelection(trigger);\n\t\t\t});\n\t\t\tdocument.addEventListener(\"kanbanActionSucceeded\", function () { setSelection(null); });\n\t\t\tdocument.addEventListener(\"htmx:afterSettle\", function (event) {\n\t\t\t\tif (!settledSnapshot(event)) return;\n\t\t\t\tapplyState(false);\n\t\t\t\trestoreSelection();\n\t\t\t});\n\t\t\twindow.addEventListener(\"popstate\", function () {\n\t\t\t\tstate = readState();\n\t\t\t\tapplyState(Boolean(state.focus));\n\t\t\t\trestoreSelection();\n\t\t\t});\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Stamp machine filings with origin kind, instance identity, source run or attempt, and a stable problem fingerprint. Accept existing audit fingerprint markers and preserve provenance through body updates.
- Reuse open repository issues with matching fingerprints by posting occurrence comments. Keep the original body and lane, revalidate closed issues, and route worker follow-ups through a typed filing tool. Remove the stale intake and lesson issue caches. Replace connector-local machine publication locking with the existing GitHub-ref publication coordinator, keyed by repository and fingerprint, and atomically deduplicate memory-backend filings.
- Show operator or machine kind on board cards and filter work by creation origin, independently of admission provenance. No aggregate cap or Health item is added.

Fingerprints are producer-supplied problem identities: wording variants collapse when the producer reuses the same underlying problem key. The September 8 disk-capacity fixture covers four differently titled occurrences producing one issue and three comments.

Machine publication uses the existing `detent-schedule-coordination` branch in the target repository, independent of scheduler ownership configuration, so all filing paths share the same boundary. GitHub credentials need Contents read/write as well as Issues write; coordination errors prevent publication. Existing scheduled-operation markers remain for their schedule-specific outcomes; no new lease implementation, recovery loop, or configuration key is added.

Fixes #2444

## UI Surface Contract

- [x] The linked issue explicitly authorizes creation-origin card markers and filtering.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] Isolated Chrome browser verification confirmed operator and all five machine kinds are visible in Cozy mode, with worker/operator filters selecting only matching cards. Origin markers sit in the existing reference row and preserve compact density budgets. The preview used ephemeral ports and left the live instance untouched.

## Test Plan

- [x] `make check` — final rebased source and lane-wrapper integration fix passed race tests, vet, lint, nilaway, 80.6% coverage and configured package/file floors.
- [x] Table-driven lane-wrapper tests and duplicate webhook regression: forward occurrence comments and closure reads while preserving original body/state and centralized lane writes.
- [x] `make generate`
- [x] Linux Playwright (v1.61.0-noble, arm64): density, work views, layout and mobile — 87 passed, 28 intentional skips; strict screenshot comparison and no retries.
- [x] Focused intake, routine, lesson, GitHub, coordination, project, worker-tool, origin parser and board tests.
- [x] Concurrent separate-connector publication, memory-backend reuse, coordination failures, same-fingerprint occurrence comments, legacy audit markers, closed/different fingerprints, original-provenance preservation, September 8 disk fixture, and browser origin filtering.

