### PR TITLE
fix(workspace): bound scans without lsof fork overhead

### DIFF
--- a/.detent/skills/supervised-lsof-scan-overhead.md
+++ b/.detent/skills/supervised-lsof-scan-overhead.md
@@ -1,25 +1,32 @@
 ---
 name: supervised-lsof-scan-overhead
-description: Diagnose macOS lsof scan deadlines caused by per-operation fork overhead on hosts with many processes.
+description: Diagnose macOS lsof deadlines caused by global filesystem lookup and fork overhead, then consolidate timeout ownership at the command boundary.
 when_to_use: Use when workspace scans return zero output at their deadline while lsof starts normally and focused cleanup tests are slow or fail under concurrent validation.
 ---
 
 Compare the exact scanner command alone and under bounded concurrency. Record
-elapsed time, exit status, output bytes, and process count. Keep probes read-only
-and their samples in the attempt temporary directory.
+elapsed time, exit status, output bytes, and host process/mount counts. Keep probes
+read-only and samples in the attempt temporary directory.
 
-Sample a running lsof process. Repeated fork/read/wait stacks indicate a different
-failure from a binary stuck in dyld startup. Compare one variable at a time:
-name resolution, recursive directory traversal, then lsof's internal timeout
-machinery. Do not attribute zero output alone to any of these causes.
+Sample a running lsof process. Repeated fork/read/wait stacks differ from a binary
+stuck in dyld startup. Compare name resolution, recursive traversal, PID selection,
+and internal timeout machinery separately. A single-PID scan that remains slow
+rules out attributing the overhead solely to process enumeration.
 
-When fork-based timeout overhead is established and the caller already owns a
-bounded command context, evaluate lsof `-O` to remove the duplicate timeout layer.
-This option disables lsof's protection against blocking kernel operations; retain
-the caller's cancellation and deadline, and do not apply it to unsupervised scans.
-Do not increase deadlines or broaden process selection to compensate for overhead.
+Do not apply `-O` alone: it removes lsof's protection from blocking operations,
+and CommandContext's kill does not guarantee Wait returns. A replacement timeout
+owner must return on cancellation independently of Wait, while retaining an
+asynchronous waiter to reap the command. Give the waiter sole ownership of output
+buffers; cancellation must not inspect buffers while output goroutines write.
+Use a buffered result channel so a late completion cannot block after return.
 
-Verify root and nested working directories are selected, sibling-prefix paths are
-excluded, and a process outside the workspace holding an open workspace file
-survives cleanup. Retain lock-release and command-cancellation assertions. Run the
-focused race tables and the full repository gate on the final contents.
+Avoid apparently simpler alternatives without checking their call paths. `-b`
+prints ambiguous filenames (control-byte caret notation can collide with literal
+characters). Native PROC_PIDVNODEPATHINFO also calls filesystem stat internally,
+so it does not by itself establish an interruptible deadline.
+
+Reproduce blocked Wait deterministically with a descendant that retains stdout
+and stderr after its parent exits. Cancel while those pipes remain open and prove
+the scanner returns before releasing the descendant. Retain ownership, observer
+survival, lock-release, error and output tests; run focused race tables and the
+full repository gate after the final change.

--- a/.detent/skills/supervised-lsof-scan-overhead.md
+++ b/.detent/skills/supervised-lsof-scan-overhead.md
@@ -1,0 +1,25 @@
+---
+name: supervised-lsof-scan-overhead
+description: Diagnose macOS lsof scan deadlines caused by per-operation fork overhead on hosts with many processes.
+when_to_use: Use when workspace scans return zero output at their deadline while lsof starts normally and focused cleanup tests are slow or fail under concurrent validation.
+---
+
+Compare the exact scanner command alone and under bounded concurrency. Record
+elapsed time, exit status, output bytes, and process count. Keep probes read-only
+and their samples in the attempt temporary directory.
+
+Sample a running lsof process. Repeated fork/read/wait stacks indicate a different
+failure from a binary stuck in dyld startup. Compare one variable at a time:
+name resolution, recursive directory traversal, then lsof's internal timeout
+machinery. Do not attribute zero output alone to any of these causes.
+
+When fork-based timeout overhead is established and the caller already owns a
+bounded command context, evaluate lsof `-O` to remove the duplicate timeout layer.
+This option disables lsof's protection against blocking kernel operations; retain
+the caller's cancellation and deadline, and do not apply it to unsupervised scans.
+Do not increase deadlines or broaden process selection to compensate for overhead.
+
+Verify root and nested working directories are selected, sibling-prefix paths are
+excluded, and a process outside the workspace holding an open workspace file
+survives cleanup. Retain lock-release and command-cancellation assertions. Run the
+focused race tables and the full repository gate on the final contents.

