### PR TITLE
fix(codex): bound and diagnose startup stalls

### DIFF
--- a/.detent/skills/startup-failure-cleanup-attribution.md
+++ b/.detent/skills/startup-failure-cleanup-attribution.md
@@ -1,0 +1,15 @@
+---
+name: startup-failure-cleanup-attribution
+description: Separate a subprocess startup fault from evidence and errors produced by cleanup.
+when_to_use: Use when startup and transport-close deadlines are joined, or a killed process is being interpreted as the cause of a startup stall.
+---
+
+# Separate startup failure from cleanup
+
+- Correlate recorded stage-start, failure, termination and process-exit times. An exit observed after cleanup starts cannot by itself establish the original cause.
+- Snapshot safe process state before cleanup and again afterward. Use cumulative message counts, receive queue depth, decode status and stderr byte counts; never capture request parameters, prompts, credentials or tool payloads in generic diagnostics.
+- Record process exit when wait returns, separately from completion of pipe drainers. Distinguish a termination request from confirmed transport completion.
+- Classify retry behavior using the primary typed operation error. Keep cleanup errors in the chain for inspection, but do not let a cleanup deadline replace a provider rejection, EOF or other primary failure. Preserve explicit operator and parent cancellation precedence.
+- Reproduce with a helper that acknowledges initialization, consumes the startup request, publishes an independent readiness signal and stops responding. Expire startup and close contexts explicitly, then assert process reaping and drainer completion. Use real time only as a deadlock guard.
+- Test unrelated notifications against an absolute response deadline; a renewable per-message timeout does not bound startup.
+- Preserve uncertainty when historical evidence lacks process samples or remote response details. Document a bounded recurrence capture and cause-specific remedies rather than inferring deadlock, OOM or outage from a timeout alone.

