### PR TITLE
fix(doctor): scope INV-4 evidence to 24h and exempt push-only jobs from INV-5

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -86,6 +86,13 @@ exercises native queue delegation. `TestRepositoryWorkflow` requires
 their chosen settings; Detent detects the queue and uses its serialized merge
 worker where no queue exists. These tests do not inspect live GitHub settings.
 
+`detent doctor` reports runtime evidence: with a queue present, any
+`merge_worker_programmatic_merge` lane event or `programmatic_merge_failed`
+attempt in the last 24 hours fails the check. The store records no queue
+activation time, so a merge from before a queue was enabled can fail the
+check until it ages out of that day; a second queue removal routing to Human
+Review is the budget, not a bypass.
+
 **Change:** Edit INV-4 and the queue delegation tests in the same PR before
 changing the ownership or fallback behavior.
 
@@ -105,6 +112,12 @@ The worker convention is to finish local validation/review before marking ready;
 Rework can produce a new ready head. Workflow assertions cannot deduplicate
 manual reruns or repeated ready/reopened events. Other projects may opt into
 label gating or their own CI convention.
+
+`detent doctor` also reads every workflow under the project's source root and
+warns when a job runs on pull_request events: a job is exempt only when its
+`if` contains `github.event_name != 'pull_request'`, is exactly the placeholder
+equality, or is made of `||` alternatives that each require some other
+`github.event_name`. Projects may keep per-push CI; the verdict is a warning.
 
 **Change:** Edit INV-5 and workflow assertions in the same PR when changing these
 triggers, draft handling, or the documented manual-run exception.

--- a/internal/cli/doctor_invariant_evidence.go
+++ b/internal/cli/doctor_invariant_evidence.go
@@ -14,7 +14,12 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
-const doctorInvariantWindow = 7 * 24 * time.Hour
+const (
+	doctorInvariantWindow = 7 * 24 * time.Hour
+	// A queue may have been enabled recently; only merges after the previous
+	// day are evidence that Detent bypassed it.
+	doctorInvariantQueueWindow = 24 * time.Hour
+)
 
 // checkDoctorInvariantEvidence reports runtime evidence against docs/invariants.md.
 // Each check is named by its invariant ID so a failing fleet points at the
@@ -27,7 +32,7 @@ func checkDoctorInvariantEvidence(ctx context.Context, id string, project global
 	db, err := deps.openSQLiteReadOnly(ctx, storePath)
 	if err != nil {
 		checks = append(checks, doctorInvariantCheck(id, "INV-1", "single lane writer", doctorOK, "runtime store unavailable; no lane evidence to measure ("+err.Error()+")"))
-		return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, nil, since)...)
+		return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, nil, deps.now().Add(-doctorInvariantQueueWindow).UTC().Format(time.RFC3339Nano))...)
 	}
 	defer func() {
 		if closeErr := db.Close(); closeErr != nil {
@@ -62,7 +67,7 @@ func checkDoctorInvariantEvidence(ctx context.Context, id string, project global
 		checks = append(checks, doctorInvariantCheck(id, "INV-9", "retired mechanisms", doctorOK, "no retired reason codes recorded in 7d"))
 	}
 
-	return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, db, since)...)
+	return append(checks, doctorInvariantRepositoryChecks(ctx, id, project, cfg, deps, db, deps.now().Add(-doctorInvariantQueueWindow).UTC().Format(time.RFC3339Nano))...)
 }
 
 func doctorInvariantCheck(id, inv, short string, status doctorStatus, detail string) doctorCheck {
@@ -110,11 +115,11 @@ func doctorInvariantQueueCheck(ctx context.Context, id, repository, branch strin
 		return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorWarn, "evidence query failed: "+err.Error())
 	}
 	if failed+merged > 0 {
-		check := doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorFail, fmt.Sprintf("%s: merge queue present on %s but %d programmatic merge(s) succeeded and %d failed outside it in 7d", repository, branch, merged, failed))
+		check := doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorFail, fmt.Sprintf("%s: merge queue present on %s but %d programmatic merge(s) succeeded and %d failed outside it in 24h", repository, branch, merged, failed))
 		check.Hint = "Merges must go through the queue (docs/invariants.md INV-4)."
 		return check
 	}
