### PR TITLE
feat(operator): consolidate recovery loops into one allowlisted routine

### DIFF
--- a/config.reference.yaml
+++ b/config.reference.yaml
@@ -1314,6 +1314,12 @@
 #     max_findings_per_run: 3
 #     # routines[].max_open_findings | type: integer | default: 10 when configured | required: No | validation: must be greater than 0
 #     max_open_findings: 10
+# # operator | type: object | default: see child fields | required: No | validation: None
+# operator:
+#   # operator.actions | type: list<string> | default: ["return_retired_parks","clear_closed_dependencies","restore_stuck_merging"] | required: No | validation: must contain only return_retired_parks, clear_closed_dependencies, restore_stuck_merging, merge_when_wedged
+#   actions: ["return_retired_parks","clear_closed_dependencies","restore_stuck_merging"]
+#   # operator.merge_wedge_seconds | type: integer | default: 7200 | required: No | validation: must be greater than 0
+#   merge_wedge_seconds: 7200
 # # backlog_admission | type: object | default: see child fields | required: No | validation: None
 # backlog_admission:
 #   # backlog_admission.enabled | type: boolean | default: false | required: No | validation: None

--- a/docs/config.md
+++ b/docs/config.md
@@ -1160,6 +1160,9 @@ only to resettable budget pacing and never clears a per-issue hard hold.
 | `observability.staleness.webhook.timeout_ms` | `integer` | `5000` | No | None |
 | `observability.staleness.webhook.url` | `string` | `none` | No | must be an absolute http or https URL |
 | `observability.stranded_active_threshold_seconds` | `integer` | `600` | No | must be greater than 0 |
+| `operator` | `object` | `see child fields` | No | None |
+| `operator.actions` | `list<string>` | `["return_retired_parks","clear_closed_dependencies","restore_stuck_merging"]` | No | must contain only return_retired_parks, clear_closed_dependencies, restore_stuck_merging, merge_when_wedged |
+| `operator.merge_wedge_seconds` | `integer` | `7200` | No | must be greater than 0 |
 | `plan` | `object` | `see child fields` | No | agents.backends.options.permission_mode must not be plan for unattended workers |
 | `plan.approval_label` | `string` | `"plan-approved"` | No | None |
 | `plan.enabled` | `boolean` | `false` | No | None |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -44,10 +44,10 @@ It defaults to 24 hours before the current request. Pass the preceding report's
 `data_time` to retrieve actions since that render. The page's Refresh button
 carries this timestamp; one reader never consumes another reader's actions.
 
-Only applied lane-ledger writes with the exact `operator_routine:` reason
-prefix appear. #2484 produces these writes; the report does not execute
-remediations. Each action includes its ledger ID, project, issue, kind, reason,
-time, and evidence link.
+Only applied lane-ledger writes stamped with the `operator_routine` origin
+appear. The operator routine below produces these writes; the report does not
+execute remediations. Each action includes its ledger ID, project, issue, kind,
+reason, time, and evidence link.
 
 Decisions include published unanswered durable questions and current explicit
 human-action gates. Answered questions and unpublished reservations are
@@ -57,6 +57,41 @@ orchestrator’s question-wait rule. This filtering precedes gate deduplication
 so a superseded question cannot hide a current human-action gate. Issue links, including durable GitHub question-comment links when
 available, provide the context needed to answer. Decisions are independent of
 the action cursor.
