### PR TITLE
fix(merge): honor native queue ownership

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -32,11 +32,12 @@ func ReportProgress(ctx context.Context) {
 }
 
 var (
-	ErrNotImplemented           = errors.New("connector operation not implemented")
-	ErrCommentNotCreated        = errors.New("comment was not created")
-	ErrResourceExhausted        = errors.New("connector resource exhausted")
-	ErrStateUpdateBlocked       = errors.New("issue state update blocked")
-	ErrPullRequestBaseOutOfDate = errors.New("pull request base is out of date")
+	ErrNotImplemented                = errors.New("connector operation not implemented")
+	ErrCommentNotCreated             = errors.New("comment was not created")
+	ErrResourceExhausted             = errors.New("connector resource exhausted")
+	ErrStateUpdateBlocked            = errors.New("issue state update blocked")
+	ErrPullRequestMergeQueueRequired = errors.New("pull request must use the merge queue")
+	ErrPullRequestBaseOutOfDate      = errors.New("pull request base is out of date")
 )
 
 type retryableError struct {

--- a/internal/connector/github/branch_merge_policy_test.go
+++ b/internal/connector/github/branch_merge_policy_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -284,6 +285,54 @@ func TestBranchRulesPlanAvailability(t *testing.T) {
 					t.Fatalf("logs after conditional recovery: %s", &logs)
 				}
 
+			}
+		})
+	}
+}
+
+func TestMergeQueueRefusalRefreshesCachedBranchPolicy(t *testing.T) {
+	t.Parallel()
+	for _, failRefresh := range []bool{false, true} {
+		t.Run(fmt.Sprintf("refresh failure=%t", failRefresh), func(t *testing.T) {
+			var refreshes atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/repos/example/repo/pulls/42/merge":
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					fmt.Fprint(w, `{"message":"Repository rule violations found. Changes must be made through the merge queue"}`)
+				case "/repos/example/repo/rules/branches/release/stable":
+					refreshes.Add(1)
+					if failRefresh {
+						w.WriteHeader(http.StatusForbidden)
+						fmt.Fprint(w, `{"message":"forbidden"}`)
+						return
+					}
+					fmt.Fprint(w, `[{"type":"merge_queue","parameters":{"max_entries_to_build":2}}]`)
+				default:
+					t.Errorf("unexpected request %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+			c, err := NewConnector(Config{Endpoint: server.URL + "/graphql", APIKey: "token"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.cacheBranchMergePolicy("example/repo", BranchMergePolicy{Branch: "release/stable"})
+			err = c.MergePullRequest(t.Context(), "example/repo", 42, "head", "squash")
+			if !errors.Is(err, connector.ErrPullRequestMergeQueueRequired) {
+				t.Fatalf("error=%v", err)
+			}
+			if refreshes.Load() != 1 {
+				t.Fatalf("refreshes=%d", refreshes.Load())
+			}
+			cached, ok := c.branchMergePolicies["example/repo@release/stable"]
+			if failRefresh && ok {
+				t.Fatal("failed refresh retained stale policy")
+			}
+			if !failRefresh && (!ok || !cached.Policy.MergeQueue) {
+				t.Fatalf("policy=%+v", cached)
 			}
 		})
 	}

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -537,6 +537,28 @@ func (c *Connector) MergePullRequest(ctx context.Context, repository string, num
 		var status *StatusError
 		if errors.As(err, &status) && status.StatusCode == http.StatusMethodNotAllowed {
 			message := strings.ToLower(status.Body)
+			if strings.Contains(message, "changes must be made through the merge queue") || strings.Contains(message, "must be merged using the merge queue") {
+				// Refresh known branch policies immediately. Inspection resolves
+				// the actual base branch when no policy has been cached yet.
+				c.mu.Lock()
+				var branches []string
+				for key, snapshot := range c.branchMergePolicies {
+					if strings.HasPrefix(key, strings.ToLower(repository)+"@") {
+						branches = append(branches, snapshot.Policy.Branch)
+						delete(c.branchMergePolicies, key)
+					}
+				}
+				c.mu.Unlock()
+				for _, branch := range branches {
+					policy, refreshErr := c.RepositoryBranchMergePolicy(ctx, repository, branch)
+					if refreshErr != nil {
+						err = errors.Join(err, refreshErr)
+						continue
+					}
+					c.cacheBranchMergePolicy(repository, policy)
+				}
+				return fmt.Errorf("merge github pull request: %w: %w", connector.ErrPullRequestMergeQueueRequired, err)
+			}
 			if strings.Contains(message, "head branch is out of date") || strings.Contains(message, "base branch was modified") {
 				return fmt.Errorf("merge github pull request: %w: %w", connector.ErrPullRequestBaseOutOfDate, err)
 			}

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1036,7 +1036,7 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 		if _, deferred := state.nativeMergeQueueDeferred[issueID]; deferred {
 			continue
 		}
-		if nativeMergeQueueOwnsIssue(state, issue) && issue.PullRequest != nil && normalizePullRequestState(issue.PullRequest.State) == "open" {
+		if nativeMergeQueueHasEntry(state, issue) && issue.PullRequest != nil && normalizePullRequestState(issue.PullRequest.State) == "open" {
 			continue
 		}
 		repository := mergeWorkerRepositoryKey(issue)

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1036,6 +1036,9 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 		if _, deferred := state.nativeMergeQueueDeferred[issueID]; deferred {
 			continue
 		}
+		if nativeMergeQueueOwnsIssue(state, issue) && issue.PullRequest != nil && normalizePullRequestState(issue.PullRequest.State) == "open" {
+			continue
+		}
 		repository := mergeWorkerRepositoryKey(issue)
 		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg)
 		if mergeWorkerRepositoryConsumed(consumedRepositories, repository) && decision.reason != string(AutoPromoteReasonCINotGreen) {
@@ -1540,7 +1543,7 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 	out := make([]connector.Issue, 0, len(candidates))
 	selectedByState := map[string]int{}
 	for _, issue := range candidates {
-		if mergeFairnessBlocks(state, stickyID, issue, now) {
+		if nativeMergeQueueOwnsIssue(state, issue) || mergeFairnessBlocks(state, stickyID, issue, now) {
 			continue
 		}
 		issueID := strings.TrimSpace(issue.ID)

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -449,6 +449,9 @@ func (o *Orchestrator) dispatchIssueWithMergeControl(
 	allowMergeControl bool,
 	retryState *Retry,
 ) dispatchIssueOutcome {
+	if mergeWorkerIssue(issue) && nativeMergeQueueOwnsIssue(state, issue) {
+		return dispatchIssueOutcome{reason: dispatchSkipInactiveState, waitReason: "waiting for native merge queue"}
+	}
 	if err := o.checkDispatchPolicy(ctx); err != nil {
 		return dispatchIssueOutcome{reason: "policy_mismatch", waitReason: err.Error()}
 	}

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -3,7 +3,6 @@ package orchestrator
 import (
 	"context"
 	"log/slog"
-	"sort"
 	"strings"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 const (
 	nativeMergeQueueEntryRefresh     = 2 * time.Minute
 	nativeMergeQueueRepositoryExpiry = 5 * time.Minute
-	nativeMergeQueueTerminalSweep    = 2 * time.Minute
 )
 
 type nativeMergeQueueEntry struct {
@@ -39,9 +37,6 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 	if state == nil {
 		return out
 	}
-	if nativeMergeQueueCleanupRequired(o.cfg) {
-		return out
-	}
 	state.nativeMergeQueueDeferred = map[string]struct{}{}
 	queue, ok := o.connector.(connector.PullRequestMergeQueue)
 	if !ok {
@@ -59,7 +54,7 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			continue
 		}
 		issueID := strings.TrimSpace(candidate.ID)
-		if !nativeMergeQueueCandidate(candidate, o.cfg) || staleMergingPullRequestDispatchActive(state, issueID) {
+		if candidate.PullRequest == nil || normalizePullRequestState(candidate.PullRequest.State) != "open" || staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
 		if cached, ok := state.nativeMergeQueueEntries[issueID]; ok && now.Sub(cached.CheckedAt) < nativeMergeQueueEntryRefresh && cached.HeadSHA == strings.TrimSpace(candidate.PullRequest.HeadSHA) {
@@ -75,11 +70,11 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 		if repositoryKnown && now.Sub(repository.CheckedAt) >= nativeMergeQueueRepositoryExpiry {
 			repositoryKnown = false
 		}
-		if repositoryKnown && !repository.Available {
+		_, previouslyQueued := state.nativeMergeQueueEntries[issueID]
+		if repositoryKnown && !repository.Available && !previouslyQueued && candidate.PullRequest.MergeQueueEntry == nil {
 			continue
 		}
 
-		_, previouslyQueued := state.nativeMergeQueueEntries[issueID]
 		status, err := queue.InspectPullRequestMergeQueue(ctx, candidate)
 		if err != nil {
 			state.nativeMergeQueueDeferred[issueID] = struct{}{}
@@ -104,14 +99,6 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			o.logNativeMergeQueueDelegated(candidate, *status.Entry, "observed")
 			continue
 		}
-		if previouslyQueued {
-			delete(state.nativeMergeQueueEntries, issueID)
-			clearNativeMergeQueueEntry(out, issueID)
-			o.logNativeMergeQueueFailure(candidate, "entry_missing", nil)
-		}
-		if !status.Available {
-			continue
-		}
 		if status.RemovalObserved && (strings.TrimSpace(status.RemovedHeadSHA) == "" || strings.TrimSpace(status.RemovedHeadSHA) == strings.TrimSpace(status.HeadSHA)) {
 			state.nativeMergeQueueDeferred[issueID] = struct{}{}
 			reason := strings.TrimSpace(status.RemovalReason)
@@ -122,12 +109,30 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 				o.logNativeMergeQueueFailure(candidate, "head_removed_from_queue", err)
 				continue
 			}
+			delete(state.nativeMergeQueueEntries, issueID)
+			clearNativeMergeQueueEntry(out, issueID)
 			for index := range out {
 				if out[index].ID == issueID {
 					out[index].State = autoPromoteReworkState
 				}
 			}
 			o.logNativeMergeQueueFailure(candidate, "head_removed_from_queue", nil)
+			continue
+		}
+		if !status.Available {
+			// A disabled queue with no provider entry releases cached ownership.
+			// This only clears our snapshot; it never dequeues a provider entry.
+			delete(state.nativeMergeQueueEntries, issueID)
+			clearNativeMergeQueueEntry(out, issueID)
+			continue
+		}
+		if previouslyQueued {
+			// Absence alone from an available queue is not an outcome.
+			applyNativeMergeQueueEntry(out, issueID, state.nativeMergeQueueEntries[issueID].Entry)
+			continue
+		}
+		if !nativeMergeQueueCandidate(candidate, o.cfg) {
+			state.nativeMergeQueueDeferred[issueID] = struct{}{}
 			continue
 		}
 		if status.AdmissionLimit <= 0 || status.Depth >= status.AdmissionLimit {
@@ -157,171 +162,6 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 		})
 	}
 	return out
-}
-
-func (o *Orchestrator) reconcileUnsafeNativeMergeQueueIssues(
-	ctx context.Context,
-	state *State,
-	issues []connector.Issue,
-	previous []connector.Issue,
-	now time.Time,
-) []connector.Issue {
-	out := mergeIssueSlices(issues, previous)
-	if state == nil || !nativeMergeQueueCleanupRequired(o.cfg) {
-		return out
-	}
-	queue, ok := o.connector.(connector.PullRequestMergeQueue)
-	if !ok {
-		return out
-	}
-	out = mergeIssueSlices(out, nativeMergeQueueRetryIssues(state.nativeQueueRetries))
-	previousDeferred := state.nativeMergeQueueDeferred
-	state.nativeMergeQueueDeferred = map[string]struct{}{}
-	state.nativeQueueRetries = map[string]connector.Issue{}
-	previousMerging := make(map[string]struct{}, len(previous))
-	for _, issue := range previous {
-		if mergeWorkerIssue(issue) {
-			previousMerging[strings.TrimSpace(issue.ID)] = struct{}{}
-		}
-	}
-	for _, issue := range out {
-		if !nativeMergeQueueCleanupCandidate(issue, state, previousMerging, previousDeferred) {
-			continue
-		}
-		o.reconcileUnsafeNativeMergeQueue(ctx, state, out, issue, queue, now)
-	}
-	pruneNativeMergeQueueEntries(state, out)
-	return out
-}
-
-func nativeMergeQueueCleanupRequired(cfg Config) bool {
-	return !cfg.MergeFastPathEnabled ||
-		gateRequiresPullRequest(cfg.AutoPromote.Gate) ||
-		gate.Effective(cfg.AutoPromote.Gate).SecurityAudit.Enabled
-}
-
-func (o *Orchestrator) fetchUnsafeNativeMergeQueueTerminalIssues(
-	ctx context.Context,
-	state *State,
-	now time.Time,
-	reserve githubBudgetReserveDecision,
-) []connector.Issue {
-	if state == nil || !nativeMergeQueueCleanupRequired(o.cfg) {
-		return nil
-	}
-	if !state.nativeQueueSweepAt.IsZero() && now.Sub(state.nativeQueueSweepAt) < nativeMergeQueueTerminalSweep {
-		return nil
-	}
-	if _, ok := o.connector.(connector.PullRequestMergeQueue); !ok {
-		state.nativeQueueSweepAt = now
-		return nil
-	}
-	if reserve.degraded {
-		return nil
-	}
-	states := displayStateNames(o.cfg.TerminalStates)
-	if len(states) == 0 {
-		state.nativeQueueSweepAt = now
-		return nil
-	}
-	issues, err := o.fetchObservedIssuesByStates(ctx, states)
-	if err != nil {
-		if o.logger != nil {
-			o.logger.Warn("fetch unsafe native merge queue terminal issues failed", "error", err)
-		}
-		markRefreshError(state, "fetch unsafe native merge queue terminal issues failed: "+err.Error(), now)
-		return nil
-	}
-	state.nativeQueueSweepAt = now
-	return terminalIssues(issues, o.cfg.TerminalStates)
-}
-
-func nativeMergeQueueCleanupCandidate(
-	issue connector.Issue,
-	state *State,
-	previousMerging map[string]struct{},
-	previousDeferred map[string]struct{},
-) bool {
-	issueID := strings.TrimSpace(issue.ID)
-	if issueID == "" {
-		return false
-	}
-	if mergeWorkerIssue(issue) {
-		return true
-	}
-	if _, ok := state.nativeMergeQueueEntries[issueID]; ok {
-		return true
-	}
-	if _, ok := previousMerging[issueID]; ok {
-		return true
-	}
-	if _, ok := previousDeferred[issueID]; ok {
-		return true
-	}
-	if issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil {
-		return true
-	}
-	return nativeMergeQueueRecoveryCandidate(issue)
-}
-
-func nativeMergeQueueRecoveryCandidate(issue connector.Issue) bool {
-	if issue.PullRequest == nil || normalizePullRequestState(issue.PullRequest.State) != "open" {
-		return false
-	}
-	return pullRequestRepository(issue) != "" && pullRequestNumber(issue) > 0
-}
-
-func (o *Orchestrator) reconcileUnsafeNativeMergeQueue(
-	ctx context.Context,
-	state *State,
-	issues []connector.Issue,
-	issue connector.Issue,
-	queue connector.PullRequestMergeQueue,
-	now time.Time,
-) {
-	issueID := strings.TrimSpace(issue.ID)
-	status, err := queue.InspectPullRequestMergeQueue(ctx, issue)
-	if err != nil {
-		state.nativeMergeQueueDeferred[issueID] = struct{}{}
-		state.nativeQueueRetries[issueID] = cloneIssue(issue)
-		o.logNativeMergeQueueFailure(issue, "inspection_failed", err)
-		return
-	}
-	if status.Entry == nil {
-		delete(state.nativeMergeQueueEntries, issueID)
-		clearNativeMergeQueueEntry(issues, issueID)
-		return
-	}
-	entry := *status.Entry
-	if err := queue.DequeuePullRequest(ctx, entry); err != nil {
-		state.nativeMergeQueueDeferred[issueID] = struct{}{}
-		state.nativeQueueRetries[issueID] = cloneIssue(issue)
-		cacheNativeMergeQueueEntry(state, issueID, entry, now)
-		applyNativeMergeQueueEntry(issues, issueID, entry)
-		o.logNativeMergeQueueFailure(issue, "dequeue_failed", err)
-		return
-	}
-	delete(state.nativeMergeQueueEntries, issueID)
-	clearNativeMergeQueueEntry(issues, issueID)
-	o.logNativeMergeQueueDequeued(issue, entry)
-	recordStateEvent(state, telemetry.ActivityEvent{
-		At:      now,
-		Event:   "merge_worker_native_queue_dequeued",
-		Message: "dequeued " + issueLabel(issue) + " from the native merge queue",
-	})
-}
-
-func nativeMergeQueueRetryIssues(retries map[string]connector.Issue) []connector.Issue {
-	issueIDs := make([]string, 0, len(retries))
-	for issueID := range retries {
-		issueIDs = append(issueIDs, issueID)
-	}
-	sort.Strings(issueIDs)
-	issues := make([]connector.Issue, 0, len(issueIDs))
-	for _, issueID := range issueIDs {
-		issues = append(issues, cloneIssue(retries[issueID]))
-	}
-	return issues
 }
 
 func nativeMergeQueueCandidate(issue connector.Issue, cfg Config) bool {
@@ -457,16 +297,6 @@ func (o *Orchestrator) logNativeMergeQueueDelegated(issue connector.Issue, entry
 	)...)
 }
 
-func (o *Orchestrator) logNativeMergeQueueDequeued(issue connector.Issue, entry connector.PullRequestMergeQueueEntry) {
-	if o.logger == nil {
-		return
-	}
-	o.logger.Info("merge_worker_native_queue_dequeued", mergeWorkerLogAttrs(issue,
-		"queue_entry_id", entry.ID,
-		"queue_state", entry.State,
-	)...)
-}
-
 func (o *Orchestrator) logNativeMergeQueueFailure(issue connector.Issue, reason string, err error) {
 	if o.logger == nil {
 		return
@@ -476,4 +306,20 @@ func (o *Orchestrator) logNativeMergeQueueFailure(issue connector.Issue, reason 
 		attrs = append(attrs, slog.Any("error", err))
 	}
 	o.logger.Warn("merge_worker_native_queue_failed", attrs...)
+}
+
+// nativeMergeQueueOwnsIssue keeps provider-owned work out of every worker path,
+// including snapshots that omit the queue entry. Availability expires only when
+// a fresh provider inspection confirms the queue is unavailable.
+func nativeMergeQueueOwnsIssue(state *State, issue connector.Issue) bool {
+	if issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil {
+		return true
+	}
+	if state == nil {
+		return false
+	}
+	if _, ok := state.nativeMergeQueueEntries[strings.TrimSpace(issue.ID)]; ok {
+		return true
+	}
+	return state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)].Available
 }

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -132,7 +132,6 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			continue
 		}
 		if !nativeMergeQueueCandidate(candidate, o.cfg) {
-			state.nativeMergeQueueDeferred[issueID] = struct{}{}
 			continue
 		}
 		if status.AdmissionLimit <= 0 || status.Depth >= status.AdmissionLimit {
@@ -312,14 +311,16 @@ func (o *Orchestrator) logNativeMergeQueueFailure(issue connector.Issue, reason 
 // including snapshots that omit the queue entry. Availability expires only when
 // a fresh provider inspection confirms the queue is unavailable.
 func nativeMergeQueueOwnsIssue(state *State, issue connector.Issue) bool {
+	return nativeMergeQueueHasEntry(state, issue) || state != nil && state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)].Available
+}
+
+func nativeMergeQueueHasEntry(state *State, issue connector.Issue) bool {
 	if issue.PullRequest != nil && issue.PullRequest.MergeQueueEntry != nil {
 		return true
 	}
 	if state == nil {
 		return false
 	}
-	if _, ok := state.nativeMergeQueueEntries[strings.TrimSpace(issue.ID)]; ok {
-		return true
-	}
-	return state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)].Available
+	_, ok := state.nativeMergeQueueEntries[strings.TrimSpace(issue.ID)]
+	return ok
 }

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -937,3 +937,33 @@ func TestNativeMergeQueueRetainsEntryAcrossConfigurationChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestNativeMergeQueueUnadmittedFailureReconciles(t *testing.T) {
+	t.Parallel()
+	for _, queued := range []bool{false, true} {
+		t.Run(fmt.Sprintf("queued=%t", queued), func(t *testing.T) {
+			issue := nativeMergeQueueTestIssue(2462, "failure")
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging", "Rework"}})
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}}}
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			now := time.Now()
+			state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)] = nativeMergeQueueRepository{Available: true, CheckedAt: now}
+			if queued {
+				tracker.entries = map[string]connector.PullRequestMergeQueueEntry{issue.ID: {ID: "entry"}}
+			}
+			issues := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			orch.reconcileStaleMergingPullRequestIssues(t.Context(), &state, issues, now.Add(time.Second))
+			if queued {
+				if len(tracker.updates) != 0 {
+					t.Fatalf("queued PR transitioned: %v", tracker.updates)
+				}
+			} else if len(tracker.updates) != 1 || tracker.updates[0].state != "Rework" {
+				t.Fatalf("unadmitted failure updates=%v, want Rework", tracker.updates)
+			}
+			if len(tracker.enqueued) != 0 || len(tracker.merges) != 0 || len(tracker.dequeued) != 0 {
+				t.Fatal("unexpected queue or merge mutation")
+			}
+		})
+	}
+}

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,7 +166,7 @@ func TestDelegateNativeMergeQueueIssuesHonorsAgedHeadReservation(t *testing.T) {
 
 			queued := orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{aged, recent}, now)
 
