### PR TITLE
fix(cli): retry GitHub credential resolution at startup

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -3610,3 +3610,24 @@ workflow readiness rule. Do not use that mode for free-form human blockers
 without explicit dependency references. If auto-unblock is disabled, a
 dependency-waiting issue in `Blocked` will remain there even after the
 dependency clears.
+
+### GitHub credentials during systemd startup
+
+With `github_token: gh`, startup waits for `gh auth token` to return a nonempty
+credential. Failed acquisition retries after 5 seconds, doubling to a maximum
+of 60 seconds between attempts until successful or shutdown is requested. Each
+failure logs a warning with its attempt number and next delay. This accommodates
+keyring or secret-service startup delays; it does not validate a token against
+GitHub or change how GitHub rejects an acquired token. One-shot commands such as
+`detent doctor` still report credential failures promptly.
+
+Generated systemd units include `After=network-online.target` and
+`Wants=network-online.target`. `detent doctor` warns when an installed unit lacks
+these effective dependencies. A user manager's network target alone does not
+guarantee host DNS or tailnet readiness.
+
+If `gh` uses a secret service, add `After=` and `Wants=` dependencies in the
+`[Unit]` section of a `systemctl --user edit detent.service` drop-in for the
+actual secret-service unit installed on that host. Unit names vary by desktop
+and keyring provider; use the unit in the same user manager, and ensure its
+keyring can unlock unattended. Ordering does not unlock a locked keyring.

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -72,7 +72,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 			ConfigPath: resolution,
 			Workflow:   workflowPath,
 			Flags:      flags,
-		}, runtimeDepsFromOptions(opts))
+		}, bootRuntimeDeps(opts))
 		if err != nil {
 			return BootConfig{}, err
 		}
@@ -103,7 +103,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 			ConfigPath: resolution,
 			Workflow:   workflowPath,
 			Flags:      flags,
-		}, runtimeDepsFromOptions(opts))
+		}, bootRuntimeDeps(opts))
 		if err != nil {
 			return BootConfig{}, err
 		}
@@ -130,7 +130,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 		ConfigPath: resolution,
 		Workflow:   workflowPath,
 		Flags:      flags,
-	}, runtimeDepsFromOptions(opts))
+	}, bootRuntimeDeps(opts))
 	if err != nil {
 		return BootConfig{}, err
 	}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -58,6 +58,10 @@ const (
 )
 
 func resolveBootConfig(ctx context.Context, configPath string, host string, flags runtimeFlags, opts options) (BootConfig, error) {
+	return resolveBootConfigWithRuntimeDeps(ctx, configPath, host, flags, opts, runtimeDepsFromOptions(opts))
+}
+
+func resolveBootConfigWithRuntimeDeps(ctx context.Context, configPath string, host string, flags runtimeFlags, opts options, deps runtimeDeps) (BootConfig, error) {
 	resolution, err := resolveConfigPathResolution(configPath, opts)
 	if err != nil {
 		return BootConfig{}, err
@@ -72,7 +76,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 			ConfigPath: resolution,
 			Workflow:   workflowPath,
 			Flags:      flags,
-		}, bootRuntimeDeps(opts))
+		}, deps)
 		if err != nil {
 			return BootConfig{}, err
 		}
@@ -103,7 +107,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 			ConfigPath: resolution,
 			Workflow:   workflowPath,
 			Flags:      flags,
-		}, bootRuntimeDeps(opts))
+		}, deps)
 		if err != nil {
 			return BootConfig{}, err
 		}
@@ -130,7 +134,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 		ConfigPath: resolution,
 		Workflow:   workflowPath,
 		Flags:      flags,
