### PR TITLE
ci: move integration checks after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
           retention-days: 14
 
   portability-verify:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     name: Portability Verify (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.os == 'windows-latest' && 45 || 10 }}
@@ -260,6 +261,7 @@ jobs:
           retention-days: 14
 
   windows-core:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     name: Windows Core
     runs-on: windows-latest
     steps:
@@ -277,6 +279,7 @@ jobs:
         run: .\tmp\detent.exe --help
 
   installer-smoke:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     name: Installer Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -366,6 +369,7 @@ jobs:
           & $binary version
 
   goreleaser-snapshot:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     name: GoReleaser Snapshot
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -397,3 +401,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINISIGN_KEY_FILE: ${{ runner.temp }}/detent-minisign.key
           MINISIGN_PASSWORD: ""
+
+  report-integration-failures:
+    name: Report integration failures
+    needs: [portability-verify, windows-core, installer-smoke, goreleaser-snapshot]
+    if: failure() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write # Existing machine intake coordinates fingerprint publication via Git refs.
+      issues: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.6'
+          cache: true
+      - name: Report failed jobs through machine intake
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" --jq '.jobs[]' > "$RUNNER_TEMP/ci-jobs.json"
+          go run ./tools/cifailure < "$RUNNER_TEMP/ci-jobs.json"

--- a/README.md
+++ b/README.md
@@ -451,8 +451,8 @@ updates to release-binary management. Source builds still print the recommended
 command instead of overwriting the binary.
 
 CI runs the `Installer Smoke` confidence job on Ubuntu and Windows against the
-current GitHub Release assets after merges to `main`, on release tags, on the
-nightly schedule, and from manual workflow dispatch. The job runs `install.sh`
+current GitHub Release assets on pushes to `main` and manual workflow dispatch.
+It does not run on pull requests, tag pushes, or the nightly CI schedule. The job runs `install.sh`
 and `install.ps1` in release mode, checks checksum output, confirms the
 requested install directory and installer lock metadata, then runs
 `detent update --check` and `detent update --yes` from the release-installer

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -37,7 +37,7 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 		name:     "Test Coverage",
 		budget:   "4m",
 		jobStart: "  test-cover:",
-		jobEnd:   "  browser-visual:",
+		jobEnd:   "  security:",
 		markers:  []string{"name: Test Coverage", "make test-cover-packages"},
 	},
 	{
@@ -47,6 +47,9 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 		jobEnd:   "  portability-verify:",
 		markers:  []string{"name: Browser Visual", "timeout-minutes: 15", "Run full browser visual gate", "Run browser smoke gate"},
 	},
+}
+
+var integrationStatusChecks = []requiredStatusCheck{
 	{
 		name:     "Portability Verify (macos-latest)",
 		budget:   "8m",
@@ -86,7 +89,7 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 		name:     "GoReleaser Snapshot",
 		budget:   "15m",
 		jobStart: "  goreleaser-snapshot:",
-		jobEnd:   "",
+		jobEnd:   "  report-integration-failures:",
 		markers:  []string{"name: GoReleaser Snapshot", "timeout-minutes: 15", "args: release --snapshot --clean", "MINISIGN_KEY_FILE: ${{ runner.temp }}/detent-minisign.key"},
 	},
 }
@@ -312,6 +315,41 @@ func TestRequiredChecksDoNotUseEventDependentGreenNoops(t *testing.T) {
 			if strings.Contains(job, forbidden) {
 				t.Fatalf("required check %q contains green no-op marker %q", check.name, forbidden)
 			}
+		}
+	}
+}
+
+func TestIntegrationChecksRunOnlyOnMainPushOrDispatch(t *testing.T) {
+	t.Parallel()
+	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
+	for _, check := range integrationStatusChecks {
+		t.Run(check.name, func(t *testing.T) {
+			t.Parallel()
+			job := workflowBetween(t, workflow, check.jobStart, check.jobEnd)
+			want := "    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')"
+			if !strings.Contains(job, want) {
+				t.Fatalf("integration job %q must run only on main pushes or dispatch", check.name)
+			}
+			for _, marker := range check.markers {
+				if !strings.Contains(job, marker) {
+					t.Fatalf("integration job %q missing %q", check.name, marker)
+				}
+			}
+		})
+	}
+	security := workflowBetween(t, workflow, "  security:", "  browser-visual:")
+	if strings.Contains(security, "    if:") || !strings.Contains(security, "make security") {
+		t.Fatal("Security must continue running on every PR")
+	}
+	reporter := workflowBetween(t, workflow, "  report-integration-failures:", "")
+	for _, marker := range []string{
+		"needs: [portability-verify, windows-core, installer-smoke, goreleaser-snapshot]",
+		"if: failure() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')",
+		"/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100",
+		"go run ./tools/cifailure",
+	} {
+		if !strings.Contains(reporter, marker) {
+			t.Fatalf("failure reporting missing %q", marker)
 		}
 	}
 }

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -125,12 +125,17 @@ real gate because non-UI pull requests run a Detent binary smoke instead of a
 green no-op.
 
 Required PR merge checks, branch protection/rulesets, and
