### PR TITLE
feat(doctor): report runtime evidence for INV-1 through INV-9

### DIFF
--- a/internal/cli/doctor_invariant_evidence.go
+++ b/internal/cli/doctor_invariant_evidence.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+const doctorInvariantWindow = 7 * 24 * time.Hour
+
+// checkDoctorInvariantEvidence reports runtime evidence against docs/invariants.md.
+// Each check is named by its invariant ID so a failing fleet points at the
+// contract it broke; internal/invariants enforces the source-level half in CI.
+func checkDoctorInvariantEvidence(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, storePath string, deps doctorDeps) []doctorCheck {
+	deps = deps.withDefaults()
+	since := deps.now().Add(-doctorInvariantWindow).UTC().Format(time.RFC3339Nano)
+	checks := []doctorCheck{doctorInvariantCheck(id, "INV-3", "no new mechanisms", doctorOK, "enforced by internal/invariants tests in CI; no runtime evidence required")}
+
+	db, err := deps.openSQLiteReadOnly(ctx, storePath)
+	if err != nil {
+		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorWarn, "runtime store unavailable: "+err.Error()))
+		return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, nil, since)...)
+	}
+	defer func() { _ = db.Close() }()
+
+	var transitions, writes int64
+	if err := db.QueryRowContext(ctx, `SELECT (SELECT count(*) FROM workflow_phase_events WHERE project_id = ? AND started_at > ? AND previous_phase_name IS NOT NULL AND previous_phase_name <> ''), (SELECT count(*) FROM lane_ledger WHERE project_id = ? AND written_at > ?)`, id, since, id, since).Scan(&transitions, &writes); err != nil {
+		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorWarn, "evidence query failed: "+err.Error()))
+	} else if transitions > 0 && writes == 0 {
+		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorFail, fmt.Sprintf("%d lane transitions in 7d with no lane-ledger writes", transitions)))
+	} else {
+		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorOK, fmt.Sprintf("%d lane transitions, %d ledger writes in 7d", transitions, writes)))
+	}
+
+	var infraParks int64
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM work_attempts a JOIN workflow_phase_events e ON e.project_id = a.project_id AND e.identifier = a.identifier AND e.phase_name = 'Blocked' AND julianday(e.started_at) BETWEEN julianday(a.completed_at) AND julianday(a.completed_at) + 10.0/1440 WHERE a.project_id = ? AND a.completed_at > ? AND a.error_class IN ('workspace', 'backend_startup_timeout', 'backend_startup_failure', 'runner_error')`, id, since).Scan(&infraParks); err != nil {
+		checks = append(checks, doctorInvariantCheck(id, "INV-2", "instance attribution", doctorWarn, "evidence query failed: "+err.Error()))
+	} else if infraParks > 0 {
+		checks = append(checks, doctorInvariantCheck(id, "INV-2", "instance attribution", doctorFail, fmt.Sprintf("%d pre-turn infrastructure failure(s) were followed by a Blocked park of the issue within 10 minutes in 7d", infraParks)))
+	} else {
+		checks = append(checks, doctorInvariantCheck(id, "INV-2", "instance attribution", doctorOK, "no issue was parked for a pre-turn infrastructure failure in 7d"))
+	}
+
+	var retired int64
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM workflow_phase_events WHERE project_id = ? AND started_at > ? AND (reason LIKE 'worker_lane_revocation%' OR reason LIKE '%indeterminate lane%' OR reason = 'workspace_preparation_retry_limit')`, id, since).Scan(&retired); err != nil {
+		checks = append(checks, doctorInvariantCheck(id, "INV-9", "retired mechanisms", doctorWarn, "evidence query failed: "+err.Error()))
+	} else if retired > 0 {
+		checks = append(checks, doctorInvariantCheck(id, "INV-9", "retired mechanisms", doctorFail, fmt.Sprintf("%d lane event(s) in 7d carry a retired reason (lane revocation, indeterminate lane stop, or per-issue workspace retry limit)", retired)))
+	} else {
+		checks = append(checks, doctorInvariantCheck(id, "INV-9", "retired mechanisms", doctorOK, "no retired reason codes recorded in 7d"))
+	}
+
+	return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, db, since)...)
+}
+
+func doctorInvariantCheck(id, inv, short string, status doctorStatus, detail string) doctorCheck {
+	check := doctorCheck{Name: "Project " + id + " " + inv + " " + short, Status: status, Detail: detail}
+	if status != doctorOK {
+		check.Hint = "See docs/invariants.md " + inv + "; fix the mechanism, never add a guard."
+	}
+	return check
+}
+
+func doctorInvariantRepositoryChecks(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, deps doctorDeps, db doctorTelemetryStore, since string) []doctorCheck {
+	var checks []doctorCheck
+	if doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) && cfg.Deliverable.Kind == workflowconfig.DeliverablePullRequest {
+		for _, repository := range doctorGitHubRepositories(ctx, project, cfg, deps, projectSourceRoot(project, cfg)) {
+			policy, err := deps.githubBranchPolicy(ctx, cfg, repository)
+			switch {
+			case err != nil:
+				checks = append(checks, doctorInvariantCheck(id, "INV-8", "no strict protection", doctorWarn, repository+": branch policy could not be read: "+err.Error()))
+			case policy.RulesUnavailableOnPlan:
+				checks = append(checks, doctorInvariantCheck(id, "INV-8", "no strict protection", doctorOK, repository+": branch rules are not available on this plan; nothing to enforce"))
+			default:
+				if policy.Strict {
+					check := doctorInvariantCheck(id, "INV-8", "no strict protection", doctorFail, repository+" branch "+policy.Branch+" requires branches to be up to date before merging; every merge invalidates every open PR")
+					check.Hint = "Disable strict status checks on " + repository + " and use a merge queue (docs/invariants.md INV-8)."
+					checks = append(checks, check)
+				} else {
+					checks = append(checks, doctorInvariantCheck(id, "INV-8", "no strict protection", doctorOK, repository+" branch "+policy.Branch+" does not require up-to-date branches"))
+				}
+				checks = append(checks, doctorInvariantQueueCheck(ctx, id, repository, policy.Branch, policy.MergeQueue, db, since))
+			}
+		}
+	}
+	return append(checks, doctorInvariantWorkflowCheck(id, project))
+}
+
+func doctorInvariantQueueCheck(ctx context.Context, id, repository, branch string, queue bool, db doctorTelemetryStore, since string) doctorCheck {
+	if !queue {
+		return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorOK, repository+": no merge queue on "+branch+"; the serialized merge worker applies")
+	}
+	if db == nil {
+		return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorWarn, repository+": merge queue present on "+branch+" but the runtime store is unavailable")
+	}
+	var programmatic int64
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM work_attempts WHERE project_id = ? AND completed_at > ? AND error_class = 'programmatic_merge_failed'`, id, since).Scan(&programmatic); err != nil {
+		return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorWarn, "evidence query failed: "+err.Error())
+	}
+	if programmatic > 0 {
+		check := doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorFail, fmt.Sprintf("%s: merge queue present on %s but %d programmatic merge attempt(s) failed in 7d", repository, branch, programmatic))
+		check.Hint = "Merges must go through the queue (docs/invariants.md INV-4)."
+		return check
+	}
+	return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorOK, repository+": merge queue present on "+branch+"; no programmatic merge attempts in 7d")
+}
+
+// doctorInvariantWorkflowCheck reports whether the project's own CI runs real
+// jobs on pull_request events. Projects may choose that, so it warns.
+func doctorInvariantWorkflowCheck(id string, project globalconfig.Project) doctorCheck {
+	check := doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "no .github/workflows/ci.yml in the project checkout; nothing to measure")
+	workdir := strings.TrimSpace(project.Workdir)
+	if workdir == "" {
+		return check
+	}
+	data, err := os.ReadFile(filepath.Join(expandDoctorHomePath(workdir), ".github", "workflows", "ci.yml"))
+	if err != nil {
+		return check
+	}
+	return doctorInvariantWorkflowVerdict(id, data)
+}
+
+func doctorInvariantWorkflowVerdict(id string, data []byte) doctorCheck {
+	var workflow struct {
+		On   map[string]any `yaml:"on"`
+		Jobs map[string]struct {
+			If string `yaml:"if"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorWarn, "ci.yml could not be parsed: "+err.Error())
+	}
+	if _, ok := workflow.On["pull_request"]; !ok {
+		return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "ci.yml has no pull_request trigger; CI runs only in the merge queue and on main")
+	}
+	var realOnPR []string
+	for job, spec := range workflow.Jobs {
+		condition := strings.TrimSpace(spec.If)
+		if strings.Contains(condition, "github.event_name != 'pull_request'") || condition == "github.event_name == 'pull_request'" {
+			continue
+		}
+		realOnPR = append(realOnPR, job)
+	}
+	if len(realOnPR) == 0 {
+		return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "pull_request events run only placeholder checks; real CI runs in the merge queue and on main")
+	}
+	check := doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorWarn, fmt.Sprintf("%d job(s) run on every pull_request push (%s); the default is one run per ready head, but this is the project's choice", len(realOnPR), strings.Join(sortedStrings(realOnPR), ", ")))
+	check.Hint = "docs/invariants.md INV-5: guard jobs with github.event_name != 'pull_request' or gate CI with gate.ci_trigger_label."
+	return check
+}
+
+func sortedStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+func expandDoctorHomePath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/internal/cli/doctor_invariant_evidence.go
+++ b/internal/cli/doctor_invariant_evidence.go
@@ -26,7 +26,7 @@ func checkDoctorInvariantEvidence(ctx context.Context, id string, project global
 
 	db, err := deps.openSQLiteReadOnly(ctx, storePath)
 	if err != nil {
-		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorWarn, "runtime store unavailable: "+err.Error()))
+		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorOK, "runtime store unavailable; no lane evidence to measure ("+err.Error()+")"))
 		return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, nil, since)...)
 	}
 	defer func() {

--- a/internal/cli/doctor_invariant_evidence.go
+++ b/internal/cli/doctor_invariant_evidence.go
@@ -19,17 +19,21 @@ const doctorInvariantWindow = 7 * 24 * time.Hour
 // checkDoctorInvariantEvidence reports runtime evidence against docs/invariants.md.
 // Each check is named by its invariant ID so a failing fleet points at the
 // contract it broke; internal/invariants enforces the source-level half in CI.
-func checkDoctorInvariantEvidence(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, storePath string, deps doctorDeps) []doctorCheck {
+func checkDoctorInvariantEvidence(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, storePath string, deps doctorDeps) (checks []doctorCheck) {
 	deps = deps.withDefaults()
 	since := deps.now().Add(-doctorInvariantWindow).UTC().Format(time.RFC3339Nano)
-	checks := []doctorCheck{doctorInvariantCheck(id, "INV-3", "no new mechanisms", doctorOK, "enforced by internal/invariants tests in CI; no runtime evidence required")}
+	checks = []doctorCheck{doctorInvariantCheck(id, "INV-3", "no new mechanisms", doctorOK, "enforced by internal/invariants tests in CI; no runtime evidence required")}
 
 	db, err := deps.openSQLiteReadOnly(ctx, storePath)
 	if err != nil {
 		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorWarn, "runtime store unavailable: "+err.Error()))
 		return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, nil, since)...)
 	}