-	return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorOK, repository+": merge queue present on "+branch+"; no programmatic merge attempts in 7d")
+	return doctorInvariantCheck(id, "INV-4", "queue is the merge path", doctorOK, repository+": merge queue present on "+branch+"; no programmatic merge attempts in 24h")
 }
 
 // doctorInvariantWorkflowCheck reports whether any of the project's own
@@ -172,8 +177,7 @@ func doctorInvariantWorkflowVerdict(id string, sources map[string][]byte) doctor
 		}
 		triggered = true
 		for job, spec := range workflow.Jobs {
-			condition := strings.TrimSpace(spec.If)
-			if strings.Contains(condition, "github.event_name != 'pull_request'") || condition == "github.event_name == 'pull_request'" {
+			if doctorWorkflowJobSkipsPullRequests(spec.If) {
 				continue
 			}
 			realOnPR = append(realOnPR, file+":"+job)
@@ -188,6 +192,16 @@ func doctorInvariantWorkflowVerdict(id string, sources map[string][]byte) doctor
 	check := doctorInvariantCheck(id, "INV-5", "CI once per ready head", doctorWarn, fmt.Sprintf("%d job(s) run on every pull_request push (%s); the default is one run per ready head, but this is the project's choice", len(realOnPR), strings.Join(sortedStrings(realOnPR), ", ")))
 	check.Hint = "docs/invariants.md INV-5: guard jobs with github.event_name != 'pull_request' or gate CI with gate.ci_trigger_label."
 	return check
+}
+
+// A job stays off pull_request events when its condition excludes them or
+// names only other events; the bare pull_request equality is a placeholder.
+func doctorWorkflowJobSkipsPullRequests(condition string) bool {
+	condition = strings.TrimSpace(condition)
+	if condition == "github.event_name == 'pull_request'" || strings.Contains(condition, "github.event_name != 'pull_request'") {
+		return true
+	}
+	return strings.Contains(condition, "github.event_name ==") && !strings.Contains(condition, "'pull_request'")
 }
 
 func mapKeys(values map[string][]byte) []string {

--- a/internal/cli/doctor_invariant_evidence.go
+++ b/internal/cli/doctor_invariant_evidence.go
@@ -194,14 +194,23 @@ func doctorInvariantWorkflowVerdict(id string, sources map[string][]byte) doctor
 	return check
 }
 
-// A job stays off pull_request events when its condition excludes them or
-// names only other events; the bare pull_request equality is a placeholder.
+// A job stays off pull_request events when its condition excludes them, or
+// when every || alternative requires a non-pull_request event; the bare
+// pull_request equality is a placeholder. Anything looser counts as a real job.
 func doctorWorkflowJobSkipsPullRequests(condition string) bool {
 	condition = strings.TrimSpace(condition)
 	if condition == "github.event_name == 'pull_request'" || strings.Contains(condition, "github.event_name != 'pull_request'") {
 		return true
 	}
-	return strings.Contains(condition, "github.event_name ==") && !strings.Contains(condition, "'pull_request'")
+	if condition == "" || strings.Contains(condition, "'pull_request'") {
+		return false
+	}
+	for _, alternative := range strings.Split(condition, "||") {
+		if !strings.Contains(alternative, "github.event_name ==") {
+			return false
+		}
+	}
+	return true
 }
 
 func mapKeys(values map[string][]byte) []string {

--- a/internal/cli/doctor_invariant_evidence_test.go
+++ b/internal/cli/doctor_invariant_evidence_test.go
@@ -175,6 +175,7 @@ func TestDoctorInvariantWorkflowVerdict(t *testing.T) {
 			"ci.yml":     []byte("on:\n  merge_group:\njobs:\n  verify:\n    runs-on: ubuntu-latest\n"),
 			"extra.yaml": []byte("on:\n  pull_request:\njobs:\n  smoke:\n    runs-on: ubuntu-latest\n"),
 		}, doctorWarn, "extra.yaml:smoke"},
+		{"other-event alternative does not exempt", map[string][]byte{"ci.yml": []byte("on:\n  pull_request:\njobs:\n  smoke:\n    if: github.event_name == 'push' || github.event.action == 'opened'\n")}, doctorWarn, "ci.yml:smoke"},
 		{"malformed", map[string][]byte{"ci.yml": []byte("on: [\n")}, doctorWarn, "could not be parsed"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cli/doctor_invariant_evidence_test.go
+++ b/internal/cli/doctor_invariant_evidence_test.go
@@ -114,6 +114,16 @@ func TestDoctorInvariantEvidence(t *testing.T) {
 			want:   map[string]doctorStatus{"INV-4": doctorFail},
 		},
 		{
+			name: "programmatic merges before the queue window are not evidence",
+			statements: []string{
+				`INSERT INTO workflow_phase_events(project_id,identifier,phase_name,previous_phase_name,reason,started_at) VALUES ('alpha','owner/repo#5','Done','Merging','merge_worker_programmatic_merge','` + now.Add(-36*time.Hour).Format(time.RFC3339Nano) + `')`,
+				`INSERT INTO work_attempts(project_id,identifier,error_class,completed_at) VALUES ('alpha','owner/repo#5','programmatic_merge_failed','` + now.Add(-30*time.Hour).Format(time.RFC3339Nano) + `')`,
+				`INSERT INTO lane_ledger(project_id,written_at) VALUES ('alpha','` + recent + `')`,
+			},
+			policy: ghconnector.BranchMergePolicy{Branch: "main", MergeQueue: true},
+			want:   map[string]doctorStatus{"INV-4": doctorOK},
+		},
+		{
 			name: "post-turn runner error is not an infrastructure park",
 			statements: []string{
 				`INSERT INTO work_attempts(project_id,identifier,error_class,completed_at) VALUES ('alpha','owner/repo#8','runner_error','` + recent + `')`,
@@ -160,6 +170,7 @@ func TestDoctorInvariantWorkflowVerdict(t *testing.T) {
 		{"no pull_request trigger", map[string][]byte{"ci.yml": []byte("on:\n  merge_group:\n    types: [checks_requested]\njobs:\n  verify:\n    runs-on: ubuntu-latest\n")}, doctorOK, "no workflow has a pull_request trigger"},
 		{"placeholders only", map[string][]byte{"ci.yml": []byte("on:\n  pull_request:\n    types: [opened]\njobs:\n  placeholders:\n    if: github.event_name == 'pull_request'\n  verify:\n    if: github.event_name != 'pull_request'\n")}, doctorOK, "placeholder"},
 		{"real jobs on every push", map[string][]byte{"ci.yml": []byte("on:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n  verify:\n    if: github.event.pull_request.draft == false\n")}, doctorWarn, "ci.yml:lint, ci.yml:verify"},
+		{"push-only integration jobs", map[string][]byte{"ci.yml": []byte("on:\n  pull_request:\n  push:\njobs:\n  placeholders:\n    if: github.event_name == 'pull_request'\n  portability:\n    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'\n  verify:\n    if: github.event_name != 'pull_request'\n")}, doctorOK, "placeholder"},
 		{"second workflow file runs on pull requests", map[string][]byte{
 			"ci.yml":     []byte("on:\n  merge_group:\njobs:\n  verify:\n    runs-on: ubuntu-latest\n"),
 			"extra.yaml": []byte("on:\n  pull_request:\njobs:\n  smoke:\n    runs-on: ubuntu-latest\n"),


### PR DESCRIPTION
## Summary

- INV-4 evidence now counts programmatic merges in the last 24h, not 7d: a queue enabled recently otherwise reports every pre-queue merge as a bypass (the dogfood project showed 248).
- INV-5 treats a job whose `if` names only other events (`github.event_name == 'push' || … 'workflow_dispatch'`) as off pull_request; this repository's integration jobs were misreported as running on every PR push.
- Found by running the v0.114.0 candidate's `detent doctor` against the live mac-studio store before tagging.

Invariants touched: INV-4, INV-5 (doctor evidence windows only; docs/invariants.md statements unchanged).

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/cli -run 'TestDoctorInvariant|TestCheckDoctorProjects'`, `make lint`
- [x] New cases: programmatic merges older than 24h are not INV-4 evidence; push-only integration jobs pass INV-5

https://claude.ai/code/session_01PK61Vw2Gr7EMRGtKohPXrw