-`gate.required_status_checks` must name the same release-blocking checks:
+`gate.required_status_checks` must name the same merge-blocking checks:
 
 - `Lint` - budget: `2m`
 - `Verify (ubuntu-latest)` - budget: `30m`
 - `Test Coverage` - budget: `4m`
 - `Browser Visual` - budget: `15m`
+
+Security also runs on every PR. The following integration checks run only on
+main pushes and manual dispatch, and must be removed from the PR-required list
+by the operator (see [Merge Train](merge-train.md)):
+
 - `Portability Verify (macos-latest)` - budget: `8m`
 - `Portability Verify (windows-latest)` - budget: `45m`
 - `Windows Core` - budget: `4m`

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -107,8 +107,8 @@ artifact workflows. GitHub PR delivery remains the default.
 - The CI lint job keeps the project-pinned golangci-lint version and caches its
   binary so cache hits avoid a per-run `go install` without changing lint
   coverage.
-- `GoReleaser Snapshot` is a release-blocking check that runs on pull requests,
-  `main`, release tags, the nightly CI schedule, and manual workflow dispatch.
+- `GoReleaser Snapshot` validates integration on pushes to `main` and manual
+  workflow dispatch; it is not a PR-required check.
 
 ### Main Branch Protection
 
@@ -157,22 +157,21 @@ costs, and the assessment of repeated build and fixture work. Full browser
 selection, release hooks, all six release targets, archives, Linux packages,
 checksums, and minisign signing remain required work.
 
-The required portability checks are limited to build, vet, and the non-race
+The post-merge portability checks are limited to build, vet, and the non-race
 test suite. Windows runs packages sequentially with four-way test parallelism
 inside a `45m` job budget and retains per-package JSON evidence plus a failure
 classification summary. `Windows Core` owns only the command smoke, so no Go
-package has two required Windows test owners. Repeated race loops, the full
+package has two Windows test owners in CI. Repeated race loops, the full
 race suite on macOS and Windows, and the Windows SQLite artifact lifecycle
 stress loop run nightly and on manual dispatch in
 `.github/workflows/portability-stress.yml`. That workflow has a `45m` ceiling;
 failures are surfaced as failed `Portability Stress` workflow runs with the
 failing command output in the job log.
 
-Release and required portability checks also run on `main`, on `v*` release
-tags, on the nightly CI schedule, and from manual workflow dispatch. They are
-still release-blocking for pull requests; Detent must not promote or merge a PR
-head where one of these checks is missing, skipped, failed, cancelled, neutral,
-or still running.
+Portability, Windows Core, installer smoke, and snapshot jobs run only on
+main pushes and manual dispatch. They are excluded from PR-required checks;
+main failures create or update CI instance-health tracking issues through
+machine intake. PR promotion still requires the fast checks listed above.
 
 GitHub merge queue adoption is deferred. Detent currently owns merge ordering,
 rebases each head onto current `main`, validates that exact head, and merges it

--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -88,7 +88,9 @@ the nightly schedule. A push to main runs the full set.
 Failed integration jobs on main (including manual runs on main) use the existing
 machine intake to open a tracking issue or comment on the open match, with
 origin kind `doctor` and a stable fingerprint per job name. The issue links to
-the failed job and records the commit. Reporting errors fail the reporting job.
+the failed job and records the commit. These track CI instance health; logs
+must establish a product defect before proposing product changes. Infrastructure
+failures remain attributed to the instance. Reporting errors fail the reporting job.
 
 The operator must update GitHub's required-checks list to match the four fast
 checks above, removing the six integration checks from branch protection and

