### PR TITLE
fix(scheduler): preserve unblock progress at REST cap

### DIFF
--- a/internal/connector/github/dependency_deferral_test.go
+++ b/internal/connector/github/dependency_deferral_test.go
@@ -1,0 +1,30 @@
+package github
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestDependencyIdentifierHydrationPropagatesRESTDeferral(t *testing.T) {
+	t.Parallel()
+	for _, cap := range []int{1, 2} {
+		name := "native dependencies"
+		if cap == 2 {
+			name = "linked pull request"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			responses := []graphqlTestResponse{{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues/1", body: `{"node_id":"I_1","number":1,"title":"Blocked","state":"open","labels":[{"name":"detent:blocked"}]}`}}
+			if cap == 2 {
+				responses = append(responses, graphqlTestResponse{method: http.MethodGet, path: "/repos/digitaldrywood/detent/issues/1/dependencies/blocked_by?per_page=100", body: `[]`})
+			}
+			server := newGraphQLTestServer(t, responses)
+			c := newGitHubTestConnector(t, server, Config{GitHubStatusSource: GitHubStatusSourceLabel, Repository: "digitaldrywood/detent", RESTFanoutMaxRequests: cap})
+			issues, err := c.FetchIssueStatesByIdentifiers(t.Context(), []string{"digitaldrywood/detent#1"})
+			if !errors.Is(err, ErrRESTFanoutDeferred) || len(issues) != 0 {
+				t.Fatalf("issues = %v, error = %v, want no partial evidence and fanout deferral", issues, err)
+			}
+		})
+	}
+}

--- a/internal/connector/github/issue_dependencies.go
+++ b/internal/connector/github/issue_dependencies.go
@@ -137,8 +137,14 @@ func (c *Connector) hydrateBlockedByRefs(ctx context.Context, issues []connector
 }
 
 func (c *Connector) hydrateIssueBlockedByRefs(ctx context.Context, issue *connector.Issue) {
-	if c == nil || issue == nil {
+	if err := c.hydrateIssueBlockedByRefsWithError(ctx, issue); err != nil {
 		return
+	}
+}
+
+func (c *Connector) hydrateIssueBlockedByRefsWithError(ctx context.Context, issue *connector.Issue) error {
+	if c == nil || issue == nil {
+		return nil
 	}
 	ref, ok := issueRefFromIdentifier(issue.Identifier)
 	if !ok {
@@ -146,40 +152,44 @@ func (c *Connector) hydrateIssueBlockedByRefs(ctx context.Context, issue *connec
 	}
 	if !ok {
 		markBlockedRefsSource(issue.BlockedBy, connector.BlockedRefSourceProse)
-		return
+		return nil
 	}
 
-	nativeRefs, nativeAvailable := c.fetchNativeBlockedByRefs(ctx, ref)
+	nativeRefs, nativeAvailable, err := c.fetchNativeBlockedByRefs(ctx, ref)
 	if !nativeAvailable {
 		markBlockedRefsSource(issue.BlockedBy, connector.BlockedRefSourceProse)
 		issue.BlockedBy = dependencyBlockedRefsWithoutSelf(issue.BlockedBy, issue.Identifier)
-		return
+		return err
 	}
 
 	if c.dependencySource == dependencySourceNativeOnly {
 		issue.BlockedBy = dependencyBlockedRefsWithoutSelf(nativeRefs, issue.Identifier)
-		return
+		return nil
 	}
 
 	issue.BlockedBy = mergeGitHubDependencyBlockedRefs(nativeRefs, issue.BlockedBy)
 	issue.BlockedBy = dependencyBlockedRefsWithoutSelf(issue.BlockedBy, issue.Identifier)
+	return nil
 }
 
-func (c *Connector) fetchNativeBlockedByRefs(ctx context.Context, ref issueRef) ([]connector.BlockedRef, bool) {
+func (c *Connector) fetchNativeBlockedByRefs(ctx context.Context, ref issueRef) ([]connector.BlockedRef, bool, error) {
 	repo := ref.Owner + "/" + ref.Name
 	if cap, ok := c.nativeDependencyCapability(repo); ok {
 		if cap.Status != nativeDependencyStatusAvailable {
-			return nil, false
+			return nil, false, nil
 		}
 	}
 
 	refs, err := c.restNativeBlockedByRefs(ctx, ref)
 	if err != nil {
 		c.handleNativeDependencyFetchError(ctx, repo, err)
-		return nil, false
+		if nativeDependencyRetryableError(err) {
+			return nil, false, err
+		}
+		return nil, false, nil
 	}
 	c.recordNativeDependencyCapability(repo, nativeDependencyStatusAvailable, "")
-	return refs, true
+	return refs, true, nil
 }
 
 func (c *Connector) nativeDependencyCapability(repo string) (nativeDependencyCapability, bool) {

--- a/internal/connector/github/issue_read.go
+++ b/internal/connector/github/issue_read.go
@@ -926,7 +926,9 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 			return nil, err
 		}
 		if ok {
-			c.hydrateIssueBlockedByRefs(ctx, &issue)
+			if err := c.hydrateIssueBlockedByRefsWithError(ctx, &issue); err != nil {
+				return nil, err
+			}
 			issues = append(issues, issue)
 		}
 	}

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -268,9 +268,6 @@ func (c *Connector) attachPullRequestMergeStates(ctx context.Context, issues []c
 	for _, repo := range repos {
 		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
 		if err != nil {
-			if restFanoutOrReserveDeferred(err) {
-				continue
-			}
 			return err
 		}
 		attachMatchingPullRequestMergeStates(repo, issues, byRepo[repo], pullRequests)

--- a/internal/orchestrator/cross_host_park.go
+++ b/internal/orchestrator/cross_host_park.go
@@ -92,6 +92,10 @@ func (o *Orchestrator) trackerRecoveryParkHold(ctx context.Context, issue connec
 			return "tracker_recovery_park_unavailable"
 		}
 	}
+	return o.trackerRecoveryParkCommentsHold(issue, comments)
+}
+
+func (o *Orchestrator) trackerRecoveryParkCommentsHold(issue connector.Issue, comments []connector.IssueComment) string {
 	settled := map[string]bool{}
 	for _, comment := range comments {
 		park, valid := parseTrackerRecoveryPark(comment.Body)

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -103,12 +103,9 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 	}
 
 	transitioned := map[string]struct{}{}
-	for _, issue := range issuesInStates(issues, cfg.SourceStates) {
+	for _, issue := range dependencyAutoUnblockOrder(issues, cfg.SourceStates, state.dependencyUnblockCursor) {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
-			continue
-		}
-		if slices.ContainsFunc(state.dependencyUnblockQueue, func(pending connector.Issue) bool { return pending.ID == issueID }) {
 			continue
 		}
 		hydrated, ok, err := o.hydrateDependencyAutoUnblockIssue(ctx, issue, cfg.SourceStates)
@@ -204,38 +201,27 @@ func (o *Orchestrator) recordDependencyAutoUnblockError(state *State, issue conn
 		}
 		return
 	}
-	if !slices.ContainsFunc(state.dependencyUnblockQueue, func(pending connector.Issue) bool { return pending.ID == issue.ID }) {
-		state.dependencyUnblockQueue = append(state.dependencyUnblockQueue, connector.Issue{ID: issue.ID, Identifier: issue.Identifier, State: issue.State})
-	}
 	o.logDependencyAutoUnblockDecision(issue, "defer", deferral.Reason, nil, "")
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      now,
 		Event:   "dependency_auto_unblock_deferred",
-		Message: fmt.Sprintf("dependency recovery deferred for %s: %s; %d queued for priority retry on subsequent refreshes", issueLabel(issue), deferral.Reason, len(state.dependencyUnblockQueue)),
+		Message: fmt.Sprintf("dependency recovery deferred for %s: %s; the rotating unblock scan receives priority on alternating refreshes", issueLabel(issue), deferral.Reason),
 	})
 }
 
-// retryDeferredDependencyAutoUnblock gives one waiting identity the first budget
-// turn every other refresh. Repeated deferrals rotate to the tail; ordinary
-// consumers retain full-budget turns even when an item cannot fit in the cap.
-func (o *Orchestrator) retryDeferredDependencyAutoUnblock(ctx context.Context, state *State, now time.Time) {
-	if !o.cfg.DependencyAutoUnblock.Enabled {
-		state.dependencyUnblockQueue = nil
-		state.dependencyUnblockYield = false
-		return
+// dependencyAutoUnblockOrder rotates the existing scan after the last priority
+// identity. Sorting makes the turn independent of tracker or map iteration order.
+func dependencyAutoUnblockOrder(issues []connector.Issue, sourceStates []string, after string) []connector.Issue {
+	ordered := slices.DeleteFunc(issuesInStates(issues, sourceStates), func(issue connector.Issue) bool { return strings.TrimSpace(issue.ID) == "" })
+	slices.SortFunc(ordered, func(a, b connector.Issue) int { return strings.Compare(a.ID, b.ID) })
+	if after == "" {
+		return ordered
 	}
-	if len(state.dependencyUnblockQueue) == 0 {
-		state.dependencyUnblockYield = false
-		return
+	index := slices.IndexFunc(ordered, func(issue connector.Issue) bool { return issue.ID > after })
+	if index <= 0 {
+		return ordered
 	}
-	if state.dependencyUnblockYield {
-		state.dependencyUnblockYield = false
-		return
-	}
-	state.dependencyUnblockYield = true
-	issue := state.dependencyUnblockQueue[0]
-	state.dependencyUnblockQueue = state.dependencyUnblockQueue[1:]
-	o.autoUnblockDependencyIssues(ctx, state, []connector.Issue{issue}, now)
+	return append(append([]connector.Issue(nil), ordered[index:]...), ordered[:index]...)
 }
 
 func dependencyAutoUnblockWorkpadHold(issue connector.Issue, current bool) bool {

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -108,8 +108,20 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if issueID == "" {
 			continue
 		}
-		hydrated, ok := o.hydrateDependencyAutoUnblockIssue(ctx, issue, cfg.SourceStates)
+		if slices.ContainsFunc(state.dependencyUnblockQueue, func(pending connector.Issue) bool { return pending.ID == issueID }) {
+			continue
+		}
+		hydrated, ok, err := o.hydrateDependencyAutoUnblockIssue(ctx, issue, cfg.SourceStates)
+		if err != nil {
+			o.recordDependencyAutoUnblockError(state, issue, err, now)
+			continue
+		}
 		if !ok || connector.NonExecutableReason(hydrated) != "" {
+			continue
+		}
+		hydrated, err = o.refreshDependencyAutoUnblockComments(ctx, hydrated)
+		if err != nil {
+			o.recordDependencyAutoUnblockError(state, issue, err, now)
 			continue
 		}
 		hydrated, workpadRefs, workpadCurrent := o.issueWithCurrentWorkpadDependencyRefs(ctx, hydrated)
@@ -136,12 +148,20 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if len(hydrated.BlockedBy) == 0 {
 			continue
 		}
-		if reason := o.trackerRecoveryParkHold(ctx, hydrated); reason != "" {
+		if reason := o.trackerRecoveryParkCommentsHold(hydrated, hydrated.Comments); reason != "" {
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", reason, nil, "")
 			continue
 		}
 		o.logDependencyProseOnly(hydrated)
-		blockers := o.resolveDependencyBlockers(ctx, hydrated)
+		blockers, err := o.resolveDependencyBlockersWithError(ctx, hydrated)
+		if err != nil {
+			o.recordDependencyAutoUnblockError(state, issue, err, now)
+			continue
+		}
+		if slices.ContainsFunc(blockers, func(blocker dependencyBlocker) bool { return !blocker.Resolved }) {
+			o.logDependencyAutoUnblockDecision(hydrated, "hold", "blockers_not_ready", blockers, "")
+			continue
+		}
 		workpadBlockers := dependencyBlockersMatchingRefs(blockers, workpadRefs)
 		if reason := o.blockedCauseHoldReason(hydrated, state, workpadBlockers, cfg, workpadCurrent); reason != "" {
 			o.logDependencyAutoUnblockDecision(hydrated, "hold", reason, blockers, "")
@@ -174,6 +194,48 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		return nil
 	}
 	return transitioned
+}
+
+func (o *Orchestrator) recordDependencyAutoUnblockError(state *State, issue connector.Issue, err error, now time.Time) {
+	deferral, ok := connector.ErrorLocalDeferral(err)
+	if !ok || deferral.Reason != connector.LocalDeferralReasonRESTFanoutCap {
+		if o.logger != nil {
+			o.logger.Warn("dependency auto-unblock check failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return
+	}
+	if !slices.ContainsFunc(state.dependencyUnblockQueue, func(pending connector.Issue) bool { return pending.ID == issue.ID }) {
+		state.dependencyUnblockQueue = append(state.dependencyUnblockQueue, connector.Issue{ID: issue.ID, Identifier: issue.Identifier, State: issue.State})
+	}
+	o.logDependencyAutoUnblockDecision(issue, "defer", deferral.Reason, nil, "")
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "dependency_auto_unblock_deferred",
+		Message: fmt.Sprintf("dependency recovery deferred for %s: %s; %d queued for priority retry on subsequent refreshes", issueLabel(issue), deferral.Reason, len(state.dependencyUnblockQueue)),
+	})
+}
+
+// retryDeferredDependencyAutoUnblock gives one waiting identity the first budget
+// turn every other refresh. Repeated deferrals rotate to the tail; ordinary
+// consumers retain full-budget turns even when an item cannot fit in the cap.
+func (o *Orchestrator) retryDeferredDependencyAutoUnblock(ctx context.Context, state *State, now time.Time) {
+	if !o.cfg.DependencyAutoUnblock.Enabled {
+		state.dependencyUnblockQueue = nil
+		state.dependencyUnblockYield = false
+		return
+	}
+	if len(state.dependencyUnblockQueue) == 0 {
+		state.dependencyUnblockYield = false
+		return
+	}
+	if state.dependencyUnblockYield {
+		state.dependencyUnblockYield = false
+		return
+	}
+	state.dependencyUnblockYield = true
+	issue := state.dependencyUnblockQueue[0]
+	state.dependencyUnblockQueue = state.dependencyUnblockQueue[1:]
+	o.autoUnblockDependencyIssues(ctx, state, []connector.Issue{issue}, now)
 }
 
 func dependencyAutoUnblockWorkpadHold(issue connector.Issue, current bool) bool {
@@ -366,21 +428,18 @@ func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(
 	ctx context.Context,
 	issue connector.Issue,
 	sourceStates []string,
-) (connector.Issue, bool) {
+) (connector.Issue, bool, error) {
 	issue = o.issueWithDependencyRefs(issue)
 	if strings.TrimSpace(issue.Identifier) == "" {
-		return issue, stateIn(issue.State, sourceStates)
+		return issue, stateIn(issue.State, sourceStates), nil
 	}
 	resolver, ok := o.connector.(connector.IssueReferenceResolver)
 	if !ok {
-		return issue, stateIn(issue.State, sourceStates)
+		return issue, stateIn(issue.State, sourceStates), nil
 	}
 	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, []string{issue.Identifier})
 	if err != nil {
-		if o.logger != nil {
-			o.logger.Warn("hydrate dependency auto-unblock issue failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
-		}
-		return connector.Issue{}, false
+		return connector.Issue{}, false, err
 	}
 	for _, hydrated := range issues {
 		if !sameIssueIdentity(issue, hydrated) {
@@ -390,9 +449,26 @@ func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(
 		merged := mergeIssueTrackerFields(issue, hydrated)
 		merged.BlockedBy = mergeDependencyBlockedRefs(merged.BlockedBy, previousBlockedBy)
 		merged = o.issueWithDependencyRefs(merged)
-		return merged, stateIn(merged.State, sourceStates)
+
+		return merged, stateIn(merged.State, sourceStates), nil
 	}
-	return issue, stateIn(issue.State, sourceStates)
+	return connector.Issue{}, false, nil
+}
+
+func (o *Orchestrator) refreshDependencyAutoUnblockComments(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
+	reader, ok := o.connector.(connector.IssueCommentReader)
+	if !ok {
+		return issue, nil
+	}
+	comments, err := reader.FetchIssueComments(ctx, issue)
+	if err != nil {
+		return connector.Issue{}, err
+	}
+	issue.Comments = comments
+	issue.WorkpadSignal = nil
+	issue.BlockerReason = ""
+	issue.WorkpadSignal, _ = autoPromoteIssueWorkpadSignal(issue)
+	return o.issueWithDependencyRefs(issue), nil
 }
 
 func (o *Orchestrator) issueWithDependencyRefs(issue connector.Issue) connector.Issue {
@@ -593,6 +669,12 @@ func dependencyRefsFromIssueText(issue connector.Issue) []connector.BlockedRef {
 	appendRefs(dependencyLineRefs(issue.Description, repo))
 	appendRefs(dependencyRefsInText(dependencyMarkdownSectionText(issue.Description, "Blockers"), repo))
 	appendRefs(dependencyReasonRefs(issue.BlockerReason, repo))
+	for _, comment := range issue.Comments {
+		if autoPromoteIsWorkpadComment(comment.Body) {
+			continue
+		}
+		appendRefs(dependencyLineRefs(comment.Body, repo))
+	}
 	return refs
 }
 
@@ -751,6 +833,14 @@ func sameIssueIdentity(left connector.Issue, right connector.Issue) bool {
 }
 
 func (o *Orchestrator) resolveDependencyBlockers(ctx context.Context, issue connector.Issue) []dependencyBlocker {
+	blockers, err := o.resolveDependencyBlockersWithError(ctx, issue)
+	if err != nil && o.logger != nil {
+		o.logger.Warn("resolve dependency blockers failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+	return blockers
+}
+
+func (o *Orchestrator) resolveDependencyBlockersWithError(ctx context.Context, issue connector.Issue) ([]dependencyBlocker, error) {
 	blockers := make([]dependencyBlocker, 0, len(issue.BlockedBy))
 	identifiers := make([]string, 0, len(issue.BlockedBy))
 	seen := map[string]struct{}{}
@@ -775,14 +865,11 @@ func (o *Orchestrator) resolveDependencyBlockers(ctx context.Context, issue conn
 
 	resolver, ok := o.connector.(connector.IssueReferenceResolver)
 	if !ok || len(identifiers) == 0 {
-		return blockers
+		return blockers, nil
 	}
 	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, identifiers)
 	if err != nil {
-		if o.logger != nil {
-			o.logger.Warn("resolve dependency blockers failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
-		}
-		return blockers
+		return blockers, err
 	}
 
 	byIdentifier := make(map[string]connector.Issue, len(issues))
@@ -811,7 +898,7 @@ func (o *Orchestrator) resolveDependencyBlockers(ctx context.Context, issue conn
 			blockers[index].Ref.TrackerState = connector.BlockedRefTrackerStateClosed
 		}
 	}
-	return blockers
+	return blockers, nil
 }
 
 func dependencyResolvedBlockerRefs(blockers []dependencyBlocker) []connector.BlockedRef {
@@ -978,9 +1065,7 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 		},
 	}
 	if err := o.updateIssueStateByIDStrictWithMetadata(ctx, state, issueID, issue, targetState, now, "dependency_auto_unblock", metadata); err != nil {
-		if o.logger != nil {
-			o.logger.Warn("dependency auto-unblock transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
-		}
+		o.recordDependencyAutoUnblockError(state, issue, err, now)
 		return false
 	}
 

--- a/internal/orchestrator/dependency_autounblock_budget_test.go
+++ b/internal/orchestrator/dependency_autounblock_budget_test.go
@@ -1,0 +1,345 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestDependencyAutoUnblockRESTBudgetProgress(t *testing.T) {
+	t.Parallel()
+	for _, competingReads := range []int{4, 9} {
+		t.Run(fmt.Sprintf("competing_reads_%d", competingReads), func(t *testing.T) {
+			t.Parallel()
+			tracker := newDependencyBudgetConnector(t, 9, competingReads)
+			orch := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+			orch.connector = tracker
+			var logs bytes.Buffer
+			orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+			state := newState(orch.cfg)
+			now := time.Date(2026, 9, 8, 23, 20, 0, 0, time.UTC)
+			for cycle := range 7 {
+				orch.tick(t.Context(), &state, now.Add(time.Duration(cycle)*time.Minute))
+				if state.RateLimits == nil || state.RateLimits.RESTUsage == nil {
+					t.Fatal("missing REST telemetry")
+				}
+				usage := state.RateLimits.RESTUsage
+				if usage.BillableRequests > 9 || usage.RateLimited || usage.ReserveHeld {
+					t.Fatalf("unexpected REST usage: %+v", usage)
+				}
+				if cycle == 0 && (!usage.FanoutDeferred || !slices.ContainsFunc(state.RecentEvents, func(event telemetry.ActivityEvent) bool { return event.Event == "dependency_auto_unblock_deferred" })) {
+					t.Fatal("missing classified dependency deferral telemetry")
+				}
+				if cycle == 0 {
+					if tracker.lastRefreshBudget == nil {
+						t.Fatal("missing shared refresh budget")
+					}
+					if _, allowed := tracker.lastRefreshBudget.Reserve(9*4, 4); allowed {
+						t.Fatal("usage flush reset the refresh budget")
+					}
+					want := 0
+					if competingReads == 4 {
+						want = 1
+					}
+					if len(tracker.updates) != want {
+						t.Fatalf("first refresh transitions = %d, want %d: %s", len(tracker.updates), want, logs.String())
+					}
+				}
+			}
+			if len(tracker.updates) != 3 {
+				t.Fatalf("transitions after seven capped refreshes = %v, want all three", tracker.updates)
+			}
+			for _, issue := range tracker.stateIssues {
+				if !slices.ContainsFunc(tracker.updates, func(update dependencyAutoUnblockUpdate) bool { return update.issueID == issue.ID }) {
+					t.Errorf("issue %s never recovered", issue.ID)
+				}
+			}
+		})
+	}
+}
+
+func TestDependencyAutoUnblockRejectsStaleRESTBudgetEvidence(t *testing.T) {
+	t.Parallel()
+	tracker := newDependencyBudgetConnector(t, 1, 0)
+	orch := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+	orch.connector = tracker
+	var logs bytes.Buffer
+	orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	state := newState(orch.cfg)
+	orch.autoUnblockDependencyIssues(t.Context(), &state, tracker.stateIssues[:1], time.Now())
+	if len(tracker.updates) != 0 {
+		t.Fatalf("transitions = %v after blocker lookup was deferred, want none", tracker.updates)
+	}
+}
+
+type dependencyBudgetConnector struct {
+	*dependencyAutoUnblockConnector
+	client                   *githubconnector.Client
+	competingReads           int
+	extraReads               map[string]int
+	lastRefreshBudget        *connector.RESTFanoutBudget
+	successfulCompetingReads int
+}
+
+func newDependencyBudgetConnector(t *testing.T, cap int64, competingReads int) *dependencyBudgetConnector {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	client, err := githubconnector.NewClient(githubconnector.ClientConfig{Endpoint: server.URL, TokenSource: githubconnector.StaticTokenSource("test-token"), HTTPClient: server.Client(), RESTPolicy: githubconnector.RESTBudgetPolicy{FanoutMaxRequests: cap}, DisableConditionalRequests: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := &dependencyAutoUnblockConnector{}
+	blocker := dependencyAutoUnblockIssue("issue-100", "Done")
+	base.blockers = []connector.Issue{blocker}
+	for _, number := range []int{1, 2, 3} {
+		issue := dependencyAutoUnblockIssue(fmt.Sprintf("issue-%d", number), "Blocked")
+		issue.BlockedBy = []connector.BlockedRef{{Identifier: blocker.Identifier, State: "Done"}}
+		base.stateIssues = append(base.stateIssues, issue)
+		base.hydratedIssues = append(base.hydratedIssues, issue)
+	}
+	return &dependencyBudgetConnector{dependencyAutoUnblockConnector: base, client: client, competingReads: competingReads}
+}
+
+func (c *dependencyBudgetConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	c.lastRefreshBudget, _ = connector.RESTFanoutBudgetFromContext(ctx)
+	for range c.competingReads {
+		if err := c.client.REST(ctx, http.MethodGet, "/repos/digitaldrywood/detent/issues/999", nil, nil); err != nil {
+			break
+		}
+		c.successfulCompetingReads++
+	}
+	return nil, nil
+}
+
+func (c *dependencyBudgetConnector) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) ([]connector.Issue, error) {
+	for _, identifier := range identifiers {
+		for range 1 + c.extraReads[identifier] {
+			if err := c.client.REST(ctx, http.MethodGet, "/repos/digitaldrywood/detent/issues/1", nil, nil); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return c.dependencyAutoUnblockConnector.FetchIssueStatesByIdentifiers(ctx, identifiers)
+}
+
+func (c *dependencyBudgetConnector) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
+	return c.client.FlushRESTRateLimitUsage()
+}
+
+func (c *dependencyBudgetConnector) UpdateIssueState(ctx context.Context, issueID, state string) error {
+	for i := range c.stateIssues {
+		if c.stateIssues[i].ID == issueID {
+			c.stateIssues[i].State = state
+		}
+	}
+	for i := range c.hydratedIssues {
+		if c.hydratedIssues[i].ID == issueID {
+			c.hydratedIssues[i].State = state
+		}
+	}
+	return c.dependencyAutoUnblockConnector.UpdateIssueState(ctx, issueID, state)
+}
+
+func TestDeferredDependencyUnblockRevalidatesEvidence(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"ready", "reopened dependency", "missing dependency", "missing issue", "human evidence removed", "workpad hold", "operator stop", "new dependency", "new comment dependency", "native-only comment"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			base := newDependencyBudgetConnector(t, 9, 9)
+			tracker := &dependencyBudgetCommentConnector{dependencyBudgetConnector: base}
+			orch := dependencyAutoUnblockOrchestrator(base.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+			orch.connector = tracker
+			state := newState(orch.cfg)
+			now := time.Date(2026, 9, 8, 23, 20, 0, 0, time.UTC)
+			_, _ = tracker.FetchCandidateIssues(t.Context())
+			orch.autoUnblockDependencyIssues(t.Context(), &state, base.stateIssues[:1], now)
+			if len(state.dependencyUnblockQueue) != 1 {
+				t.Fatalf("queue = %v, want one deferred identity", state.dependencyUnblockQueue)
+			}
+			queued := state.dependencyUnblockQueue[0]
+			if len(queued.BlockedBy) > 0 || queued.WorkpadSignal != nil {
+				t.Fatal("queue retained stale evidence")
+			}
+			tracker.FlushRESTRateLimitUsage()
+			switch name {
+			case "reopened dependency":
+				base.blockers[0].State = "In Progress"
+			case "missing dependency":
+				base.blockers = nil
+			case "missing issue":
+				base.hydratedIssues = nil
+				base.stateIssues = nil
+			case "human evidence removed":
+				human := humanDependencyIssue("", true)
+				human.Identifier = base.blockers[0].Identifier
+				base.blockers[0] = human
+			case "workpad hold":
+				tracker.currentComments = []connector.IssueComment{{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\nblockers: []\nhuman_action: wait for approval\n```"}}
+			case "operator stop":
+				state.Blocked[queued.ID] = Blocked{Issue: base.stateIssues[0], Source: BlockedSourceOperatorStop, Reason: "operator stop"}
+			case "new dependency":
+				base.hydratedIssues[0].Description = "Depends on: #200"
+			case "new comment dependency", "native-only comment":
+				tracker.currentComments = []connector.IssueComment{{Body: "Depends on: #200"}}
+				if name == "native-only comment" {
+					orch.cfg.DependencySource = "native_only"
+				}
+			}
+			orch.retryDeferredDependencyAutoUnblock(t.Context(), &state, now.Add(time.Minute))
+			want := 0
+			if name == "ready" || name == "native-only comment" {
+				want = 1
+			}
+			if len(base.updates) != want {
+				t.Fatalf("transitions = %v, want %d with fresh %s evidence", base.updates, want, name)
+			}
+		})
+	}
+}
+
+type dependencyBudgetCommentConnector struct {
+	*dependencyBudgetConnector
+	currentComments []connector.IssueComment
+}
+
+func (c *dependencyBudgetCommentConnector) FetchIssueComments(ctx context.Context, _ connector.Issue) ([]connector.IssueComment, error) {
+	if err := c.client.REST(ctx, http.MethodGet, "/repos/digitaldrywood/detent/issues/1/comments", nil, nil); err != nil {
+		return nil, err
+	}
+	return c.currentComments, nil
+}
+
+func TestDeferredDependencyUnblockQueueFairness(t *testing.T) {
+	t.Parallel()
+	tracker := newDependencyBudgetConnector(t, 9, 9)
+	tracker.extraReads = map[string]int{tracker.stateIssues[0].Identifier: 10}
+	orch := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+	orch.connector = tracker
+	state := newState(orch.cfg)
+	now := time.Date(2026, 9, 8, 23, 20, 0, 0, time.UTC)
+	for cycle := range 13 {
+		orch.tick(t.Context(), &state, now.Add(time.Duration(cycle)*time.Minute))
+		if cycle == 0 {
+			newcomer := dependencyAutoUnblockIssue("issue-4", "Blocked")
+			newcomer.BlockedBy = tracker.stateIssues[1].BlockedBy
+			tracker.stateIssues = append(tracker.stateIssues, newcomer)
+			tracker.hydratedIssues = append(tracker.hydratedIssues, newcomer)
+		}
+	}
+	want := []dependencyAutoUnblockUpdate{{issueID: "issue-2", state: "Todo"}, {issueID: "issue-3", state: "Todo"}, {issueID: "issue-4", state: "Todo"}}
+	if !slices.Equal(tracker.updates, want) {
+		t.Fatalf("transitions = %v, want FIFO progress %v despite oversized first item", tracker.updates, want)
+	}
+	if len(state.dependencyUnblockQueue) != 1 || state.dependencyUnblockQueue[0].ID != "issue-1" {
+		t.Fatalf("queue = %v, want oversized issue retained once", state.dependencyUnblockQueue)
+	}
+}
+
+func TestDeferredDependencyUnblockPreservesProviderLimits(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		remaining string
+		status    int
+		reserve   int64
+	}{
+		{name: "primary", remaining: "0", status: http.StatusForbidden},
+		{name: "reserve", remaining: "1", status: http.StatusOK, reserve: 1},
+		{name: "secondary", remaining: "99", status: http.StatusTooManyRequests},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-RateLimit-Limit", "100")
+				w.Header().Set("X-RateLimit-Remaining", tc.remaining)
+				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
+				if tc.status == http.StatusTooManyRequests {
+					w.Header().Set("Retry-After", "60")
+				}
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+			client, err := githubconnector.NewClient(githubconnector.ClientConfig{Endpoint: server.URL, HTTPClient: server.Client(), TokenSource: githubconnector.StaticTokenSource("test-token"), RESTPolicy: githubconnector.RESTBudgetPolicy{FanoutMaxRequests: 9, MinRemainingReserve: tc.reserve}, DisableConditionalRequests: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tracker := newDependencyBudgetConnector(t, 9, 0)
+			tracker.client = client
+			orch := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+			orch.connector = tracker
+			state := newState(orch.cfg)
+			state.dependencyUnblockQueue = []connector.Issue{{ID: tracker.stateIssues[0].ID, Identifier: tracker.stateIssues[0].Identifier, State: "Blocked"}}
+			orch.retryDeferredDependencyAutoUnblock(connector.WithRESTFanoutBudget(t.Context(), "refresh"), &state, time.Now())
+			if len(tracker.updates) != 0 || calls.Load() != 1 {
+				t.Fatalf("transitions = %v, requests = %d, want no transition or request past provider limit", tracker.updates, calls.Load())
+			}
+		})
+	}
+}
+
+func TestDependencyAutoUnblockRefreshesCommentsWithoutIdentifier(t *testing.T) {
+	t.Parallel()
+	for _, hold := range []bool{false, true} {
+		t.Run(fmt.Sprintf("workpad_hold_%t", hold), func(t *testing.T) {
+			t.Parallel()
+			base := newDependencyBudgetConnector(t, 9, 0)
+			base.stateIssues[0].Identifier = ""
+			tracker := &dependencyBudgetCommentConnector{dependencyBudgetConnector: base}
+			if hold {
+				tracker.currentComments = []connector.IssueComment{{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\nblockers: []\nhuman_action: wait for approval\n```"}}
+			}
+			orch := dependencyAutoUnblockOrchestrator(base.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+			orch.connector = tracker
+			state := newState(orch.cfg)
+			orch.autoUnblockDependencyIssues(t.Context(), &state, base.stateIssues[:1], time.Now())
+			want := 1
+			if hold {
+				want = 0
+			}
+			if len(tracker.updates) != want {
+				t.Fatalf("transitions = %v, want %d after current workpad check", tracker.updates, want)
+			}
+		})
+	}
+}
+
+func TestDeferredDependencyUnblockYieldsRefreshBudget(t *testing.T) {
+	t.Parallel()
+	tracker := newDependencyBudgetConnector(t, 9, 9)
+	tracker.stateIssues = tracker.stateIssues[:1]
+	tracker.hydratedIssues = tracker.hydratedIssues[:1]
+	tracker.extraReads = map[string]int{tracker.stateIssues[0].Identifier: 10}
+	orch := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
+	orch.connector = tracker
+	state := newState(orch.cfg)
+	now := time.Date(2026, 9, 8, 23, 20, 0, 0, time.UTC)
+	for cycle := range 4 {
+		orch.tick(t.Context(), &state, now.Add(time.Duration(cycle)*time.Minute))
+	}
+	if tracker.successfulCompetingReads <= 9 {
+		t.Fatalf("ordinary reads = %d, want continued progress after an oversized recovery is queued", tracker.successfulCompetingReads)
+	}
+	if len(tracker.updates) != 0 || len(state.dependencyUnblockQueue) != 1 {
+		t.Fatalf("transitions = %v, queue = %v, want oversized recovery retained", tracker.updates, state.dependencyUnblockQueue)
+	}
+}

--- a/internal/orchestrator/dependency_autounblock_budget_test.go
+++ b/internal/orchestrator/dependency_autounblock_budget_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -88,6 +89,8 @@ type dependencyBudgetConnector struct {
 	*dependencyAutoUnblockConnector
 	client                   *githubconnector.Client
 	competingReads           int
+	candidateErr             error
+	identifierReads          map[string]int
 	extraReads               map[string]int
 	lastRefreshBudget        *connector.RESTFanoutBudget
 	successfulCompetingReads int
@@ -113,7 +116,7 @@ func newDependencyBudgetConnector(t *testing.T, cap int64, competingReads int) *
 		base.stateIssues = append(base.stateIssues, issue)
 		base.hydratedIssues = append(base.hydratedIssues, issue)
 	}
-	return &dependencyBudgetConnector{dependencyAutoUnblockConnector: base, client: client, competingReads: competingReads}
+	return &dependencyBudgetConnector{dependencyAutoUnblockConnector: base, client: client, competingReads: competingReads, identifierReads: map[string]int{}}
 }
 
 func (c *dependencyBudgetConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
@@ -124,11 +127,12 @@ func (c *dependencyBudgetConnector) FetchCandidateIssues(ctx context.Context) ([
 		}
 		c.successfulCompetingReads++
 	}
-	return nil, nil
+	return nil, c.candidateErr
 }
 
 func (c *dependencyBudgetConnector) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) ([]connector.Issue, error) {
 	for _, identifier := range identifiers {
+		c.identifierReads[identifier]++
 		for range 1 + c.extraReads[identifier] {
 			if err := c.client.REST(ctx, http.MethodGet, "/repos/digitaldrywood/detent/issues/1", nil, nil); err != nil {
 				return nil, err
@@ -158,7 +162,7 @@ func (c *dependencyBudgetConnector) UpdateIssueState(ctx context.Context, issueI
 
 func TestDeferredDependencyUnblockRevalidatesEvidence(t *testing.T) {
 	t.Parallel()
-	for _, name := range []string{"ready", "reopened dependency", "missing dependency", "missing issue", "human evidence removed", "workpad hold", "operator stop", "new dependency", "new comment dependency", "native-only comment"} {
+	for _, name := range []string{"ready", "human owned issue", "changed source state", "reopened dependency", "missing dependency", "missing issue", "human evidence removed", "workpad hold", "operator stop", "new dependency", "new comment dependency", "native-only comment"} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			base := newDependencyBudgetConnector(t, 9, 9)
@@ -169,15 +173,16 @@ func TestDeferredDependencyUnblockRevalidatesEvidence(t *testing.T) {
 			now := time.Date(2026, 9, 8, 23, 20, 0, 0, time.UTC)
 			_, _ = tracker.FetchCandidateIssues(t.Context())
 			orch.autoUnblockDependencyIssues(t.Context(), &state, base.stateIssues[:1], now)
-			if len(state.dependencyUnblockQueue) != 1 {
-				t.Fatalf("queue = %v, want one deferred identity", state.dependencyUnblockQueue)
-			}
-			queued := state.dependencyUnblockQueue[0]
-			if len(queued.BlockedBy) > 0 || queued.WorkpadSignal != nil {
-				t.Fatal("queue retained stale evidence")
-			}
+			state.BoardIssues = cloneIssues(base.stateIssues[:1])
+			state.dependencyUnblockEarly = true
+			tracker.candidateErr = errors.New("ordinary fetch unavailable")
+			tracker.competingReads = 0
 			tracker.FlushRESTRateLimitUsage()
 			switch name {
+			case "human owned issue":
+				base.hydratedIssues[0].Labels = []string{"human-owned"}
+			case "changed source state":
+				base.hydratedIssues[0].State = "In Progress"
 			case "reopened dependency":
 				base.blockers[0].State = "In Progress"
 			case "missing dependency":
@@ -192,7 +197,7 @@ func TestDeferredDependencyUnblockRevalidatesEvidence(t *testing.T) {
 			case "workpad hold":
 				tracker.currentComments = []connector.IssueComment{{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\nblockers: []\nhuman_action: wait for approval\n```"}}
 			case "operator stop":
-				state.Blocked[queued.ID] = Blocked{Issue: base.stateIssues[0], Source: BlockedSourceOperatorStop, Reason: "operator stop"}
+				state.Blocked[base.stateIssues[0].ID] = Blocked{Issue: base.stateIssues[0], Source: BlockedSourceOperatorStop, Reason: "operator stop"}
 			case "new dependency":
 				base.hydratedIssues[0].Description = "Depends on: #200"
 			case "new comment dependency", "native-only comment":
@@ -201,7 +206,7 @@ func TestDeferredDependencyUnblockRevalidatesEvidence(t *testing.T) {
 					orch.cfg.DependencySource = "native_only"
 				}
 			}
-			orch.retryDeferredDependencyAutoUnblock(t.Context(), &state, now.Add(time.Minute))
+			orch.tick(t.Context(), &state, now.Add(time.Minute))
 			want := 0
 			if name == "ready" || name == "native-only comment" {
 				want = 1
@@ -225,7 +230,7 @@ func (c *dependencyBudgetCommentConnector) FetchIssueComments(ctx context.Contex
 	return c.currentComments, nil
 }
 
-func TestDeferredDependencyUnblockQueueFairness(t *testing.T) {
+func TestDependencyUnblockScanFairness(t *testing.T) {
 	t.Parallel()
 	tracker := newDependencyBudgetConnector(t, 9, 9)
 	tracker.extraReads = map[string]int{tracker.stateIssues[0].Identifier: 10}
@@ -246,8 +251,8 @@ func TestDeferredDependencyUnblockQueueFairness(t *testing.T) {
 	if !slices.Equal(tracker.updates, want) {
 		t.Fatalf("transitions = %v, want FIFO progress %v despite oversized first item", tracker.updates, want)
 	}
-	if len(state.dependencyUnblockQueue) != 1 || state.dependencyUnblockQueue[0].ID != "issue-1" {
-		t.Fatalf("queue = %v, want oversized issue retained once", state.dependencyUnblockQueue)
+	if tracker.stateIssues[0].State != "Blocked" {
+		t.Fatal("oversized issue must remain blocked for a later scan")
 	}
 }
 
@@ -288,8 +293,11 @@ func TestDeferredDependencyUnblockPreservesProviderLimits(t *testing.T) {
 			orch := dependencyAutoUnblockOrchestrator(tracker.dependencyAutoUnblockConnector, DependencyAutoUnblockConfig{Enabled: true})
 			orch.connector = tracker
 			state := newState(orch.cfg)
-			state.dependencyUnblockQueue = []connector.Issue{{ID: tracker.stateIssues[0].ID, Identifier: tracker.stateIssues[0].Identifier, State: "Blocked"}}
-			orch.retryDeferredDependencyAutoUnblock(connector.WithRESTFanoutBudget(t.Context(), "refresh"), &state, time.Now())
+			state.BoardIssues = cloneIssues(tracker.stateIssues[:1])
+			state.dependencyUnblockEarly = true
+			tracker.candidateErr = errors.New("ordinary fetch unavailable")
+			tracker.competingReads = 0
+			orch.tick(t.Context(), &state, time.Now())
 			if len(tracker.updates) != 0 || calls.Load() != 1 {
 				t.Fatalf("transitions = %v, requests = %d, want no transition or request past provider limit", tracker.updates, calls.Load())
 			}
@@ -336,10 +344,43 @@ func TestDeferredDependencyUnblockYieldsRefreshBudget(t *testing.T) {
 	for cycle := range 4 {
 		orch.tick(t.Context(), &state, now.Add(time.Duration(cycle)*time.Minute))
 	}
+	if got := tracker.identifierReads[tracker.stateIssues[0].Identifier]; got != 4 {
+		t.Fatalf("unblock scans = %d, want exactly one per refresh", got)
+	}
 	if tracker.successfulCompetingReads <= 9 {
 		t.Fatalf("ordinary reads = %d, want continued progress after an oversized recovery is queued", tracker.successfulCompetingReads)
 	}
-	if len(tracker.updates) != 0 || len(state.dependencyUnblockQueue) != 1 {
-		t.Fatalf("transitions = %v, queue = %v, want oversized recovery retained", tracker.updates, state.dependencyUnblockQueue)
+	if len(tracker.updates) != 0 || tracker.stateIssues[0].State != "Blocked" {
+		t.Fatalf("transitions = %v, want oversized issue left blocked", tracker.updates)
+	}
+}
+
+func TestDependencyAutoUnblockScanOrder(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		after string
+		want  []string
+	}{
+		{name: "initial", want: []string{"a", "b", "d"}},
+		{name: "next identity", after: "a", want: []string{"b", "d", "a"}},
+		{name: "removed cursor", after: "c", want: []string{"d", "a", "b"}},
+		{name: "wrap", after: "z", want: []string{"a", "b", "d"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			issues := []connector.Issue{{ID: "d", State: "Blocked"}, {ID: "", State: "Blocked"}, {ID: "b", State: "Blocked"}, {ID: "c", State: "Todo"}, {ID: "a", State: "Blocked"}}
+			ordered := dependencyAutoUnblockOrder(issues, []string{"Blocked"}, tc.after)
+			var got []string
+			for _, issue := range ordered {
+				got = append(got, issue.ID)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("order = %v, want %v", got, tc.want)
+			}
+			if issues[0].ID != "d" {
+				t.Fatal("scan mutated shared board snapshot")
+			}
+		})
 	}
 }

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -1745,7 +1745,7 @@ func (c *dependencyAutoUnblockConnector) FetchIssueStatesByIdentifiers(_ context
 		c.identifierCalls = append(c.identifierCalls, normalized)
 	}
 	out := make([]connector.Issue, 0, len(c.hydratedIssues)+len(c.blockers))
-	for _, issue := range append(c.hydratedIssues, c.blockers...) {
+	for _, issue := range mergeIssueSlices(mergeIssueSlices(c.hydratedIssues, c.stateIssues), c.blockers) {
 		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
 			out = append(out, cloneIssue(issue))
 		}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -95,6 +95,8 @@ type State struct {
 	nativeMergeQueueExcluded map[string]string
 	TransientCheckRetries    map[string]TransientCheckRetry
 	DependencyAutoUnblocks   map[string]DependencyAutoUnblockRecord
+	dependencyUnblockQueue   []connector.Issue
+	dependencyUnblockYield   bool
 	BudgetRefusals           map[string]BudgetRefusal
 	PriorAttempts            map[string]runpkg.PriorAttempt
 	InstantFailures          map[string]InstantFailure
@@ -505,6 +507,8 @@ func (s State) clone() State {
 		nativeMergeQueueExcluded: maps.Clone(s.nativeMergeQueueExcluded),
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		DependencyAutoUnblocks:   maps.Clone(s.DependencyAutoUnblocks),
+		dependencyUnblockQueue:   cloneIssues(s.dependencyUnblockQueue),
+		dependencyUnblockYield:   s.dependencyUnblockYield,
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		PriorAttempts:            clonePriorAttempts(s.PriorAttempts),
 		InstantFailures:          make(map[string]InstantFailure, len(s.InstantFailures)),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -95,8 +95,8 @@ type State struct {
 	nativeMergeQueueExcluded map[string]string
 	TransientCheckRetries    map[string]TransientCheckRetry
 	DependencyAutoUnblocks   map[string]DependencyAutoUnblockRecord
-	dependencyUnblockQueue   []connector.Issue
-	dependencyUnblockYield   bool
+	dependencyUnblockCursor  string
+	dependencyUnblockEarly   bool
 	BudgetRefusals           map[string]BudgetRefusal
 	PriorAttempts            map[string]runpkg.PriorAttempt
 	InstantFailures          map[string]InstantFailure
@@ -507,8 +507,8 @@ func (s State) clone() State {
 		nativeMergeQueueExcluded: maps.Clone(s.nativeMergeQueueExcluded),
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		DependencyAutoUnblocks:   maps.Clone(s.DependencyAutoUnblocks),
-		dependencyUnblockQueue:   cloneIssues(s.dependencyUnblockQueue),
-		dependencyUnblockYield:   s.dependencyUnblockYield,
+		dependencyUnblockCursor:  s.dependencyUnblockCursor,
+		dependencyUnblockEarly:   s.dependencyUnblockEarly,
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		PriorAttempts:            clonePriorAttempts(s.PriorAttempts),
 		InstantFailures:          make(map[string]InstantFailure, len(s.InstantFailures)),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -100,8 +100,23 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	if o.trackerAvailabilityPaused(ctx, state, now) && o.scheduling == nil {
 		return
 	}
-	if !state.Draining && !o.dispatchQuiesced() {
-		o.retryDeferredDependencyAutoUnblock(ctx, state, now)
+	// Place the existing unblock scan before other consumers every other refresh.
+	// Only its starting identity is retained; readiness always comes from fresh reads.
+	earlyDependencyUnblock := state.dependencyUnblockEarly
+	state.dependencyUnblockEarly = !earlyDependencyUnblock
+	var earlyUnblocked map[string]struct{}
+	if earlyDependencyUnblock && o.cfg.DependencyAutoUnblock.Enabled && !state.Draining && !o.dispatchQuiesced() {
+		cfg := normalizeDependencyAutoUnblockConfig(o.cfg.DependencyAutoUnblock)
+		issues := dependencyAutoUnblockOrder(mergeIssueSlices(state.BoardIssues, previous.blockedStatusIssues), cfg.SourceStates, state.dependencyUnblockCursor)
+		if len(issues) > 0 {
+			for i, issue := range issues {
+				issues[i] = connector.Issue{ID: issue.ID, Identifier: issue.Identifier, State: issue.State}
+			}
+			earlyUnblocked = o.autoUnblockDependencyIssues(ctx, state, issues, now)
+			// Advance even if the first identity cannot fit inside the cap. The late
+			// scan never changes this cursor, so it cannot undo priority progress.
+			state.dependencyUnblockCursor = issues[0].ID
+		}
 	}
 	if !o.retryDeferredCompletions(ctx, state, now) && o.scheduling == nil {
 		return
@@ -139,6 +154,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	if !ok {
 		return
 	}
+	fetched = filterReconciledTickIssues(state, fetched, earlyUnblocked)
 	for _, issue := range mergeIssueSlices(fetched.candidates, fetched.status) {
 		if _, _, err := o.observeLane(ctx, state, issue, now); err != nil {
 			if o.logger != nil {
@@ -195,11 +211,13 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			fetched,
 			o.autoPromoteBlockerIssues(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now),
 		)
-		fetched = filterReconciledTickIssues(
-			state,
-			fetched,
-			o.autoUnblockDependencyIssues(ctx, state, fetched.status, now),
-		)
+		if !earlyDependencyUnblock {
+			fetched = filterReconciledTickIssues(
+				state,
+				fetched,
+				o.autoUnblockDependencyIssues(ctx, state, fetched.status, now),
+			)
+		}
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -53,6 +53,7 @@ func (o *Orchestrator) tickManual(ctx context.Context, state *State, request man
 }
 
 func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now time.Time, manual *manualRefreshRequest) {
+	ctx = connector.WithRESTFanoutBudget(ctx, "refresh")
 	o.beginGlobalProjectCycle()
 	defer o.endGlobalProjectCycle()
 	completed := false
@@ -98,6 +99,9 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	}
 	if o.trackerAvailabilityPaused(ctx, state, now) && o.scheduling == nil {
 		return
+	}
+	if !state.Draining && !o.dispatchQuiesced() {
+		o.retryDeferredDependencyAutoUnblock(ctx, state, now)
 	}
 	if !o.retryDeferredCompletions(ctx, state, now) && o.scheduling == nil {
 		return


### PR DESCRIPTION
## Summary

When earlier refresh consumers repeatedly exhaust the REST cap, resolved blocked issues can receive no fresh hydration attempts. Run the existing unblock scan once per refresh, alternating early and normal placement. A single deterministic scan cursor rotates first priority so oversized items cannot starve other issues, and ordinary consumers retain full-budget turns. One shared budget covers the entire refresh, including requests after telemetry flushes.

Early scans use identities from the existing board/blocked snapshots, then require fresh issue, comment, workpad, and dependency evidence. Propagate native-dependency and linked-PR deferrals instead of using partial or cached Done evidence. Preserve current ownership handling, human completion evidence, operator stops, native-only behavior, configured caps, reserves, and provider limits.

Mechanism moratorium: consolidate priority handling into the existing unblock scan; there is no deferred-issue queue or separate replay helper. The scan executes once per refresh, reuses one current-comment read across its checks, and shares the refresh budget. Removing auto-unblock would restore the manual operator step; removing the cap would violate provider-budget requirements. No new service, configuration, reason code, or reconciliation loop. With a stable set of N known identities, each gets first priority within 2N eligible refreshes. Completion requires provider capacity and a cap sufficient for the complete fresh check; oversized items remain blocked and receive future scan turns.

Fixes #2368

## UI Surface Contract

- [x] N/A: no UI layout or responsive changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens; existing activity telemetry reports classified dependency deferrals.

## Test Plan

- [x] Reproduced on current main: seven fully consumed refreshes leave all three ready issues blocked; a capped blocker read incorrectly unblocks from cached Done evidence.
- [x] Deterministic regressions cover partial recovery, repeated exhaustion, rotating order, new arrivals, oversized items, ordinary-consumer progress, exactly one scan per refresh, cursor removal/wrap, shared-cap enforcement, fresh comments/workpads, missing/reopened dependencies, human evidence, operator stops, reserves, and primary/secondary limits.
- [x] Focused orchestrator and GitHub connector regressions pass.
- [x] Independent validator review: pass, score 9/10, blocking severities P1/P2, no findings.
- [x] Revised `make check` passed on the consolidated scan: build, lint (zero issues), vet, NilAway, race tests, 80.7% coverage, and all package/file floors (10m7s execution).
