### PR TITLE
fix(github): treat plan-limited branch rules as no merge queue

### DIFF
--- a/internal/cli/doctor_merge_queue.go
+++ b/internal/cli/doctor_merge_queue.go
@@ -46,6 +46,10 @@ func checkDoctorMergeQueue(ctx context.Context, id string, project globalconfig.
 			check.Detail = "branch protection could not be read: " + err.Error()
 			return check
 		}
+		if policy.RulesUnavailableOnPlan {
+			check.Detail = repository + ": merge queue not available on this plan"
+			continue
+		}
 		if !policy.Strict || policy.MergeQueue {
 			continue
 		}

--- a/internal/cli/doctor_merge_queue_test.go
+++ b/internal/cli/doctor_merge_queue_test.go
@@ -19,10 +19,12 @@ func TestDoctorMergeQueueRecordedHistory(t *testing.T) {
 	for _, tt := range []struct {
 		name               string
 		strict, queue      bool
+		unavailable        bool
 		minutes            int
 		branch             string
 		wantRecommendation bool
 	}{
+		{name: "plan unavailable", strict: true, unavailable: true, minutes: 22, branch: "main"},
 		{name: "strict busy branch", strict: true, minutes: 22, branch: "main", wantRecommendation: true},
 		{name: "non strict busy branch", minutes: 22, branch: "main"},
 		{name: "existing queue", strict: true, queue: true, minutes: 22, branch: "main"},
@@ -57,10 +59,13 @@ func TestDoctorMergeQueueRecordedHistory(t *testing.T) {
 				now:                func() time.Time { return now },
 				openSQLiteReadOnly: openDoctorSQLiteReadOnly,
 				githubBranchPolicy: func(context.Context, workflowconfig.Config, string) (ghconnector.BranchMergePolicy, error) {
-					return ghconnector.BranchMergePolicy{Branch: "main", Strict: tt.strict, MergeQueue: tt.queue}, nil
+					return ghconnector.BranchMergePolicy{Branch: "main", Strict: tt.strict, MergeQueue: tt.queue, RulesUnavailableOnPlan: tt.unavailable}, nil
 				},
 			})
 			if (got.Status == doctorWarn) != tt.wantRecommendation {
+				t.Fatalf("check = %+v", got)
+			}
+			if tt.unavailable && !strings.Contains(got.Detail, "not available on this plan") {
 				t.Fatalf("check = %+v", got)
 			}
 			if tt.wantRecommendation {

--- a/internal/connector/github/branch_merge_policy.go
+++ b/internal/connector/github/branch_merge_policy.go
@@ -2,19 +2,22 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
 type BranchMergePolicy struct {
-	Branch         string
-	MergeQueue     bool
-	Strict         bool
-	AdmissionLimit int
+	RulesUnavailableOnPlan bool
+	Branch                 string
+	MergeQueue             bool
+	Strict                 bool
+	AdmissionLimit         int
 }
 
 type branchMergePolicySnapshot struct {
@@ -51,6 +54,9 @@ func (c *Connector) RepositoryBranchMergePolicy(ctx context.Context, repository,
 		}
 		path := fmt.Sprintf("%s/rules/branches/%s?per_page=100&page=%d", base, url.PathEscape(branch), page)
 		if err := c.client.REST(ctx, http.MethodGet, path, nil, &rules); err != nil {
+			if errors.Is(err, errBranchRulesUnavailableOnPlan) {
+				return BranchMergePolicy{Branch: branch, RulesUnavailableOnPlan: true}, nil
+			}
 			return BranchMergePolicy{}, fmt.Errorf("read branch rules: %w", err)
 		}
 		for _, rule := range rules {
@@ -71,7 +77,7 @@ func (c *Connector) RepositoryBranchMergePolicy(ctx context.Context, repository,
 
 func (c *Connector) RepositoryStrictMergePolicy(ctx context.Context, repository string) (BranchMergePolicy, error) {
 	policy, err := c.RepositoryBranchMergePolicy(ctx, repository, "")
-	if err != nil {
+	if err != nil || policy.RulesUnavailableOnPlan {
 		return policy, err
 	}
 	var checks struct {
@@ -122,4 +128,44 @@ func (c *Connector) cacheBranchMergePolicy(repository string, policy BranchMerge
 	}
 	key := strings.ToLower(repository) + "@" + policy.Branch
 	c.branchMergePolicies[key] = branchMergePolicySnapshot{Policy: policy, CheckedAt: c.now()}
+}
+
+// The plan response is endpoint-specific: other 403s retain their normal
+// authentication and rate-limit handling.
+var errBranchRulesUnavailableOnPlan = errors.New("branch rules unavailable on this plan")
+
+func branchRulesRepository(method, path string) string {
+	if method != http.MethodGet {
+		return ""
+	}
+	parts := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 6)
+	if len(parts) != 6 || parts[0] != "repos" || parts[3] != "rules" || parts[4] != "branches" {
+		return ""
+	}
+	return strings.ToLower(parts[1] + "/" + parts[2])
+}
+
+func branchRulesUnavailableOnPlan(status int, raw []byte) bool {
+	if status != http.StatusForbidden {
+		return false
+	}
+	var body struct {
+		Message string `json:"message"`
+	}
+	return json.Unmarshal(raw, &body) == nil && body.Message == "Upgrade to GitHub Pro or make this repository public to enable this feature."
+}
+
+// Keep informational deduplication across connector recreation on workflow reload.
+// Successful probes clear the entry so a later plan change is reported again.
+var unavailableBranchRules sync.Map
+
+func (c *Client) recordBranchRulesAvailability(ctx context.Context, repository string, unavailable bool) {
+	key := c.restEndpoint + "/" + repository
+	if !unavailable {
+		unavailableBranchRules.Delete(key)
+		return
+	}
+	if _, loaded := unavailableBranchRules.LoadOrStore(key, http.StatusForbidden); !loaded {
+		c.logger.InfoContext(ctx, "github branch rules not available on this plan", "repository", repository, "status", http.StatusForbidden)
+	}
 }

--- a/internal/connector/github/branch_merge_policy_test.go
+++ b/internal/connector/github/branch_merge_policy_test.go
@@ -1,12 +1,16 @@
 package github
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 )
@@ -14,19 +18,21 @@ import (
 func TestRepositoryBranchMergePolicy(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name       string
-		rules      string
-		protection string
-		wantQueue  bool
-		wantStrict bool
-		wantLimit  int
-		status     int
-		wantError  bool
+		name            string
+		rules           string
+		protection      string
+		wantQueue       bool
+		wantStrict      bool
+		wantLimit       int
+		status          int
+		wantError       bool
+		wantUnavailable bool
 	}{
 		{name: "queue", rules: `[{"type":"merge_queue","parameters":{"max_entries_to_build":5}}]`, wantQueue: true, wantLimit: 5},
 		{name: "classic strict", rules: `[]`, protection: `{"strict":true}`, wantStrict: true},
 		{name: "ruleset strict", rules: `[{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true}}]`, wantStrict: true},
 		{name: "unprotected", rules: `[]`},
+		{name: "plan unavailable", status: 403, rules: `{"message":"Upgrade to GitHub Pro or make this repository public to enable this feature."}`, wantUnavailable: true},
 		{name: "unavailable rules", status: 500, wantError: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -42,6 +48,7 @@ func TestRepositoryBranchMergePolicy(t *testing.T) {
 				case "/repos/example/repo/rules/branches/release/stable":
 					if tt.status != 0 {
 						w.WriteHeader(tt.status)
+						fmt.Fprint(w, tt.rules)
 						return
 					}
 					fmt.Fprint(w, tt.rules)
@@ -69,7 +76,7 @@ func TestRepositoryBranchMergePolicy(t *testing.T) {
 			if tt.wantError {
 				return
 			}
-			if got.Branch != "release/stable" || got.MergeQueue != tt.wantQueue || got.Strict != tt.wantStrict || got.AdmissionLimit != tt.wantLimit {
+			if got.Branch != "release/stable" || got.MergeQueue != tt.wantQueue || got.Strict != tt.wantStrict || got.AdmissionLimit != tt.wantLimit || got.RulesUnavailableOnPlan != tt.wantUnavailable {
 				t.Fatalf("policy = %+v", got)
 			}
 		})
@@ -172,5 +179,75 @@ func TestInspectMergeQueueScopesPolicyToPullRequestTarget(t *testing.T) {
 	}
 	if reads.Load() != int64(len(targets)) {
 		t.Fatalf("policy reads=%d, want one per repository/branch", reads.Load())
+	}
+}
+
+func TestBranchRulesPlanAvailability(t *testing.T) {
+	for _, tt := range []struct {
+		name, body      string
+		status          int
+		wantUnavailable bool
+	}{
+		{"plan", `{"message":"Upgrade to GitHub Pro or make this repository public to enable this feature."}`, 403, true},
+		{"permission", `{"message":"Resource not accessible by integration"}`, 403, false},
+		{"wrong status", `{"message":"Upgrade to GitHub Pro or make this repository public to enable this feature."}`, 401, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			status := tt.status
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/repos/example/repo" {
+					fmt.Fprint(w, `{"default_branch":"main"}`)
+					return
+				}
+				w.WriteHeader(status)
+				if status == 200 {
+					fmt.Fprint(w, "[]")
+				} else {
+					fmt.Fprint(w, tt.body)
+				}
+			}))
+			defer server.Close()
+			c, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: t.Name(), Repository: "example/repo", GitHubStatusSource: GitHubStatusSourceLabel, Logger: slog.New(slog.NewTextHandler(&logs, nil))})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for range 3 {
+				err := c.RefreshMergeQueuePolicy(t.Context())
+				if tt.wantUnavailable {
+					if err != nil {
+						t.Fatal(err)
+					}
+					policy, err := c.branchMergePolicy(t.Context(), "example/repo", "main")
+					if err != nil || policy.MergeQueue || !policy.RulesUnavailableOnPlan {
+						t.Fatalf("policy=%+v error=%v", policy, err)
+					}
+					if c.client.hasAuthHealth {
+						t.Fatal("plan response affected auth health")
+					}
+					if err := c.client.restBackoffError(c.client.restBackoffKey, time.Now()); err != nil {
+						t.Fatalf("backoff: %v", err)
+					}
+				} else if err == nil {
+					t.Fatal("expected authentication error")
+				}
+			}
+			if tt.wantUnavailable {
+				if strings.Contains(logs.String(), "WARN") || strings.Count(logs.String(), "level=INFO") != 1 {
+					t.Fatalf("logs: %s", &logs)
+				}
+				status = 200
+				if err := c.RefreshMergeQueuePolicy(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				status = 403
+				if err := c.RefreshMergeQueuePolicy(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				if strings.Count(logs.String(), "level=INFO") != 2 {
+					t.Fatalf("logs after plan change: %s", &logs)
+				}
+			}
+		})
 	}
 }

--- a/internal/connector/github/branch_merge_policy_test.go
+++ b/internal/connector/github/branch_merge_policy_test.go
@@ -200,7 +200,20 @@ func TestBranchRulesPlanAvailability(t *testing.T) {
 					fmt.Fprint(w, `{"default_branch":"main"}`)
 					return
 				}
+				if tt.wantUnavailable {
+					w.Header().Set("X-RateLimit-Limit", "5000")
+					w.Header().Set("X-RateLimit-Remaining", "4900")
+					w.Header().Set("X-RateLimit-Used", "100")
+					w.Header().Set("X-RateLimit-Resource", "core")
+					w.Header().Set("Retry-After", "60")
+				}
+				if status == http.StatusOK {
+					w.Header().Set("ETag", `"rules"`)
+				}
 				w.WriteHeader(status)
+				if status == http.StatusNotModified {
+					return
+				}
 				if status == 200 {
 					fmt.Fprint(w, "[]")
 				} else {
@@ -221,6 +234,18 @@ func TestBranchRulesPlanAvailability(t *testing.T) {
 					policy, err := c.branchMergePolicy(t.Context(), "example/repo", "main")
 					if err != nil || policy.MergeQueue || !policy.RulesUnavailableOnPlan {
 						t.Fatalf("policy=%+v error=%v", policy, err)
+					}
+					usage := c.client.FlushRESTRateLimitUsage()
+					if !usage.HasRateLimit || usage.RateLimit.Remaining != 4900 || usage.RateLimited || !usage.BackoffUntil.IsZero() {
+						t.Fatalf("usage=%+v", usage)
+					}
+					var count, billable int64
+					for _, request := range usage.Requests {
+						count += request.Count
+						billable += request.Billable
+					}
+					if count != 2 || billable != 2 {
+						t.Fatalf("request count=%d billable=%d, want 2 each", count, billable)
 					}
 					if c.client.hasAuthHealth {
 						t.Fatal("plan response affected auth health")
@@ -247,6 +272,18 @@ func TestBranchRulesPlanAvailability(t *testing.T) {
 				if strings.Count(logs.String(), "level=INFO") != 2 {
 					t.Fatalf("logs after plan change: %s", &logs)
 				}
+				status = http.StatusNotModified
+				if err := c.RefreshMergeQueuePolicy(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				status = http.StatusForbidden
+				if err := c.RefreshMergeQueuePolicy(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				if strings.Count(logs.String(), "level=INFO") != 3 {
+					t.Fatalf("logs after conditional recovery: %s", &logs)
+				}
+
 			}
 		})
 	}

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -534,6 +534,15 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
+	if repository := branchRulesRepository(method, path); repository != "" {
+		if branchRulesUnavailableOnPlan(resp.StatusCode, raw) {
+			c.recordBranchRulesAvailability(ctx, repository, true)
+			return nil, errBranchRulesUnavailableOnPlan
+		}
+		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+			c.recordBranchRulesAvailability(ctx, repository, false)
+		}
+	}
 	c.recordRESTRateLimitFromHeaders(ctx, backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, conditional)
 	if resp.StatusCode == http.StatusNotModified {
 		if !conditional {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -534,16 +534,16 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	connector.ReportProgress(ctx)
 	receivedAt := time.Now()
+	c.recordRESTRateLimitFromHeaders(ctx, backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, conditional)
 	if repository := branchRulesRepository(method, path); repository != "" {
 		if branchRulesUnavailableOnPlan(resp.StatusCode, raw) {
 			c.recordBranchRulesAvailability(ctx, repository, true)
 			return nil, errBranchRulesUnavailableOnPlan
 		}
-		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices || resp.StatusCode == http.StatusNotModified && conditional {
 			c.recordBranchRulesAvailability(ctx, repository, false)
 		}
 	}
-	c.recordRESTRateLimitFromHeaders(ctx, backoffKey, credentialIdentity, method, path, resp.StatusCode, resp.Header, raw, receivedAt, conditional)
 	if resp.StatusCode == http.StatusNotModified {
 		if !conditional {
 			return nil, ErrInvalidResponse
@@ -1059,7 +1059,9 @@ func (c *Client) recordRESTRateLimitFromHeaders(ctx context.Context, backoffKey 
 	reset, hasReset := int64Header(headers, "X-RateLimit-Reset")
 	retryAfter, hasRetryAfter := parseRetryAfter(headers.Get("Retry-After"), now)
 	headerRateLimited := restStatusRateLimited(status, headers, nil)
-	rateLimited := restStatusRateLimited(status, headers, body)
+	// Plan limitations still consume quota, but are not throttling responses.
+	planUnavailable := branchRulesRepository(method, path) != "" && branchRulesUnavailableOnPlan(status, body)
+	rateLimited := !planUnavailable && restStatusRateLimited(status, headers, body)
 	family := restEndpointFamily(method, path)
 	resourceHeader := strings.TrimSpace(headers.Get("X-RateLimit-Resource"))
 	resource := restRateLimitResourceName(resourceHeader, family)

--- a/internal/project/merge_queue_test.go
+++ b/internal/project/merge_queue_test.go
@@ -27,10 +27,12 @@ func (c *mergeQueuePolicyConnector) RefreshMergeQueuePolicy(context.Context) err
 func TestBuildConnectorRefreshesMergeQueuePolicy(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name string
-		err  error
+		name   string
+		err    error
+		paused bool
 	}{
 		{name: "available"},
+		{name: "paused", paused: true},
 		{name: "discovery failure retains PR inspection", err: errors.New("rules unavailable")},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -38,12 +40,16 @@ func TestBuildConnectorRefreshesMergeQueuePolicy(t *testing.T) {
 			c := &mergeQueuePolicyConnector{Connector: memory.New(memory.Config{}), err: tt.err}
 			factory := func(workflowconfig.Config) (connector.Connector, error) { return c, nil }
 			for range 2 {
-				got, err := buildConnector(t.Context(), workflowconfig.Config{}, factory)
+				got, err := buildConnector(t.Context(), workflowconfig.Config{}, factory, tt.paused)
 				if err != nil || got != c {
 					t.Fatalf("connector=%v error=%v", got, err)
 				}
 			}
-			if c.refreshes != 2 {
+			want := 2
+			if tt.paused {
+				want = 0
+			}
+			if c.refreshes != want {
 				t.Fatalf("refreshes=%d, want load and reload", c.refreshes)
 			}
 		})

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -283,7 +283,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		}
 		connectorFactory = func(workflowconfig.Config) (connector.Connector, error) { return native, nil }
 	}
-	projectConnector, err := buildConnector(context.Background(), workflow.Config, connectorFactory)
+	projectConnector, err := buildConnector(context.Background(), workflow.Config, connectorFactory, cfg.Project.Paused)
 	if err != nil {
 		return nil, err
 	}
@@ -1522,7 +1522,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		}
 	}
 
-	projectConnector, err := buildConnector(ctx, workflow.Config, connectorFactory)
+	projectConnector, err := buildConnector(ctx, workflow.Config, connectorFactory, projectConfig.Paused)
 	if err != nil {
 		return p.workflowReloadError("workflow reload connector failed", update.Path, err)
 	}
@@ -2076,7 +2076,7 @@ func buildRetroIssueStores(
 		}},
 		AllowPublicCrossProjectDetails: cfg.Retro.AllowPublicCrossProjectDetails,
 	}
-	productConnector, err := buildConnector(ctx, productConfig, connectorFactory)
+	productConnector, err := buildConnector(ctx, productConfig, connectorFactory, true)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -2245,7 +2245,7 @@ func resolveConnectorFactory(deps Dependencies) ConnectorFactory {
 	}
 }
 
-func buildConnector(ctx context.Context, cfg workflowconfig.Config, connectorFactory ConnectorFactory) (connector.Connector, error) {
+func buildConnector(ctx context.Context, cfg workflowconfig.Config, connectorFactory ConnectorFactory, paused bool) (connector.Connector, error) {
 	projectConnector, err := connectorFactory(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("%w: create project connector: %w", ErrConnectorCreation, err)
@@ -2254,7 +2254,9 @@ func buildConnector(ctx context.Context, cfg workflowconfig.Config, connectorFac
 		return nil, ErrMissingConnector
 	}
 
-	refreshMergeQueuePolicy(ctx, projectConnector)
+	if !paused {
+		refreshMergeQueuePolicy(ctx, projectConnector)
+	}
 	return projectConnector, nil
 }
 


### PR DESCRIPTION
## Summary

- Treat GitHub's branch-rules upgrade-plan 403 as an absent merge queue, without authentication refresh, WARN logging, or REST backoff; retain the actual quota headers and billable request telemetry.
- Report the limitation once at INFO per repository until a successful rules probe clears it, including across connector recreation. Skip discovery for paused projects and report “not available on this plan” in doctor.

This corrects classification in the existing REST path; it adds no brake, recovery path, configuration, or lane writer. The in-memory map only deduplicates informational logs.

Fixes #2455

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no browser UI changes.

## Test Plan

- [x] `make check`
- [x] Recorded upgrade-message regression failed before the fix with the original authentication WARN.
- [x] Table-driven tests cover plan-limited responses, ordinary permission failures, wrong status, repeated refresh logging, availability changes, absent queue, unchanged auth health/backoff, quota and billable accounting, conditional 304 recovery, paused discovery, and doctor's informational result.