--- a/docs/diagnosis.md
+++ b/docs/diagnosis.md
@@ -34,6 +34,94 @@ Read the served build directly from the live page:
 curl -fsS http://127.0.0.1:4000/ | rg -o 'data-detent-served-version="[^"]+"' -m 1
 ```
 
+## Codex startup stalls
+
+A `backend_startup_timeout` identifies a missed handshake deadline, not a
+provider outage. The `codex app-server startup failed` log event contains
+payload-free `startup` evidence even for admission runs. Issue attempts also
+persist it in `work_attempts.worker_metadata_json.backend_startup`.
+
+Compare `before_cleanup` with `process` (after cleanup). An absent
+`before_cleanup` means the older runtime or transport did not capture it;
+do not interpret absent counters as observed zeroes. Counters are cumulative
+for that app-server process, including initialization and optional account
+checks. They contain no methods, arguments, credentials, prompts, or stderr
+contents.
+
+| Observation | Interpretation and next check |
+|---|---|
+| `ready: false` | Initialization did not complete. Check executable/version, spawn errors, and local process pressure before investigating thread configuration. |
+| `ready: true`, sent messages advance, received messages do not | Bytes were written to the provider pipe, but no additional complete RPC frame was decoded. This does not prove the provider consumed the request. Capture a bounded process sample to distinguish local blocking from remote I/O. |
+| `receive_queue_depth` grows or `read_failed: true` | Investigate RPC decoding or consumer backpressure. A nonempty queue alone does not establish deadlock. |
+| `stderr_bytes` grows | The provider emitted diagnostics. Inspect them locally under the operator's privacy rules; the startup event intentionally records only the count. |
+| `before_cleanup.exit_observed: true` | The process exited before Detent began closing the transport. Check its exit status and launch environment. |
+| Exit observed only after `termination_requested: true` | Detent requested termination during cleanup. A resulting `signal: killed` is not evidence of an earlier crash or OOM. |
+| `exit_observed: true`, `cleanup_complete: false` | Process exit was observed, but the transport wait/drainers have not finished. Check inherited pipes and descendants. `cleanup_complete` records transport completion, not successful termination of every descendant. |
+
+Response waits use one `read_timeout_ms` deadline across notifications and
+server requests. Streaming turns retain their separate activity/stall rules.
+A close timeout is retained in the error chain, but cannot turn an explicit
+startup rejection or EOF into a startup timeout for capacity classification.
+Retries retain workspace state and the existing startup failure breaker.
+Admission startup failures retain their error in failed-run records instead
+of becoming generic capacity deferrals. Quota and provider-overload errors
+continue to defer admission without marking model output malformed.
+
+For a recurrence, capture only the affected worker, without restarting or
+signaling the live Detent service:
+
+1. Record the attempt/session IDs, startup event, executable version, and
+   failed stage. Correlate the PID with `codex_sessions.worker_pid` and
+   `worker_started_at` and verify its executable and start time before sampling;
+   a stale PID may belong to a different process.
+2. During the stall, take a one-second macOS `sample <worker-pid> 1 1 -file
+   "$TMPDIR/codex-startup.sample"` with an outer five-second command deadline.
+   Record `ps -p <worker-pid> -o pid,ppid,lstart,state,%cpu,rss` alongside
+   host memory/CPU pressure. Keep the raw sample private; report only relevant
+   stack symbols and aggregate metrics. Existing worker concurrency and free
+   disk space cannot exclude memory pressure or per-process blocking.
+3. Reproduce `initialize`, `initialized`, and `thread/start` in an isolated
+   app-server process with an absolute temporary workspace, no prompt or
+   `turn/start`, a fixed request deadline, and guaranteed process-group cleanup.
+   Match the installed protocol schema and runtime model/config. Compare a
+   minimal Codex home with the configured plugins, hooks, and skills restored
+   one category at a time. Keep credentials local and never print RPC payloads.
+4. For launchd-only failures, compare an isolated temporary launch agent with
+   a direct process. A matching TCC denial or blocking filesystem stack supports
+   fixing access to that particular skill/config path; a successful direct
+   launch alone does not. Do not mutate operator-owned links during diagnosis.
+5. Apply a remedy only to the established cause: correct a rejected startup
+   setting; remove or repair the isolated failing plugin/hook; repair the proven
+   launchd access restriction; reduce spawn pressure when correlated resource
+   evidence supports it; or use the provider's recovery guidance when remote
+   response/connection evidence establishes an outage. Preserve existing work
+   and let the existing instance breaker limit repeated pre-turn failures. Do not increase the
+   timeout or restart the service to substitute for diagnosis.
+
+### September 9, 2026 incident (#2376)
+
+Read-only recorded history shows attempts 4959, 4960, and 4961 initialized
+within 533–791 ms, then spent 5000–5001 ms waiting for `thread/start`. Attempt
+4964 initialized within 338 ms and still failed after 30000 ms. All four
+recorded one concurrent startup, with 8–10 active workers, and exited with
+`signal: killed` after a further close deadline. Sessions 5844–5846 and 5849
+were subsequently recorded as already exited by worker cleanup. Admission
+session 5848 failed during the same interval and was also reaped.
+Its admission run 9529 (00:45:00–00:46:10 UTC) instead recorded `deferred`,
+`agent_backend_capacity`, and no error text. That loss of startup failure
+attribution is reproduced by the admission regression and corrected here.
+
+Attempt 4966 began at 00:48:20 UTC and obtained a provider identity around
+00:49, before the unsuccessful timeout trial was reverted around 00:50.
+The unpushed workspace commit was preserved across the failed retries.
+The incident therefore establishes intermittent post-initialization silence
+and bounded termination, not a cause or a timeout-setting remedy. The recorded
+history lacks pre-cleanup I/O counters and process samples, so it cannot
+distinguish provider deadlock, configuration/plugin I/O, resource pressure, or
+external service failure retroactively. The notification deadline renewal and
+cleanup-error misclassification regressions reproduce independently; neither
+is claimed as the cause of these four silent waits.
+
 ## Ready-to-paste SQLite queries
 
 These queries default to a rolling 24-hour window. Replace `'-24 hours'` or

--- a/internal/admission/manager.go
+++ b/internal/admission/manager.go
@@ -21,6 +21,7 @@ import (
 
 	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
 	"github.com/digitaldrywood/detent/internal/agentoverride"
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/dispatchpriority"
@@ -551,6 +552,19 @@ type malformedEvaluation struct {
 	output     []byte
 }
 
+type startupEvaluationError struct {
+	kind string
+	err  error
+}
+
+func (e startupEvaluationError) Error() string {
+	return "agent backend " + e.kind
+}
+
+func (e startupEvaluationError) Unwrap() error {
+	return e.err
+}
+
 func (m *Manager) evaluateCandidate(
 	ctx context.Context,
 	settings Settings,
@@ -567,6 +581,9 @@ func (m *Manager) evaluateCandidate(
 		AgentToolHandler: collector.handle,
 	})
 	if err != nil {
+		if capacityErr, ok := backendcapacity.As(err); ok && backendcapacity.IsStartupFailureKind(capacityErr.Details.Kind) {
+			return AgentEvaluation{}, nil, "", startupEvaluationError{kind: strings.TrimSpace(capacityErr.Details.Kind), err: err}
+		}
 		if runner.IsCapacityError(err) {
 			return AgentEvaluation{}, nil, "agent_backend_capacity", nil
 		}

--- a/internal/admission/manager_test.go
+++ b/internal/admission/manager_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/activehours"
 	admissionmodel "github.com/digitaldrywood/detent/internal/admission/model"
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/local"
@@ -3381,34 +3382,71 @@ func TestManagerBoundsVaryingMalformedAdmissionOutputs(t *testing.T) {
 
 func TestManagerRecoversAfterRunnerErrors(t *testing.T) {
 	t.Parallel()
+	for _, kind := range []string{"authentication", backendcapacity.StartupTimeoutKind, backendcapacity.StartupFailureKind, "usage_limit_exceeded", "server_overloaded"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			now := time.Date(2026, 9, 4, 12, 50, 0, 0, time.UTC)
+			issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
+			tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
+			wantErr := errors.New("backend authentication failed")
+			deferred := kind == "usage_limit_exceeded" || kind == "server_overloaded"
+			if kind != "authentication" {
+				details := backendcapacity.Details{Type: backendcapacity.ErrorTypeTransientOverload, Kind: kind}
+				if kind == "usage_limit_exceeded" {
+					details.Type = backendcapacity.ErrorTypeUsageLimit
+				}
+				if !deferred {
+					details.Startup = &backendcapacity.StartupEvidence{Stage: "thread/start"}
+				}
+				wantErr = backendcapacity.NewError(backendcapacity.Scope{BackendKind: "codex"}, details, errors.New("private backend output"))
+			}
+			agent := &recoveringAdmissionRunner{errorsRemaining: 4, err: wantErr}
+			backend := openManagerTestStore(t)
+			settings := admissionTestSettings(tracker, agent)
+			settings.Scheduler = scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 1})
+			manager := newAdmissionTestManager(
+				t,
+				settings,
+				backend,
+				func() time.Time { return now },
+			)
 
-	now := time.Date(2026, 9, 4, 12, 50, 0, 0, time.UTC)
-	issue := admissionIssueFixture("issue-1", "DD-1", 1, now)
-	tracker := memory.New(memory.Config{Issues: []connector.Issue{issue}, Stateful: true})
-	wantErr := errors.New("backend authentication failed")
-	agent := &recoveringAdmissionRunner{errorsRemaining: 4, err: wantErr}
-	backend := openManagerTestStore(t)
-	manager := newAdmissionTestManager(
-		t,
-		admissionTestSettings(tracker, agent),
-		backend,
-		func() time.Time { return now },
-	)
+			for attempt := 1; attempt <= 4; attempt++ {
+				result, err := manager.RunOnce(t.Context())
+				if deferred {
+					if err != nil || result.DeferredReason != "agent_backend_capacity" {
+						t.Fatalf("RunOnce() capacity deferral = %#v, %v", result, err)
+					}
+				} else if !errors.Is(err, wantErr) || result.DeferredReason != "" {
+					t.Fatalf("RunOnce() attempt %d = %#v, %v", attempt, result, err)
+				}
+				if len(result.Malformed) != 0 {
+					t.Fatalf("backend error recorded as malformed output: %#v", result.Malformed)
+				}
+			}
+			result, err := manager.RunOnce(t.Context())
+			if err != nil || len(result.Proposals) != 1 || result.Proposals[0].IssueID != issue.ID || agent.calls != 5 {
+				t.Fatalf("corrected RunOnce() = %#v, %v; runner calls = %d", result, err, agent.calls)
+			}
+			runs, err := backend.RecentAdmissionRuns(t.Context(), "detent", 5)
+			wantOutcome := "failed"
+			if deferred {
+				wantOutcome = "deferred"
+			}
+			if err != nil || len(runs) != 5 || runs[1].Outcome != wantOutcome || len(runs[1].Malformed) != 0 {
+				t.Fatalf("RecentAdmissionRuns() = %#v, %v", runs, err)
+			}
+			if !deferred && !strings.Contains(runs[1].Error, "runner_error") {
+				t.Fatalf("failed run lost error: %#v", runs[1])
+			}
+			if strings.Contains(runs[1].Error, "private backend output") {
+				t.Fatalf("admission history contains private output: %s", runs[1].Error)
+			}
+			if backendcapacity.IsStartupFailureKind(kind) && !strings.Contains(runs[1].Error, kind) {
+				t.Fatalf("admission history lost startup kind: %s", runs[1].Error)
+			}
 
-	for attempt := 1; attempt <= 4; attempt++ {
-		result, err := manager.RunOnce(t.Context())
-		if !errors.Is(err, wantErr) || len(result.Malformed) != 0 {
-			t.Fatalf("RunOnce() attempt %d = %#v, %v", attempt, result, err)
-		}
-	}
-	result, err := manager.RunOnce(t.Context())
-	if err != nil || len(result.Proposals) != 1 || result.Proposals[0].IssueID != issue.ID || agent.calls != 5 {
-		t.Fatalf("corrected RunOnce() = %#v, %v; runner calls = %d", result, err, agent.calls)
-	}
-	runs, err := backend.RecentAdmissionRuns(t.Context(), "detent", 5)
-	if err != nil || len(runs) != 5 || runs[1].Outcome != "failed" || len(runs[1].Malformed) != 0 ||
-		!strings.Contains(runs[1].Error, "runner_error") {
-		t.Fatalf("RecentAdmissionRuns() = %#v, %v", runs, err)
+		})
 	}
 }
 

--- a/internal/backendcapacity/capacity.go
+++ b/internal/backendcapacity/capacity.go
@@ -76,26 +76,34 @@ type Details struct {
 }
 
 type StartupEvidence struct {
-	Stage              string                 `json:"stage"`
-	StageStartedAt     time.Time              `json:"stage_started_at"`
-	FailedAt           time.Time              `json:"failed_at"`
-	ElapsedMS          int64                  `json:"elapsed_ms"`
-	DeadlineMS         int64                  `json:"deadline_ms"`
-	WorkerHost         string                 `json:"worker_host"`
-	ConcurrentStartups int                    `json:"concurrent_startups"`
-	ActiveWorkers      int                    `json:"active_workers"`
-	Process            StartupProcessEvidence `json:"process"`
+	Stage              string                  `json:"stage"`
+	StageStartedAt     time.Time               `json:"stage_started_at"`
+	FailedAt           time.Time               `json:"failed_at"`
+	ElapsedMS          int64                   `json:"elapsed_ms"`
+	DeadlineMS         int64                   `json:"deadline_ms"`
+	WorkerHost         string                  `json:"worker_host"`
+	ConcurrentStartups int                     `json:"concurrent_startups"`
+	ActiveWorkers      int                     `json:"active_workers"`
+	Process            StartupProcessEvidence  `json:"process"`
+	BeforeCleanup      *StartupProcessEvidence `json:"before_cleanup,omitempty"`
 }
 
 type StartupProcessEvidence struct {
-	StartedAt    *time.Time `json:"started_at,omitempty"`
-	Ready        bool       `json:"ready"`
-	ReadyAt      *time.Time `json:"ready_at,omitempty"`
-	ReadyAfterMS int64      `json:"ready_after_ms,omitempty"`
-	ExitObserved bool       `json:"exit_observed"`
-	ExitedAt     *time.Time `json:"exited_at,omitempty"`
-	ExitAfterMS  int64      `json:"exit_after_ms,omitempty"`
-	ExitStatus   string     `json:"exit_status,omitempty"`
+	StartedAt            *time.Time `json:"started_at,omitempty"`
+	Ready                bool       `json:"ready"`
+	ReadyAt              *time.Time `json:"ready_at,omitempty"`
+	ReadyAfterMS         int64      `json:"ready_after_ms,omitempty"`
+	ExitObserved         bool       `json:"exit_observed"`
+	ExitedAt             *time.Time `json:"exited_at,omitempty"`
+	ExitAfterMS          int64      `json:"exit_after_ms,omitempty"`
+	ExitStatus           string     `json:"exit_status,omitempty"`
+	SentMessages         uint64     `json:"sent_messages"`
+	ReceivedMessages     uint64     `json:"received_messages"`
+	ReceiveQueueDepth    int        `json:"receive_queue_depth"`
+	ReadFailed           bool       `json:"read_failed"`
+	StderrBytes          int64      `json:"stderr_bytes"`
+	TerminationRequested bool       `json:"termination_requested"`
+	CleanupComplete      bool       `json:"cleanup_complete"`
 }
 
 type Error struct {
@@ -219,6 +227,13 @@ func cloneDetails(details Details) Details {
 		startup.Process.StartedAt = cloneTime(details.Startup.Process.StartedAt)
 		startup.Process.ReadyAt = cloneTime(details.Startup.Process.ReadyAt)
 		startup.Process.ExitedAt = cloneTime(details.Startup.Process.ExitedAt)
+		if details.Startup.BeforeCleanup != nil {
+			before := *details.Startup.BeforeCleanup
+			before.StartedAt = cloneTime(before.StartedAt)
+			before.ReadyAt = cloneTime(before.ReadyAt)
+			before.ExitedAt = cloneTime(before.ExitedAt)
+			startup.BeforeCleanup = &before
+		}
 		details.Startup = &startup
 	}
 	return details

--- a/internal/backendcapacity/capacity_test.go
+++ b/internal/backendcapacity/capacity_test.go
@@ -1,9 +1,45 @@
 package backendcapacity
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
+
+func TestStartupEvidenceSnapshotsAreIndependent(t *testing.T) {
+	t.Parallel()
+	for _, beforeCleanup := range []bool{false, true} {
+		name := "after cleanup"
+		if beforeCleanup {
+			name = "before cleanup"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			now := time.Now().UTC()
+			process := StartupProcessEvidence{StartedAt: &now, ReadyAt: &now, ExitedAt: &now, SentMessages: 3}
+			evidence := &StartupEvidence{Process: process, BeforeCleanup: &process}
+			err := NewError(Scope{}, Details{Startup: evidence}, errors.New("startup failed"))
+			first, ok := As(err)
+			if !ok {
+				t.Fatal("missing capacity error")
+			}
+			selected := &first.Details.Startup.Process
+			if beforeCleanup {
+				selected = first.Details.Startup.BeforeCleanup
+			}
+			*selected.StartedAt = time.Time{}
+			*selected.ReadyAt = time.Time{}
+			*selected.ExitedAt = time.Time{}
+			selected.SentMessages = 0
+			second, _ := As(err)
+			for _, snapshot := range []*StartupProcessEvidence{&second.Details.Startup.Process, second.Details.Startup.BeforeCleanup, &evidence.Process, evidence.BeforeCleanup} {
+				if !snapshot.StartedAt.Equal(now) || !snapshot.ReadyAt.Equal(now) || !snapshot.ExitedAt.Equal(now) || snapshot.SentMessages != 3 {
+					t.Fatalf("consumer mutated original snapshot: %+v", snapshot)
+				}
+			}
+		})
+	}
+}
 
 func TestClassify(t *testing.T) {
 	t.Parallel()

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -426,11 +426,15 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		return RunTurnResult{}, startupStageError(fmt.Errorf("start codex app-server transport: %w", err), "process/start", now, now, 0)
 	}
 	defer func() {
+		attachStartupProcessEvidenceBeforeCleanup(err, transport)
 		closeErr := closeTransport(ctx, transport, s.readTimeout)
 		if closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 		attachStartupProcessEvidence(err, transport)
+		if evidence, ok := startupEvidence(err); ok {
+			s.logger.WarnContext(context.WithoutCancel(ctx), "codex app-server startup failed", "startup", evidence)
+		}
 	}()
 
 	if identity := transportProcessIdentity(transport); identity != "" {
@@ -1086,8 +1090,17 @@ func (s *AppServer) awaitResponse(
 	elicitationState *mcpElicitationState,
 	onUpdate UpdateHandler,
 ) (json.RawMessage, error) {
+	ctx = contextOrBackground(ctx)
+	if s.readTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = s.timeoutContext(ctx, s.readTimeout, nil)
+		defer cancel()
+	}
 	for {
-		msg, err := receiveWithTimeout(ctx, transport, s.readTimeout, s.timeoutContext)
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("wait for %s response: %w", requestName(requestID), err)
+		}
+		msg, err := transport.Receive(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("wait for %s response: %w", requestName(requestID), err)
 		}

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -12,11 +12,54 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
 )
+
+func TestAppServerResponseDeadlineSurvivesNotifications(t *testing.T) {
+	t.Parallel()
+	for _, requestID := range []int{initializeRequestID, threadStartRequestID, threadResumeRequestID, turnStartRequestID} {
+		t.Run(requestName(requestID), func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				transport := &notifyingStartupTransport{requestID: requestID}
+				server, err := NewAppServer(staticTransportFactory{transport: transport}, WithReadTimeout(3*time.Second))
+				if err != nil {
+					t.Fatal(err)
+				}
+				startedAt := time.Now()
+				_, err = server.awaitResponse(t.Context(), transport, requestID, nil, nil, nil)
+				if !errors.Is(err, context.DeadlineExceeded) || time.Since(startedAt) != 3*time.Second {
+					t.Fatalf("response wait = %v after %s, want deadline after 3s", err, time.Since(startedAt))
+				}
+			})
+		})
+	}
+}
+
+type notifyingStartupTransport struct {
+	fakeAppServerTransport
+	requestID int
+	messages  int
+}
+
+func (t *notifyingStartupTransport) Receive(ctx context.Context) (Message, error) {
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return Message{}, ctx.Err()
+	case <-timer.C:
+		t.messages++
+		if t.messages == 10 {
+			return Message{ID: requestID(t.requestID), Result: json.RawMessage(`{}`)}, nil
+		}
+		return Message{Method: "private/notification", Params: json.RawMessage(`{"private":"payload"}`)}, nil
+	}
+}
 
 func TestAppServerStartupFailuresIdentifyStageAndDeadline(t *testing.T) {
 	t.Parallel()
@@ -167,6 +210,9 @@ func TestAppServerStartupFailureRetainsProcessReadinessAndExit(t *testing.T) {
 	}
 	if !evidence.Process.Ready || evidence.Process.ReadyAt == nil || !evidence.Process.ExitObserved || evidence.Process.ExitedAt == nil || evidence.Process.ExitStatus != "closed after startup failure" {
 		t.Fatalf("process evidence = %#v, want ready and exit observations", evidence.Process)
+	}
+	if evidence.BeforeCleanup == nil || !evidence.BeforeCleanup.Ready || evidence.BeforeCleanup.ExitObserved {
+		t.Fatalf("before cleanup = %+v, want initialized process without an observed exit", evidence.BeforeCleanup)
 	}
 }
 

--- a/internal/codex/capacity.go
+++ b/internal/codex/capacity.go
@@ -72,9 +72,15 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 	}
 	text := codexCapacityErrorText(err)
 	startup, hasStartupEvidence := startupEvidence(err)
+	startupCause := err
+	var startupErr *StartupError
+	if errors.As(err, &startupErr) && startupErr != nil && startupErr.Err != nil {
+		startupCause = startupErr.Err
+	}
+	startupText := strings.ToLower(codexCapacityErrorText(startupCause))
 	if hasStartupEvidence || codexStartupOperation(text) {
 		switch {
-		case errors.Is(err, context.DeadlineExceeded):
+		case errors.Is(startupCause, context.DeadlineExceeded):
 			return backendcapacity.Details{
 				Type:    backendcapacity.ErrorTypeTransientOverload,
 				Kind:    backendcapacity.StartupTimeoutKind,
@@ -82,7 +88,7 @@ func ClassifyCapacityError(err error, limits *telemetry.RateLimits, now time.Tim
 				Trigger: boundedCapacityTrigger(text),
 				Startup: startupEvidencePointer(startup, hasStartupEvidence),
 			}, true
-		case errors.Is(err, io.EOF), strings.Contains(strings.ToLower(text), "process exited"), strings.Contains(strings.ToLower(text), "start codex app-server transport"):
+		case errors.Is(startupCause, io.EOF), strings.Contains(startupText, "process exited"), strings.Contains(startupText, "start codex app-server transport"):
 			return backendcapacity.Details{
 				Type:    backendcapacity.ErrorTypeTransientOverload,
 				Kind:    backendcapacity.StartupFailureKind,

--- a/internal/codex/capacity_test.go
+++ b/internal/codex/capacity_test.go
@@ -146,6 +146,23 @@ func TestAgentBackendClassifyCapacityError(t *testing.T) {
 			err:  fmt.Errorf("run agent turn: wait for output: %w", context.DeadlineExceeded),
 		},
 		{
+			name: "startup rejection with cleanup deadline",
+			err: errors.Join(&StartupError{
+				Evidence: backendcapacity.StartupEvidence{Stage: "thread/start"},
+				Err:      &ResponseError{Request: "thread/start", Code: -32602, Message: "invalid model"},
+			}, &TransportCloseError{Err: context.DeadlineExceeded}),
+		},
+		{
+			name: "startup EOF with cleanup deadline",
+			err: errors.Join(&StartupError{
+				Evidence: backendcapacity.StartupEvidence{Stage: "thread/start"},
+				Err:      io.EOF,
+			}, &TransportCloseError{Err: context.DeadlineExceeded}),
+			want:     true,
+			wantType: backendcapacity.ErrorTypeTransientOverload,
+			wantKind: backendcapacity.StartupFailureKind,
+		},
+		{
 			name: "invalid request",
 			err:  &TurnFailedError{Status: "failed", Body: `{"error":{"type":"invalid_request_error"}}`},
 		},

--- a/internal/codex/startup.go
+++ b/internal/codex/startup.go
@@ -70,6 +70,20 @@ func attachStartupProcessEvidence(err error, transport Transport) {
 	startupErr.Evidence.Process = provider.StartupProcessEvidence()
 }
 
+func attachStartupProcessEvidenceBeforeCleanup(err error, transport Transport) {
+	if _, ok := transport.(interface {
+		StartupProcessEvidence() backendcapacity.StartupProcessEvidence
+	}); !ok {
+		return
+	}
+	attachStartupProcessEvidence(err, transport)
+	var startupErr *StartupError
+	if errors.As(err, &startupErr) && startupErr != nil {
+		before := startupErr.Evidence.Process
+		startupErr.Evidence.BeforeCleanup = &before
+	}
+}
+
 func markTransportReady(transport Transport, readyAt time.Time) {
 	marker, ok := transport.(interface {
 		MarkStartupReady(time.Time)

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -35,30 +35,35 @@ type LocalTransportFactory struct {
 }
 
 type localTransport struct {
-	cmd            *exec.Cmd
-	processGroupID int
-	workerProcess  procgroup.Identity
-	startedAt      time.Time
-	readyAt        time.Time
-	exitedAt       time.Time
-	exitStatus     string
-	stdin          io.WriteCloser
-	stdout         io.ReadCloser
-	stderr         io.ReadCloser
-	stderrTail     *tailBuffer
-	codec          *Codec
-	received       chan transportResult
-	readStop       chan struct{}
-	readDone       chan struct{}
-	stderrDone     chan error
-	done           chan struct{}
-	sendLock       chan struct{}
-	waitErr        error
-	waitMu         sync.Mutex
-	readStopOnce   sync.Once
-	closeOnce      sync.Once
-	closeErr       error
-	readDrainErr   error
+	cmd                  *exec.Cmd
+	processGroupID       int
+	workerProcess        procgroup.Identity
+	startedAt            time.Time
+	readyAt              time.Time
+	exitedAt             time.Time
+	exitStatus           string
+	stdin                io.WriteCloser
+	stdout               io.ReadCloser
+	stderr               io.ReadCloser
+	stderrTail           *tailBuffer
+	codec                *Codec
+	received             chan transportResult
+	readStop             chan struct{}
+	readDone             chan struct{}
+	stderrDone           chan error
+	done                 chan struct{}
+	sendLock             chan struct{}
+	waitErr              error
+	waitMu               sync.Mutex
+	readStopOnce         sync.Once
+	closeOnce            sync.Once
+	closeErr             error
+	readDrainErr         error
+	sentMessages         uint64
+	receivedMessages     uint64
+	readFailed           bool
+	terminationRequested bool
+	cleanupComplete      bool
 }
 
 type transportResult struct {
@@ -67,9 +72,10 @@ type transportResult struct {
 }
 
 type tailBuffer struct {
-	mu    sync.Mutex
-	limit int
-	buf   []byte
+	mu      sync.Mutex
+	limit   int
+	buf     []byte
+	written int64
 }
 
 type workerTempDirContextKey struct{}
@@ -230,7 +236,13 @@ func (t *localTransport) Send(ctx context.Context, msg Message) error {
 
 	writeDone := make(chan error, 1)
 	go func() {
-		writeDone <- t.codec.WriteMessage(msg)
+		err := t.codec.WriteMessage(msg)
+		if err == nil {
+			t.waitMu.Lock()
+			t.sentMessages++
+			t.waitMu.Unlock()
+		}
+		writeDone <- err
 	}()
 
 	select {
@@ -287,6 +299,9 @@ func (t *localTransport) Close(ctx context.Context) error {
 		return errors.Join(closeErr, waitErr)
 	case <-ctx.Done():
 		var killErr error
+		t.waitMu.Lock()
+		t.terminationRequested = true
+		t.waitMu.Unlock()
 		killErr = procgroup.TerminateTree(t.cmd, t.processGroupID)
 
 		select {
@@ -328,12 +343,23 @@ func (t *localTransport) StartupProcessEvidence() backendcapacity.StartupProcess
 		startedAt = t.workerProcess.StartedAt.UTC()
 	}
 	evidence := backendcapacity.StartupProcessEvidence{
-		StartedAt:    timePointer(startedAt),
-		Ready:        !t.readyAt.IsZero(),
-		ReadyAt:      timePointer(t.readyAt),
-		ExitObserved: !t.exitedAt.IsZero(),
-		ExitedAt:     timePointer(t.exitedAt),
-		ExitStatus:   strings.TrimSpace(t.exitStatus),
+		StartedAt:            timePointer(startedAt),
+		Ready:                !t.readyAt.IsZero(),
+		ReadyAt:              timePointer(t.readyAt),
+		ExitObserved:         !t.exitedAt.IsZero(),
+		ExitedAt:             timePointer(t.exitedAt),
+		ExitStatus:           strings.TrimSpace(t.exitStatus),
+		SentMessages:         t.sentMessages,
+		ReceivedMessages:     t.receivedMessages,
+		ReceiveQueueDepth:    len(t.received),
+		ReadFailed:           t.readFailed,
+		TerminationRequested: t.terminationRequested,
+		CleanupComplete:      t.cleanupComplete,
+	}
+	if t.stderrTail != nil {
+		t.stderrTail.mu.Lock()
+		evidence.StderrBytes = t.stderrTail.written
+		t.stderrTail.mu.Unlock()
 	}
 	if !startedAt.IsZero() && !t.readyAt.IsZero() {
 		evidence.ReadyAfterMS = max(t.readyAt.Sub(startedAt).Milliseconds(), 0)
@@ -398,6 +424,9 @@ func (t *localTransport) readLoop() {
 	for {
 		msg, err := t.codec.ReadMessage()
 		if err != nil {
+			t.waitMu.Lock()
+			t.readFailed = !errors.Is(err, io.EOF)
+			t.waitMu.Unlock()
 			if !t.readingStopped() {
 				t.publishReceived(transportResult{err: err})
 			}
@@ -406,6 +435,9 @@ func (t *localTransport) readLoop() {
 			}
 			return
 		}
+		t.waitMu.Lock()
+		t.receivedMessages++
+		t.waitMu.Unlock()
 
 		if t.readingStopped() {
 			continue
@@ -421,6 +453,12 @@ func (t *localTransport) readStderr() {
 
 func (t *localTransport) wait() {
 	err := t.cmd.Wait()
+	t.waitMu.Lock()
+	t.exitedAt = time.Now().UTC()
+	if t.cmd != nil && t.cmd.ProcessState != nil {
+		t.exitStatus = t.cmd.ProcessState.String()
+	}
+	t.waitMu.Unlock()
 	if cleanupErr := procgroup.Cleanup(t.processGroupID); cleanupErr != nil {
 		err = errors.Join(err, cleanupErr)
 	}
@@ -436,10 +474,7 @@ func (t *localTransport) wait() {
 	}
 	t.waitMu.Lock()
 	t.waitErr = err
-	t.exitedAt = time.Now().UTC()
-	if t.cmd != nil && t.cmd.ProcessState != nil {
-		t.exitStatus = t.cmd.ProcessState.String()
-	}
+	t.cleanupComplete = true
 	t.waitMu.Unlock()
 	close(t.done)
 }
@@ -547,6 +582,7 @@ func (b *tailBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.written += int64(len(p))
 	b.buf = append(b.buf, p...)
 	if len(b.buf) > b.limit {
 		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -2,11 +2,13 @@ package codex
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -15,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
 	"github.com/digitaldrywood/detent/internal/procgroup"
 )
 
@@ -28,6 +31,114 @@ const (
 	helperDrainWriteStartedSignal       = "drain write started"
 	helperDrainWriteCompletedSignal     = "drain write completed"
 )
+
+func TestStartupTimeoutCapturesCleanupEvidence(t *testing.T) {
+	t.Parallel()
+	for _, timeout := range []time.Duration{5 * time.Second, 30 * time.Second} {
+		t.Run(timeout.String(), func(t *testing.T) {
+			t.Parallel()
+			factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+				return helperCommand(ctx, "startup-stall")
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			transport, err := factory.NewTransport(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			local := transport.(*localTransport)
+			t.Cleanup(func() {
+				select {
+				case <-local.done:
+				default:
+					if err := recoverLocalTransportTest(local); err != nil {
+						t.Errorf("recover transport: %v", err)
+					}
+				}
+			})
+			controlled := &controlledStartupTransport{localTransport: local, test: t}
+			var logs bytes.Buffer
+			server, err := NewAppServer(staticTransportFactory{transport: controlled}, WithReadTimeout(timeout), WithLogger(slog.New(slog.NewJSONHandler(&logs, nil))))
+			if err != nil {
+				t.Fatal(err)
+			}
+			timers := newControlledTimeoutFactory()
+			server.timeoutContext = timers.context
+			err = runWithTimeoutExpiration(t, timers, timeout, nil, func() error {
+				_, err := server.RunTurn(t.Context(), RunTurnRequest{}, nil)
+				return err
+			})
+			if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, ErrTransportClose) {
+				t.Fatalf("startup error = %v, want startup and cleanup deadlines", err)
+			}
+			evidence, ok := startupEvidence(err)
+			if !ok || evidence.Stage != "thread/start" || evidence.DeadlineMS != timeout.Milliseconds() {
+				t.Fatalf("startup evidence = %+v", evidence)
+			}
+			before := evidence.BeforeCleanup
+			if before == nil || !before.Ready || before.ExitObserved || before.TerminationRequested || before.CleanupComplete || before.SentMessages != 3 || before.ReceivedMessages != 1 || before.StderrBytes == 0 {
+				t.Fatalf("before cleanup = %+v", before)
+			}
+			if !evidence.Process.TerminationRequested || !evidence.Process.ExitObserved || !evidence.Process.CleanupComplete {
+				t.Fatalf("after cleanup = %+v", evidence.Process)
+			}
+			encoded, encodeErr := json.Marshal(evidence)
+			if encodeErr != nil {
+				t.Fatal(encodeErr)
+			}
+			if strings.Contains(string(encoded), "private") {
+				t.Fatalf("private output in evidence: %s", encoded)
+			}
+			if strings.Contains(logs.String(), "private") || !strings.Contains(logs.String(), `"before_cleanup"`) || !strings.Contains(logs.String(), `"termination_requested":true`) {
+				t.Fatalf("startup log lacks safe diagnostics: %s", &logs)
+			}
+			details, ok := ClassifyCapacityError(err, nil, time.Now())
+			if !ok || details.Kind != backendcapacity.StartupTimeoutKind {
+				t.Fatalf("startup classification = %+v", details)
+			}
+			assertLocalTransportClosed(t, local, "startup timeout")
+		})
+	}
+}
+
+type controlledStartupTransport struct {
+	*localTransport
+	test       *testing.T
+	threadSent bool
+}
+
+func (t *controlledStartupTransport) Send(ctx context.Context, msg Message) error {
+	if msg.Method == "thread/start" {
+		t.threadSent = true
+	}
+	return t.localTransport.Send(ctx, msg)
+}
+
+func (t *controlledStartupTransport) Receive(ctx context.Context) (Message, error) {
+	if t.threadSent {
+		waitForLocalTransportStderr(t.test, t.localTransport, "private startup marker")
+		ctx.(*controlledTimeoutContext).activate()
+	}
+	return t.localTransport.Receive(ctx)
+}
+
+func (t *controlledStartupTransport) Close(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); !ok || ctx.Err() != nil {
+		t.test.Errorf("cleanup context must have a fresh bounded deadline")
+	}
+	expired := &controlledTimeoutContext{done: make(chan struct{})}
+	expired.expire(context.DeadlineExceeded)
+	err := t.localTransport.Close(expired)
+	timer := time.NewTimer(transportTestDeadlockTimeout)
+	defer timer.Stop()
+	select {
+	case <-t.done:
+	case <-timer.C:
+		t.test.Error("startup cleanup did not finish")
+	}
+	return err
+}
 
 func TestLocalTransportRoundTrip(t *testing.T) {
 	t.Parallel()
@@ -703,6 +814,13 @@ func TestLocalTransportHelperProcess(t *testing.T) {
 	case "block-send":
 		time.Sleep(time.Hour)
 	case "ignore-close":
+		time.Sleep(time.Hour)
+	case "startup-stall":
+		codec := NewCodec(os.Stdin, os.Stdout)
+		helperBackpressureRespond(codec, initializeRequestID, "initialize", json.RawMessage(`{"userAgent":"private"}`))
+		helperBackpressureExpect(codec, 0, "initialized")
+		helperBackpressureExpect(codec, threadStartRequestID, "thread/start")
+		helperBackpressureSignal("private startup marker")
 		time.Sleep(time.Hour)
 	case "exit":
 		return


### PR DESCRIPTION
## Summary

- Bound Codex response waits across unrelated notifications. A 3-second response deadline previously renewed until a response arrived at 10 seconds; startup now observes the original deadline.
- Classify the primary startup failure independently of transport cleanup deadlines. Record payload-free process and I/O evidence before and after cleanup, distinguishing observed exit, requested termination, and completed draining.
- Record admission startup errors as visible failures while preserving quota/overload deferrals and capacity release. Existing instance failure handling remains responsible for pre-turn retry attribution; no new recovery mechanism is introduced.

Historical September 9 stalls remain causally unconfirmed. The recorded 30-second failures and recovery before timeout reversion are preserved alongside bounded recurrence capture and cause-specific operator remedies. No live runtime restart or mutation was used.

Fixes #2376

## UI Surface Contract

- [x] N/A: no UI surface or layout changes.
- [x] No persistent top-of-screen messaging added.
- [x] N/A: no visual changes requiring browser verification.

## Test Plan

- [x] Current-main baseline overlays reproduce deadline renewal, cleanup misclassification, and admission startup failure suppression; patched focused race suites pass.
- [x] Controlled startup cleanup regressions cover 5s/30s settings, process reaping, drainer completion, and private-output exclusion.
- [x] Focused runner/orchestrator race tests verify host evidence, instance draining, taxonomy, and dispatch lane restoration.
- [x] Required safety fuzz: 853,738 executions passed.
- [x] `make check`: 80.7% overall coverage; admission manager exact-file coverage 92.30% (90% floor).
