### PR TITLE
fix(merge): align native queue ownership with gates

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1543,7 +1543,7 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 	out := make([]connector.Issue, 0, len(candidates))
 	selectedByState := map[string]int{}
 	for _, issue := range candidates {
-		if nativeMergeQueueOwnsIssue(state, issue) || mergeFairnessBlocks(state, stickyID, issue, now) {
+		if nativeMergeQueueOwnsIssue(state, issue, o.cfg) || mergeFairnessBlocks(state, stickyID, issue, now) {
 			continue
 		}
 		issueID := strings.TrimSpace(issue.ID)

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -449,7 +449,7 @@ func (o *Orchestrator) dispatchIssueWithMergeControl(
 	allowMergeControl bool,
 	retryState *Retry,
 ) dispatchIssueOutcome {
-	if mergeWorkerIssue(issue) && nativeMergeQueueOwnsIssue(state, issue) {
+	if mergeWorkerIssue(issue) && nativeMergeQueueOwnsIssue(state, issue, o.cfg) {
 		return dispatchIssueOutcome{reason: dispatchSkipInactiveState, waitReason: "waiting for native merge queue"}
 	}
 	if err := o.checkDispatchPolicy(ctx); err != nil {

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -131,7 +131,10 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			applyNativeMergeQueueEntry(out, issueID, state.nativeMergeQueueEntries[issueID].Entry)
 			continue
 		}
-		if !nativeMergeQueueCandidate(candidate, o.cfg) {
+		if reason := nativeMergeQueueExclusion(state, candidate, o.cfg); reason != "" {
+			if o.logger != nil {
+				o.logger.Info("merge_worker_native_queue_excluded", mergeWorkerLogAttrs(candidate, "reason", reason)...)
+			}
 			continue
 		}
 		if status.AdmissionLimit <= 0 || status.Depth >= status.AdmissionLimit {
@@ -163,32 +166,44 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 	return out
 }
 
-func nativeMergeQueueCandidate(issue connector.Issue, cfg Config) bool {
+func nativeMergeQueueCandidate(state *State, issue connector.Issue, cfg Config) bool {
+	return nativeMergeQueueExclusion(state, issue, cfg) == ""
+}
+
+func nativeMergeQueueExclusion(state *State, issue connector.Issue, cfg Config) string {
 	if strings.TrimSpace(issue.ID) == "" || issue.PullRequest == nil {
-		return false
+		return "missing issue or pull request"
 	}
-	if gateRequiresPullRequest(cfg.AutoPromote.Gate) {
-		return false
+	effective := gate.Effective(cfg.AutoPromote.Gate)
+	if effective.SecurityAudit.Enabled {
+		return "security audit requires worker validation"
 	}
-	if gate.Effective(cfg.AutoPromote.Gate).SecurityAudit.Enabled {
-		return false
+	if gateRequiresPullRequest(effective) {
+		if effective.Kind != gate.KindCommand {
+			return "gate requires worker validation"
+		}
+		if state == nil {
+			return "command gate has no current passed evidence"
+		}
+		required := state.RequiredGates[issue.ID]
+		if required.State != "passed" || required.PRNumber != issue.PullRequest.Number || required.HeadSHA != strings.TrimSpace(issue.PullRequest.HeadSHA) || required.BaseSHA != strings.TrimSpace(issue.PullRequest.BaseSHA) {
+			return "command gate has no current passed evidence"
+		}
 	}
 	if _, revoked := mergeApprovalLabelRevoked(issue, cfg); revoked {
-		return false
+		return "merge approval revoked"
 	}
 	pullRequest := issue.PullRequest
 	if pullRequestHydrationBlocksProgress(pullRequest) {
-		return false
+		return "pull request hydration unavailable"
 	}
 	if _, revoked := mergeCITriggerLabelRevoked(issue, cfg); revoked {
-		return false
+		return "CI trigger approval revoked"
 	}
-	return normalizePullRequestState(pullRequest.State) == "open" &&
-		!pullRequest.Draft &&
-		strings.TrimSpace(pullRequest.HeadSHA) != "" &&
-		mergeWorkerCIGreen(pullRequest.CIStatus) &&
-		pullRequestRepository(issue) != "" &&
-		pullRequestNumber(issue) > 0
+	if normalizePullRequestState(pullRequest.State) != "open" || pullRequest.Draft || strings.TrimSpace(pullRequest.HeadSHA) == "" || !mergeWorkerCIGreen(pullRequest.CIStatus) || pullRequestRepository(issue) == "" || pullRequestNumber(issue) <= 0 {
+		return "pull request is not ready for queue admission"
+	}
+	return ""
 }
 
 func nativeMergeQueueRepositoryKey(issue connector.Issue) string {
@@ -308,10 +323,10 @@ func (o *Orchestrator) logNativeMergeQueueFailure(issue connector.Issue, reason 
 }
 
 // nativeMergeQueueOwnsIssue keeps provider-owned work out of every worker path,
-// including snapshots that omit the queue entry. Availability expires only when
-// a fresh provider inspection confirms the queue is unavailable.
-func nativeMergeQueueOwnsIssue(state *State, issue connector.Issue) bool {
-	return nativeMergeQueueHasEntry(state, issue) || state != nil && state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)].Available
+// including snapshots that omit the queue entry. Repository availability owns
+// only candidates; excluded projects retain their existing worker path.
+func nativeMergeQueueOwnsIssue(state *State, issue connector.Issue, cfg Config) bool {
+	return nativeMergeQueueHasEntry(state, issue) || state != nil && state.nativeMergeQueueRepos[nativeMergeQueueRepositoryKey(issue)].Available && nativeMergeQueueCandidate(state, issue, cfg)
 }
 
 func nativeMergeQueueHasEntry(state *State, issue connector.Issue) bool {

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -131,6 +131,14 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			applyNativeMergeQueueEntry(out, issueID, state.nativeMergeQueueEntries[issueID].Entry)
 			continue
 		}
+		if gate.Effective(o.cfg.AutoPromote.Gate).Kind == gate.KindCommand {
+			// Review findings and activity can change without a new head/base.
+			// Evaluate the same snapshot that is about to enter the queue.
+			if state.RequiredGates == nil {
+				state.RequiredGates = make(map[string]telemetry.RequiredGate)
+			}
+			state.RequiredGates[issueID] = o.requiredGateEvidence(ctx, state, candidate, now)
+		}
 		if reason := nativeMergeQueueExclusion(state, candidate, o.cfg); reason != "" {
 			if o.logger != nil {
 				o.logger.Info("merge_worker_native_queue_excluded", mergeWorkerLogAttrs(candidate, "reason", reason)...)

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestDelegateNativeMergeQueueIssuesEnqueuesGreenTrainWithoutWorkerDispatch(t *testing.T) {
@@ -344,7 +345,7 @@ func TestDelegateNativeMergeQueueIssuesRefreshesQueueOwnership(t *testing.T) {
 				t.Fatalf("queue mutations: enqueue=%v dequeue=%v", tracker.enqueued, tracker.dequeued)
 			}
 			for _, issue := range second {
-				if got := nativeMergeQueueOwnsIssue(&state, issue); got != (tt.wantWorkers == 0) {
+				if got := nativeMergeQueueOwnsIssue(&state, issue, cfg); got != (tt.wantWorkers == 0) {
 					t.Fatalf("%s ownership=%t", issue.ID, got)
 				}
 			}
@@ -448,7 +449,7 @@ func TestNativeMergeQueueCandidate(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(&issue)
 			}
-			if got := nativeMergeQueueCandidate(issue, nativeMergeQueueTestConfig(Config{})); got != tt.want {
+			if got := nativeMergeQueueCandidate(nil, issue, nativeMergeQueueTestConfig(Config{})); got != tt.want {
 				t.Fatalf("nativeMergeQueueCandidate() = %t, want %t", got, tt.want)
 			}
 		})
@@ -463,7 +464,7 @@ func TestNativeMergeQueueCandidateRejectsNonAtomicSecurityAuditGate(t *testing.T
 		Kind:          gate.KindArtifact,
 		SecurityAudit: gate.SecurityAuditConfig{Enabled: true},
 	}}})
-	if nativeMergeQueueCandidate(issue, cfg) {
+	if nativeMergeQueueCandidate(nil, issue, cfg) {
 		t.Fatal("nativeMergeQueueCandidate() = true, want programmatic exact-head merge")
 	}
 }
@@ -868,7 +869,7 @@ func TestNativeMergeQueueWorkerHandoff(t *testing.T) {
 			if tracker.inspections != 1 {
 				t.Fatalf("inspections=%d", tracker.inspections)
 			}
-			if !nativeMergeQueueOwnsIssue(&state, issue) {
+			if !nativeMergeQueueOwnsIssue(&state, issue, cfg) {
 				t.Fatal("lost queue ownership")
 			}
 			if strings.Contains(logs.String(), "merge_worker_retry_exhausted") {
@@ -963,6 +964,94 @@ func TestNativeMergeQueueUnadmittedFailureReconciles(t *testing.T) {
 			}
 			if len(tracker.enqueued) != 0 || len(tracker.merges) != 0 || len(tracker.dequeued) != 0 {
 				t.Fatal("unexpected queue or merge mutation")
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueProjectRouting(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		audit     bool
+		passed    bool
+		wantQueue bool
+	}{
+		{"passed command", false, true, true},
+		{"pending command", false, false, false},
+		{"security audit", true, true, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := nativeMergeQueueTestIssue(2465, "success")
+			issue.PullRequest.BaseSHA = "base-1"
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, MaxConcurrentAgents: 1, ActiveStates: []string{"Merging"}})
+			cfg.AutoPromote.Gate.Kind = gate.KindCommand
+			cfg.AutoPromote.Gate.SecurityAudit.Enabled = tt.audit
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			var logs strings.Builder
+			orch := &Orchestrator{cfg: cfg, connector: tracker, logger: slog.New(slog.NewTextHandler(&logs, nil))}
+			orch.cfg.Project.ID = "detent"
+			orch.cfg.ServiceIdentity = "detent:detent"
+			memo := newSecurityAuditMemoryStore()
+			memo.runs = append(memo.runs, securityAuditPassingRun(issue))
+			orch.securityAuditStore = memo
+			state := newState(cfg)
+			if tt.passed {
+				state.RequiredGates = map[string]telemetry.RequiredGate{issue.ID: {State: "passed", PRNumber: issue.PullRequest.Number, HeadSHA: issue.PullRequest.HeadSHA, BaseSHA: issue.PullRequest.BaseSHA}}
+			}
+			now := time.Now()
+			issues := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			if got := len(tracker.enqueued) == 1; got != tt.wantQueue {
+				t.Errorf("enqueued=%v, want queue=%t", tracker.enqueued, tt.wantQueue)
+			}
+			workers := orch.mergeWorkerDispatchCandidates(&state, issues, now)
+			if got := len(workers) == 0; got != tt.wantQueue {
+				t.Errorf("workers=%d, want queue=%t", len(workers), tt.wantQueue)
+			}
+			if !tt.wantQueue && !strings.Contains(logs.String(), "merge_worker_native_queue_excluded") {
+				t.Error("missing exclusion log")
+			}
+			if tt.passed {
+				event := runpkg.Completion{IssueID: issue.ID, CompletedAt: now, Result: runpkg.RunResult{FinalState: runpkg.FinalStateCompleted}}
+				running := Running{Issue: issues[0], StartedAt: now}
+				if !orch.completeProgrammaticMergeWorkerResult(t.Context(), &state, event, running, issues[0]) {
+					t.Fatal("completion not handled")
+				}
+				wantMerges := 0
+				if tt.audit {
+					wantMerges = 1
+				}
+				if len(tracker.merges) != wantMerges {
+					t.Fatalf("merges=%d, want %d; logs=%s", len(tracker.merges), wantMerges, logs.String())
+				}
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueCommandGateEvidence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name   string
+		change func(*telemetry.RequiredGate)
+		want   bool
+	}{
+		{"current pass", func(*telemetry.RequiredGate) {}, true},
+		{"failed", func(g *telemetry.RequiredGate) { g.State = "failed" }, false},
+		{"old head", func(g *telemetry.RequiredGate) { g.HeadSHA = "old" }, false},
+		{"old base", func(g *telemetry.RequiredGate) { g.BaseSHA = "old" }, false},
+		{"different PR", func(g *telemetry.RequiredGate) { g.PRNumber++ }, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := nativeMergeQueueTestIssue(2465, "success")
+			cfg := nativeMergeQueueTestConfig(Config{})
+			cfg.AutoPromote.Gate.Kind = gate.KindCommand
+			state := newState(cfg)
+			evidence := telemetry.RequiredGate{State: "passed", PRNumber: issue.PullRequest.Number, HeadSHA: issue.PullRequest.HeadSHA, BaseSHA: issue.PullRequest.BaseSHA}
+			tt.change(&evidence)
+			state.RequiredGates = map[string]telemetry.RequiredGate{issue.ID: evidence}
+			if got := nativeMergeQueueCandidate(&state, issue, cfg); got != tt.want {
+				t.Fatalf("candidate=%t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -986,7 +986,11 @@ func TestNativeMergeQueueProjectRouting(t *testing.T) {
 			issue.PullRequest.BaseSHA = "base-1"
 			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, MaxConcurrentAgents: 1, ActiveStates: []string{"Merging"}})
 			cfg.AutoPromote.Gate.Kind = gate.KindCommand
+			cfg.AutoPromote.Gate.RequireAutomatedReview = new(false)
 			cfg.AutoPromote.Gate.SecurityAudit.Enabled = tt.audit
+			if !tt.passed {
+				issue.PullRequest.UnresolvedReviewThreads = []connector.PullRequestReviewThread{{}}
+			}
 			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
 			var logs strings.Builder
 			orch := &Orchestrator{cfg: cfg, connector: tracker, logger: slog.New(slog.NewTextHandler(&logs, nil))}
@@ -1046,12 +1050,51 @@ func TestNativeMergeQueueCommandGateEvidence(t *testing.T) {
 			issue := nativeMergeQueueTestIssue(2465, "success")
 			cfg := nativeMergeQueueTestConfig(Config{})
 			cfg.AutoPromote.Gate.Kind = gate.KindCommand
+			cfg.AutoPromote.Gate.RequireAutomatedReview = new(false)
 			state := newState(cfg)
 			evidence := telemetry.RequiredGate{State: "passed", PRNumber: issue.PullRequest.Number, HeadSHA: issue.PullRequest.HeadSHA, BaseSHA: issue.PullRequest.BaseSHA}
 			tt.change(&evidence)
 			state.RequiredGates = map[string]telemetry.RequiredGate{issue.ID: evidence}
 			if got := nativeMergeQueueCandidate(&state, issue, cfg); got != tt.want {
 				t.Fatalf("candidate=%t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueReevaluatesCurrentSnapshot(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		change    func(*connector.Issue, time.Time)
+		wantQueue bool
+	}{
+		{"unchanged", func(*connector.Issue, time.Time) {}, true},
+		{"new unresolved thread", func(i *connector.Issue, _ time.Time) {
+			i.PullRequest.UnresolvedReviewThreads = []connector.PullRequestReviewThread{{}}
+		}, false},
+		{"new activity", func(i *connector.Issue, now time.Time) { i.PullRequest.ActivityAt = &now }, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			issue := nativeMergeQueueTestIssue(2465, "success")
+			old := now.Add(-time.Hour)
+			issue.PullRequest.ActivityAt = &old
+			cfg := nativeMergeQueueTestConfig(Config{ActiveStates: []string{"Merging"}})
+			cfg.AutoPromote.Gate.Kind = gate.KindCommand
+			cfg.AutoPromote.Gate.RequireAutomatedReview = new(false)
+			cfg.AutoPromote.QuietDuration = time.Minute
+			tracker := &nativeMergeQueueConnector{autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}}}
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			orch.refreshRequiredGateEvidence(t.Context(), &state, []connector.Issue{issue})
+			if state.RequiredGates[issue.ID].State != "passed" {
+				t.Fatalf("initial gate=%+v", state.RequiredGates[issue.ID])
+			}
+			tt.change(&issue, now)
+			orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now)
+			if got := len(tracker.enqueued) == 1; got != tt.wantQueue {
+				t.Fatalf("enqueued=%v, want queue=%t", tracker.enqueued, tt.wantQueue)
 			}
 		})
 	}

--- a/internal/orchestrator/required_gate.go
+++ b/internal/orchestrator/required_gate.go
@@ -14,7 +14,6 @@ import (
 func (o *Orchestrator) refreshRequiredGateEvidence(ctx context.Context, state *State, issues []connector.Issue) []connector.Issue {
 	issues = cloneIssues(issues)
 	now := time.Now()
-	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
 	state.RequiredGates = make(map[string]telemetry.RequiredGate, len(issues))
 	for i, issue := range issues {
 		if issue.PullRequest == nil {
@@ -26,15 +25,20 @@ func (o *Orchestrator) refreshRequiredGateEvidence(ctx context.Context, state *S
 				issues[i] = refreshed
 			}
 		}
-		summary := AutoPromoteSummaryFromIssue(issue)
-		summary.SecurityAudit = o.securityAuditEvaluation(ctx, issue)
-		if gate.Effective(cfg.Gate).Validator.Enabled {
-			summary.Validator, _, _ = o.validatorStageResult(ctx, issue)
-		}
-		summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(state, issue.ID, cfg, now)
-		state.RequiredGates[issue.ID] = requiredGateFromSummary(issue, summary, cfg, now)
+		state.RequiredGates[issue.ID] = o.requiredGateEvidence(ctx, state, issue, now)
 	}
 	return issues
+}
+
+func (o *Orchestrator) requiredGateEvidence(ctx context.Context, state *State, issue connector.Issue, now time.Time) telemetry.RequiredGate {
+	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	summary := AutoPromoteSummaryFromIssue(issue)
+	summary.SecurityAudit = o.securityAuditEvaluation(ctx, issue)
+	if gate.Effective(cfg.Gate).Validator.Enabled {
+		summary.Validator, _, _ = o.validatorStageResult(ctx, issue)
+	}
+	summary.AutomatedReviewWaitExpired = autoPromoteReviewWaitExpired(state, issue.ID, cfg, now)
+	return requiredGateFromSummary(issue, summary, cfg, now)
 }
 
 func requiredGateFromSummary(issue connector.Issue, summary AutoPromoteSummary, cfg AutoPromoteConfig, now time.Time) telemetry.RequiredGate {

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -162,7 +162,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if o.handleGitHubMonitorCompletion(ctx, state, event, running) {
 		return
 	}
-	if mergeWorkerIssue(running.Issue) && nativeMergeQueueOwnsIssue(state, running.Issue) {
+	if mergeWorkerIssue(running.Issue) && nativeMergeQueueOwnsIssue(state, running.Issue, o.cfg) {
 		o.completeNativeMergeQueueWorker(ctx, state, event, running, running.Issue)
 		return
 	}
@@ -1440,7 +1440,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	if state != nil && state.Draining {
 		return false
 	}
-	if nativeMergeQueueOwnsIssue(state, issue) {
+	if nativeMergeQueueOwnsIssue(state, issue, o.cfg) {
 		o.completeNativeMergeQueueWorker(ctx, state, event, running, issue)
 		return true
 	}
@@ -1462,7 +1462,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		return true
 	}
 	issue = refreshedIssue
-	if nativeMergeQueueOwnsIssue(state, issue) {
+	if nativeMergeQueueOwnsIssue(state, issue, o.cfg) {
 		o.completeNativeMergeQueueWorker(ctx, state, event, running, issue)
 		return true
 	}


### PR DESCRIPTION
## Summary

- Fix Merging issues stranded when repository queue availability claimed ownership but project gates excluded queue admission. Queue delegation and all worker ownership checks now share candidacy; existing queue entries retain provider ownership.
- Admit command gates with passed evidence evaluated against the exact queue-admission snapshot, including review and activity changes that preserve PR/head/base. Preserve security-audit and revoked-approval exclusions, and log an INFO explanation when an available queue excludes an issue.
- Consolidates the conflicting ownership mechanism without adding recovery paths, configuration, or persistent reason codes.

Fixes #2465

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] No visual changes requiring browser verification.

## Test Plan

- [x] Reproduced command-gate enqueue failure and excluded-project worker starvation before the fix.
- [x] Focused native queue tests: passed command gate enqueues with zero programmatic merges; security-audit exclusion completes through the worker after audit validation; stale gate evidence and newer unresolved-thread/quiet-window snapshots rejected; existing queue ownership/removal cases preserved.
- [x] `make check` passed after review fixes in 7m34s; 80.6% coverage and all package/file floors passed.
- [ ] Live: deploy the fixed binary, enable the repository merge_queue rule, and observe one queued PR merge. This worker cannot replace/restart the live instance under its isolation contract.