--- a/internal/runner/duration_limit_unix_test.go
+++ b/internal/runner/duration_limit_unix_test.go
@@ -72,7 +72,7 @@ func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
 					if runtime.GOOS != "linux" {
 						probeCtx, cancelProbe := context.WithTimeout(ctx, 5*time.Second)
 						probeStarted := time.Now()
-						output, err := exec.CommandContext(probeCtx, "lsof", "-FpcRfn", "+D", path).CombinedOutput()
+						output, err := exec.CommandContext(probeCtx, "lsof", "-O", "-FpcRfn", "+D", path).CombinedOutput()
 						t.Logf("workspace file matches before reap: elapsed=%s context_error=%v error=%v\n%s", time.Since(probeStarted), probeCtx.Err(), err, output)
 						cancelProbe()
 					}

--- a/internal/runner/duration_limit_unix_test.go
+++ b/internal/runner/duration_limit_unix_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -69,13 +68,7 @@ func TestRunnerTerminalSessionReapsEscapedWorkspaceProcess(t *testing.T) {
 					t.Logf("workspace holder: pid=%d cwd=%q lock=%q; outside holder: pid=%d cwd=%q lock=%q",
 						backend.command.Process.Pid, backend.command.Dir, lockPath,
 						observer.command.Process.Pid, observer.command.Dir, observerLockPath)
-					if runtime.GOOS != "linux" {
-						probeCtx, cancelProbe := context.WithTimeout(ctx, 5*time.Second)
-						probeStarted := time.Now()
-						output, err := exec.CommandContext(probeCtx, "lsof", "-O", "-FpcRfn", "+D", path).CombinedOutput()
-						t.Logf("workspace file matches before reap: elapsed=%s context_error=%v error=%v\n%s", time.Since(probeStarted), probeCtx.Err(), err, output)
-						cancelProbe()
-					}
+
 					reapStarted := time.Now()
 					reaped, reapErr = workspace.ReapProcesses(ctx, path, grace)
 					t.Logf("workspace reap: elapsed=%s count=%d error=%v holder_exited=%t observer_exited=%t",

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -216,7 +216,10 @@ func linuxWorkspaceProcessIDs(path string) ([]int, error) {
 }
 
 func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
-	cmd := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-t", "+D", path) // #nosec G204 -- the workspace path is passed as an lsof argument without a shell.
+	// Detent owns the scan deadline through CommandContext. Disable lsof's
+	// per-operation fork timeout machinery: on macOS its overhead grows with
+	// the host process count and can exhaust that deadline before any output.
+	cmd := exec.CommandContext(ctx, "lsof", "-O", "-a", "-d", "cwd", "-t", "+D", path) // #nosec G204 -- the workspace path is passed as an lsof argument without a shell.
 	output, err := workspaceScanOutput(ctx, cmd)
 	if err != nil && len(output) == 0 {
 		var exitErr *exec.ExitError

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -217,8 +217,8 @@ func linuxWorkspaceProcessIDs(path string) ([]int, error) {
 
 func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
 	// Detent owns the scan deadline through CommandContext. Disable lsof's
-	// per-operation fork timeout machinery: on macOS its overhead grows with
-	// the host process count and can exhaust that deadline before any output.
+	// per-operation fork timeout machinery: on macOS its global filesystem
+	// lookup overhead can exhaust that deadline before any output.
 	cmd := exec.CommandContext(ctx, "lsof", "-O", "-a", "-d", "cwd", "-t", "+D", path) // #nosec G204 -- the workspace path is passed as an lsof argument without a shell.
 	output, err := workspaceScanOutput(ctx, cmd)
 	if err != nil && len(output) == 0 {
@@ -281,16 +281,38 @@ func workspaceScanOutput(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
 			startElapsed, hasDeadline, remaining, contextAtStart, fmt.Sprint(ctx.Err()), startErr)
 	}
 	waiting := time.Now()
-	err := cmd.Wait()
-	if err != nil {
+	// Keep the existing context deadline authoritative even if Wait is stuck
+	// in an uninterruptible kernel operation or draining inherited pipes.
+	// The waiter still owns and eventually reaps the command. Only it reads
+	// the buffers, so cancellation can return without racing output writers.
+	type result struct {
+		output []byte
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		err := cmd.Wait()
 		var exitErr *exec.ExitError
 		if captureStderr && errors.As(err, &exitErr) {
 			exitErr.Stderr = []byte(stderr.String())
 		}
-		return output.Bytes(), fmt.Errorf("workspace scan command stage=wait pid=%d start_elapsed=%s wait_elapsed=%s deadline_set=%t deadline_remaining=%s context_at_start=%v context_error=%v output_bytes=%d: %w",
-			cmd.Process.Pid, startElapsed, time.Since(waiting), hasDeadline, remaining, contextAtStart, fmt.Sprint(ctx.Err()), output.Len(), err)
+		done <- result{output: output.Bytes(), err: err}
+	}()
+	var completed result
+	select {
+	case completed = <-done:
+	case <-ctx.Done():
+		completed.err = ctx.Err()
 	}
-	return output.Bytes(), nil
+	err := completed.err
+	if ctx.Err() != nil {
+		err = errors.Join(err, ctx.Err())
+	}
+	if err != nil {
+		return completed.output, fmt.Errorf("workspace scan command stage=wait pid=%d start_elapsed=%s wait_elapsed=%s deadline_set=%t deadline_remaining=%s context_at_start=%v context_error=%v output_bytes=%d: %w",
+			cmd.Process.Pid, startElapsed, time.Since(waiting), hasDeadline, remaining, contextAtStart, fmt.Sprint(ctx.Err()), len(completed.output), err)
+	}
+	return completed.output, nil
 }
 
 func pathInside(root string, path string) bool {

--- a/internal/workspace/process_unix_test.go
+++ b/internal/workspace/process_unix_test.go
@@ -309,3 +309,55 @@ func TestWorkspaceScanOutputStderr(t *testing.T) {
 		})
 	}
 }
+
+func TestLsofWorkspaceProcessIDs(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof is unavailable")
+	}
+	root := t.TempDir()
+	tests := []struct {
+		name string
+		cwd  string
+		want bool
+	}{
+		{name: "workspace root", cwd: root, want: true},
+		{name: "nested directory with spaces", cwd: filepath.Join(root, "nested directory"), want: true},
+		{name: "sibling prefix", cwd: root + "-outside"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.MkdirAll(tt.cwd, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if !tt.want {
+				t.Cleanup(func() { _ = os.Remove(tt.cwd) })
+			}
+			cmd := exec.CommandContext(t.Context(), "sleep", "60")
+			cmd.Dir = tt.cwd
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+			})
+			canonical, err := canonicalExistingPath(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			pids, err := lsofWorkspaceProcessIDs(ctx, canonical)
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, pid := range pids {
+				found = found || pid == cmd.Process.Pid
+			}
+			if found != tt.want {
+				t.Fatalf("scanner includes process %d = %t, want %t (pids=%v)", cmd.Process.Pid, found, tt.want, pids)
+			}
+		})
+	}
+}

