### PR TITLE
fix(orchestrator): accept clean completion retries

### DIFF
--- a/internal/orchestrator/completion_cleanliness.go
+++ b/internal/orchestrator/completion_cleanliness.go
@@ -25,7 +25,6 @@ const (
 	completionCleanlinessDiscarded         = "discarded"
 	completionCleanlinessIntentionallyLeft = "intentionally_left"
 	dirtyCompletionReason                  = "dirty_worktree_completion_rejected"
-	dirtyCompletionResolutionReason        = "dirty_worktree_resolution_required"
 	dirtyCompletionEscalationReason        = "dirty_worktree_completion_unresolved"
 	completionCleanlinessRejectionLimit    = 2
 )
@@ -138,20 +137,9 @@ func (o *Orchestrator) evaluateCompletionCleanliness(
 		return decision
 	}
 	if !completionCleanlinessDirty(evidence) {
-		if previousRejections > 0 && !completionCleanlinessResolutionValid(decision.Declaration) {
-			decision.Outcome = completionCleanlinessRejected
-			decision.Reason = dirtyCompletionResolutionReason
-			decision.ConsecutiveRejections = previousRejections + 1
-			decision.Block = decision.ConsecutiveRejections >= completionCleanlinessRejectionLimit
-			if decision.Block {
-				decision.Outcome = completionCleanlinessEscalated
-				decision.Reason = dirtyCompletionEscalationReason
-			}
-			return decision
-		}
 		decision.Outcome = completionCleanlinessAccepted
 		decision.Resolution = completionCleanlinessClean
-		if previousRejections > 0 {
+		if previousRejections > 0 && completionCleanlinessResolutionValid(decision.Declaration) {
 			decision.Resolution = decision.Declaration
 		}
 		return decision
@@ -309,7 +297,7 @@ func completionCleanlinessRejectionComment(decision completionCleanlinessDecisio
 	appendQuotedEvidence(&b, "untracked_paths", decision.Evidence.UntrackedPaths)
 	appendQuotedEvidence(&b, "unpushed_commit_refs", decision.Evidence.UnpushedCommitRefs)
 	appendQuotedEvidence(&b, "commits_not_in_pull_request", decision.Evidence.CommitsNotInPullRequest)
-	b.WriteString("\n\nInspect every path before the next completion attempt. Commit and publish work that belongs to the issue, discard stray artifacts or mistakes, or set the Workpad to `status: blocked` and state why files are intentionally left. For a clean retry, add `completion_cleanliness_resolution: committed` or `completion_cleanliness_resolution: discarded` under `fields:` in the current completion block. Detent will not accept `status: complete` while this evidence remains.")
+	b.WriteString("\n\nInspect every path before the next completion attempt. Commit and publish work that belongs to the issue, discard stray artifacts or mistakes, or set the Workpad to `status: blocked` and state why files are intentionally left. For a clean retry, you may record `completion_cleanliness_resolution: committed` or `completion_cleanliness_resolution: discarded` under `fields:` in the current completion block. Detent will not accept `status: complete` while this evidence remains.")
 	return b.String()
 }
 

--- a/internal/orchestrator/completion_cleanliness.go
+++ b/internal/orchestrator/completion_cleanliness.go
@@ -320,7 +320,7 @@ func (o *Orchestrator) blockCompletionCleanliness(
 	)
 	humanAction := strings.TrimSpace(decision.Statement)
 	if humanAction == "" {
-		humanAction = "inspect the preserved workspace, commit and publish required work or discard stray changes, move the issue to Rework, then record completion_cleanliness_resolution as committed or discarded under `fields:` on completion"
+		humanAction = "inspect the preserved workspace, commit and publish required work or discard stray changes, move the issue to Rework; optionally record completion_cleanliness_resolution as committed or discarded under `fields:` on completion"
 	}
 	event.Err = errors.New(detail)
 	running.DiffStats = decision.Evidence

--- a/internal/orchestrator/completion_cleanliness_test.go
+++ b/internal/orchestrator/completion_cleanliness_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -104,12 +106,20 @@ func TestEvaluateCompletionCleanliness(t *testing.T) {
 			wantResolution: completionCleanlinessDiscarded,
 		},
 		{
-			name:         "clean retry without explicit resolution escalates",
-			evidence:     DiffStats{Status: "clean", HeadSHA: "resolved-head"},
-			history:      []store.WorkAttempt{previousRejected},
-			wantOutcome:  completionCleanlinessEscalated,
-			wantRejected: 2,
-			wantBlock:    true,
+			name:           "clean retry without explicit resolution",
+			evidence:       DiffStats{Status: "clean", HeadSHA: "resolved-head"},
+			history:        []store.WorkAttempt{previousRejected, previousRejected},
+			wantOutcome:    completionCleanlinessAccepted,
+			wantResolution: completionCleanlinessClean,
+		},
+		{
+			name:           "repeated unpushed completion escalates",
+			evidence:       DiffStats{Status: "clean", HeadSHA: "head", UnpushedCommits: 1},
+			history:        []store.WorkAttempt{previousRejected},
+			wantOutcome:    completionCleanlinessEscalated,
+			wantResolution: "required",
+			wantRejected:   2,
+			wantBlock:      true,
 		},
 		{
 			name: "recovery evidence unavailable",
@@ -343,6 +353,47 @@ func TestHandleRunResultRejectsDirtyCompletionAndEscalates(t *testing.T) {
 				}
 			} else if !strings.Contains(comment, "preserve debug.log for operator inspection") {
 				t.Fatalf("comment missing intentional-left statement:\n%s", comment)
+			}
+		})
+	}
+}
+
+func TestHandleRunResultCleanRetryUsesPRGate(t *testing.T) {
+	t.Parallel()
+	for _, rejections := range []int{1, 2} {
+		t.Run(fmt.Sprintf("after_%d_rejections", rejections), func(t *testing.T) {
+			t.Parallel()
+			issue := completionTransitionIssue("In Progress", "OPEN")
+			issue.PullRequest = &connector.PullRequest{Number: 2493, State: "OPEN", CIStatus: "pass", UnresolvedReviewThreads: []connector.PullRequestReviewThread{{Path: "worker.go", Line: 1}}}
+			issue.Comments = []connector.IssueComment{{Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nfields:\n  completion_work_attempt_id: \"2493\"\n  completion_generation: \"7\"\nblockers: []\nhuman_action: null\n```"}}
+			history := make([]store.WorkAttempt, rejections)
+			for i := range history {
+				history[i] = store.WorkAttempt{TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: marshalWorkAttemptJSON(completionCleanlinessMetadata(completionCleanlinessDecision{Attempted: true, Outcome: completionCleanlinessRejected}))}
+			}
+			attempts := &implementProgressAttemptStore{history: history}
+			tracker := &implementProgressConnector{refreshed: issue, hydrated: issue}
+			cfg := normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}, ActiveStates: []string{"Todo", "In Progress", "Rework", "Merging"}, TerminalStates: []string{"Done", "Cancelled"}, AutoPromote: AutoPromoteConfig{Enabled: true, Gate: gate.Config{Kind: gate.KindHumanReview}}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker, workAttempts: attempts, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			state := newState(cfg)
+			now := time.Date(2026, 9, 11, 15, 0, 0, 0, time.UTC)
+			state.Running[issue.ID] = Running{Issue: issue, Attempt: 1, WorkAttemptID: 2493, Generation: 7, Mode: runpkg.RunModeImplement, StartedAt: now.Add(-time.Minute)}
+			state.Claimed[issue.ID] = Claimed{Issue: issue}
+			orch.handleRunResult(t.Context(), &state, runpkg.Completion{IssueID: issue.ID, CompletedAt: now, Request: runpkg.RunRequest{Issue: issue, Mode: runpkg.RunModeImplement, WorkAttemptID: 2493, Generation: 7}, Result: runpkg.RunResult{FinalState: runpkg.FinalStateCompleted, DiffStats: DiffStats{Status: "clean", HeadSHA: "head", RecoveryStateExpected: true, RecoveryStateAvailable: true}}})
+			if _, blocked := state.Blocked[issue.ID]; blocked {
+				t.Fatal("clean retry was parked")
+			}
+			if len(tracker.updates) != 1 || tracker.updates[0].state != "Rework" {
+				t.Fatalf("updates = %#v, want Rework", tracker.updates)
+			}
+			if len(tracker.comments) == 0 || !strings.Contains(tracker.comments[len(tracker.comments)-1].body, "unresolved review thread") {
+				t.Fatalf("comments = %#v, want PR gate reason", tracker.comments)
+			}
+			if len(attempts.completions) != 1 {
+				t.Fatalf("completions = %#v", attempts.completions)
+			}
+			record, ok := completionCleanlinessRecordFromAttempt(store.WorkAttempt{WorkerMetadataJSON: attempts.completions[0].WorkerMetadataJSON})
+			if !ok || record.Outcome != completionCleanlinessAccepted {
+				t.Fatalf("cleanliness = %#v", record)
 			}
 		})
 	}

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -217,7 +217,7 @@ func appendWorkspaceRecoveryBlock(prompt string, state *workspace.RecoveryState)
 	appendWorkspaceRecoveryPaths(&b, "tracked paths", state.TrackedPaths)
 	appendWorkspaceRecoveryPaths(&b, "untracked paths", state.UntrackedPaths)
 	appendWorkspaceRecoveryPaths(&b, "unpushed commits", state.UnpushedCommitRefs)
