### PR TITLE
ci: skip draft PRs and shard Verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags: ['v*']
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
   schedule:
@@ -21,6 +22,7 @@ concurrency:
 
 jobs:
   lint:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -53,8 +55,22 @@ jobs:
 
   verify:
     name: Verify (ubuntu-latest)
+    needs: [verify-fast, verify-race]
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 1
+    steps:
+      - name: Require every Verify job to succeed
+        env:
+          FAST_RESULT: ${{ needs.verify-fast.result }}
+          RACE_RESULT: ${{ needs.verify-race.result }}
+        run: test "$FAST_RESULT" = success && test "$RACE_RESULT" = success
+
+  verify-fast:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    name: Verify build and vet
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 
@@ -79,30 +95,48 @@ jobs:
         run: go test ./...
 
       - name: Repeat subprocess lifecycle readiness
+        if: github.event_name != 'pull_request'
         run: go test -race ./internal/claudecode ./internal/codex -run '^(TestRunTurnCancellationKillsChildProcessGroup|TestRunTurnDetectsExitedParentWithInheritedStdout|TestLocalTransportCloseKillsChildProcessGroup|TestLocalTransportReapsChildAfterParentExits)$' -count=20 -timeout=5m
 
-      - name: Race test
-        run: make test-race
-
-      - name: Upload Hub race evidence
+  verify-race:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    name: Verify race (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.6'
+          cache: false
+      - name: Cache race build and modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: verify-race-${{ runner.os }}-${{ runner.arch }}-go1.26.6-${{ matrix.shard }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            verify-race-${{ runner.os }}-${{ runner.arch }}-go1.26.6-${{ matrix.shard }}-
+      - name: Race test shard
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: bash scripts/ci-race-shard.sh "$SHARD"
+      - name: Upload race evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: hub-race-evidence
-          path: tmp/hub-race-evidence
+          name: race-evidence-${{ matrix.shard }}
+          path: tmp/*-race-evidence
           if-no-files-found: error
           retention-days: 14
 
-      - name: Upload orchestrator race evidence
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: orchestrator-race-evidence
-          path: tmp/orchestrator-race-evidence
-          if-no-files-found: warn
-          retention-days: 14
-
   test-cover:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Test Coverage
     runs-on: ubuntu-latest
     steps:
@@ -117,6 +151,7 @@ jobs:
         run: make test-cover-packages
 
   security:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Security
     runs-on: ubuntu-latest
     steps:
@@ -131,6 +166,7 @@ jobs:
         run: make security
 
   browser-visual:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Browser Visual
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags: ['v*']
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -497,7 +497,7 @@ func workflowBetween(t *testing.T, content string, startMarker string, endMarker
 func TestCIDraftAndVerifyDependencies(t *testing.T) {
 	t.Parallel()
 	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
-	if !strings.Contains(workflow, "types: [opened, synchronize, reopened, ready_for_review]") {
+	if !strings.Contains(workflow, "types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]") {
 		t.Fatal("PR CI must run on readiness and later head updates")
 	}
 	for _, job := range []string{"lint", "verify", "verify-fast", "verify-race", "test-cover", "security", "browser-visual"} {

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -28,10 +28,10 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 	},
 	{
 		name:     "Verify (ubuntu-latest)",
-		budget:   "45m",
+		budget:   "8m",
 		jobStart: "  verify:",
-		jobEnd:   "  test-cover:",
-		markers:  []string{"name: Verify (ubuntu-latest)", "runs-on: ubuntu-latest", "timeout-minutes: 45"},
+		jobEnd:   "  verify-fast:",
+		markers:  []string{"name: Verify (ubuntu-latest)", "needs: [verify-fast, verify-race]", "FAST_RESULT", "RACE_RESULT"},
 	},
 	{
 		name:     "Test Coverage",
@@ -305,9 +305,7 @@ func TestRequiredChecksDoNotUseEventDependentGreenNoops(t *testing.T) {
 	for _, check := range requiredPRStatusChecks {
 		job := workflowBetween(t, workflow, check.jobStart, check.jobEnd)
 		for _, forbidden := range []string{
-			"github.event_name",
 			"EVENT_NAME",
-			"pull_request",
 			"steps.policy.outputs",
 			"Skip ",
 			" skipped:",
@@ -338,8 +336,8 @@ func TestIntegrationChecksRunOnlyOnMainPushOrDispatch(t *testing.T) {
 		})
 	}
 	security := workflowBetween(t, workflow, "  security:", "  browser-visual:")
-	if strings.Contains(security, "    if:") || !strings.Contains(security, "make security") {
-		t.Fatal("Security must continue running on every PR")
+	if !strings.Contains(security, "github.event.pull_request.draft == false") || !strings.Contains(security, "make security") {
+		t.Fatal("Security must continue running on every ready PR")
 	}
 	reporter := workflowBetween(t, workflow, "  report-integration-failures:", "")
 	for _, marker := range []string{
@@ -494,4 +492,165 @@ func workflowBetween(t *testing.T, content string, startMarker string, endMarker
 		t.Fatalf("workflow missing end marker %q after %q", endMarker, startMarker)
 	}
 	return section[:len(startMarker)+end]
+}
+
+func TestCIDraftAndVerifyDependencies(t *testing.T) {
+	t.Parallel()
+	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
+	if !strings.Contains(workflow, "types: [opened, synchronize, reopened, ready_for_review]") {
+		t.Fatal("PR CI must run on readiness and later head updates")
+	}
+	for _, job := range []string{"lint", "verify", "verify-fast", "verify-race", "test-cover", "security", "browser-visual"} {
+		t.Run(job, func(t *testing.T) {
+			section := workflowBetween(t, workflow, "  "+job+":\n", "    steps:")
+			if !strings.Contains(section, "github.event_name != 'pull_request' || github.event.pull_request.draft == false") {
+				t.Fatal("job must skip drafts and retain non-PR triggers")
+			}
+		})
+	}
+	aggregate := workflowBetween(t, workflow, "  verify:\n", "  verify-fast:\n")
+	for _, want := range []string{"needs: [verify-fast, verify-race]", "if: always()", `test "$FAST_RESULT" = success && test "$RACE_RESULT" = success`} {
+		if !strings.Contains(aggregate, want) {
+			t.Errorf("aggregate must reject failed, cancelled and skipped dependencies: missing %q", want)
+		}
+	}
+	race := workflowBetween(t, workflow, "  verify-race:\n", "  test-cover:\n")
+	for _, want := range []string{"shard: [0, 1, 2, 3]", "fail-fast: false", "~/go/pkg/mod", "~/.cache/go-build", "hashFiles('go.sum')", `bash scripts/ci-race-shard.sh "$SHARD"`} {
+		if !strings.Contains(race, want) {
+			t.Errorf("race shards missing %q", want)
+		}
+	}
+}
+
+func TestCIRacePartition(t *testing.T) {
+	t.Parallel()
+	awk, err := exec.LookPath("awk")
+	if err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("Linux CI partition uses awk")
+		}
+		t.Fatal(err)
+	}
+	const prefix = "github.com/digitaldrywood/detent/"
+	packages := []string{prefix + "internal/hubserver", prefix + "internal/orchestrator", prefix + "internal/cli", prefix + "internal/config", prefix + "tools/testgate", "github.com/digitaldrywood/detent"}
+	partition := func(input []string) map[string]int {
+		t.Helper()
+		result := make(map[string]int)
+		for _, shard := range []string{"0", "1", "2", "3"} {
+			cmd := exec.CommandContext(t.Context(), awk, "-v", "shard="+shard, "-f", "scripts/ci-race-packages.awk")
+			cmd.Stdin = strings.NewReader(strings.Join(input, "\n") + "\n")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("partition: %v: %s", err, out)
+			}
+			for _, pkg := range strings.Fields(string(out)) {
+				if _, exists := result[pkg]; exists {
+					t.Fatalf("package %s assigned more than once", pkg)
+				}
+				result[pkg] = int(shard[0] - '0')
+			}
+		}
+		if len(result) != len(input) {
+			t.Fatalf("assigned %d of %d packages", len(result), len(input))
+		}
+		return result
+	}
+	original := partition(packages)
+	for _, tc := range []struct {
+		name  string
+		input []string
+	}{
+		{"reordered", []string{packages[5], packages[4], packages[3], packages[2], packages[1], packages[0]}},
+		{"added", append(append([]string{}, packages...), prefix+"internal/newpackage")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := partition(tc.input)
+			for pkg, shard := range original {
+				if got[pkg] != shard {
+					t.Errorf("%s moved from shard %d to %d", pkg, shard, got[pkg])
+				}
+			}
+		})
+	}
+	for _, tc := range []struct {
+		pkg   string
+		shard int
+	}{{packages[0], 0}, {packages[1], 1}} {
+		if original[tc.pkg] != tc.shard {
+			t.Errorf("%s must have dedicated shard %d", tc.pkg, tc.shard)
+		}
+	}
+	for _, pkg := range packages[2:] {
+		if original[pkg] < 2 {
+			t.Errorf("%s shares a dedicated runner", pkg)
+		}
+	}
+}
+
+func TestCIRaceShardFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Linux CI runner script uses bash")
+	}
+	for _, tc := range []struct {
+		name        string
+		shard       string
+		listExit    string
+		testExit    string
+		wantSuccess bool
+		wantTests   bool
+	}{
+		{"success", "2", "0", "0", true, true},
+		{"discovery failure", "2", "1", "0", false, false},
+		{"race failure survives tee", "2", "0", "1", false, true},
+		{"invalid shard", "4", "0", "0", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for _, dir := range []string{"scripts", "bin"} {
+				if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, file := range []string{"ci-race-shard.sh", "ci-race-packages.awk"} {
+				if err := os.WriteFile(filepath.Join(root, "scripts", file), []byte(readNormalizedFile(t, "scripts/"+file)), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			fakeGo := `#!/bin/sh
+case "$1" in
+list)
+  printf '%s\n' github.com/digitaldrywood/detent/internal/cli github.com/digitaldrywood/detent/internal/config
+  exit "$LIST_EXIT"
+  ;;
+test)
+  test -z "${DETENT_API_TOKEN:-}" || exit 99
+  echo invoked > invoked
+  echo '{"Action":"pass"}'
+  exit "$TEST_EXIT"
+  ;;
+esac
+exit 98
+`
+			if err := os.WriteFile(filepath.Join(root, "bin", "go"), []byte(fakeGo), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.CommandContext(t.Context(), "bash", "scripts/ci-race-shard.sh", tc.shard)
+			cmd.Dir = root
+			cmd.Env = append(os.Environ(), "PATH="+filepath.Join(root, "bin")+string(os.PathListSeparator)+os.Getenv("PATH"), "LIST_EXIT="+tc.listExit, "TEST_EXIT="+tc.testExit, "DETENT_API_TOKEN=fixture-token")
+			out, err := cmd.CombinedOutput()
+			if (err == nil) != tc.wantSuccess {
+				t.Fatalf("success=%v, want %v: %s", err == nil, tc.wantSuccess, out)
+			}
+			_, err = os.Stat(filepath.Join(root, "invoked"))
+			if (err == nil) != tc.wantTests {
+				t.Fatalf("tests invoked=%v, want %v: %s", err == nil, tc.wantTests, out)
+			}
+			if tc.wantTests {
+				data, err := os.ReadFile(filepath.Join(root, "tmp", "shard-2-race-evidence", "tests.jsonl"))
+				if err != nil || !strings.Contains(string(data), `"Action":"pass"`) {
+					t.Fatalf("missing race evidence: %v: %s", err, data)
+				}
+			}
+		})
+	}
 }

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -128,7 +128,7 @@ Required PR merge checks, branch protection/rulesets, and
 `gate.required_status_checks` must name the same merge-blocking checks:
 
 - `Lint` - budget: `2m`
-- `Verify (ubuntu-latest)` - budget: `45m`
+- `Verify (ubuntu-latest)` - budget: `8m`
 - `Test Coverage` - budget: `4m`
 - `Browser Visual` - budget: `15m`
 
@@ -189,6 +189,21 @@ Push, tag, schedule, and manual runs use a unique run group and must not be
 cancelled by later runs. The workflow test in `ci_workflow_test.go` checks this
 section against `.github/workflows/ci.yml` so job-name, required-check, wall-time
 budget, confidence-check, and green no-op drift fails in local validation.
+
+### Verify sharding
+
+CI skips draft pull-request jobs and starts work on `ready_for_review` and
+subsequent ready-head pushes. GitHub may display a skipped workflow run for a
+draft event; no runner executes its jobs. Merge groups run all PR checks plus
+the repeated subprocess lifecycle tests. Main pushes retain integration jobs.
+
+`Verify (ubuntu-latest)` aggregates build/vet/tests and four race runners, failing
+if any dependency fails, is cancelled, or is skipped. Hub and orchestrator each
+have a dedicated runner; the remaining import paths are deterministically hashed
+across two runners. Each shard retains JSON test evidence and caches Go modules
+and compiled race packages by OS, architecture, Go version, shard, and `go.sum`.
+The eight-minute budget is a wall-clock target, not a shortened test timeout.
+
 
 ## Still Git/PR Coupled
 

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -194,7 +194,8 @@ budget, confidence-check, and green no-op drift fails in local validation.
 
 CI skips draft pull-request jobs and starts work on `ready_for_review` and
 subsequent ready-head pushes. GitHub may display a skipped workflow run for a
-draft event; no runner executes its jobs. Merge groups run all PR checks plus
+draft event; no runner executes its jobs. Converting back to draft cancels the
+previous PR run through the existing concurrency group. Merge groups run all PR checks plus
 the repeated subprocess lifecycle tests. Main pushes retain integration jobs.
 
 `Verify (ubuntu-latest)` aggregates build/vet/tests and four race runners, failing

--- a/scripts/ci-race-packages.awk
+++ b/scripts/ci-race-packages.awk
@@ -1,0 +1,12 @@
+# Keep the two expensive suites on dedicated runners. Hash all other import
+# paths so adding or reordering packages never moves existing packages.
+$0 == "github.com/digitaldrywood/detent/internal/hubserver" { if (shard == 0) print; next }
+$0 == "github.com/digitaldrywood/detent/internal/orchestrator" { if (shard == 1) print; next }
+{
+    alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-"
+    hash = 0
+    for (i = 1; i <= length($0); i++) {
+        hash = (hash * 31 + index(alphabet, substr($0, i, 1))) % 65521
+    }
+    if (2 + hash % 2 == shard) print
+}

--- a/scripts/ci-race-shard.sh
+++ b/scripts/ci-race-shard.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+    0) exec make test-race-hub ;;
+    1) exec make test-race-orchestrator ;;
+    2|3) ;;
+    *) echo 'usage: ci-race-shard.sh {0|1|2|3}' >&2; exit 2 ;;
+esac
+
+mkdir -p tmp
+# Materialize go list first so discovery failures cannot silently omit tests.
+go list ./... > "tmp/race-packages-$1.txt"
+awk -v shard="$1" -f scripts/ci-race-packages.awk "tmp/race-packages-$1.txt" > "tmp/race-shard-$1.txt"
+packages=()
+while IFS= read -r package; do
+    packages+=("$package")
+done < "tmp/race-shard-$1.txt"
+if [ "${#packages[@]}" -eq 0 ]; then
+    echo "Race shard $1 has no packages" >&2
+    exit 1
+fi
+mkdir -p "tmp/shard-$1-race-evidence"
+env -u DETENT_API_TOKEN go test -race -json "${packages[@]}" | tee "tmp/shard-$1-race-evidence/tests.jsonl"


### PR DESCRIPTION
## Summary

- Skip runner work for draft PRs and start CI on ready_for_review and later ready-head updates. Converting back to draft cancels the previous run. GitHub can still display a workflow record with skipped jobs for draft events; job conditions cannot suppress creation of that record.
- Run Verify build/vet/tests alongside four race shards. Hub and orchestrator have dedicated runners; the remaining package names hash stably across two runners. Each shard caches Go build/module data using go.sum and retains JSON evidence.
- Preserve the required `Verify (ubuntu-latest)` check as an aggregate that fails unless every dependency succeeds. No ruleset changes. Merge groups retain all checks and repeated lifecycle stress; main retains portability, installer, and snapshot checks.

Fixes #2481

## UI Surface Contract

- [x] N/A: no product UI changes.
- [x] No persistent top-of-screen messaging added.
- [x] No primary operator-screen visual changes.

## Test Plan

- [x] Focused CI regression tests: complete/stable partitioning, draft/readiness routing, aggregate dependencies, discovery failure, race failure propagation through evidence capture.
- [x] Bash syntax and actionlint workflow validation. A repeated invocation hung waiting for ShellCheck integration; workflow-only actionlint passed as well.
- [x] `make check` (build, lint, vet, NilAway, all race tests, coverage thresholds).
- [x] Draft jobs skipped; ready event started CI. Review finding about converted_to_draft addressed.
- [x] [Final-head CI](https://github.com/digitaldrywood/detent/actions/runs/34614727355) is entirely green at `78fe6657`. Verify wall-clock **6m00s** (6m04s from workflow creation), including all dependencies and aggregate. Shards: Hub 5m34s, orchestrator 5m52s, general 4m11s/2m38s.

Timing limitation: this meets the target with populated caches, not a universal cold-cache guarantee. Earlier samples included cold Hub at 9m10s and orchestrator at 10m7s. The first run passed all race tests but failed a GitHub artifact upload with ETIMEDOUT; the unchanged rerun recovered. Browser Visual on the final head took 11m29s and passed.