--- a/docs/merge-train.md
+++ b/docs/merge-train.md
@@ -59,9 +59,9 @@ or cannot prove the final rebase was source-clean, it must run the full
 configured gate again.
 
 CI waiting should poll current-head REST check runs with backoff, not loop on
-GraphQL-heavy PR status commands. Required release checks must run on the PR
-head before merge; post-merge-only failures cannot be part of the merge
-decision. Merge handoff telemetry should record the
+GraphQL-heavy PR status commands. Required checks must run on the PR
+head before merge; post-merge integration failures are tracked separately.
+Merge handoff telemetry should record the
 quiet-window wait, GitHub queue/start wait, local merge-gate duration,
 current-head PR CI duration, active slow-check runtimes, and whether post-merge
 `main` CI is still running. The quiet window, current-head required CI, and
@@ -72,9 +72,28 @@ duplicated non-blocking post-merge work are optimization targets.
 The repository CI caches the project-pinned golangci-lint binary and only builds
 it with `go install` on cache miss. CI builds golangci-lint `v2.9.0` with the
 repository Go toolchain so analyzer behavior and toolchain provenance stay
-aligned. `GoReleaser Snapshot` runs on pull requests, `main`, release tags,
-nightly schedule, and manual dispatch so packaging signal is available before
-and after merge.
+aligned.
+
+PR-required checks are `Lint`, `Verify (ubuntu-latest)`, `Test Coverage`, and
+`Browser Visual`. `Security` also runs on every PR. These jobs run for docs-only
+PRs too; Browser Visual uses its existing smoke path for nonvisual changes.
+The same set runs for merge groups.
+
+`Portability Verify (macos-latest)`, `Portability Verify (windows-latest)`,
+`Windows Core`, `Installer Smoke (ubuntu-latest)`,
+`Installer Smoke (windows-latest)`, and `GoReleaser Snapshot` run only on pushes
+to `main` and manual dispatch. They do not run for PRs, merge groups, tag pushes, or
+the nightly schedule. A push to main runs the full set.
+
+Failed integration jobs on main (including manual runs on main) use the existing
+machine intake to open a tracking issue or comment on the open match, with
+origin kind `doctor` and a stable fingerprint per job name. The issue links to
+the failed job and records the commit. Reporting errors fail the reporting job.
+
+The operator must update GitHub's required-checks list to match the four fast
+checks above, removing the six integration checks from branch protection and
+rulesets. Preserve any separately required Security policy. Changing this
+workflow does not change GitHub protection settings.
 
 When implementation workers fill project or global capacity, a clean PR with
 passing current-head checks and a known base can complete through the existing

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,9 +17,10 @@ package-manager manifests. Scoop publishing targets
 skips publishing when `SCOOP_BUCKET_GITHUB_TOKEN` or `WINGET_GITHUB_TOKEN` is
 not configured.
 
-CI runs `GoReleaser Snapshot` after merges to `main`, on `v*` release tags, on
-pull requests, on the nightly schedule, and from manual workflow dispatch so
-release packaging is validated before the PR merge lane and after it lands.
+CI runs `GoReleaser Snapshot` on pushes to `main` and manual workflow dispatch
+to validate packaging after merge. It is not a PR-required check and does not
+run on tag pushes or the nightly CI schedule. See [Merge Train](merge-train.md)
+for the required-check split and main failure tracking.
 Required branch checks must not pass as path- or event-dependent no-ops on pull
 requests when the same check name runs real validation on `main`.
 