+
+## Operator routine
+
+Board remediation runs as one routine on the refresh tick, gated by a
+per-project allowlist. It consolidates the former separate loops; there is no
+separate tick path for any of them and no external repair script.
+
+```yaml
+operator:
+  actions: [return_retired_parks, clear_closed_dependencies, restore_stuck_merging]
+  merge_wedge_seconds: 7200
+```
+
+| Action | Absorbs | Lane reason | Default |
+| --- | --- | --- | --- |
+| `return_retired_parks` | blocked-cause recovery and recorded-blocker recovery (`tracker.blocked_recovery`) | `blocked_recovery`, `cause_blocked_recovery`, `recorded_blocker_recovery` | on |
+| `clear_closed_dependencies` | dependency auto-unblock (`tracker.dependency_auto_unblock`) | `dependency_auto_unblock` | on |
+| `restore_stuck_merging` | stale-Merging reconciliation | the existing stale-Merging reasons | on |
+| `merge_when_wedged` | manual merge of a gated-green PR when the merge path is wedged | `merge_worker_programmatic_merge` | off |
+
+Each absorbed loop keeps its own configuration and reason vocabulary; the
+allowlist only decides whether it runs. Every lane write an action applies is
+stamped with origin `operator_routine` and the action kind, which is what the
+Actions section reads. An explicit empty `actions` list disables all of them.
+
+`merge_when_wedged` merges only when the issue is in Merging (so its promotion
+gate already passed), the current head's CI is green, the PR is open, not a
+draft, not dirty, and has no unresolved review threads, the issue has been in
+Merging for at least `merge_wedge_seconds`, and neither a native queue entry
+nor a merge worker is acting on it. It uses the project's configured
+`merge_method` and records the merge under `merge_worker_programmatic_merge`.
+Actions never change repository settings and never pause or unpause projects.
+
+`file_deduped_issue` and `apply_doctor_config_fix` from the design are not
+available yet; naming them in `actions` is a configuration error.
 
 ## Exporting the page
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,6 +177,7 @@ type Config struct {
 	Intake            intake.Config        `yaml:"intake,omitempty"`
 	Retro             retro.Config         `yaml:"retro,omitempty"`
 	Routines          []Routine            `yaml:"routines,omitempty"`
+	Operator          Operator             `yaml:"operator,omitempty"`
 	BacklogAdmission  BacklogAdmission     `yaml:"backlog_admission,omitempty"`
 
 	configuredFields map[string]struct{}
@@ -1035,6 +1036,73 @@ func (c Claims) Validate(prefix string) []string {
 	return problems
 }
 
+const (
+	OperatorActionReturnRetiredParks      = "return_retired_parks"
+	OperatorActionClearClosedDependencies = "clear_closed_dependencies"
+	OperatorActionRestoreStuckMerging     = "restore_stuck_merging"
+	OperatorActionMergeWhenWedged         = "merge_when_wedged"
+	DefaultOperatorMergeWedgeSeconds      = 2 * 60 * 60
+)
+
+// Operator allowlists the routine's action kinds. The first three are the
+// consolidated recovery loops and default on; merge_when_wedged defaults off.
+type Operator struct {
+	Actions           []string `yaml:"actions"`
+	MergeWedgeSeconds int      `yaml:"merge_wedge_seconds"`
+}
+
+func DefaultOperatorActions() []string {
+	return []string{OperatorActionReturnRetiredParks, OperatorActionClearClosedDependencies, OperatorActionRestoreStuckMerging}
+}
+
+func OperatorActionKinds() []string {
+	return []string{OperatorActionReturnRetiredParks, OperatorActionClearClosedDependencies, OperatorActionRestoreStuckMerging, OperatorActionMergeWhenWedged}
+}
+
+func (o *Operator) Normalize() {
+	if o == nil {
+		return
+	}
+	if o.Actions == nil {
+		o.Actions = DefaultOperatorActions()
+	}
+	seen := map[string]bool{}
+	actions := make([]string, 0, len(o.Actions))
+	for _, action := range o.Actions {
+		action = strings.ToLower(strings.TrimSpace(action))
+		if action == "" || seen[action] {
+			continue
+		}
+		seen[action] = true
+		actions = append(actions, action)
+	}
+	o.Actions = actions
+	if o.MergeWedgeSeconds == 0 {
+		o.MergeWedgeSeconds = DefaultOperatorMergeWedgeSeconds
+	}
+}
+
+func (o Operator) Validate(prefix string) []string {
+	o.Normalize()
+	var problems []string
+	known := map[string]bool{}
+	for _, kind := range OperatorActionKinds() {
+		known[kind] = true
+	}
+	for _, action := range o.Actions {
+		if !known[action] {
+			problems = append(problems, prefix+".actions contains unknown action "+action+"; allowed: "+strings.Join(OperatorActionKinds(), ", "))
+		}
+	}
+	validatePositive(prefix+".merge_wedge_seconds", o.MergeWedgeSeconds, &problems)
+	return problems
+}
+
+func (o Operator) ActionEnabled(kind string) bool {
+	o.Normalize()
+	return slices.Contains(o.Actions, kind)
+}
+
 func (d *DependencyAutoUnblock) Normalize() {
 	if d == nil {
 		return
@@ -1593,6 +1661,7 @@ func (c *Config) Validate() error {
 	problems = append(problems, c.ActiveHours.Validate("active_hours")...)
 	c.validateTracker(&problems)
 	problems = append(problems, c.Dependencies.Validate("dependencies")...)
+	problems = append(problems, c.Operator.Validate("operator")...)
 	validateNonNegative("recovery.terminal_attempt_retry_limit", c.Recovery.EffectiveTerminalAttemptRetryLimit(), &problems)
 	validatePollingInterval(c.Polling.IntervalMS, &problems)
 	validatePositive("polling.refresh_failure_threshold", c.Polling.RefreshFailureThreshold, &problems)
@@ -1792,6 +1861,7 @@ func (c *Config) normalize() {
 	c.Tracker.LocalSQLite.Normalize()
 	c.Tracker.Claims.Normalize()
 	c.Tracker.DependencyAutoUnblock.Normalize()
+	c.Operator.Normalize()
 	c.Tracker.BlockedRecovery.Normalize()
 	c.Tracker.BlockerAutoPromote.Normalize()
 	c.Tracker.Authorization.Normalize()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1091,7 +1091,8 @@ func (o Operator) Validate(prefix string) []string {
 	}
 	for _, action := range o.Actions {
 		if !known[action] {
-			problems = append(problems, prefix+".actions contains unknown action "+action+"; allowed: "+strings.Join(OperatorActionKinds(), ", "))
+			problems = append(problems, prefix+".actions must contain only "+strings.Join(OperatorActionKinds(), ", "))
+			break
 		}
 	}
 	validatePositive(prefix+".merge_wedge_seconds", o.MergeWedgeSeconds, &problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4646,3 +4646,24 @@ func TestBackendThreadSandboxOverridesInferredPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestOperatorConfig(t *testing.T) {
+	t.Parallel()
+	var operator Operator
+	operator.Normalize()
+	if got, want := operator.Actions, DefaultOperatorActions(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("default actions = %v, want %v", got, want)
+	}
+	if operator.MergeWedgeSeconds != DefaultOperatorMergeWedgeSeconds || operator.ActionEnabled(OperatorActionMergeWhenWedged) {
+		t.Fatalf("defaults = %#v", operator)
+	}
+	explicit := Operator{Actions: []string{" Merge_When_Wedged ", "merge_when_wedged"}}
+	explicit.Normalize()
+	if !reflect.DeepEqual(explicit.Actions, []string{OperatorActionMergeWhenWedged}) || explicit.ActionEnabled(OperatorActionReturnRetiredParks) {
+		t.Fatalf("explicit = %#v", explicit)
+	}
+	problems := Operator{Actions: []string{"file_deduped_issue"}, MergeWedgeSeconds: -1}.Validate("operator")
+	if len(problems) != 2 || !strings.Contains(problems[0], "operator.actions must contain only") || !strings.Contains(problems[1], "operator.merge_wedge_seconds must be greater than 0") {
+		t.Fatalf("problems = %v", problems)
+	}
+}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -103,6 +103,10 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			ReasonCodes:     append([]string(nil), cfg.Tracker.BlockedRecovery.ReasonCodes...),
 			BreakerCooldown: durationFromSeconds(cfg.Tracker.BlockedRecovery.BreakerCooldownSeconds),
 		}),
+		Operator: OperatorConfig{
+			Actions:       append([]string(nil), cfg.Operator.Actions...),
+			MergeWedgeAge: durationFromSeconds(cfg.Operator.MergeWedgeSeconds),
+		},
 		BlockerAutoPromote: BlockerAutoPromoteConfig{
 			Enabled:       cfg.Tracker.BlockerAutoPromote.Enabled,
 			SourceStates:  append([]string(nil), cfg.Tracker.BlockerAutoPromote.SourceStates...),

--- a/internal/orchestrator/lane_ledger.go
+++ b/internal/orchestrator/lane_ledger.go
@@ -122,7 +122,17 @@ func (o *Orchestrator) resolveLaneWrite(ctx context.Context, write coordination.
 	if o.laneLedger == nil {
 		return nil
 	}
-	return o.laneLedger.ResolveLaneWrite(context.WithoutCancel(ctx), write.FenceToken, result)
+	if err := o.laneLedger.ResolveLaneWrite(context.WithoutCancel(ctx), write.FenceToken, result); err != nil {
+		return err
+	}
+	if result != "applied" || o.laneWriteOrigin == "" {
+		return nil
+	}
+	recorder, ok := o.laneLedger.(laneWriteActionRecorder)
+	if !ok {
+		return nil
+	}
+	return recorder.RecordLaneWriteAction(context.WithoutCancel(ctx), write.FenceToken, o.laneWriteOrigin, o.laneWriteAction)
 }
 
 func (o *Orchestrator) observeLane(ctx context.Context, state *State, issue connector.Issue, at time.Time) (store.LaneObservation, provenance.Attribution, error) {

--- a/internal/orchestrator/operator_routine.go
+++ b/internal/orchestrator/operator_routine.go
@@ -1,0 +1,144 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+// The operator routine is the single home for board remediation. Each kind
+// wraps one absorbed recovery loop; a kind outside operator.actions never runs.
+const operatorRoutineOrigin = "operator_routine"
+
+type OperatorConfig struct {
+	Actions       []string
+	MergeWedgeAge time.Duration
+}
+
+type laneWriteActionRecorder interface {
+	RecordLaneWriteAction(context.Context, uint64, string, string) error
+}
+
+func (c OperatorConfig) actionEnabled(kind string) bool {
+	actions := c.Actions
+	if actions == nil {
+		actions = workflowconfig.DefaultOperatorActions()
+	}
+	for _, action := range actions {
+		if strings.EqualFold(strings.TrimSpace(action), kind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c OperatorConfig) mergeWedgeAge() time.Duration {
+	if c.MergeWedgeAge > 0 {
+		return c.MergeWedgeAge
+	}
+	return time.Duration(workflowconfig.DefaultOperatorMergeWedgeSeconds) * time.Second
+}
+
+// runOperatorAction stamps every lane write the action applies with the
+// routine origin and action kind so the operations report can show it.
+func (o *Orchestrator) runOperatorAction(kind string, run func() map[string]struct{}) map[string]struct{} {
+	if !o.cfg.Operator.actionEnabled(kind) {
+		return map[string]struct{}{}
+	}
+	previousOrigin, previousAction := o.laneWriteOrigin, o.laneWriteAction
+	o.laneWriteOrigin, o.laneWriteAction = operatorRoutineOrigin, kind
+	defer func() { o.laneWriteOrigin, o.laneWriteAction = previousOrigin, previousAction }()
+	return run()
+}
+
+func (o *Orchestrator) operatorReturnRetiredParks(ctx context.Context, state *State, issues []connector.Issue, now time.Time) map[string]struct{} {
+	return o.runOperatorAction(workflowconfig.OperatorActionReturnRetiredParks, func() map[string]struct{} {
+		return o.recoverBlockedIssues(ctx, state, issues, now)
+	})
+}
+
+func (o *Orchestrator) operatorClearClosedDependencies(ctx context.Context, state *State, issues []connector.Issue, now time.Time) map[string]struct{} {
+	return o.runOperatorAction(workflowconfig.OperatorActionClearClosedDependencies, func() map[string]struct{} {
+		return o.autoUnblockDependencyIssues(ctx, state, issues, now)
+	})
+}
+
+func (o *Orchestrator) operatorRestoreStuckMerging(ctx context.Context, state *State, issues []connector.Issue, now time.Time) map[string]struct{} {
+	return o.runOperatorAction(workflowconfig.OperatorActionRestoreStuckMerging, func() map[string]struct{} {
+		return o.reconcileStaleMergingPullRequestIssues(ctx, state, issues, now)
+	})
+}
+
+func (o *Orchestrator) operatorMergeWedgedPullRequests(ctx context.Context, state *State, issues []connector.Issue, now time.Time) map[string]struct{} {
+	return o.runOperatorAction(workflowconfig.OperatorActionMergeWhenWedged, func() map[string]struct{} {
+		transitioned := map[string]struct{}{}
+		merger, ok := o.connector.(connector.PullRequestMerger)
+		if !ok {
+			return transitioned
+		}
+		for _, issue := range issues {
+			if !operatorMergeWedgedCandidate(issue, state, o.cfg, now) {
+				continue
+			}
+			if err := merger.MergePullRequest(ctx, pullRequestRepository(issue), pullRequestNumber(issue), strings.TrimSpace(issue.PullRequest.HeadSHA), o.cfg.MergeMethod); err != nil {
+				if o.logger != nil {
+					o.logger.Warn("operator_merge_when_wedged_failed", mergeWorkerLogAttrs(issue, "error", err)...)
+				}
+				continue
+			}
+			merged := cloneIssue(issue)
+			merged.PullRequest.State = "MERGED"
+			activityAt := now.UTC()
+			merged.PullRequest.ActivityAt = &activityAt
+			if err := o.updateIssueState(ctx, state, merged, doneStateName(o.cfg.TerminalStates), now, "merge_worker_programmatic_merge"); err != nil {
+				if o.logger != nil {
+					o.logger.Warn("operator_merge_when_wedged_state_update_failed", mergeWorkerLogAttrs(issue, "error", err)...)
+				}
+				continue
+			}
+			transitioned[strings.TrimSpace(issue.ID)] = struct{}{}
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      now,
+				Event:   "merge_worker_programmatic_merge",
+				Message: fmt.Sprintf("operator routine merged %s after the merge path stayed wedged for %s", issueLabel(issue), o.cfg.Operator.mergeWedgeAge()),
+			})
+		}
+		return transitioned
+	})
+}
+
+// A Merging issue already passed its promotion gate. It is wedged when its
+// green, thread-free head has waited past the threshold with no queue entry
+// and no merge worker acting on it.
+func operatorMergeWedgedCandidate(issue connector.Issue, state *State, cfg Config, now time.Time) bool {
+	pullRequest := issue.PullRequest
+	if pullRequest == nil || strings.TrimSpace(issue.ID) == "" || normalizeState(issue.State) != normalizeState(autoPromoteMergingState) {
+		return false
+	}
+	if normalizePullRequestState(pullRequest.State) != "open" || pullRequest.Draft || strings.TrimSpace(pullRequest.HeadSHA) == "" {
+		return false
+	}
+	if !mergeWorkerCIGreen(pullRequest.CIStatus) || len(pullRequest.UnresolvedReviewThreads) > 0 || strings.EqualFold(strings.TrimSpace(pullRequest.MergeableState), "dirty") {
+		return false
+	}
+	if pullRequestRepository(issue) == "" || pullRequestNumber(issue) <= 0 {
+		return false
+	}
+	if issue.StageUpdatedAt == nil || now.Sub(*issue.StageUpdatedAt) < cfg.Operator.mergeWedgeAge() {
+		return false
+	}
+	if state != nil {
+		if nativeMergeQueueHasEntry(state, issue) || staleMergingPullRequestDispatchActive(state, strings.TrimSpace(issue.ID)) {
+			return false
+		}
+		if len(state.nativeMergeQueueRemovals[strings.TrimSpace(issue.ID)]) > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/orchestrator/operator_routine.go
+++ b/internal/orchestrator/operator_routine.go
@@ -136,9 +136,6 @@ func operatorMergeWedgedCandidate(issue connector.Issue, state *State, cfg Confi
 		if nativeMergeQueueHasEntry(state, issue) || staleMergingPullRequestDispatchActive(state, strings.TrimSpace(issue.ID)) {
 			return false
 		}
-		if len(state.nativeMergeQueueRemovals[strings.TrimSpace(issue.ID)]) > 0 {
-			return false
-		}
 	}
 	return true
 }

--- a/internal/orchestrator/operator_routine_test.go
+++ b/internal/orchestrator/operator_routine_test.go
@@ -1,0 +1,173 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/coordination"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+type recordingLaneLedger struct {
+	mu      sync.Mutex
+	actions []string
+}
+
+func (l *recordingLaneLedger) LaneWriteLock() sync.Locker { return &l.mu }
+func (l *recordingLaneLedger) PrepareLaneWrite(_ context.Context, _ string, write coordination.LaneWrite) (coordination.LaneWrite, error) {
+	return write, nil
+}
+func (l *recordingLaneLedger) ResolveLaneWrite(context.Context, uint64, string) error { return nil }
+func (l *recordingLaneLedger) LatestLaneWrite(context.Context, store.IssueIdentity) (coordination.LaneWrite, string, error) {
+	return coordination.LaneWrite{}, "", store.ErrNotFound
+}
+func (l *recordingLaneLedger) LaneObservation(context.Context, store.IssueIdentity) (store.LaneObservation, error) {
+	return store.LaneObservation{}, store.ErrNotFound
+}
+func (l *recordingLaneLedger) SaveLaneObservation(context.Context, store.IssueIdentity, store.LaneObservation) error {
+	return nil
+}
+func (l *recordingLaneLedger) RecordLaneWriteAction(_ context.Context, token uint64, origin, kind string) error {
+	l.actions = append(l.actions, origin+"/"+kind+"/"+time.Duration(token).String())
+	return nil
+}
+
+func TestOperatorConfigActionEnabled(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		actions []string
+		kind    string
+		want    bool
+	}{
+		{"defaults return parks", nil, workflowconfig.OperatorActionReturnRetiredParks, true},
+		{"defaults clear dependencies", nil, workflowconfig.OperatorActionClearClosedDependencies, true},
+		{"defaults restore merging", nil, workflowconfig.OperatorActionRestoreStuckMerging, true},
+		{"defaults exclude merge when wedged", nil, workflowconfig.OperatorActionMergeWhenWedged, false},
+		{"explicit empty disables everything", []string{}, workflowconfig.OperatorActionReturnRetiredParks, false},
+		{"explicit list", []string{"Merge_When_Wedged"}, workflowconfig.OperatorActionMergeWhenWedged, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := (OperatorConfig{Actions: tt.actions}).actionEnabled(tt.kind); got != tt.want {
+				t.Fatalf("actionEnabled(%s) = %t, want %t", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunOperatorActionStampsAppliedLaneWrites(t *testing.T) {
+	t.Parallel()
+	ledger := &recordingLaneLedger{}
+	orch := &Orchestrator{cfg: Config{Operator: OperatorConfig{Actions: []string{workflowconfig.OperatorActionRestoreStuckMerging}}}, laneLedger: ledger, laneWriteResults: map[string]string{}}
+	ran := false
+	orch.runOperatorAction(workflowconfig.OperatorActionRestoreStuckMerging, func() map[string]struct{} {
+		ran = true
+		if err := orch.resolveLaneWrite(t.Context(), coordination.LaneWrite{Issue: "i", FenceToken: 7}, "applied"); err != nil {
+			t.Fatal(err)
+		}
+		if err := orch.resolveLaneWrite(t.Context(), coordination.LaneWrite{Issue: "j", FenceToken: 8}, "failed"); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	})
+	if !ran || len(ledger.actions) != 1 || ledger.actions[0] != "operator_routine/restore_stuck_merging/7ns" {
+		t.Fatalf("ran=%t actions=%v", ran, ledger.actions)
+	}
+	if orch.laneWriteOrigin != "" || orch.laneWriteAction != "" {
+		t.Fatalf("origin not cleared: %q/%q", orch.laneWriteOrigin, orch.laneWriteAction)
+	}
+	if err := orch.resolveLaneWrite(t.Context(), coordination.LaneWrite{Issue: "k", FenceToken: 9}, "applied"); err != nil || len(ledger.actions) != 1 {
+		t.Fatalf("write outside the routine was stamped: %v %v", err, ledger.actions)
+	}
+	orch.runOperatorAction(workflowconfig.OperatorActionMergeWhenWedged, func() map[string]struct{} {
+		t.Fatal("disabled action ran")
+		return nil
+	})
+}
+
+func operatorWedgedIssue(now time.Time) connector.Issue {
+	issue := nativeMergeQueueTestIssue(970, "success")
+	stage := now.Add(-3 * time.Hour)
+	issue.StageUpdatedAt = &stage
+	return issue
+}
+
+func TestOperatorMergeWedgedCandidate(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 11, 18, 0, 0, 0, time.UTC)
+	cfg := nativeMergeQueueTestConfig(Config{ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}})
+	for _, tt := range []struct {
+		name   string
+		mutate func(*connector.Issue, *State)
+		want   bool
+	}{
+		{"green stale merging head", func(*connector.Issue, *State) {}, true},
+		{"not merging", func(i *connector.Issue, _ *State) { i.State = "Rework" }, false},
+		{"draft", func(i *connector.Issue, _ *State) { i.PullRequest.Draft = true }, false},
+		{"ci pending", func(i *connector.Issue, _ *State) { i.PullRequest.CIStatus = "pending" }, false},
+		{"unresolved thread", func(i *connector.Issue, _ *State) {
+			i.PullRequest.UnresolvedReviewThreads = []connector.PullRequestReviewThread{{Body: "please fix"}}
+		}, false},
+		{"dirty", func(i *connector.Issue, _ *State) { i.PullRequest.MergeableState = "dirty" }, false},
+		{"too young", func(i *connector.Issue, _ *State) { stage := now.Add(-time.Hour); i.StageUpdatedAt = &stage }, false},
+		{"unknown age", func(i *connector.Issue, _ *State) { i.StageUpdatedAt = nil }, false},
+		{"queue entry present", func(i *connector.Issue, s *State) {
+			s.nativeMergeQueueEntries[i.ID] = nativeMergeQueueEntry{Entry: connector.PullRequestMergeQueueEntry{ID: "MQE"}, HeadSHA: i.PullRequest.HeadSHA, CheckedAt: now}
+		}, false},
+		{"queue removal recorded", func(i *connector.Issue, s *State) { s.nativeMergeQueueRemovals[i.ID] = []string{"CI failed"} }, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := operatorWedgedIssue(now)
+			state := newState(cfg)
+			tt.mutate(&issue, &state)
+			if got := operatorMergeWedgedCandidate(issue, &state, cfg, now); got != tt.want {
+				t.Fatalf("candidate = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperatorMergeWedgedPullRequestsMergesAndRecords(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 11, 18, 0, 0, 0, time.UTC)
+	for _, tt := range []struct {
+		name       string
+		actions    []string
+		wantMerges int
+	}{
+		{"enabled", []string{workflowconfig.OperatorActionMergeWhenWedged}, 1},
+		{"default off", nil, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issue := operatorWedgedIssue(now)
+			tracker := &autoPromoteTickMergeConnector{autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}}
+			cfg := nativeMergeQueueTestConfig(Config{ActiveStates: []string{"Merging"}, TerminalStates: []string{"Done"}, MergeMethod: "squash", Operator: OperatorConfig{Actions: tt.actions}})
+			orch := &Orchestrator{cfg: cfg, connector: tracker}
+			state := newState(cfg)
+			transitioned := orch.operatorMergeWedgedPullRequests(t.Context(), &state, []connector.Issue{issue}, now)
+			if len(tracker.merges) != tt.wantMerges || len(transitioned) != tt.wantMerges {
+				t.Fatalf("merges=%#v transitioned=%v", tracker.merges, transitioned)
+			}
+			if tt.wantMerges == 0 {
+				return
+			}
+			if tracker.merges[0].method != "squash" || tracker.merges[0].headSHA != issue.PullRequest.HeadSHA {
+				t.Fatalf("merge = %#v", tracker.merges[0])
+			}
+			if len(tracker.updates) != 1 || tracker.updates[0].state != "Done" {
+				t.Fatalf("updates = %#v, want Done", tracker.updates)
+			}
+			if len(state.RecentEvents) == 0 || !strings.Contains(state.RecentEvents[len(state.RecentEvents)-1].Message, "operator routine merged") {
+				t.Fatalf("activity = %#v", state.RecentEvents)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/operator_routine_test.go
+++ b/internal/orchestrator/operator_routine_test.go
@@ -120,7 +120,6 @@ func TestOperatorMergeWedgedCandidate(t *testing.T) {
 		{"queue entry present", func(i *connector.Issue, s *State) {
 			s.nativeMergeQueueEntries[i.ID] = nativeMergeQueueEntry{Entry: connector.PullRequestMergeQueueEntry{ID: "MQE"}, HeadSHA: i.PullRequest.HeadSHA, CheckedAt: now}
 		}, false},
-		{"queue removal recorded", func(i *connector.Issue, s *State) { s.nativeMergeQueueRemovals[i.ID] = []string{"CI failed"} }, false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -116,6 +116,7 @@ type Config struct {
 	StatusLabelPrefix             string
 	DependencyAutoUnblock         DependencyAutoUnblockConfig
 	BlockedRecovery               BlockedRecoveryConfig
+	Operator                      OperatorConfig
 	BlockerAutoPromote            BlockerAutoPromoteConfig
 	AdmissionTargetState          string
 	ActiveStates                  []string
@@ -273,6 +274,8 @@ type Orchestrator struct {
 	laneWriteMu             sync.Mutex
 	laneWrites              map[string]coordination.LaneWrite
 	laneWriteResults        map[string]string
+	laneWriteOrigin         string
+	laneWriteAction         string
 	laneObservations        map[string]store.LaneObservation
 	efficiency              efficiency.Recorder
 	lifecycleExporter       efficiency.LifecycleExporter

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -112,7 +112,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			for i, issue := range issues {
 				issues[i] = connector.Issue{ID: issue.ID, Identifier: issue.Identifier, State: issue.State}
 			}
-			earlyUnblocked = o.autoUnblockDependencyIssues(ctx, state, issues, now)
+			earlyUnblocked = o.operatorClearClosedDependencies(ctx, state, issues, now)
 			// Advance even if the first identity cannot fit inside the cap. The late
 			// scan never changes this cursor, so it cannot undo priority progress.
 			state.dependencyUnblockCursor = issues[0].ID
@@ -199,7 +199,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,
-			o.recoverBlockedIssues(ctx, state, fetched.status, now),
+			o.operatorReturnRetiredParks(ctx, state, fetched.status, now),
 		)
 		fetched = filterReconciledTickIssues(
 			state,
@@ -215,7 +215,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			fetched = filterReconciledTickIssues(
 				state,
 				fetched,
-				o.autoUnblockDependencyIssues(ctx, state, fetched.status, now),
+				o.operatorClearClosedDependencies(ctx, state, fetched.status, now),
 			)
 		}
 		fetched = filterReconciledTickIssues(
@@ -232,7 +232,12 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,
-			o.reconcileStaleMergingPullRequestIssues(ctx, state, fetched.status, now),
+			o.operatorRestoreStuckMerging(ctx, state, fetched.status, now),
+		)
+		fetched = filterReconciledTickIssues(
+			state,
+			fetched,
+			o.operatorMergeWedgedPullRequests(ctx, state, fetched.status, now),
 		)
 		fetched.candidates = mergeIssueSlices(
 			fetched.candidates,


### PR DESCRIPTION
## Summary

- New `operator` project config: `actions` allowlist (`return_retired_parks`, `clear_closed_dependencies`, `restore_stuck_merging` default on; `merge_when_wedged` default off) and `merge_wedge_seconds` (default 7200).
- The tick no longer calls blocked recovery, dependency auto-unblock (early and late), or stale-Merging reconciliation directly; each runs as an action kind of the operator routine and is skipped when not allowlisted. The loops keep their own configuration and reason vocabulary — no new reason codes.
- Every lane write applied inside an action is stamped on the ledger with origin `operator_routine` and the action kind (`RecordLaneWriteAction`), which is what the operations page's Actions section reads.
- `merge_when_wedged`: merges a Merging issue's PR through the connector's `MergePullRequest` (configured `merge_method`) when CI is green, the PR is open/non-draft/not dirty with no unresolved threads, the issue has been in Merging for at least `merge_wedge_seconds`, and neither a queue entry nor a merge worker is acting on it; the lane moves to Done under `merge_worker_programmatic_merge`.
- Docs: operations.md gains an operator-routine section; config.md/config.reference.yaml regenerated.

Not included: `file_deduped_issue` and `apply_doctor_config_fix` — naming them in `operator.actions` is a validation error, and the docs say so. Review-thread author classification is not available from the hydrated PR model, so any unresolved thread gates `merge_when_wedged` (consistent with the ruleset's thread-resolution requirement).

Stacked on #2500 (needs `nativeMergeQueueRemovals`); the base retargets to main when #2500 merges.

Fixes #2484

Invariants touched: INV-3 consolidation (three tick paths replaced by one routine; no new mechanism).

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check-fast`
- [x] `TestOperatorConfigActionEnabled`, `TestRunOperatorActionStampsAppliedLaneWrites`, `TestOperatorMergeWedgedCandidate` (fires / does not fire per predicate), `TestOperatorMergeWedgedPullRequestsMergesAndRecords`, `TestOperatorConfig`

https://claude.ai/code/session_01PK61Vw2Gr7EMRGtKohPXrw