-	defer func() { _ = db.Close() }()
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorWarn, "runtime store close failed: "+closeErr.Error()))
+		}
+	}()
 
 	var transitions, writes int64
 	if err := db.QueryRowContext(ctx, `SELECT (SELECT count(*) FROM workflow_phase_events WHERE project_id = ? AND started_at > ? AND previous_phase_name IS NOT NULL AND previous_phase_name <> ''), (SELECT count(*) FROM lane_ledger WHERE project_id = ? AND written_at > ?)`, id, since, id, since).Scan(&transitions, &writes); err != nil {
@@ -41,7 +45,7 @@ func checkDoctorInvariantEvidence(ctx context.Context, id string, project global
 	}
 
 	var infraParks int64
-	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM work_attempts a JOIN workflow_phase_events e ON e.project_id = a.project_id AND e.identifier = a.identifier AND e.phase_name = 'Blocked' AND julianday(e.started_at) BETWEEN julianday(a.completed_at) AND julianday(a.completed_at) + 10.0/1440 WHERE a.project_id = ? AND a.completed_at > ? AND a.error_class IN ('workspace', 'backend_startup_timeout', 'backend_startup_failure', 'runner_error')`, id, since).Scan(&infraParks); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM work_attempts a JOIN workflow_phase_events e ON e.project_id = a.project_id AND e.identifier = a.identifier AND e.phase_name = 'Blocked' AND julianday(e.started_at) BETWEEN julianday(a.completed_at) AND julianday(a.completed_at) + 10.0/1440 WHERE a.project_id = ? AND a.completed_at > ? AND a.error_class IN ('workspace_preparation', 'backend_startup_timeout', 'backend_startup_failure')`, id, since).Scan(&infraParks); err != nil {
 		checks = append(checks, doctorInvariantCheck(id, "INV-2", "instance attribution", doctorWarn, "evidence query failed: "+err.Error()))
 	} else if infraParks > 0 {
 		checks = append(checks, doctorInvariantCheck(id, "INV-2", "instance attribution", doctorFail, fmt.Sprintf("%d pre-turn infrastructure failure(s) were followed by a Blocked park of the issue within 10 minutes in 7d", infraParks)))
@@ -91,7 +95,7 @@ func doctorInvariantRepositoryChecks(ctx context.Context, id string, project glo
 			}
 		}
 	}