-	}, bootRuntimeDeps(opts))
+	}, deps)
 	if err != nil {
 		return BootConfig{}, err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -428,7 +428,7 @@ detent --format json config path`),
 				LogLevel: runtimeStringFlag{Value: logLevel, Set: flagChanged(cmd, "log-level")},
 				Port:     runtimeIntFlag{Value: port, Set: flagChanged(cmd, "port")},
 			}
-			boot, err := resolveBootConfig(cmd.Context(), configPath, host, flags, opts)
+			boot, err := resolveBootConfigWithRuntimeDeps(cmd.Context(), configPath, host, flags, opts, bootRuntimeDeps(opts))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -520,6 +520,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	}
 	jobs = append(jobs,
 		doctorCheckJob{
+			Name: "Systemd network ordering",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return checkDoctorSystemdNetwork(jobCtx, resolution.Path, opts)
+			},
+		},
+		doctorCheckJob{
 			Name: "Remote Detent service",
 			Run: func(jobCtx context.Context) []doctorCheck {
 				return checkDoctorDetentService(jobCtx, liveBoot, cfg.Build, deps)

--- a/internal/cli/doctor_startup_preflight_test.go
+++ b/internal/cli/doctor_startup_preflight_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -76,5 +78,43 @@ func TestRunDoctorStartupPreflightRejectsUnresolvableBootConfig(t *testing.T) {
 	assertDoctorCheck(t, report, "Candidate startup", doctorFail, "cannot resolve global config")
 	if !report.HasFailures() {
 		t.Fatal("HasFailures() = false, want candidate rejection")
+	}
+}
+
+func TestStartupPreflightDoesNotRetryCredentials(t *testing.T) {
+	for _, empty := range []bool{false, true} {
+		t.Run(map[bool]string{false: "failed command", true: "empty credential"}[empty], func(t *testing.T) {
+			dir := t.TempDir()
+			workflow := filepath.Join(dir, "WORKFLOW.md")
+			if err := os.WriteFile(workflow, []byte("---\ntracker:\n  kind: github\n  project_slug: PVT_test\n---\nPrompt\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(dir, "global.yaml")
+			global := validDoctorGlobalWithProjects(configPath, "alpha")
+			global.GitHubToken = "gh"
+			global.Projects[0].Workflow = workflow
+			global.Projects[0].Workdir = dir
+			opts := successfulDoctorOptionsWithConfig(configPath, global)
+			opts.lookupEnv = func(string) string { return "" }
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			calls := 0
+			opts.ghAuthToken = func(context.Context) (string, error) {
+				calls++
+				// A second call cancels a regressed retry loop instead of hanging the suite.
+				if calls > 1 {
+					cancel()
+				}
+				if empty {
+					return "", nil
+				}
+				return "", errors.New("keyring unavailable")
+			}
+			report := runDoctorStartupPreflight(ctx, doctorConfig{ConfigPath: configPath}, opts, successfulDoctorDeps())
+			if calls != 1 {
+				t.Fatalf("credential calls=%d, want 1", calls)
+			}
+			assertDoctorCheck(t, report, "Candidate startup", doctorFail, "gh auth token")
+		})
 	}
 }

--- a/internal/cli/doctor_systemd.go
+++ b/internal/cli/doctor_systemd.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	servicepkg "github.com/digitaldrywood/detent/internal/service"
+)
+
+// Inspect effective dependencies so system and user units, including drop-ins,
+// are checked using the same service discovery as detent status.
+func checkDoctorSystemdNetwork(ctx context.Context, configPath string, opts options) []doctorCheck {
+	factory := opts.service
+	if factory == nil {
+		factory = defaultServiceFactory
+	}
+	run := opts.runCommand
+	if run == nil {
+		run = defaultCommandRunner
+	}
+	runner, err := factory(servicepkg.Config{GOOS: runtime.GOOS, ConfigPath: configPath, LockPath: filepath.Join(filepath.Dir(configPath), "detent.db.lock"), RunCommand: servicepkg.CommandRunner(run)})
+	if err != nil {
+		return nil
+	}
+	status, err := runner.Status(ctx)
+	if err != nil || status.ServiceManager != servicepkg.ManagerSystemd {
+		return nil
+	}
+	args := []string{"show", status.Service, "--property=LoadState", "--property=After", "--property=Wants"}
+	if status.ServiceScope == "user" {
+		args = append([]string{"--user"}, args...)
+	}
+	output, err := run(ctx, "systemctl", args...)
+	check := doctorCheck{Name: "Systemd network ordering", Status: doctorWarn, Hint: "Add After=network-online.target and Wants=network-online.target to the installed unit's [Unit] section, then run systemctl daemon-reload (with --user for a user service)."}
+	if err != nil {
+		check.Detail = "Cannot inspect systemd network dependencies: " + err.Error()
+		return []doctorCheck{check}
+	}
+	properties := map[string]string{}
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			properties[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	if properties["LoadState"] == "not-found" {
+		return nil
+	}
+	var missing []string
+	for _, key := range []string{"After", "Wants"} {
+		found := false
+		for _, target := range strings.Fields(properties[key]) {
+			if target == "network-online.target" {
+				found = true
+			}
+		}
+		if !found {
+			missing = append(missing, key+"=network-online.target")
+		}
+	}
+	if len(missing) == 0 {
+		check.Status = doctorOK
+		check.Detail = "Installed systemd unit orders startup after and requests network-online.target"
+		check.Hint = ""
+	} else {
+		check.Detail = "Installed systemd unit lacks " + strings.Join(missing, " and ")
+	}
+	return []doctorCheck{check}
+}

--- a/internal/cli/doctor_systemd_test.go
+++ b/internal/cli/doctor_systemd_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	servicepkg "github.com/digitaldrywood/detent/internal/service"
+)
+
+func TestDoctorSystemdNetwork(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name, scope, output string
+		err                 error
+		want                doctorStatus
+		absent              bool
+	}{
+		{name: "ordered user unit", scope: "user", output: "LoadState=loaded\nAfter=basic.target network-online.target\nWants=network-online.target", want: doctorOK},
+		{name: "missing both", scope: "system", output: "LoadState=loaded\nAfter=basic.target", want: doctorWarn},
+		{name: "missing wants", output: "After=network-online.target", want: doctorWarn},
+		{name: "missing after", output: "Wants=network-online.target", want: doctorWarn},
+		{name: "similar target", output: "After=network-online.target.other\nWants=network-online.target", want: doctorWarn},
+		{name: "not installed", output: "LoadState=not-found", absent: true},
+		{name: "inspection failure", err: errors.New("systemctl unavailable"), want: doctorWarn},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &serviceRunnerStub{status: servicepkg.Status{ServiceManager: servicepkg.ManagerSystemd, ServiceScope: tt.scope, Service: "detent.service"}}
+			checks := checkDoctorSystemdNetwork(t.Context(), "/tmp/detent/global.yaml", options{service: serviceFactoryFor(runner), runCommand: func(_ context.Context, name string, args ...string) (string, error) {
+				want := []string{"show", "detent.service", "--property=LoadState", "--property=After", "--property=Wants"}
+				if tt.scope == "user" {
+					want = append([]string{"--user"}, want...)
+				}
+				if name != "systemctl" || !reflect.DeepEqual(args, want) {
+					t.Fatalf("command = %s %v", name, args)
+				}
+				return tt.output, tt.err
+			}})
+			if tt.absent {
+				if len(checks) != 0 {
+					t.Fatalf("checks = %v", checks)
+				}
+				return
+			}
+			if len(checks) != 1 || checks[0].Status != tt.want {
+				t.Fatalf("checks = %v", checks)
+			}
+			if tt.want == doctorWarn && !strings.Contains(checks[0].Hint, "network-online.target") {
+				t.Fatalf("missing repair hint: %v", checks)
+			}
+		})
+	}
+}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -343,6 +344,9 @@ func resolveRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, de
 func resolveConfiguredGitHubToken(ctx context.Context, token string, deps runtimeDeps) (RuntimeSecret, error) {
 	if githubTokenSentinel(token) {
 		resolved, err := deps.ghAuthToken(ctx)
+		if ctx.Err() != nil {
+			return RuntimeSecret{}, ctx.Err()
+		}
 		if err != nil {
 			cause := fmt.Errorf("resolve github_token via gh auth token: %w", err)
 			return RuntimeSecret{}, GitHubAuthError(hintedError(cause, cause.Error(), githubAuthHint, ghAuthLoginCommand))
@@ -568,6 +572,49 @@ func runtimeDepsFromOptions(opts options) runtimeDeps {
 		lookupEnv:   opts.lookupEnv,
 		ghAuthToken: opts.ghAuthToken,
 	}.withDefaults()
+}
+
+// bootRuntimeDeps retries local credential acquisition only during startup.
+// Doctor, reloads, and other one-shot callers retain bounded command execution.
+func bootRuntimeDeps(opts options) runtimeDeps {
+	deps := runtimeDepsFromOptions(opts)
+	resolve := deps.ghAuthToken
+	deps.ghAuthToken = func(ctx context.Context) (string, error) {
+		return retryBootGitHubToken(ctx, resolve, waitBootGitHubToken)
+	}
+	return deps
+}
+
+func retryBootGitHubToken(ctx context.Context, resolve func(context.Context) (string, error), wait func(context.Context, time.Duration) error) (string, error) {
+	delay := 5 * time.Second
+	for attempt := 1; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		token, err := resolve(ctx)
+		if err == nil && strings.TrimSpace(token) != "" {
+			return token, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		slog.WarnContext(ctx, "GitHub credentials unavailable; retrying startup", "attempt", attempt, "retry_in", delay)
+		if err := wait(ctx, delay); err != nil {
+			return "", err
+		}
+		delay = min(delay*2, time.Minute)
+	}
+}
+
+func waitBootGitHubToken(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func defaultGHAuthToken(ctx context.Context) (string, error) {

--- a/internal/cli/runtime_boot_test.go
+++ b/internal/cli/runtime_boot_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRetryBootGitHubToken(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		failures int
+		empty    bool
+		cancel   bool
+	}{
+		{name: "ready"},
+		{name: "keyring unavailable", failures: 7},
+		{name: "empty token", failures: 2, empty: true},
+		{name: "shutdown during wait", failures: 1, cancel: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			calls := 0
+			var delays []time.Duration
+			token, err := retryBootGitHubToken(ctx, func(context.Context) (string, error) {
+				calls++
+				if calls <= tt.failures {
+					if tt.empty {
+						return "  ", nil
+					}
+					return "", errors.New("secret service unavailable")
+				}
+				return "test-token", nil
+			}, func(ctx context.Context, delay time.Duration) error {
+				delays = append(delays, delay)
+				if tt.cancel {
+					cancel()
+					return ctx.Err()
+				}
+				return nil
+			})
+			if tt.cancel {
+				if !errors.Is(err, context.Canceled) || calls != 1 {
+					t.Fatalf("token=%q err=%v calls=%d", token, err, calls)
+				}
+				return
+			}
+			if err != nil || token != "test-token" || calls != tt.failures+1 {
+				t.Fatalf("token=%q err=%v calls=%d", token, err, calls)
+			}
+			var want []time.Duration
+			delay := 5 * time.Second
+			for range tt.failures {
+				want = append(want, delay)
+				delay = min(delay*2, time.Minute)
+			}
+			if !reflect.DeepEqual(delays, want) {
+				t.Fatalf("delays=%v want %v", delays, want)
+			}
+		})
+	}
+}
+
+func TestWaitBootGitHubToken(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "elapsed", true: "canceled"}[canceled], func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			delay := time.Duration(0)
+			if canceled {
+				cancel()
+				delay = time.Hour
+			}
+			err := waitBootGitHubToken(ctx, delay)
+			if canceled && !errors.Is(err, context.Canceled) || !canceled && err != nil {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
+func TestBootRuntimeCredentialsCancellation(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		canceledBefore bool
+	}{
+		{name: "before resolution", canceledBefore: true},
+		{name: "during resolution"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			calls := 0
+			opts := defaultOptions()
+			opts.ghAuthToken = func(context.Context) (string, error) {
+				calls++
+				cancel()
+				return "", errors.New("keyring unavailable")
+			}
+			if tt.canceledBefore {
+				cancel()
+			}
+			_, err := resolveConfiguredGitHubToken(ctx, "gh", bootRuntimeDeps(opts))
+			if !errors.Is(err, context.Canceled) || errors.Is(err, ErrGitHubAuth) {
+				t.Fatalf("error=%v", err)
+			}
+			want := 1
+			if tt.canceledBefore {
+				want = 0
+			}
+			if calls != want {
+				t.Fatalf("calls=%d want %d", calls, want)
+			}
+		})
+	}
+}

--- a/internal/connector/github/auth_network_test.go
+++ b/internal/connector/github/auth_network_test.go
@@ -28,6 +28,7 @@ func TestAuthenticateNetworkClassification(t *testing.T) {
 		{name: "DNS unavailable", transportErr: &net.DNSError{Err: "no such host", Name: "api.github.com"}, want: ErrTransient, retryable: true},
 		{name: "dial unavailable", transportErr: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("network unreachable")}, want: ErrTransient, retryable: true},
 		{name: "unauthorized", status: http.StatusUnauthorized, want: ErrAuthenticationFailed},
+		{name: "forbidden", status: http.StatusForbidden, want: ErrAuthenticationFailed},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := NewConnector(Config{APIKey: "test-token", ProjectSlug: "PVT_1", HTTPClient: &http.Client{Transport: authPreflightTransport(func(*http.Request) (*http.Response, error) {

--- a/internal/connector/github/auth_network_test.go
+++ b/internal/connector/github/auth_network_test.go
@@ -1,0 +1,48 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+type authPreflightTransport func(*http.Request) (*http.Response, error)
+
+func (f authPreflightTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestAuthenticateNetworkClassification(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name         string
+		transportErr error
+		status       int
+		want         error
+		retryable    bool
+	}{
+		{name: "DNS unavailable", transportErr: &net.DNSError{Err: "no such host", Name: "api.github.com"}, want: ErrTransient, retryable: true},
+		{name: "dial unavailable", transportErr: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("network unreachable")}, want: ErrTransient, retryable: true},
+		{name: "unauthorized", status: http.StatusUnauthorized, want: ErrAuthenticationFailed},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewConnector(Config{APIKey: "test-token", ProjectSlug: "PVT_1", HTTPClient: &http.Client{Transport: authPreflightTransport(func(*http.Request) (*http.Response, error) {
+				if tt.transportErr != nil {
+					return nil, tt.transportErr
+				}
+				return &http.Response{StatusCode: tt.status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"message":"Bad credentials"}`))}, nil
+			})}, GHToken: func(context.Context, string) (string, error) { return "", errors.New("no fallback token") }})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = c.Authenticate(t.Context())
+			if !errors.Is(err, tt.want) || connector.IsRetryable(err) != tt.retryable {
+				t.Fatalf("Authenticate = %v; retryable = %v", err, connector.IsRetryable(err))
+			}
+		})
+	}
+}