-			if len(tracker.enqueued) != tt.wantEnqueued || tracker.inspections != tt.wantEnqueued {
+			if len(tracker.enqueued) != tt.wantEnqueued || tracker.inspections < tt.wantEnqueued {
 				t.Fatalf("native queue activity = enqueued %#v, inspections %d; want %d", tracker.enqueued, tracker.inspections, tt.wantEnqueued)
 			}
 			for _, issue := range queued {
@@ -192,6 +192,7 @@ func TestTickDelegatesNativeMergeQueueTrainWithoutAgentDispatch(t *testing.T) {
 		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
 			autoPromoteTickConnector: &autoPromoteTickConnector{
 				stateIssues:        issues,
+				candidateIssues:    issues,
 				candidateIssuesSet: true,
 			},
 		},
@@ -211,9 +212,11 @@ func TestTickDelegatesNativeMergeQueueTrainWithoutAgentDispatch(t *testing.T) {
 		ObservedStates: []string{"Merging"},
 		TerminalStates: []string{"Done", "Cancelled"},
 	})
+	var logs strings.Builder
 	runner := newWorkerHostRunner()
 	orch := &Orchestrator{
 		cfg:        cfg,
+		logger:     slog.New(slog.NewTextHandler(&logs, nil)),
 		connector:  tracker,
 		supervisor: newTestSupervisor(t, runner, cfg),
 		runResults: make(chan runpkg.Completion, 1),
@@ -221,6 +224,7 @@ func TestTickDelegatesNativeMergeQueueTrainWithoutAgentDispatch(t *testing.T) {
 	state := newState(cfg)
 
 	orch.tick(context.Background(), &state, now)
+	orch.tick(context.Background(), &state, now.Add(10*time.Second))
 
 	if got, want := tracker.enqueued, []string{"issue-111", "issue-112", "issue-113"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("enqueued issue ids = %#v, want %#v", got, want)
@@ -229,6 +233,12 @@ func TestTickDelegatesNativeMergeQueueTrainWithoutAgentDispatch(t *testing.T) {
 	case request := <-runner.started:
 		t.Fatalf("unexpected merge worker dispatch for %q", request.Issue.ID)
 	default:
+	}
+	if strings.Contains(logs.String(), "merge_worker_attempt") {
+		t.Fatal(logs.String())
+	}
+	if got := strings.Count(logs.String(), "msg=merge_queue_entered "); got != len(issues) {
+		t.Fatalf("queue entered events=%d want %d: %s", got, len(issues), logs.String())
 	}
 	queued := 0
 	for _, issue := range state.BoardIssues {
@@ -270,7 +280,7 @@ func TestDelegateNativeMergeQueueIssuesCachesQueueEntries(t *testing.T) {
 	}
 }
 
-func TestDelegateNativeMergeQueueIssuesReenqueuesMissingCachedEntry(t *testing.T) {
+func TestDelegateNativeMergeQueueIssuesWaitsForMissingEntryOutcome(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 13, 18, 0, 0, 0, time.UTC)
@@ -291,50 +301,58 @@ func TestDelegateNativeMergeQueueIssuesReenqueuesMissingCachedEntry(t *testing.T
 	first := orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{issue}, now)
 	second := orch.delegateNativeMergeQueueIssues(context.Background(), &state, first, now.Add(nativeMergeQueueEntryRefresh))
 
-	if tracker.inspections != 2 || len(tracker.enqueued) != 2 {
-		t.Fatalf("queue calls = %d inspections and %d enqueues, want two each after entry disappears", tracker.inspections, len(tracker.enqueued))
+	if tracker.inspections != 2 || len(tracker.enqueued) != 1 {
+		t.Fatalf("queue calls = %d inspections and %d enqueues, want two inspections and one enqueue after entry disappears", tracker.inspections, len(tracker.enqueued))
 	}
 	if second[0].PullRequest == nil || second[0].PullRequest.MergeQueueEntry == nil || second[0].PullRequest.MergeQueueEntry.State == "MISSING" {
 		t.Fatalf("re-enqueued queue entry = %#v, want active replacement", second[0].PullRequest)
 	}
 }
 
-func TestDelegateNativeMergeQueueIssuesFallsBackWhenCachedQueueDisappears(t *testing.T) {
+func TestDelegateNativeMergeQueueIssuesRefreshesQueueOwnership(t *testing.T) {
 	t.Parallel()
-
-	now := time.Date(2026, 7, 13, 18, 0, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(203, "success")
-	available := true
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{},
-		},
-		available: &available,
-	}
-	cfg := nativeMergeQueueTestConfig(Config{
-		MergeFastPathEnabled: true,
-		MaxConcurrentAgentsByState: map[string]int{
-			"Merging": 1,
-		},
-		ActiveStates:   []string{"Merging"},
-		TerminalStates: []string{"Done"},
-	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
-	state := newState(cfg)
-
-	first := orch.delegateNativeMergeQueueIssues(context.Background(), &state, []connector.Issue{issue}, now)
-	available = false
-	second := orch.delegateNativeMergeQueueIssues(context.Background(), &state, first, now.Add(nativeMergeQueueEntryRefresh))
-
-	if len(tracker.enqueued) != 1 {
-		t.Fatalf("enqueued = %#v, want no enqueue after queue disappears", tracker.enqueued)
-	}
-	if second[0].PullRequest == nil || second[0].PullRequest.MergeQueueEntry != nil {
-		t.Fatalf("pull request = %#v, want stale queue entry cleared", second[0].PullRequest)
-	}
-	candidates := orch.mergeWorkerDispatchCandidates(&state, second, now.Add(nativeMergeQueueEntryRefresh))
-	if len(candidates) != 1 || candidates[0].ID != issue.ID {
-		t.Fatalf("merge worker candidates = %#v, want fallback issue %q", candidates, issue.ID)
+	for _, tt := range []struct {
+		name                    string
+		available, entryPresent bool
+		wantWorkers             int
+	}{
+		{name: "queue and entry gone", wantWorkers: 1},
+		{name: "queue remains", available: true},
+		{name: "provider entry remains", entryPresent: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 13, 18, 0, 0, 0, time.UTC)
+			issues := []connector.Issue{nativeMergeQueueTestIssue(203, "success"), nativeMergeQueueTestIssue(204, "success")}
+			available := true
+			tracker := &nativeMergeQueueConnector{
+				autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}},
+				available:                     &available,
+			}
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, MaxConcurrentAgentsByState: map[string]int{"Merging": 1}, ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			first := orch.delegateNativeMergeQueueIssues(t.Context(), &state, issues, now)
+			available = tt.available
+			if tt.entryPresent {
+				tracker.entries = map[string]connector.PullRequestMergeQueueEntry{}
+				for _, issue := range first {
+					tracker.entries[issue.ID] = *issue.PullRequest.MergeQueueEntry
+				}
+			}
+			second := orch.delegateNativeMergeQueueIssues(t.Context(), &state, first, now.Add(nativeMergeQueueEntryRefresh))
+			if len(tracker.enqueued) != 2 || len(tracker.dequeued) != 0 {
+				t.Fatalf("queue mutations: enqueue=%v dequeue=%v", tracker.enqueued, tracker.dequeued)
+			}
+			for _, issue := range second {
+				if got := nativeMergeQueueOwnsIssue(&state, issue); got != (tt.wantWorkers == 0) {
+					t.Fatalf("%s ownership=%t", issue.ID, got)
+				}
+			}
+			candidates := orch.mergeWorkerDispatchCandidates(&state, second, now.Add(nativeMergeQueueEntryRefresh))
+			if len(candidates) != tt.wantWorkers {
+				t.Fatalf("worker candidates=%d want %d", len(candidates), tt.wantWorkers)
+			}
+		})
 	}
 }
 
@@ -447,539 +465,6 @@ func TestNativeMergeQueueCandidateRejectsNonAtomicSecurityAuditGate(t *testing.T
 	}}})
 	if nativeMergeQueueCandidate(issue, cfg) {
 		t.Fatal("nativeMergeQueueCandidate() = true, want programmatic exact-head merge")
-	}
-}
-
-func TestReconcileUnsafeNativeMergeQueueIssues(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
-	queueEntry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-403", State: "QUEUED"}
-	tests := []struct {
-		name           string
-		gateKind       string
-		entry          *connector.PullRequestMergeQueueEntry
-		inspectErr     error
-		dequeueErr     error
-		wantCandidates int
-		wantQueued     bool
-		wantDequeued   int
-	}{
-		{name: "dispatches when no native entry exists", wantCandidates: 1},
-		{name: "dequeues existing native entry before dispatch", entry: &queueEntry, wantCandidates: 1, wantDequeued: 1},
-		{name: "dequeues existing native entry for human review gate", gateKind: gate.KindHumanReview, entry: &queueEntry, wantCandidates: 1, wantDequeued: 1},
-		{name: "defers when queue inspection fails", inspectErr: errors.New("inspect unavailable")},
-		{name: "defers when dequeue fails", entry: &queueEntry, dequeueErr: errors.New("dequeue unavailable"), wantQueued: true, wantDequeued: 1},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			issue := nativeMergeQueueTestIssue(403, "success")
-			gateKind := tt.gateKind
-			if gateKind == "" {
-				gateKind = gate.KindCommand
-			}
-			if gateKind == gate.KindHumanReview {
-				issue.Labels = append(issue.Labels, gate.DefaultApprovalLabel)
-			}
-			tracker := &nativeMergeQueueConnector{
-				autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-					autoPromoteTickConnector: &autoPromoteTickConnector{},
-				},
-				inspectErr: tt.inspectErr,
-				dequeueErr: tt.dequeueErr,
-			}
-			if tt.entry != nil {
-				tracker.entries = map[string]connector.PullRequestMergeQueueEntry{issue.ID: *tt.entry}
-			}
-			cfg := normalizeConfig(Config{
-				MergeFastPathEnabled: false,
-				MaxConcurrentAgentsByState: map[string]int{
-					"Merging": 1,
-				},
-				AutoPromote:  AutoPromoteConfig{Gate: gate.Config{Kind: gateKind}},
-				ActiveStates: []string{"Merging"},
-			})
-			orch := &Orchestrator{cfg: cfg, connector: tracker}
-			state := newState(cfg)
-
-			queued := orch.reconcileUnsafeNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, nil, now)
-
-			if tracker.inspections != 1 || len(tracker.enqueued) != 0 {
-				t.Fatalf("native queue activity = %d inspections and %#v enqueues, want one inspection and no enqueue", tracker.inspections, tracker.enqueued)
-			}
-			if got := len(tracker.dequeued); got != tt.wantDequeued {
-				t.Fatalf("dequeue calls = %d, want %d", got, tt.wantDequeued)
-			}
-			queuedEntry := queued[0].PullRequest.MergeQueueEntry
-			if (queuedEntry != nil) != tt.wantQueued {
-				t.Fatalf("queued entry = %#v, want present %t", queuedEntry, tt.wantQueued)
-			}
-			candidates := orch.mergeWorkerDispatchCandidates(&state, queued, now)
-			if len(candidates) != tt.wantCandidates {
-				t.Fatalf("merge worker candidates = %#v, want %d", candidates, tt.wantCandidates)
-			}
-			if tt.wantCandidates == 1 && candidates[0].ID != issue.ID {
-				t.Fatalf("merge worker candidate = %#v, want issue %q", candidates[0], issue.ID)
-			}
-		})
-	}
-}
-
-func TestTickReconcilesUnsafeNativeQueueBeforeStaleMerging(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 16, 0, 0, 0, time.UTC)
-	tests := []struct {
-		name        string
-		dequeueErr  error
-		wantUpdates []autoPromoteTickUpdate
-	}{
-		{
-			name:        "dequeues before approval revocation transition",
-			wantUpdates: []autoPromoteTickUpdate{{issueID: "issue-404", state: "Human Review"}},
-		},
-		{
-			name:       "defers approval revocation when dequeue fails",
-			dequeueErr: errors.New("dequeue unavailable"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			issue := nativeMergeQueueTestIssue(404, "success")
-			entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-404", State: "QUEUED"}
-			tracker := &nativeMergeQueueConnector{
-				autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-					autoPromoteTickConnector: &autoPromoteTickConnector{
-						stateIssues:        []connector.Issue{issue},
-						candidateIssuesSet: true,
-					},
-				},
-				dequeueErr: tt.dequeueErr,
-				entries:    map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
-			}
-			cfg := normalizeConfig(Config{
-				PollInterval:         time.Minute,
-				MergeFastPathEnabled: false,
-				MaxConcurrentAgents:  1,
-				MaxConcurrentAgentsByState: map[string]int{
-					"Merging": 1,
-				},
-				AutoPromote: AutoPromoteConfig{
-					Enabled: true,
-					Gate:    gate.Config{Kind: gate.KindHumanReview},
-				},
-				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
-				ObservedStates: []string{"Merging"},
-				TerminalStates: []string{"Done", "Cancelled"},
-			})
-			orch := &Orchestrator{cfg: cfg, connector: tracker}
-			state := newState(cfg)
-
-			orch.tick(t.Context(), &state, now)
-
-			if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
-				t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
-			}
-			if !reflect.DeepEqual(tracker.updates, tt.wantUpdates) {
-				t.Fatalf("updates = %#v, want %#v", tracker.updates, tt.wantUpdates)
-			}
-			_, deferred := state.nativeMergeQueueDeferred[issue.ID]
-			if deferred != (tt.dequeueErr != nil) {
-				t.Fatalf("nativeMergeQueueDeferred[%q] present = %t, want %t", issue.ID, deferred, tt.dequeueErr != nil)
-			}
-		})
-	}
-}
-
-func TestTickReconcilesUnsafeNativeQueueWithoutObservedStatus(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 17, 0, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(405, "success")
-	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-405", State: "QUEUED"}
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{
-				candidateIssuesSet: true,
-			},
-		},
-		statusErr: errors.New("status unavailable"),
-		entries:   map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
-	}
-	cfg := normalizeConfig(Config{
-		PollInterval:         time.Minute,
-		MergeFastPathEnabled: false,
-		MaxConcurrentAgents:  1,
-		MaxConcurrentAgentsByState: map[string]int{
-			"Merging": 1,
-		},
-		AutoPromote: AutoPromoteConfig{
-			Enabled: true,
-			Gate:    gate.Config{Kind: gate.KindHumanReview},
-		},
-		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
-		ObservedStates: []string{"Merging"},
-		TerminalStates: []string{"Done", "Cancelled"},
-	})
-	orch := &Orchestrator{
-		cfg:       cfg,
-		connector: tracker,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}
-	state := newState(cfg)
-	state.Pipeline = []connector.Issue{issue}
-
-	orch.tick(t.Context(), &state, now)
-
-	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
-	}
-	if len(tracker.enqueued) != 0 {
-		t.Fatalf("enqueued issues = %#v, want none", tracker.enqueued)
-	}
-	if len(state.Pipeline) != 1 || state.Pipeline[0].ID != issue.ID {
-		t.Fatalf("pipeline = %#v, want prior issue %q retained", state.Pipeline, issue.ID)
-	}
-}
-
-func TestTickReconcilesUnsafeNativeQueueAfterLeavingMerging(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 17, 15, 0, 0, time.UTC)
-	previous := nativeMergeQueueTestIssue(406, "success")
-	current := cloneIssue(previous)
-	current.State = "Human Review"
-	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-406", State: "QUEUED"}
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{
-				stateIssues:        []connector.Issue{current},
-				candidateIssuesSet: true,
-			},
-		},
-		entries: map[string]connector.PullRequestMergeQueueEntry{previous.ID: entry},
-	}
-	cfg := normalizeConfig(Config{
-		PollInterval:         time.Minute,
-		MergeFastPathEnabled: false,
-		MaxConcurrentAgents:  1,
-		MaxConcurrentAgentsByState: map[string]int{
-			"Merging": 1,
-		},
-		AutoPromote: AutoPromoteConfig{
-			Gate: gate.Config{Kind: gate.KindHumanReview},
-		},
-		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
-		ObservedStates: []string{"Human Review", "Merging"},
-		TerminalStates: []string{"Done", "Cancelled"},
-	})
-	orch := &Orchestrator{
-		cfg:       cfg,
-		connector: tracker,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}
-	state := newState(cfg)
-	state.Pipeline = []connector.Issue{previous}
-	cacheNativeMergeQueueEntry(&state, previous.ID, entry, now.Add(-time.Minute))
-
-	orch.tick(t.Context(), &state, now)
-
-	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
-	}
-	if len(state.Pipeline) != 1 || state.Pipeline[0].State != current.State {
-		t.Fatalf("pipeline = %#v, want current %q state retained", state.Pipeline, current.State)
-	}
-	if _, ok := state.nativeMergeQueueEntries[previous.ID]; ok {
-		t.Fatalf("nativeMergeQueueEntries[%q] remains after dequeue", previous.ID)
-	}
-}
-
-func TestReconcileUnsafeNativeQueueRetriesAfterLeavingMerging(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 17, 30, 0, 0, time.UTC)
-	previous := nativeMergeQueueTestIssue(407, "success")
-	current := cloneIssue(previous)
-	current.State = "Human Review"
-	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-407", State: "QUEUED"}
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{},
-		},
-		inspectErr: errors.New("inspect unavailable"),
-		entries:    map[string]connector.PullRequestMergeQueueEntry{previous.ID: entry},
-	}
-	cfg := normalizeConfig(Config{
-		AutoPromote:  AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
-		ActiveStates: []string{"Merging"},
-	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
-	state := newState(cfg)
-
-	orch.reconcileUnsafeNativeMergeQueueIssues(
-		t.Context(),
-		&state,
-		[]connector.Issue{current},
-		[]connector.Issue{previous},
-		now,
-	)
-	if _, ok := state.nativeMergeQueueDeferred[previous.ID]; !ok {
-		t.Fatalf("nativeMergeQueueDeferred[%q] missing after inspection failure", previous.ID)
-	}
-
-	tracker.inspectErr = nil
-	orch.reconcileUnsafeNativeMergeQueueIssues(
-		t.Context(),
-		&state,
-		[]connector.Issue{current},
-		nil,
-		now.Add(time.Minute),
-	)
-
-	if tracker.inspections != 2 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want two inspections and one dequeue", tracker.inspections, len(tracker.dequeued))
-	}
-	if _, ok := state.nativeMergeQueueDeferred[previous.ID]; ok {
-		t.Fatalf("nativeMergeQueueDeferred[%q] remains after successful retry", previous.ID)
-	}
-}
-
-func TestReconcileNativeMergeQueueAfterSecurityAuditEnabled(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 17, 45, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(408, "success")
-	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-408", State: "QUEUED"}
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{},
-		},
-		entries: map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
-	}
-	cfg := normalizeConfig(Config{
-		MergeFastPathEnabled: true,
-		AutoPromote: AutoPromoteConfig{Gate: gate.Config{
-			Kind:          gate.KindArtifact,
-			SecurityAudit: gate.SecurityAuditConfig{Enabled: true},
-		}},
-		ActiveStates: []string{"Merging"},
-	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
-	state := newState(cfg)
-
-	orch.reconcileUnsafeNativeMergeQueueIssues(
-		t.Context(),
-		&state,
-		[]connector.Issue{issue},
-		nil,
-		now,
-	)
-
-	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
-	}
-}
-
-func TestReconcileNativeMergeQueueRecoversDepartedIssueAfterRestart(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 18, 0, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(409, "success")
-	issue.State = "Rework"
-	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-409", State: "QUEUED"}
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{},
-		},
-		entries: map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
-	}
-	cfg := normalizeConfig(Config{
-		MergeFastPathEnabled: true,
-		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
-		ActiveStates:         []string{"Rework", "Merging"},
-	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
-	state := newState(cfg)
-
-	orch.reconcileUnsafeNativeMergeQueueIssues(
-		t.Context(),
-		&state,
-		[]connector.Issue{issue},
-		nil,
-		now,
-	)
-
-	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
-	}
-}
-
-func TestReconcileNativeMergeQueueRechecksEmptyRecoveryInspection(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 18, 15, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(410, "success")
-	issue.State = "Human Review"
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{},
-		},
-	}
-	cfg := normalizeConfig(Config{
-		MergeFastPathEnabled: true,
-		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindHumanReview}},
-		ActiveStates:         []string{"Merging"},
-	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
-	state := newState(cfg)
-
-	for _, checkedAt := range []time.Time{now, now.Add(time.Minute), now.Add(nativeMergeQueueEntryRefresh)} {
-		orch.reconcileUnsafeNativeMergeQueueIssues(
-			t.Context(),
-			&state,
-			[]connector.Issue{issue},
-			nil,
-			checkedAt,
-		)
-	}
-
-	if tracker.inspections != 3 {
-		t.Fatalf("native queue inspections = %d, want 3", tracker.inspections)
-	}
-	if len(tracker.dequeued) != 0 {
-		t.Fatalf("dequeued entries = %#v, want none", tracker.dequeued)
-	}
-}
-
-func TestTickReconcilesUnsafeNativeQueueTerminalIssueAfterRestart(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 18, 30, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(411, "success")
-	issue.State = "Cancelled"
-	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-411", State: "QUEUED"}
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{
-				stateIssues:        []connector.Issue{issue},
-				candidateIssuesSet: true,
-			},
-		},
-		entries: map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
-	}
-	cfg := normalizeConfig(Config{
-		PollInterval:         time.Minute,
-		MergeFastPathEnabled: true,
-		MaxConcurrentAgents:  1,
-		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
-		ActiveStates:         []string{"Todo", "In Progress", "Rework", "Merging"},
-		ObservedStates:       []string{"Merging"},
-		TerminalStates:       []string{"Done", "Cancelled"},
-	})
-	orch := &Orchestrator{
-		cfg:       cfg,
-		connector: tracker,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}
-	state := newState(cfg)
-
-	orch.tick(t.Context(), &state, now)
-
-	if tracker.inspections != 1 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want one each", tracker.inspections, len(tracker.dequeued))
-	}
-	if state.nativeQueueSweepAt != now {
-		t.Fatalf("nativeQueueSweepAt = %s, want %s", state.nativeQueueSweepAt, now)
-	}
-}
-
-func TestTickPeriodicallyReconcilesUnsafeNativeQueueTerminalIssues(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 18, 40, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(413, "success")
-	issue.State = "Done"
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{
-				stateIssues:        []connector.Issue{issue},
-				candidateIssuesSet: true,
-			},
-		},
-	}
-	cfg := normalizeConfig(Config{
-		PollInterval:         time.Minute,
-		MergeFastPathEnabled: true,
-		MaxConcurrentAgents:  1,
-		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
-		ActiveStates:         []string{"Todo", "In Progress", "Rework", "Merging"},
-		ObservedStates:       []string{"Merging"},
-		TerminalStates:       []string{"Done", "Cancelled"},
-	})
-	orch := &Orchestrator{
-		cfg:       cfg,
-		connector: tracker,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}
-	state := newState(cfg)
-
-	orch.tick(t.Context(), &state, now)
-	tracker.entries = map[string]connector.PullRequestMergeQueueEntry{
-		issue.ID: {ID: "MQE_issue-413", State: "QUEUED"},
-	}
-	orch.tick(t.Context(), &state, now.Add(time.Minute))
-	orch.tick(t.Context(), &state, now.Add(nativeMergeQueueTerminalSweep))
-
-	if tracker.inspections != 2 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want two inspections and one dequeue", tracker.inspections, len(tracker.dequeued))
-	}
-	if state.nativeQueueSweepAt != now.Add(nativeMergeQueueTerminalSweep) {
-		t.Fatalf("nativeQueueSweepAt = %s, want %s", state.nativeQueueSweepAt, now.Add(nativeMergeQueueTerminalSweep))
-	}
-}
-
-func TestReconcileUnsafeNativeQueueRetriesTerminalIssueWithoutRefetch(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, 9, 4, 18, 45, 0, 0, time.UTC)
-	issue := nativeMergeQueueTestIssue(412, "success")
-	issue.State = "Cancelled"
-	entry := connector.PullRequestMergeQueueEntry{ID: "MQE_issue-412", State: "QUEUED"}
-	tracker := &nativeMergeQueueConnector{
-		autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{
-			autoPromoteTickConnector: &autoPromoteTickConnector{},
-		},
-		inspectErr: errors.New("inspect unavailable"),
-		entries:    map[string]connector.PullRequestMergeQueueEntry{issue.ID: entry},
-	}
-	cfg := normalizeConfig(Config{
-		MergeFastPathEnabled: true,
-		AutoPromote:          AutoPromoteConfig{Gate: gate.Config{Kind: gate.KindCommand}},
-		TerminalStates:       []string{"Done", "Cancelled"},
-	})
-	orch := &Orchestrator{cfg: cfg, connector: tracker}
-	state := newState(cfg)
-
-	orch.reconcileUnsafeNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, nil, now)
-	if _, ok := state.nativeQueueRetries[issue.ID]; !ok {
-		t.Fatalf("nativeQueueRetries[%q] missing after inspection failure", issue.ID)
-	}
-
-	tracker.inspectErr = nil
-	orch.reconcileUnsafeNativeMergeQueueIssues(t.Context(), &state, nil, nil, now.Add(time.Minute))
-
-	if tracker.inspections != 2 || len(tracker.dequeued) != 1 {
-		t.Fatalf("native queue activity = %d inspections and %d dequeues, want two inspections and one dequeue", tracker.inspections, len(tracker.dequeued))
-	}
-	if _, ok := state.nativeQueueRetries[issue.ID]; ok {
-		t.Fatalf("nativeQueueRetries[%q] remains after successful retry", issue.ID)
 	}
 }
 