--- a/internal/workspace/process_unix_test.go
+++ b/internal/workspace/process_unix_test.go
@@ -3,6 +3,7 @@
 package workspace
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -249,10 +250,10 @@ func TestWorkspaceScanOutput(t *testing.T) {
 				}
 			}
 			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) != tt.wantExit {
+			if !tt.cancelReady && errors.As(err, &exitErr) != tt.wantExit {
 				t.Errorf("exit error = %v, want %t", err, tt.wantExit)
 			}
-			if tt.cancelBefore && !errors.Is(err, context.Canceled) {
+			if (tt.cancelBefore || tt.cancelReady) && !errors.Is(err, context.Canceled) {
 				t.Errorf("cancellation identity lost: %v", err)
 			}
 			if tt.expired && !errors.Is(err, context.DeadlineExceeded) {
@@ -357,6 +358,62 @@ func TestLsofWorkspaceProcessIDs(t *testing.T) {
 			}
 			if found != tt.want {
 				t.Fatalf("scanner includes process %d = %t, want %t (pids=%v)", cmd.Process.Pid, found, tt.want, pids)
+			}
+		})
+	}
+}
+
+func TestWorkspaceScanOutputCancellationWithInheritedPipes(t *testing.T) {
+	for _, command := range []string{
+		"sleep 60 & echo $! >&3; wait",
+		"sleep 60 & echo $! >&3; exit 0",
+	} {
+		t.Run(command, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			reader, writer, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer reader.Close()
+			defer writer.Close()
+			if err := reader.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.CommandContext(ctx, "sh", "-c", command)
+			cmd.ExtraFiles = []*os.File{writer}
+			done := make(chan error, 1)
+			go func() {
+				_, err := workspaceScanOutput(ctx, cmd)
+				done <- err
+			}()
+			line, err := bufio.NewReader(reader).ReadString('\n')
+			if err != nil {
+				t.Fatal(err)
+			}
+			pid, err := strconv.Atoi(strings.TrimSpace(line))
+			if err != nil {
+				t.Fatal(err)
+			}
+			received := false
+			defer func() {
+				_ = syscall.Kill(pid, syscall.SIGKILL)
+				if !received {
+					<-done // Join before closing descriptors even on the regression failure.
+				}
+			}()
+			cancel()
+			select {
+			case err := <-done:
+				received = true
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("scan error = %v, want context cancellation", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("scan cancellation waited for inherited pipes to close")
+			}
+			if err := syscall.Kill(pid, 0); err != nil {
+				t.Fatalf("pipe holder exited before test released it: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

macOS workspace cleanup could exhaust its scan deadline before `lsof` produced output. Twelve concurrent production scans reproduced five-second deadlines with zero stdout. Sampling showed repeated fork/read/wait overhead; guarded single-PID scans still took 3.1s, showing that global filesystem lookup overhead persisted even with narrow process selection.

Consolidate timeout ownership at the existing command boundary. Use `lsof -O` to remove per-operation fork timeouts, and let scan cancellation return independently of `cmd.Wait`, which can stall in kernel operations or while draining inherited pipes. A buffered asynchronous waiter retains responsibility for reaping the command and exclusively reads its output buffers; cancellation returns an error without claiming successful cleanup or racing the writers. Deadlines, process selection, signaling, observer survival, and lock-release assertions remain unchanged. Remove the obsolete broad diagnostic scan from the runner test.

Single scans fell from 3.56s to approximately 0.50s. All twelve concurrent `-O` scans completed in approximately 3.32s. New pipe-holding regression tests fail against the original synchronous waiter and pass with the revised command boundary. Include a diagnostic skill draft.

Fixes #2462

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Reproduce five-second, zero-output scan deadlines with twelve concurrent baseline commands; compare the same commands with `-O`.
- [x] Confirm the inherited-pipe cancellation table fails against the original waiter in both cases and passes with the revision.
- [x] Three focused race repetitions covering scan output/errors/cancellation, real-lsof selection, escaped workspace process cleanup, observer survival, and Claude Code backend routes.
- [x] `make check` — final native macOS gate passed in 7m49s; 80.6% total coverage and all package/file floors passed.