--- a/internal/service/systemd_test.go
+++ b/internal/service/systemd_test.go
@@ -21,6 +21,8 @@ func TestSystemdUnitIncludesRuntimeAndShutdownSettings(t *testing.T) {
 	for _, want := range []string{
 		`ExecStart="/opt/Detent Release/detent" "--config" "/home/user/.config/detent/global.yaml" "--port" "4100" "--headless"`,
 		`Environment="PATH=/home/user/bin:/usr/bin:%%h/bin"`,
+		"After=network-online.target",
+		"Wants=network-online.target",
 		"Restart=on-failure",
 		"KillMode=control-group",
 		"WantedBy=default.target",


### PR DESCRIPTION
## Summary

- When startup cannot acquire `github_token: gh` because the keyring or host services are unavailable, keep the process alive and retry after 5 seconds, doubling to 60 seconds until success or shutdown. Emit one warning per failed attempt without exposing credential subprocess output. One-shot commands, including doctor --startup-preflight used by manual and automatic updates, retain prompt error reporting.
- Preserve existing connector DNS/dial transient classification and HTTP 401/403 authentication rejection. Current startup has no HTTP auth preflight; this targets local credential resolution confirmed by the operator's Detent 0.110.0 evidence.
- Keep generated systemd network-online ordering covered by tests, add doctor diagnostics for missing effective ordering, and document host-specific secret-service dependencies and unattended unlock requirements.

This replaces fatal startup credential handling with the bounded retry explicitly requested in the operator reply. There is no existing in-process acquisition retry to consolidate; this prevents repeated whole-process restarts without adding a separate recovery subsystem or configuration key.

Fixes #2461

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: CLI diagnostics only.

## Test Plan

- [x] Focused table-driven CLI, service, and connector tests: retry success/backoff cap, empty credentials, shutdown cancellation, one-shot credential errors, one-shot update preflight failures, effective systemd ordering, and DNS/dial versus HTTP 401/403 classification.
- [x] `make check` passed: build, lint, vet, nil analysis, race tests, 80.6% coverage, and configured package/file coverage floors. Final review-fix gate: queue wait 35ms; execution 9m35s. The earlier #2462 failure did not recur.
