### PR TITLE
fix(github): drop rateLimit from merge queue mutations

### DIFF
--- a/internal/connector/github/merge_queue.go
+++ b/internal/connector/github/merge_queue.go
@@ -56,7 +56,6 @@ mutation DetentEnqueuePullRequest($pullRequestId: ID!, $expectedHeadOid: GitObje
       }
     }
   }
-  rateLimit { limit used remaining cost resetAt }
 }`
 
 const dequeuePullRequestMutation = `
@@ -64,7 +63,6 @@ mutation DetentDequeuePullRequest($mergeQueueEntryId: ID!) {
   dequeuePullRequest(input: {id: $mergeQueueEntryId}) {
     mergeQueueEntry { id }
   }
-  rateLimit { limit used remaining cost resetAt }
 }`
 
 type mergeQueueEntryNode struct {

--- a/internal/connector/github/merge_queue_mutation_test.go
+++ b/internal/connector/github/merge_queue_mutation_test.go
@@ -1,0 +1,27 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMergeQueueMutationsOmitRootRateLimit(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		document string
+	}{
+		{"enqueue", enqueuePullRequestMutation},
+		{"dequeue", dequeuePullRequestMutation},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if !strings.HasPrefix(strings.TrimSpace(tt.document), "mutation ") {
+				t.Fatalf("document is not a mutation: %q", tt.document)
+			}
+			if strings.Contains(tt.document, "rateLimit") {
+				t.Fatalf("mutation selects rateLimit, which GitHub rejects on the Mutation type:\n%s", tt.document)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Remove the root-level `rateLimit` selection from `enqueuePullRequestMutation` and `dequeuePullRequestMutation`; the Mutation type has no such field and GitHub rejected every enqueue with `Field 'rateLimit' doesn't exist on type 'Mutation'`.
- Guard test that the queue mutation documents never select `rateLimit`.

Fixes #2472

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/connector/github -run 'MergeQueue|Enqueue|Dequeue|RateLimit'`
- [x] `make check` passes
- [ ] Live: enqueue succeeds on this repository with the merge_queue rule enabled.

https://claude.ai/code/session_01PK61Vw2Gr7EMRGtKohPXrw