### PR TITLE
test(cli): isolate Claude route process scans

### DIFF
--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -178,6 +178,14 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 }
 
 func TestBuildRunnerSupportsClaudeCodeBackendRoutes(t *testing.T) {
+	// The Claude stub leaves no orphan processes. Keep its route assertions
+	// independent of host-wide lsof scans, which can time out on busy macOS hosts.
+	scanDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(scanDir, "lsof"), []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
+		t.Fatalf("write empty workspace scan stub: %v", err)
+	}
+	t.Setenv("PATH", scanDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	source := initRunnerSourceRepo(t)
 	claudeCommand, argsPath, stdinPath := writeRunnerClaudeStub(t)
 	sessionStore := &runnerSessionStore{sessionID: 833}


### PR DESCRIPTION
## Summary

- Isolate the Claude Code backend route test from host `lsof` scanning with a per-test executable that reports no orphan processes. PATH is restored by `t.Setenv`; all backend routing, stream, identity, usage, and argument assertions remain.
- Reproduced the reported revision failing during workspace process reaping with a scan timeout. The blank-project messages came from a separate validation test. A deliberately failing inherited `lsof` also breaks the original test and passes after isolation.

Fixes #2468

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: test-only change.

## Test Plan

- [x] `go test ./internal/cli -race -count=5` (407.894s).
- [x] Focused route race test, count=5, with an inherited `lsof` that exits 2 (passes after isolation; failed before).
- [x] `make check` (80.6% coverage; all package/file floors passed).
