### PR TITLE
fix(merge): recognize queue removals by enqueue time

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -152,6 +152,7 @@ type PullRequestMergeQueue interface {
 
 type PullRequestMergeQueueStatus struct {
 	RemovalObserved   bool
+	RemovedAt         *time.Time
 	RemovedHeadSHA    string
 	RemovalReason     string
 	Depth             int

--- a/internal/connector/github/merge_queue.go
+++ b/internal/connector/github/merge_queue.go
@@ -18,7 +18,7 @@ query DetentInspectPullRequestMergeQueue($owner: String!, $name: String!, $numbe
       headRefOid
       baseRefName
       timelineItems(last: 1, itemTypes: [REMOVED_FROM_MERGE_QUEUE_EVENT]) {
-        nodes { ... on RemovedFromMergeQueueEvent { beforeCommit { oid } reason } }
+        nodes { ... on RemovedFromMergeQueueEvent { beforeCommit { oid } reason createdAt } }
       }
       mergeQueue { url entries { totalCount } configuration { maximumEntriesToBuild } }
       mergeQueueEntry {
@@ -98,7 +98,8 @@ func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue conn
 				BaseRefName   string `json:"baseRefName"`
 				TimelineItems struct {
 					Nodes []struct {
-						Reason       string `json:"reason"`
+						CreatedAt    *time.Time `json:"createdAt"`
+						Reason       string     `json:"reason"`
 						BeforeCommit struct {
 							OID string `json:"oid"`
 						} `json:"beforeCommit"`
@@ -147,6 +148,7 @@ func (c *Connector) InspectPullRequestMergeQueue(ctx context.Context, issue conn
 	}
 	if len(pullRequest.TimelineItems.Nodes) > 0 {
 		status.RemovalObserved = true
+		status.RemovedAt = cloneGitHubTime(pullRequest.TimelineItems.Nodes[0].CreatedAt)
 		status.RemovalReason = strings.TrimSpace(pullRequest.TimelineItems.Nodes[0].Reason)
 		status.RemovedHeadSHA = strings.TrimSpace(pullRequest.TimelineItems.Nodes[0].BeforeCommit.OID)
 	}

--- a/internal/connector/github/merge_queue_test.go
+++ b/internal/connector/github/merge_queue_test.go
@@ -36,7 +36,7 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 			name:        "rejected queue entry",
 			response:    mergeQueueFixture(t, "rejected_entry.json"),
 			available:   true,
-			wantRemoval: "Required check build failed",
+			wantRemoval: "failed_checks",
 		},
 		{
 			name:      "recognizes existing queue entry",
@@ -77,6 +77,11 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 			if status.RemovalReason != tt.wantRemoval {
 				t.Fatalf("removal reason = %q, want %q", status.RemovalReason, tt.wantRemoval)
 			}
+			if tt.wantRemoval != "" {
+				if status.RemovedAt == nil || !status.RemovedAt.Equal(*mergeQueueTestTime("2026-09-11T03:50:00Z")) || status.RemovedHeadSHA == status.HeadSHA {
+					t.Fatalf("removal timestamp or non-head identity lost: %+v", status)
+				}
+			}
 			if !reflect.DeepEqual(status.Entry, tt.wantEntry) {
 				t.Fatalf("entry = %#v, want %#v", status.Entry, tt.wantEntry)
 			}
@@ -85,7 +90,7 @@ func TestConnectorInspectPullRequestMergeQueue(t *testing.T) {
 			}
 			request := server.requests()[0]
 			query := request["query"].(string)
-			if !strings.Contains(query, "configuration { maximumEntriesToBuild }") || strings.Contains(query, "mergeStateStatus") {
+			if !strings.Contains(query, "createdAt") || !strings.Contains(query, "configuration { maximumEntriesToBuild }") || strings.Contains(query, "mergeStateStatus") {
 				t.Fatalf("query = %q, want mergeQueue capability field without mergeStateStatus", query)
 			}
 			variables := request["variables"].(map[string]any)

--- a/internal/connector/github/testdata/merge_queue/rejected_entry.json
+++ b/internal/connector/github/testdata/merge_queue/rejected_entry.json
@@ -14,14 +14,15 @@
           }
         },
         "mergeQueueEntry": null,
-        "headRefOid": "removed-head",
+        "headRefOid": "b339d71",
         "timelineItems": {
           "nodes": [
             {
               "beforeCommit": {
                 "oid": "removed-head"
               },
-              "reason": "Required check build failed"
+              "reason": "failed_checks",
+              "createdAt": "2026-09-11T03:50:00Z"
             }
           ]
         }

--- a/internal/orchestrator/merge_queue.go
+++ b/internal/orchestrator/merge_queue.go
@@ -70,7 +70,7 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 		if repositoryKnown && now.Sub(repository.CheckedAt) >= nativeMergeQueueRepositoryExpiry {
 			repositoryKnown = false
 		}
-		_, previouslyQueued := state.nativeMergeQueueEntries[issueID]
+		previous, previouslyQueued := state.nativeMergeQueueEntries[issueID]
 		if repositoryKnown && !repository.Available && !previouslyQueued && candidate.PullRequest.MergeQueueEntry == nil {
 			continue
 		}
@@ -99,7 +99,13 @@ func (o *Orchestrator) delegateNativeMergeQueueIssues(
 			o.logNativeMergeQueueDelegated(candidate, *status.Entry, "observed")
 			continue
 		}
-		if status.RemovalObserved && (strings.TrimSpace(status.RemovedHeadSHA) == "" || strings.TrimSpace(status.RemovedHeadSHA) == strings.TrimSpace(status.HeadSHA)) {
+		removalApplies := status.RemovalObserved && (strings.TrimSpace(status.RemovedHeadSHA) == "" || strings.TrimSpace(status.RemovedHeadSHA) == strings.TrimSpace(status.HeadSHA))
+		if previouslyQueued && previous.Entry.EnqueuedAt != nil {
+			// beforeCommit can identify a merge-group commit rather than the PR head.
+			// A known enqueue time identifies which queue attempt the removal ended.
+			removalApplies = status.RemovalObserved && status.RemovedAt != nil && status.RemovedAt.After(*previous.Entry.EnqueuedAt)
+		}
+		if removalApplies {
 			state.nativeMergeQueueDeferred[issueID] = struct{}{}
 			reason := strings.TrimSpace(status.RemovalReason)
 			if reason == "" {
@@ -218,6 +224,9 @@ func pruneNativeMergeQueueEntries(state *State, issues []connector.Issue) {
 }
 
 func cacheNativeMergeQueueEntry(state *State, issueID string, entry connector.PullRequestMergeQueueEntry, now time.Time) {
+	if entry.EnqueuedAt == nil {
+		entry.EnqueuedAt = &now
+	}
 	state.nativeMergeQueueEntries[issueID] = nativeMergeQueueEntry{
 		Entry:     clonePullRequestMergeQueueEntry(entry),
 		CheckedAt: now,

--- a/internal/orchestrator/merge_queue_test.go
+++ b/internal/orchestrator/merge_queue_test.go
@@ -499,6 +499,7 @@ type nativeMergeQueueConnector struct {
 	admissionLimit *int
 	removedHeads   map[string]string
 	removalReason  string
+	removedAt      *time.Time
 	dequeueErr     error
 	statusErr      error
 	inspections    int
@@ -530,6 +531,7 @@ func (c *nativeMergeQueueConnector) InspectPullRequestMergeQueue(_ context.Conte
 	status := connector.PullRequestMergeQueueStatus{Available: available, AdmissionLimit: limit, Depth: len(c.enqueued)}
 	status.RemovedHeadSHA, status.RemovalObserved = c.removedHeads[issue.ID]
 	status.RemovalReason = c.removalReason
+	status.RemovedAt = c.removedAt
 	if issue.PullRequest != nil {
 		status.HeadSHA = issue.PullRequest.HeadSHA
 	}
@@ -963,6 +965,68 @@ func TestNativeMergeQueueUnadmittedFailureReconciles(t *testing.T) {
 			}
 			if len(tracker.enqueued) != 0 || len(tracker.merges) != 0 || len(tracker.dequeued) != 0 {
 				t.Fatal("unexpected queue or merge mutation")
+			}
+		})
+	}
+}
+
+func TestNativeMergeQueueRemovalOrdering(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 11, 3, 50, 0, 0, time.UTC)
+	for _, tt := range []struct {
+		name         string
+		offset       time.Duration
+		missingTime  bool
+		sameHead     bool
+		localEnqueue bool
+		wantRework   bool
+	}{
+		{name: "newer removal with non-head beforeCommit", offset: time.Minute, wantRework: true},
+		{name: "older removal with non-head beforeCommit", offset: -time.Minute},
+		{name: "older removal even with matching head", offset: -time.Minute, sameHead: true},
+		{name: "equal timestamp", sameHead: true},
+		{name: "missing removal timestamp", missingTime: true, sameHead: true},
+		{name: "local enqueue timestamp", offset: time.Minute, localEnqueue: true, wantRework: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := nativeMergeQueueTestIssue(2474, "success")
+			removedHead := "merge-group-before-commit"
+			if tt.sameHead {
+				removedHead = issue.PullRequest.HeadSHA
+			}
+			tracker := &nativeMergeQueueConnector{
+				removedHeads:                  map[string]string{issue.ID: removedHead},
+				removalReason:                 "failed_checks",
+				removedAt:                     timePointer(now.Add(tt.offset)),
+				autoPromoteTickMergeConnector: &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{}},
+			}
+			if tt.missingTime {
+				tracker.removedAt = nil
+			}
+			cfg := nativeMergeQueueTestConfig(Config{MergeFastPathEnabled: true, ActiveStates: []string{"Merging", "Rework"}})
+			recorder := &workflowMetricsRecorderSpy{}
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workflowMetrics: recorder}
+			state := newState(cfg)
+			entry := connector.PullRequestMergeQueueEntry{ID: "cached-entry", State: "QUEUED"}
+			if !tt.localEnqueue {
+				entry.EnqueuedAt = timePointer(now)
+			}
+			cacheNativeMergeQueueEntry(&state, issue.ID, entry, now)
+			got := orch.delegateNativeMergeQueueIssues(t.Context(), &state, []connector.Issue{issue}, now.Add(3*time.Minute))
+			if len(tracker.enqueued) != 0 {
+				t.Fatalf("unexpected enqueue: %v", tracker.enqueued)
+			}
+			_, cached := state.nativeMergeQueueEntries[issue.ID]
+			if tt.wantRework {
+				if got[0].State != "Rework" || cached || got[0].PullRequest.MergeQueueEntry != nil {
+					t.Fatalf("removal not applied: issue=%+v cached=%v", got[0], cached)
+				}
+				if len(recorder.events) != 2 || recorder.events[1].Reason != "failed_checks" {
+					t.Fatalf("provider reason missing: %+v", recorder.events)
+				}
+			} else if got[0].State != "Merging" || !cached || got[0].PullRequest.MergeQueueEntry == nil || got[0].PullRequest.MergeQueueEntry.ID != entry.ID {
+				t.Fatalf("cached entry not retained: issue=%+v cached=%v", got[0], cached)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Recognize a GitHub merge-queue removal after the cached enqueue time even when beforeCommit differs from the PR head. Route the issue to Rework with GitHub's reason, clear the cached entry, and avoid re-enqueue.
- Retain cached entries when there is no newer removal, including older events for the same head. Record a local timestamp when the provider omits enqueuedAt.
- Replace the existing SHA-only decision for known queue entries; no new recovery mechanism is introduced. Preserve the existing identity fallback when enqueue history is unavailable.

Fixes #2474

## UI Surface Contract

- [x] N/A: no UI surface or layout changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes requiring browser verification.

## Test Plan

- [x] Reproduced mismatched-beforeCommit removal remaining in Merging before the fix.
- [x] Focused table-driven queue tests: newer, older, equal, missing timestamps, local enqueue fallback, reason propagation, cache retention/clearing, and no re-enqueue.
- [x] Connector fixture verifies removal timestamp and non-head beforeCommit.
- [x] `make check`