@@ -1134,7 +619,7 @@ func TestNativeMergeQueueIntegrationContinuity(t *testing.T) {
 				state = newState(cfg)
 			}
 			orch.delegateNativeMergeQueueIssues(ctx, &state, issues, now.Add(time.Second))
-			wantInspections := 2
+			wantInspections := 4
 			if tt.changeHead {
 				wantInspections++
 			}
@@ -1313,6 +798,141 @@ func TestNativeMergeQueueRejectionRecordsProviderReason(t *testing.T) {
 			}
 			if len(orch.mergeWorkerDispatchCandidates(&state, got, now)) != 0 {
 				t.Fatal("rejection entered merge worker CI loop")
+			}
+		})
+	}
+}
+
+func TestNativeQueueRepositoryOwnsDispatch(t *testing.T) {
+	t.Parallel()
+	for _, available := range []bool{false, true} {
+		t.Run(fmt.Sprintf("available=%t", available), func(t *testing.T) {
+			issue := nativeMergeQueueTestIssue(2459, "success")
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, MaxConcurrentAgents: 1, ActiveStates: []string{"Merging"}})
+			orch := &Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			now := time.Now()
+			state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)] = nativeMergeQueueRepository{Available: available, CheckedAt: now}
+			candidates := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{issue}, now)
+			if available && len(candidates) != 0 {
+				t.Fatalf("queue available dispatched %d workers", len(candidates))
+			}
+			if !available && len(candidates) != 1 {
+				t.Fatalf("queue unavailable dispatched %d workers", len(candidates))
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueWorkerHandoff(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		known      bool
+		workerErr  error
+		inspectErr error
+	}{
+		{name: "known queue", known: true},
+		{name: "known queue worker failure", known: true, workerErr: errors.New("obsolete fallback failed")},
+		{name: "stale policy 405"},
+		{name: "405 inspection failure", inspectErr: errors.New("provider unavailable")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := nativeMergeQueueTestIssue(2459, "success")
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging", "Rework"}, TerminalStates: []string{"Done"}})
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}, err: connector.ErrPullRequestMergeQueueRequired}, inspectErr: tt.inspectErr}
+			var logs strings.Builder
+			orch := &Orchestrator{cfg: cfg, connector: tracker, logger: slog.New(slog.NewTextHandler(&logs, nil))}
+			state := newState(cfg)
+			now := time.Now()
+			state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)] = nativeMergeQueueRepository{Available: tt.known, CheckedAt: now}
+			running := Running{Issue: issue, Attempt: maxMergeWorkerRunnerFailures, StartedAt: now.Add(-time.Minute)}
+			event := runpkg.Completion{IssueID: issue.ID, CompletedAt: now, Result: runpkg.RunResult{FinalState: runpkg.FinalStateCompleted}}
+			state.Running[issue.ID] = running
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now}
+			event.Err = tt.workerErr
+			orch.handleRunResult(t.Context(), &state, event)
+			wantMerges := 1
+			if tt.known {
+				wantMerges = 0
+			}
+			if len(tracker.merges) != wantMerges {
+				t.Fatalf("merges=%d want %d", len(tracker.merges), wantMerges)
+			}
+			if len(state.Retry) != 0 || len(tracker.updates) != 0 {
+				t.Fatalf("retry or lane change: %v %v", state.Retry, tracker.updates)
+			}
+			if tt.inspectErr == nil && len(tracker.enqueued) != 1 {
+				t.Fatalf("enqueued=%v", tracker.enqueued)
+			}
+			if tracker.inspections != 1 {
+				t.Fatalf("inspections=%d", tracker.inspections)
+			}
+			if !nativeMergeQueueOwnsIssue(&state, issue) {
+				t.Fatal("lost queue ownership")
+			}
+			if strings.Contains(logs.String(), "merge_worker_retry_exhausted") {
+				t.Fatal(logs.String())
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueOutcomes(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct{ name, state, ci, want string }{
+		{"queued checks failing", "OPEN", "failure", ""},
+		{"queue merged", "MERGED", "success", "Done"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := nativeMergeQueueTestIssue(2460, tt.ci)
+			issue.PullRequest.State = tt.state
+			issue.PullRequest.MergeQueueEntry = &connector.PullRequestMergeQueueEntry{ID: "entry"}
+			cfg := nativeMergeQueueTestConfig(Config{ActiveStates: []string{"Merging", "Rework"}, TerminalStates: []string{"Done"}})
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}}}
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			orch.reconcileStaleMergingPullRequestIssues(t.Context(), &state, []connector.Issue{issue}, time.Now())
+			if tt.want == "" {
+				if len(tracker.updates) != 0 {
+					t.Fatalf("updates=%v", tracker.updates)
+				}
+			} else if len(tracker.updates) != 1 || tracker.updates[0].state != tt.want {
+				t.Fatalf("updates=%v want %s", tracker.updates, tt.want)
+			}
+			if len(tracker.dequeued) != 0 || len(tracker.merges) != 0 {
+				t.Fatal("programmatic queue mutation")
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueRetainsEntryAcrossConfigurationChanges(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		change func(*Config)
+	}{
+		{"fast path disabled", func(c *Config) { c.MergeFastPathEnabled = false }},
+		{"review gate enabled", func(c *Config) { c.AutoPromote.Gate.Kind = gate.KindCommand }},
+		{"audit enabled", func(c *Config) { c.AutoPromote.Gate.SecurityAudit.Enabled = true }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := nativeMergeQueueTestIssue(2461, "success")
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging"}})
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			now := time.Now()
+			queued := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			tracker.entries = map[string]connector.PullRequestMergeQueueEntry{issue.ID: *queued[0].PullRequest.MergeQueueEntry}
+			tt.change(&orch.cfg)
+			queued = orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now.Add(nativeMergeQueueEntryRefresh))
+			if len(tracker.dequeued) != 0 || len(tracker.enqueued) != 1 || queued[0].PullRequest.MergeQueueEntry == nil {
+				t.Fatal("configuration changed provider entry")
+			}
+			if got := orch.mergeWorkerDispatchCandidates(&state, queued, now); len(got) != 0 {
+				t.Fatal("configuration enabled worker fallback")
 			}
 		})
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1370,9 +1370,6 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 		o.ownershipStartupLogged = false
 	}
 	o.cfg = cfg
