### PR TITLE
fix(boot): continue startup when prior-instance worker cleanup fails

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -263,10 +263,14 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 			logShutdownBoundaryEnd(logger, "runtime_store_close", closeStarted, nil, "component", "runtime_store")
 		}
 	}()
-	// Prior-instance cleanup is best effort: a workspace scan that times out
-	// on a large tree must not keep this instance from serving.
 	if err := reapWorkerProcesses(runCtx, runtimeStore, logger, "startup", procgroup.DefaultTerminationGrace, time.Now, nil); err != nil {
-		logger.Warn("reap worker processes from prior instance failed; continuing startup", "error", err)
+		// Prior workers are gone; a workspace artifact scan that cannot finish
+		// on a large tree must not keep this instance from serving.
+		var cleanupOnly *workerArtifactCleanupError
+		if !errors.As(err, &cleanupOnly) {
+			return fmt.Errorf("reap worker processes from prior instance: %w", err)
+		}
+		logger.Warn("prior-instance worker artifact cleanup failed; continuing startup", "error", err)
 	}
 	if cfg.Isolated != nil && cfg.Isolated.Demo == "screenshots" {
 		if err := demofixtures.SeedUsageEvents(runCtx, runtimeStore); err != nil {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -263,8 +263,10 @@ func startRunningWithDependencies(ctx context.Context, cfg BootConfig, deps star
 			logShutdownBoundaryEnd(logger, "runtime_store_close", closeStarted, nil, "component", "runtime_store")
 		}
 	}()
+	// Prior-instance cleanup is best effort: a workspace scan that times out
+	// on a large tree must not keep this instance from serving.
 	if err := reapWorkerProcesses(runCtx, runtimeStore, logger, "startup", procgroup.DefaultTerminationGrace, time.Now, nil); err != nil {
-		return fmt.Errorf("reap worker processes from prior instance: %w", err)
+		logger.Warn("reap worker processes from prior instance failed; continuing startup", "error", err)
 	}
 	if cfg.Isolated != nil && cfg.Isolated.Demo == "screenshots" {
 		if err := demofixtures.SeedUsageEvents(runCtx, runtimeStore); err != nil {

--- a/internal/cli/worker_processes.go
+++ b/internal/cli/worker_processes.go
@@ -68,6 +68,7 @@ func reapWorkerProcessesWithCleanup(
 		return err
 	}
 	var result error
+	terminationFailed := false
 	for _, process := range processes {
 		identity := procgroup.Identity{
 			PID:       process.PID,
@@ -90,6 +91,7 @@ func reapWorkerProcessesWithCleanup(
 			attrs = append(attrs, "error", reapErr)
 			logger.Info("worker process lifecycle decision", attrs...)
 			result = errors.Join(result, reapErr)
+			terminationFailed = true
 			continue
 		}
 		if outcome != procgroup.TerminationOutcomeStaleIdentity {
@@ -107,10 +109,25 @@ func reapWorkerProcessesWithCleanup(
 			Reason:   strings.TrimSpace(reason),
 		}); err != nil {
 			result = errors.Join(result, err)
+			terminationFailed = true
 		}
+	}
+	if result != nil && !terminationFailed {
+		return &workerArtifactCleanupError{err: result}
 	}
 	return result
 }
+
+// workerArtifactCleanupError reports that every prior worker was confirmed
+// terminated but at least one workspace artifact cleanup failed; the session
+// rows stay unreaped so cleanup is retried on the next start.
+type workerArtifactCleanupError struct {
+	err error
+}
+
+func (e *workerArtifactCleanupError) Error() string { return e.err.Error() }
+
+func (e *workerArtifactCleanupError) Unwrap() error { return e.err }
 
 func retryWorkerProcessArtifactCleanup(ctx context.Context, process store.WorkerProcess, logger *slog.Logger, cleanup func(store.WorkerProcess) error) error {
 	const maxAttempts = 5

--- a/internal/cli/worker_processes_test.go
+++ b/internal/cli/worker_processes_test.go
@@ -526,3 +526,40 @@ func TestReapWorkerProcessesPreservesArtifactsOnFailure(t *testing.T) {
 		})
 	}
 }
+
+func TestReapWorkerProcessesClassifiesCleanupOnlyFailures(t *testing.T) {
+	t.Parallel()
+	process := store.WorkerProcess{SessionID: 7, WorkerProcessIdentity: store.WorkerProcessIdentity{PID: 4242, GroupID: 4242, StartedAt: time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)}}
+	for _, tt := range []struct {
+		name        string
+		reapErr     error
+		cleanupErr  error
+		wantCleanup bool
+	}{
+		{"cleanup timeout after termination", nil, context.DeadlineExceeded, true},
+		{"termination failure", errors.New("remained alive after SIGKILL"), nil, false},
+		{"termination failure beside cleanup failure", errors.New("operation not permitted"), context.DeadlineExceeded, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			processStore := &shutdownWorkerProcessStore{processes: []store.WorkerProcess{process}}
+			reap := func(context.Context, procgroup.Identity, time.Duration) (procgroup.TerminationOutcome, error) {
+				if tt.reapErr != nil {
+					return "", tt.reapErr
+				}
+				return procgroup.TerminationOutcomeAlreadyExited, nil
+			}
+			err := reapWorkerProcessesWithCleanup(t.Context(), processStore, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), "startup", time.Millisecond, time.Now, reap, func(store.WorkerProcess) error { return tt.cleanupErr })
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			var cleanupOnly *workerArtifactCleanupError
+			if got := errors.As(err, &cleanupOnly); got != tt.wantCleanup {
+				t.Fatalf("cleanup-only = %t (%v), want %t", got, err, tt.wantCleanup)
+			}
+			if tt.reapErr == nil && tt.cleanupErr != nil && !errors.Is(err, tt.cleanupErr) {
+				t.Fatalf("error %v does not wrap %v", err, tt.cleanupErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `reapWorkerProcesses` at startup is now best effort: its error is logged as a warning and boot continues. Every start of v0.114.0 on mac-studio aborted with `reap worker processes from prior instance: … workspace scan command … context deadline exceeded` because six dead detent.build#50 worker sessions pointed at a 15 GB retained workspace whose `lsof +D` scan cannot finish inside the deadline. The prior instance's processes were already gone; refusing to serve the board over a cleanup timeout is the wrong failure mode.

Invariants touched: none (INV-2 spirit: an instance-level cleanup failure no longer takes the service down).

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/cli -run 'Boot|Reap|WorkerProcess'`, `make lint`
- [x] Reproduced on mac-studio: two consecutive starts failed identically; after marking the dead sessions reaped the service starts

https://claude.ai/code/session_01PK61Vw2Gr7EMRGtKohPXrw