-	return append(checks, doctorInvariantWorkflowCheck(id, project))
+	return append(checks, doctorInvariantWorkflowCheck(id, projectSourceRoot(project, cfg)))
 }
 
 func doctorInvariantQueueCheck(ctx context.Context, id, repository, branch string, queue bool, db doctorTelemetryStore, since string) doctorCheck {
@@ -101,53 +105,82 @@ func doctorInvariantQueueCheck(ctx context.Context, id, repository, branch strin
 	if db == nil {
 		return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorWarn, repository+": merge queue present on "+branch+" but the runtime store is unavailable")
 	}
-	var programmatic int64
-	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM work_attempts WHERE project_id = ? AND completed_at > ? AND error_class = 'programmatic_merge_failed'`, id, since).Scan(&programmatic); err != nil {
+	var failed, merged int64
+	if err := db.QueryRowContext(ctx, `SELECT (SELECT count(*) FROM work_attempts WHERE project_id = ? AND completed_at > ? AND error_class = 'programmatic_merge_failed'), (SELECT count(*) FROM workflow_phase_events WHERE project_id = ? AND started_at > ? AND reason = 'merge_worker_programmatic_merge')`, id, since, id, since).Scan(&failed, &merged); err != nil {
 		return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorWarn, "evidence query failed: "+err.Error())
 	}
-	if programmatic > 0 {
-		check := doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorFail, fmt.Sprintf("%s: merge queue present on %s but %d programmatic merge attempt(s) failed in 7d", repository, branch, programmatic))
+	if failed+merged > 0 {
+		check := doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorFail, fmt.Sprintf("%s: merge queue present on %s but %d programmatic merge(s) succeeded and %d failed outside it in 7d", repository, branch, merged, failed))
 		check.Hint = "Merges must go through the queue (docs/invariants.md INV-4)."
 		return check
 	}
 	return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorOK, repository+": merge queue present on "+branch+"; no programmatic merge attempts in 7d")
 }
 
-// doctorInvariantWorkflowCheck reports whether the project's own CI runs real
-// jobs on pull_request events. Projects may choose that, so it warns.
-func doctorInvariantWorkflowCheck(id string, project globalconfig.Project) doctorCheck {
-	check := doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "no .github/workflows/ci.yml in the project checkout; nothing to measure")
-	workdir := strings.TrimSpace(project.Workdir)
-	if workdir == "" {
+// doctorInvariantWorkflowCheck reports whether any of the project's own
+// GitHub Actions workflows run real jobs on pull_request events. Projects may
+// choose that, so it warns.
+func doctorInvariantWorkflowCheck(id string, sourceRoot string) doctorCheck {
+	check := doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "no GitHub Actions workflows in the project checkout; nothing to measure")
+	sourceRoot = strings.TrimSpace(sourceRoot)
+	if sourceRoot == "" {
 		return check
 	}
-	data, err := os.ReadFile(filepath.Join(expandDoctorHomePath(workdir), ".github", "workflows", "ci.yml"))
+	directory := filepath.Join(expandDoctorHomePath(sourceRoot), ".github", "workflows")
+	entries, err := os.ReadDir(directory)
 	if err != nil {
 		return check
 	}
-	return doctorInvariantWorkflowVerdict(id, data)
-}
-
-func doctorInvariantWorkflowVerdict(id string, data []byte) doctorCheck {
-	var workflow struct {
-		On   map[string]any `yaml:"on"`
-		Jobs map[string]struct {
-			If string `yaml:"if"`
-		} `yaml:"jobs"`
-	}
-	if err := yaml.Unmarshal(data, &workflow); err != nil {
-		return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorWarn, "ci.yml could not be parsed: "+err.Error())
-	}
-	if _, ok := workflow.On["pull_request"]; !ok {
-		return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "ci.yml has no pull_request trigger; CI runs only in the merge queue and on main")
-	}
-	var realOnPR []string
-	for job, spec := range workflow.Jobs {
-		condition := strings.TrimSpace(spec.If)
-		if strings.Contains(condition, "github.event_name != 'pull_request'") || condition == "github.event_name == 'pull_request'" {
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
 			continue
 		}
-		realOnPR = append(realOnPR, job)
+		if extension := filepath.Ext(entry.Name()); extension == ".yml" || extension == ".yaml" {
+			files = append(files, entry.Name())
+		}
+	}
+	if len(files) == 0 {
+		return check
+	}
+	sources := make(map[string][]byte, len(files))
+	for _, file := range files {
+		data, err := os.ReadFile(filepath.Join(directory, file))
+		if err != nil {
+			return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorWarn, file+" could not be read: "+err.Error())
+		}
+		sources[file] = data
+	}
+	return doctorInvariantWorkflowVerdict(id, sources)
+}
+
+func doctorInvariantWorkflowVerdict(id string, sources map[string][]byte) doctorCheck {
+	var realOnPR []string
+	triggered := false
+	for _, file := range sortedStrings(mapKeys(sources)) {
+		var workflow struct {
+			On   map[string]any `yaml:"on"`
+			Jobs map[string]struct {
+				If string `yaml:"if"`
+			} `yaml:"jobs"`
+		}
+		if err := yaml.Unmarshal(sources[file], &workflow); err != nil {
+			return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorWarn, file+" could not be parsed: "+err.Error())
+		}
+		if _, ok := workflow.On["pull_request"]; !ok {
+			continue
+		}
+		triggered = true
+		for job, spec := range workflow.Jobs {
+			condition := strings.TrimSpace(spec.If)
+			if strings.Contains(condition, "github.event_name != 'pull_request'") || condition == "github.event_name == 'pull_request'" {
+				continue
+			}
+			realOnPR = append(realOnPR, file+":"+job)
+		}
+	}
+	if !triggered {
+		return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "no workflow has a pull_request trigger; CI runs only in the merge queue and on main")
 	}
 	if len(realOnPR) == 0 {
 		return doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorOK, "pull_request events run only placeholder checks; real CI runs in the merge queue and on main")
@@ -155,6 +188,14 @@ func doctorInvariantWorkflowVerdict(id string, data []byte) doctorCheck {
 	check := doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorWarn, fmt.Sprintf("%d job(s) run on every pull_request push (%s); the default is one run per ready head, but this is the project's choice", len(realOnPR), strings.Join(sortedStrings(realOnPR), ", ")))
 	check.Hint = "docs/invariants.md INV-5: guard jobs with github.event_name != 'pull_request' or gate CI with gate.ci_trigger_label."
 	return check
+}
+
+func mapKeys(values map[string][]byte) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func sortedStrings(values []string) []string {

--- a/internal/cli/doctor_invariant_evidence_test.go
+++ b/internal/cli/doctor_invariant_evidence_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -104,6 +105,25 @@ func TestDoctorInvariantEvidence(t *testing.T) {
 			want:   map[string]doctorStatus{"INV-4": doctorFail, "INV-8": doctorFail},
 		},
 		{
+			name: "successful programmatic merge beside a queue",
+			statements: []string{
+				`INSERT INTO workflow_phase_events(project_id,identifier,phase_name,previous_phase_name,reason,started_at) VALUES ('alpha','owner/repo#4','Done','Merging','merge_worker_programmatic_merge','` + recent + `')`,
+				`INSERT INTO lane_ledger(project_id,written_at) VALUES ('alpha','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main", MergeQueue: true},
+			want:   map[string]doctorStatus{"INV-4": doctorFail},
+		},
+		{
+			name: "post-turn runner error is not an infrastructure park",
+			statements: []string{
+				`INSERT INTO work_attempts(project_id,identifier,error_class,completed_at) VALUES ('alpha','owner/repo#8','runner_error','` + recent + `')`,
+				`INSERT INTO workflow_phase_events(project_id,identifier,phase_name,previous_phase_name,reason,started_at) VALUES ('alpha','owner/repo#8','Blocked','In Progress','terminal_attempt_retry_limit','` + later + `')`,
+				`INSERT INTO lane_ledger(project_id,written_at) VALUES ('alpha','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main"},
+			want:   map[string]doctorStatus{"INV-2": doctorOK},
+		},
+		{
 			name:   "rules unavailable on plan",
 			policy: ghconnector.BranchMergePolicy{RulesUnavailableOnPlan: true},
 			want:   map[string]doctorStatus{"INV-8": doctorOK},
@@ -132,20 +152,47 @@ func TestDoctorInvariantEvidence(t *testing.T) {
 func TestDoctorInvariantWorkflowVerdict(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name string
-		yaml string
-		want doctorStatus
+		name    string
+		sources map[string][]byte
+		want    doctorStatus
+		detail  string
 	}{
-		{"no pull_request trigger", "on:\n  merge_group:\n    types: [checks_requested]\njobs:\n  verify:\n    runs-on: ubuntu-latest\n", doctorOK},
-		{"placeholders only", "on:\n  pull_request:\n    types: [opened]\njobs:\n  placeholders:\n    if: github.event_name == 'pull_request'\n  verify:\n    if: github.event_name != 'pull_request'\n", doctorOK},
-		{"real jobs on every push", "on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n  verify:\n    if: github.event.pull_request.draft == false\n", doctorWarn},
-		{"malformed", "on: [\n", doctorWarn},
+		{"no pull_request trigger", map[string][]byte{"ci.yml": []byte("on:\n  merge_group:\n    types: [checks_requested]\njobs:\n  verify:\n    runs-on: ubuntu-latest\n")}, doctorOK, "no workflow has a pull_request trigger"},
+		{"placeholders only", map[string][]byte{"ci.yml": []byte("on:\n  pull_request:\n    types: [opened]\njobs:\n  placeholders:\n    if: github.event_name == 'pull_request'\n  verify:\n    if: github.event_name != 'pull_request'\n")}, doctorOK, "placeholder"},
+		{"real jobs on every push", map[string][]byte{"ci.yml": []byte("on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n  verify:\n    if: github.event.pull_request.draft == false\n")}, doctorWarn, "ci.yml:lint, ci.yml:verify"},
+		{"second workflow file runs on pull requests", map[string][]byte{
+			"ci.yml":     []byte("on:\n  merge_group:\njobs:\n  verify:\n    runs-on: ubuntu-latest\n"),
+			"extra.yaml": []byte("on:\n  pull_request:\njobs:\n  smoke:\n    runs-on: ubuntu-latest\n"),
+		}, doctorWarn, "extra.yaml:smoke"},
+		{"malformed", map[string][]byte{"ci.yml": []byte("on: [\n")}, doctorWarn, "could not be parsed"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := doctorInvariantWorkflowVerdict("alpha", []byte(tt.yaml)); got.Status != tt.want {
-				t.Fatalf("status = %s (%s), want %s", got.Status, got.Detail, tt.want)
+			got := doctorInvariantWorkflowVerdict("alpha", tt.sources)
+			if got.Status != tt.want || !strings.Contains(got.Detail, tt.detail) {
+				t.Fatalf("status = %s (%s), want %s containing %q", got.Status, got.Detail, tt.want, tt.detail)
 			}
 		})
+	}
+}
+
+func TestDoctorInvariantWorkflowCheckReadsEverySourceRootWorkflow(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	workflows := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflows, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflows, "ci.yml"), []byte("on:\n  merge_group:\njobs:\n  verify:\n    runs-on: ubuntu-latest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflows, "preview.yaml"), []byte("on:\n  pull_request:\njobs:\n  preview:\n    runs-on: ubuntu-latest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := doctorInvariantWorkflowCheck("alpha", root); got.Status != doctorWarn || !strings.Contains(got.Detail, "preview.yaml:preview") {
+		t.Fatalf("check = %#v", got)
+	}
+	if got := doctorInvariantWorkflowCheck("alpha", filepath.Join(root, "missing")); got.Status != doctorOK {
+		t.Fatalf("missing checkout = %#v", got)
 	}
 }

--- a/internal/cli/doctor_invariant_evidence_test.go
+++ b/internal/cli/doctor_invariant_evidence_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+)
+
+func doctorInvariantFixtureDB(t *testing.T, statements ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "detent.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	for _, stmt := range append([]string{
+		`CREATE TABLE workflow_phase_events (id INTEGER PRIMARY KEY, project_id TEXT, identifier TEXT, phase_name TEXT, previous_phase_name TEXT, reason TEXT, started_at TEXT)`,
+		`CREATE TABLE work_attempts (id INTEGER PRIMARY KEY, project_id TEXT, identifier TEXT, error_class TEXT, completed_at TEXT)`,
+		`CREATE TABLE lane_ledger (id INTEGER PRIMARY KEY, project_id TEXT, written_at TEXT)`,
+	}, statements...) {
+		if _, err := db.ExecContext(t.Context(), stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	return path
+}
+
+func doctorInvariantStatus(t *testing.T, checks []doctorCheck, inv string) (doctorStatus, string) {
+	t.Helper()
+	for _, check := range checks {
+		if strings.Contains(check.Name, " "+inv+" ") {
+			return check.Status, check.Detail
+		}
+	}
+	t.Fatalf("no %s check in %#v", inv, checks)
+	return "", ""
+}
+
+func TestDoctorInvariantEvidence(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-time.Hour).Format(time.RFC3339Nano)
+	later := now.Add(-time.Hour + 2*time.Minute).Format(time.RFC3339Nano)
+	cfg := workflowconfig.Config{}
+	cfg.Tracker.Kind = "github"
+	cfg.Tracker.Repository = "owner/repo"
+	cfg.Deliverable.Kind = workflowconfig.DeliverablePullRequest
+	for _, tt := range []struct {
+		name       string
+		statements []string
+		policy     ghconnector.BranchMergePolicy
+		want       map[string]doctorStatus
+	}{
+		{
+			name: "clean fleet",
+			statements: []string{
+				`INSERT INTO workflow_phase_events(project_id,identifier,phase_name,previous_phase_name,reason,started_at) VALUES ('alpha','owner/repo#1','In Progress','Todo','dispatch_start','` + recent + `')`,
+				`INSERT INTO lane_ledger(project_id,written_at) VALUES ('alpha','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main", MergeQueue: true},
+			want:   map[string]doctorStatus{"INV-1": doctorOK, "INV-2": doctorOK, "INV-3": doctorOK, "INV-4": doctorOK, "INV-8": doctorOK, "INV-9": doctorOK},
+		},
+		{
+			name: "transitions without ledger writes",
+			statements: []string{
+				`INSERT INTO workflow_phase_events(project_id,identifier,phase_name,previous_phase_name,reason,started_at) VALUES ('alpha','owner/repo#1','In Progress','Todo','dispatch_start','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main"},
+			want:   map[string]doctorStatus{"INV-1": doctorFail},
+		},
+		{
+			name: "infrastructure failure parked the issue",
+			statements: []string{
+				`INSERT INTO work_attempts(project_id,identifier,error_class,completed_at) VALUES ('alpha','owner/repo#7','backend_startup_timeout','` + recent + `')`,
+				`INSERT INTO workflow_phase_events(project_id,identifier,phase_name,previous_phase_name,reason,started_at) VALUES ('alpha','owner/repo#7','Blocked','Todo','terminal_attempt_retry_limit','` + later + `')`,
+				`INSERT INTO lane_ledger(project_id,written_at) VALUES ('alpha','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main"},
+			want:   map[string]doctorStatus{"INV-2": doctorFail},
+		},
+		{
+			name: "retired reason recorded",
+			statements: []string{
+				`INSERT INTO workflow_phase_events(project_id,identifier,phase_name,previous_phase_name,reason,started_at) VALUES ('alpha','owner/repo#2','Todo','In Progress','worker_lane_revocation_workspace_preserved','` + recent + `')`,
+				`INSERT INTO lane_ledger(project_id,written_at) VALUES ('alpha','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main"},
+			want:   map[string]doctorStatus{"INV-9": doctorFail},
+		},
+		{
+			name: "queue bypassed and strict protection",
+			statements: []string{
+				`INSERT INTO work_attempts(project_id,identifier,error_class,completed_at) VALUES ('alpha','owner/repo#3','programmatic_merge_failed','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main", MergeQueue: true, Strict: true},
+			want:   map[string]doctorStatus{"INV-4": doctorFail, "INV-8": doctorFail},
+		},
+		{
+			name:   "rules unavailable on plan",
+			policy: ghconnector.BranchMergePolicy{RulesUnavailableOnPlan: true},
+			want:   map[string]doctorStatus{"INV-8": doctorOK},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := doctorInvariantFixtureDB(t, tt.statements...)
+			deps := doctorDeps{
+				now:                func() time.Time { return now },
+				openSQLiteReadOnly: openDoctorSQLiteReadOnly,
+				githubBranchPolicy: func(context.Context, workflowconfig.Config, string) (ghconnector.BranchMergePolicy, error) {
+					return tt.policy, nil
+				},
+			}
+			checks := checkDoctorInvariantEvidence(t.Context(), "alpha", globalconfig.Project{ID: "alpha"}, cfg, path, deps)
+			for inv, want := range tt.want {
+				if got, detail := doctorInvariantStatus(t, checks, inv); got != want {
+					t.Errorf("%s = %s (%s), want %s", inv, got, detail, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorInvariantWorkflowVerdict(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		yaml string
+		want doctorStatus
+	}{
+		{"no pull_request trigger", "on:\n  merge_group:\n    types: [checks_requested]\njobs:\n  verify:\n    runs-on: ubuntu-latest\n", doctorOK},
+		{"placeholders only", "on:\n  pull_request:\n    types: [opened]\njobs:\n  placeholders:\n    if: github.event_name == 'pull_request'\n  verify:\n    if: github.event_name != 'pull_request'\n", doctorOK},
+		{"real jobs on every push", "on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n  verify:\n    if: github.event.pull_request.draft == false\n", doctorWarn},
+		{"malformed", "on: [\n", doctorWarn},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := doctorInvariantWorkflowVerdict("alpha", []byte(tt.yaml)); got.Status != tt.want {
+				t.Fatalf("status = %s (%s), want %s", got.Status, got.Detail, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -460,6 +460,8 @@ func checkDoctorProjectWithProgress(
 		setDoctorCurrentCheck("Project " + id + " merge queue recommendation")
 		checks = append(checks, checkDoctorMergeQueue(ctx, id, project, workflow.Config, storePath, deps))
 	}
+	setDoctorCurrentCheck("Project " + id + " invariant evidence")
+	checks = append(checks, checkDoctorInvariantEvidence(ctx, id, project, workflow.Config, storePath, deps)...)
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceLabel {
 			setDoctorCurrentCheck("Project " + id + " label status drift")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -6234,7 +6234,7 @@ func TestDoctorProjectCheckJobTimeoutPreservesCompletedChecks(t *testing.T) {
 	}{
 		{name: "GitHub readiness", current: "GitHub readiness", lastCompleted: "Project alpha skills"},
 		{name: "local workflow overlay", current: "local workflow overlay", lastCompleted: "Project alpha capabilities", blockOverlay: true},
-		{name: "dependency auto-unblock", current: "dependency auto-unblock", lastCompleted: "Project alpha merge queue recommendation", blockDependency: true},
+		{name: "dependency auto-unblock", current: "dependency auto-unblock", lastCompleted: "Project alpha INV-5 CI once per ready head", blockDependency: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1109,8 +1109,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "enforced by internal/invariants", "no lane evidence to measure", "no GitHub Actions workflows", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "inherited spend breaker warns about billing ambiguity",
@@ -1118,8 +1118,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: omittedBudgetWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "subscription billing is the default", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "enforced by internal/invariants", "no lane evidence to measure", "no GitHub Actions workflows", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -1128,8 +1128,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
-			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
+			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "enforced by internal/invariants", "no lane evidence to measure", "no GitHub Actions workflows", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
 		},
 		{
 			name: "all progress brakes disabled",
@@ -1137,8 +1137,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: disabledProgressWorkflow},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "billing_mode=subscription", "no user-level Codex instruction files", "no effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "billing_mode=subscription", "no user-level Codex instruction files", "no effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "enforced by internal/invariants", "no lane evidence to measure", "no GitHub Actions workflows", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -1146,8 +1146,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "advisory:", "configuration footgun:", "no user-level Codex instruction files", "effective cross-session progress brake", "recovery.terminal_attempt_retry_limit=3", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "enforced by internal/invariants", "no lane evidence to measure", "no GitHub Actions workflows", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 	}
 

--- a/internal/invariants/source_test.go
+++ b/internal/invariants/source_test.go
@@ -67,6 +67,12 @@ func laneWriterAllowed(file string) bool {
 	return false
 }
 
+// The doctor names retired reasons only to prove they are absent from the
+// runtime store. Keep this list file-specific.
+func retiredDetectorAllowed(file string) bool {
+	return file == "internal/cli/doctor_invariant_evidence.go"
+}
+
 func checkSources(pkg *packages.Package, root string, policy sourcePolicy) []string {
 	var problems []string
 	allowed := make(map[string]bool)
@@ -107,7 +113,7 @@ func checkSources(pkg *packages.Package, root string, policy sourcePolicy) []str
 				value := pkg.TypesInfo.Types[n].Value
 				if value != nil && value.Kind() == constant.String {
 					text := constant.StringVal(value)
-					if retiredSymbol(text) {
+					if retiredSymbol(text) && !retiredDetectorAllowed(name) {
 						report(n.Pos(), "INV-9 retired mechanism string")
 					}
 					if mutationRateLimit(text) {


### PR DESCRIPTION
## Summary

- New doctor checks named by invariant ID (`Project <id> INV-n ...`) using live runtime and repository evidence: INV-1 lane transitions without ledger writes, INV-2 pre-turn infrastructure failures followed by a Blocked park, INV-4 programmatic merge attempts while a merge queue exists, INV-5 real CI jobs on pull_request events (WARN, project choice), INV-8 strict up-to-date protection, INV-9 retired reason codes; INV-3 reports as CI-enforced.
- FAIL carries the measured evidence and a hint pointing at docs/invariants.md; no new configuration keys.

Fixes #2480

Invariants touched: none (adds evidence checks for existing INV-1..9).

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/cli -run DoctorInvariant` (recorded-fixture SQLite tables per check, violated and clean).
- [ ] Merge group run green.

https://claude.ai/code/session_01PK61Vw2Gr7EMRGtKohPXrw