-	b.WriteString("\n\nA prior completion cannot be accepted until you explicitly resolve this state. Inspect every path and choose the correct outcome: commit and publish work that belongs to the issue, discard stray artifacts or mistakes, or update the Workpad to `status: blocked` and state why the files are intentionally left. For a clean retry, add `completion_cleanliness_resolution: committed` or `completion_cleanliness_resolution: discarded` under `fields:` in the current completion block. Do not repeat `status: complete` while the worktree remains dirty. After resolving it, run the required validation gate and update the pull request.")
+	b.WriteString("\n\nA prior completion cannot be accepted until you explicitly resolve this state. Inspect every path and choose the correct outcome: commit and publish work that belongs to the issue, discard stray artifacts or mistakes, or update the Workpad to `status: blocked` and state why the files are intentionally left. For a clean retry, you may record `completion_cleanliness_resolution: committed` or `completion_cleanliness_resolution: discarded` under `fields:` in the current completion block. Do not repeat `status: complete` while the worktree remains dirty. After resolving it, run the required validation gate and update the pull request.")
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + b.String()
 }
 


### PR DESCRIPTION
## Summary

- Remove the branch that parked verified-clean completion retries solely because their Workpad lacked a resolution declaration. Clean retries now reach the existing PR/gate evaluation and retain its actual Rework reason.
- Preserve dirty-workspace and unpushed-commit escalation. Committed/discarded declarations remain optional audit metadata, and recovery instructions consistently describe them as optional.

Fixes #2493

## UI Surface Contract

- [x] N/A: no UI surface, layout, density, viewport, or responsive visibility changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Reproduced clean-evidence escalation with a failing regression before the fix.
- [x] Focused table-driven tests cover clean retries after prior rejections, existing unpushed escalation, and handler routing to Rework with the unresolved PR review-thread reason.
- [x] Independent validator: approve, score 97, no P1/P2 findings.
- [x] `make check` passed; coverage 80.7%, all configured floors met.