-	if nativeMergeQueueCleanupRequired(cfg) {
-		state.nativeQueueSweepAt = time.Time{}
-	}
 	now := time.Now
 	if o.now != nil {
 		now = o.now

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -162,6 +162,10 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleGitHubMonitorCompletion(ctx, state, event, running) {
 		return
 	}
+	if mergeWorkerIssue(running.Issue) && nativeMergeQueueOwnsIssue(state, running.Issue) {
+		o.completeNativeMergeQueueWorker(ctx, state, event, running, running.Issue)
+		return
+	}
 	o.refreshEfficiencyReceipt(ctx, running.Issue, event.CompletedAt)
 	if o.handleModelPermitDeferred(ctx, state, event, running) {
 		return
@@ -1436,6 +1440,10 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	if state != nil && state.Draining {
 		return false
 	}
+	if nativeMergeQueueOwnsIssue(state, issue) {
+		o.completeNativeMergeQueueWorker(ctx, state, event, running, issue)
+		return true
+	}
 	if !mergeWorkerTurnSucceeded(event) {
 		return false
 	}
@@ -1454,6 +1462,10 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		return true
 	}
 	issue = refreshedIssue
+	if nativeMergeQueueOwnsIssue(state, issue) {
+		o.completeNativeMergeQueueWorker(ctx, state, event, running, issue)
+		return true
+	}
 	if revocation, revoked := mergeRevocationForIssue(
 		issue,
 		o.cfg,
@@ -1569,6 +1581,13 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	number := pullRequestNumber(issue)
 	headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA)
 	if err := merger.MergePullRequest(ctx, repository, number, headSHA, o.cfg.MergeMethod); err != nil {
+		if errors.Is(err, connector.ErrPullRequestMergeQueueRequired) {
+			// The provider has established queue ownership even if the policy
+			// refresh fails. Never charge this routing correction as a retry.
+			state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)] = nativeMergeQueueRepository{Available: true}
+			o.completeNativeMergeQueueWorker(ctx, state, event, running, issue)
+			return true
+		}
 		if errors.Is(err, connector.ErrPullRequestBaseOutOfDate) {
 			o.refreshMergeWorkerBase(ctx, state, event, running, issue, "merge_api_rejected_out_of_date_base")
 			return true
@@ -2894,4 +2913,17 @@ func (o *Orchestrator) releaseRunningSlots(state *State) {
 		running.globalSlot = scheduler.Slot{}
 		state.Running[issueID] = running
 	}
+}
+
+func (o *Orchestrator) completeNativeMergeQueueWorker(ctx context.Context, state *State, event runpkg.Completion, running Running, issue connector.Issue) {
+	running.Issue = issue
+	o.recordProjectAttemptOutcome(state, event.IssueID, event.CompletedAt, store.WorkAttemptTerminalSuccess, nil, "", "")
+	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", "waiting for native merge queue")
+	o.releaseTerminalAttemptClaim(ctx, state, issue, event.CompletedAt)
+	delete(state.Retry, issue.ID)
+	if reservation := state.mergeReservations[mergeWorkerRepositoryKey(issue)]; reservation.IssueID == issue.ID {
+		delete(state.mergeReservations, mergeWorkerRepositoryKey(issue))
+	}
+	queued := o.delegateNativeMergeQueueIssues(ctx, state, mergeIssueSlices([]connector.Issue{issue}, state.Pipeline), event.CompletedAt)
+	state.Pipeline = overlayNativeMergeQueueIssues(state.Pipeline, queued)
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -92,8 +92,6 @@ type State struct {
 	nativeMergeQueueEntries  map[string]nativeMergeQueueEntry
 	nativeMergeQueueRepos    map[string]nativeMergeQueueRepository
 	nativeMergeQueueDeferred map[string]struct{}
-	nativeQueueRetries       map[string]connector.Issue
-	nativeQueueSweepAt       time.Time
 	TransientCheckRetries    map[string]TransientCheckRetry
 	DependencyAutoUnblocks   map[string]DependencyAutoUnblockRecord
 	BudgetRefusals           map[string]BudgetRefusal
@@ -408,7 +406,6 @@ func newState(cfg Config) State {
 		nativeMergeQueueEntries:  map[string]nativeMergeQueueEntry{},
 		nativeMergeQueueRepos:    map[string]nativeMergeQueueRepository{},
 		nativeMergeQueueDeferred: map[string]struct{}{},
-		nativeQueueRetries:       map[string]connector.Issue{},
 		TransientCheckRetries:    map[string]TransientCheckRetry{},
 		DependencyAutoUnblocks:   map[string]DependencyAutoUnblockRecord{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
@@ -502,8 +499,6 @@ func (s State) clone() State {
 		nativeMergeQueueEntries:  cloneNativeMergeQueueEntries(s.nativeMergeQueueEntries),
 		nativeMergeQueueRepos:    maps.Clone(s.nativeMergeQueueRepos),
 		nativeMergeQueueDeferred: maps.Clone(s.nativeMergeQueueDeferred),
-		nativeQueueRetries:       cloneIssueMap(s.nativeQueueRetries),
-		nativeQueueSweepAt:       s.nativeQueueSweepAt,
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		DependencyAutoUnblocks:   maps.Clone(s.DependencyAutoUnblocks),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -143,7 +143,6 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			return
 		}
 	}
-	nativeQueueTerminalIssues := o.fetchUnsafeNativeMergeQueueTerminalIssues(ctx, state, now, reserve)
 	timing.next("reconciliation")
 	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
 	fetched = applyStatusPullRequestHydrationBlocksToCandidates(fetched)
@@ -173,19 +172,6 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched,
 		o.reconcileClosedCompletedIssueStatuses(ctx, state, transitions.issues, now),
 	)
-	reviewThreadQueueIssues := o.reconcileUnsafeNativeMergeQueueIssues(
-		ctx,
-		state,
-		mergeIssueSlices(
-			mergeIssueSlices(fetched.status, fetched.candidates),
-			nativeQueueTerminalIssues,
-		),
-		previous.pipeline,
-		now,
-	)
-	fetched.status = overlayNativeMergeQueueIssues(fetched.status, reviewThreadQueueIssues)
-	fetched.candidates = overlayNativeMergeQueueIssues(fetched.candidates, reviewThreadQueueIssues)
-	state.Pipeline = overlayNativeMergeQueueIssues(state.Pipeline, reviewThreadQueueIssues)
 	if fetched.statusOK {
 		fetched = filterReconciledTickIssues(
 			state,


### PR DESCRIPTION
## Summary

Native merge queue ownership now excludes programmatic merge workers even when a PR snapshot omits its queue entry. Queue-required 405 responses refresh branch policy and hand work to native admission without consuming retries. Removed the configuration-driven dequeue sweep and its retry state.

A missing entry in an available queue waits for GitHub's outcome: removal routes to Rework with its reason, and a merge routes to Done. If refreshed policy confirms the queue is gone and GitHub reports no entry, cached ownership releases within one refresh, including multiple PRs on the same base.

Repository availability suppresses workers without suppressing ordinary reconciliation for PRs that never entered the queue; unadmitted failed PRs still move to Rework.

Fixes #2459

## UI Surface Contract

- [x] N/A: no UI surface changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Reproduced the dispatch ownership gap and the disabled-queue stale-entry regression before their fixes.
- [x] Focused table-driven queue and connector tests: repeated ticks enqueue once per PR with zero worker attempts; removal reason, merged outcome, configuration changes, stale 405 at retry limit, and policy/inspection failure.
- [x] Regression for P1 review: unadmitted failing PR transitions to Rework while a queued failing PR waits.
- [x] `make check` passed: build, static checks, race tests, and coverage gate.
- [ ] Live: run the fixed binary, restore the repository merge queue rule, and observe two consecutive queue merges with zero worker attempts. The worker cannot connect to port 4000 and has no authorization to restart the live instance.