--- a/tools/cifailure/main.go
+++ b/tools/cifailure/main.go
@@ -1,0 +1,84 @@
+// Command cifailure reports failed post-merge CI jobs through machine intake.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+)
+
+type job struct {
+	Name       string `json:"name"`
+	Conclusion string `json:"conclusion"`
+	URL        string `json:"html_url"`
+}
+
+type issueCreator interface {
+	CreateIntakeIssue(context.Context, intake.IssueDraft) (intake.Issue, error)
+}
+
+func main() {
+	if err := run(os.Stdin, os.Getenv); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(input io.Reader, getenv func(string) string) error {
+	backend, err := github.NewConnector(github.Config{
+		APIKey:             getenv("GH_TOKEN"),
+		Repository:         getenv("GITHUB_REPOSITORY"),
+		GitHubStatusSource: github.GitHubStatusSourceLabel,
+	})
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	return report(ctx, input, backend, getenv("GITHUB_SHA"))
+}
+
+func report(ctx context.Context, input io.Reader, backend issueCreator, sha string) error {
+	decoder := json.NewDecoder(input)
+	var failures []error
+	for {
+		var j job
+		if err := decoder.Decode(&j); errors.Is(err, io.EOF) {
+			return errors.Join(failures...)
+		} else if err != nil {
+			return errors.Join(append(failures, fmt.Errorf("decode CI jobs: %w", err))...)
+		}
+		if !integrationJob(j.Name) || (j.Conclusion != "failure" && j.Conclusion != "timed_out") {
+			continue
+		}
+		body := fmt.Sprintf("Post-merge integration job **%s** failed on main.\n\nJob: %s\nCommit: %s\n\nInvestigate the linked job logs and repair the integration failure.\n\n```detent-agent\nschema: 1\neffort: low\n```", j.Name, j.URL, sha)
+		body = issueorigin.Stamp(body, issueorigin.Origin{
+			Kind: "doctor", Instance: "github-actions", Source: j.URL,
+			Fingerprint: issueorigin.Fingerprint("ci integration job " + j.Name),
+		})
+		if _, err := backend.CreateIntakeIssue(ctx, intake.IssueDraft{
+			Title: "ci: " + j.Name + " failed on main", Body: body,
+		}); err != nil {
+			failures = append(failures, fmt.Errorf("report %s: %w", j.Name, err))
+		}
+	}
+}
+
+func integrationJob(name string) bool {
+	switch name {
+	case "Portability Verify (macos-latest)", "Portability Verify (windows-latest)",
+		"Windows Core", "Installer Smoke (ubuntu-latest)", "Installer Smoke (windows-latest)",
+		"GoReleaser Snapshot":
+		return true
+	default:
+		return false
+	}
+}

--- a/tools/cifailure/main.go
+++ b/tools/cifailure/main.go
@@ -59,7 +59,7 @@ func report(ctx context.Context, input io.Reader, backend issueCreator, sha stri
 		if !integrationJob(j.Name) || (j.Conclusion != "failure" && j.Conclusion != "timed_out") {
 			continue
 		}
-		body := fmt.Sprintf("Post-merge integration job **%s** failed on main.\n\nJob: %s\nCommit: %s\n\nInvestigate the linked job logs and repair the integration failure.\n\n```detent-agent\nschema: 1\neffort: low\n```", j.Name, j.URL, sha)
+		body := fmt.Sprintf("Post-merge integration job **%s** failed on main.\n\nJob: %s\nCommit: %s\n\nThis tracks CI instance health; it does not attribute a defect to the merged issue or change. Diagnose the linked logs before proposing a fix. Runner setup, backend startup, network/download, and protocol failures belong to the CI instance. Propose product changes only when the logs establish a product defect.\n\n```detent-agent\nschema: 1\neffort: low\n```", j.Name, j.URL, sha)
 		body = issueorigin.Stamp(body, issueorigin.Origin{
 			Kind: "doctor", Instance: "github-actions", Source: j.URL,
 			Fingerprint: issueorigin.Fingerprint("ci integration job " + j.Name),

--- a/tools/cifailure/main_test.go
+++ b/tools/cifailure/main_test.go
@@ -46,7 +46,7 @@ func TestReport(t *testing.T) {
 			}
 			for _, draft := range backend.drafts {
 				origin, ok := issueorigin.Parse(draft.Body)
-				if !ok || origin.Kind != "doctor" || origin.Fingerprint == "" || !strings.Contains(draft.Body, "abc123") {
+				if !ok || origin.Kind != "doctor" || origin.Fingerprint == "" || !strings.Contains(draft.Body, "abc123") || !strings.Contains(draft.Body, "This tracks CI instance health") {
 					t.Fatalf("invalid draft: %+v", draft)
 				}
 			}

--- a/tools/cifailure/main_test.go
+++ b/tools/cifailure/main_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/intake"
+	"github.com/digitaldrywood/detent/internal/issueorigin"
+)
+
+type fakeCreator struct {
+	drafts []intake.IssueDraft
+	err    error
+}
+
+func (f *fakeCreator) CreateIntakeIssue(_ context.Context, draft intake.IssueDraft) (intake.Issue, error) {
+	f.drafts = append(f.drafts, draft)
+	return intake.Issue{}, f.err
+}
+
+func TestReport(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, input string
+		storeErr    error
+		wantCount   int
+		wantErr     bool
+	}{
+		{"failure", `{"name":"Windows Core","conclusion":"failure","html_url":"https://example.test/job/1"}`, nil, 1, false},
+		{"timeout", `{"name":"Windows Core","conclusion":"timed_out"}`, nil, 1, false},
+		{"success", `{"name":"Windows Core","conclusion":"success"}`, nil, 0, false},
+		{"skipped", `{"name":"Windows Core","conclusion":"skipped"}`, nil, 0, false},
+		{"cancelled", `{"name":"Windows Core","conclusion":"cancelled"}`, nil, 0, false},
+		{"fast job", `{"name":"Lint","conclusion":"failure"}`, nil, 0, false},
+		{"malformed", `{`, nil, 0, true},
+		{"report error continues", `{"name":"Windows Core","conclusion":"failure"} {"name":"GoReleaser Snapshot","conclusion":"failure"}`, errors.New("unavailable"), 2, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			backend := &fakeCreator{err: tt.storeErr}
+			err := report(t.Context(), strings.NewReader(tt.input), backend, "abc123")
+			if (err != nil) != tt.wantErr || len(backend.drafts) != tt.wantCount {
+				t.Fatalf("report = %v, %d drafts; want error %v, %d drafts", err, len(backend.drafts), tt.wantErr, tt.wantCount)
+			}
+			for _, draft := range backend.drafts {
+				origin, ok := issueorigin.Parse(draft.Body)
+				if !ok || origin.Kind != "doctor" || origin.Fingerprint == "" || !strings.Contains(draft.Body, "abc123") {
+					t.Fatalf("invalid draft: %+v", draft)
+				}
+			}
+		})
+	}
+}
+
+func TestJobFingerprints(t *testing.T) {
+	t.Parallel()
+	names := []string{
+		"Portability Verify (macos-latest)", "Portability Verify (windows-latest)",
+		"Windows Core", "Installer Smoke (ubuntu-latest)", "Installer Smoke (windows-latest)",
+		"GoReleaser Snapshot",
+	}
+	seen := map[string]bool{}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			backend := &fakeCreator{}
+			for _, url := range []string{"first", "second"} {
+				input := `{"name":"` + name + `","conclusion":"failure","html_url":"` + url + `"}`
+				if err := report(t.Context(), strings.NewReader(input), backend, url); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if len(backend.drafts) != 2 {
+				t.Fatalf("got %d drafts", len(backend.drafts))
+			}
+			first, _ := issueorigin.Parse(backend.drafts[0].Body)
+			second, _ := issueorigin.Parse(backend.drafts[1].Body)
+			if first.Fingerprint != second.Fingerprint || seen[first.Fingerprint] {
+				t.Fatal("fingerprint must be stable across runs and distinct across jobs")
+			}
+			seen[first.Fingerprint] = true
+		})
+	}
+}
+
+func TestRunEmptyJobs(t *testing.T) {
+	t.Parallel()
+	err := run(strings.NewReader(""), func(key string) string {
+		switch key {
+		case "GH_TOKEN":
+			return "test-token"
+		case "GITHUB_REPOSITORY":
+			return "owner/repo"
+		default:
+			return ""
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- Run portability, Windows Core, installer smoke, and GoReleaser snapshot checks on main pushes and manual dispatch. PRs and merge groups retain Lint, Ubuntu Verify, Test Coverage, Browser Visual, and Security.
- Report failed main integration jobs as CI instance-health diagnostics through existing machine intake, using doctor origins and stable job fingerprints to reuse open tracking issues. Require log evidence before attributing a product defect.
- Document the operator's required-checks update in GitHub and align all existing CI-scope guidance.

Fixes #2456

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] N/A: no visual changes to operator screens.

## Test Plan

- [x] `make check` (80.6% overall coverage; configured package/file floors pass).
- [x] Helper table tests: failure/timeout selection, skipped and unrelated jobs, malformed input, reporting errors, and stable distinct fingerprints (84.6% coverage).
- [x] Existing GitHub machine-issue tests.
- [x] actionlint v1.7.11 with optional shellcheck disabled; event matrix verifies PR, main push, dispatch, merge group, tag push, and schedule selection.
- [x] Current-head GitHub CI: [run 34523284025](https://github.com/digitaldrywood/detent/actions/runs/34523284025), all five executed checks green; integration/report jobs skipped.
