### PR TITLE
fix(workspace): exclude base commits from completion evidence

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -4068,6 +4068,12 @@ func effectiveModel(values ...string) string {
 }
 
 func workspaceIssue(projectID string, issue connector.Issue) workspace.Issue {
+	if issue.PullRequest != nil {
+		switch strings.ToUpper(strings.TrimSpace(issue.PullRequest.State)) {
+		case "CLOSED", "MERGED":
+			issue.PullRequest = nil
+		}
+	}
 	baseRef := ""
 	progressBaseRef := ""
 	if issue.PullRequest != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -7607,3 +7607,21 @@ func TestAgentRunProgressRetainsLastCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkspaceIssuePullRequestComparison(t *testing.T) {
+	t.Parallel()
+	for _, state := range []string{"OPEN", "CLOSED", "MERGED", " closed "} {
+		t.Run(state, func(t *testing.T) {
+			got := workspaceIssue("project", connector.Issue{PullRequest: &connector.PullRequest{
+				State: state, HeadSHA: "old-head", BaseSHA: "old-base", BaseRef: "main",
+			}})
+			if state == "OPEN" {
+				if got.PullRequestHeadSHA != "old-head" || got.BaseRef != "old-base" || got.ProgressBaseRef != "main" {
+					t.Fatalf("open PR comparison = %+v", got)
+				}
+			} else if got.PullRequestHeadSHA != "" || got.BaseRef != "" || got.ProgressBaseRef != "" {
+				t.Fatalf("terminal PR must use default base only: %+v", got)
+			}
+		})
+	}
+}

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -65,7 +65,11 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 	if err != nil {
 		return RecoveryState{}, err
 	}
-	unpushedCommits, unpushedCommitRefs, err := gitUnpushedCommitEvidence(ctx, normalized.Path)
+	base, err := l.localProgressBase(ctx, normalized.Path, issue)
+	if err != nil {
+		return RecoveryState{}, fmt.Errorf("resolve recovery base: %w", err)
+	}
+	unpushedCommits, unpushedCommitRefs, err := gitUnpushedCommitEvidence(ctx, normalized.Path, base)
 	if err != nil {
 		return RecoveryState{}, err
 	}
@@ -87,6 +91,7 @@ func (l *LocalGit) RecoveryState(ctx context.Context, info Info, issue Issue) (R
 		normalized.Path,
 		head,
 		issue.PullRequestHeadSHA,
+		base,
 	)
 	if err != nil {
 		return RecoveryState{}, err
@@ -222,7 +227,7 @@ func gitDiffStatOutput(ctx context.Context, workspacePath string) (DiffStat, err
 	return gitDiffStatWithEnv(ctx, workspacePath, env, "HEAD")
 }
 
-func gitUnpushedCommitEvidence(ctx context.Context, workspacePath string) (int, []string, error) {
+func gitUnpushedCommitEvidence(ctx context.Context, workspacePath string, base string) (int, []string, error) {
 	remoteRefs, err := runGitAt(ctx, workspacePath, "for-each-ref", "--count=1", "--format=%(refname)", "refs/remotes")
 	if err != nil {
 		return 0, nil, fmt.Errorf("git list remote refs: %w", err)
@@ -230,7 +235,7 @@ func gitUnpushedCommitEvidence(ctx context.Context, workspacePath string) (int, 
 	if strings.TrimSpace(remoteRefs) == "" {
 		return 0, nil, nil
 	}
-	output, err := runGitAt(ctx, workspacePath, "rev-list", "--count", "HEAD", "--not", "--remotes")
+	output, err := runGitAt(ctx, workspacePath, "rev-list", "--count", "HEAD", "--not", "--remotes", base)
 	if err != nil {
 		return 0, nil, fmt.Errorf("git count unpushed commits: %w", err)
 	}
@@ -241,7 +246,7 @@ func gitUnpushedCommitEvidence(ctx context.Context, workspacePath string) (int, 
 	if count == 0 {
 		return 0, nil, nil
 	}
-	refs, err := gitCommitEvidence(ctx, workspacePath, "HEAD", "--not", "--remotes")
+	refs, err := gitCommitEvidence(ctx, workspacePath, "HEAD", "--not", "--remotes", base)
 	if err != nil {
 		return 0, nil, fmt.Errorf("git list unpushed commits: %w", err)
 	}
@@ -269,6 +274,7 @@ func gitCommitsNotInPullRequest(
 	workspacePath string,
 	head string,
 	pullRequestHead string,
+	base string,
 ) ([]string, bool, error) {
 	head = strings.TrimSpace(head)
 	pullRequestHead = strings.TrimSpace(pullRequestHead)
@@ -281,7 +287,7 @@ func gitCommitsNotInPullRequest(
 	if _, err := runGitAt(ctx, workspacePath, "cat-file", "-e", pullRequestHead+"^{commit}"); err != nil {
 		return nil, false, nil
 	}
-	refs, err := gitCommitEvidence(ctx, workspacePath, head, "--not", pullRequestHead)
+	refs, err := gitCommitEvidence(ctx, workspacePath, head, "--not", pullRequestHead, base)
 	if err != nil {
 		return nil, false, fmt.Errorf("git compare workspace commits to pull request: %w", err)
 	}

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -635,5 +636,49 @@ func TestIsMissingWorkspaceErrorIgnoresUnmarkedNotExist(t *testing.T) {
 	err := &os.PathError{Op: "read", Path: filepath.Join(t.TempDir(), "index"), Err: os.ErrNotExist}
 	if IsMissingWorkspaceError(err) {
 		t.Fatalf("IsMissingWorkspaceError(%v) = true, want false", err)
+	}
+}
+
+func TestLocalGitRecoveryStateExcludesBaseCommits(t *testing.T) {
+	t.Parallel()
+	for _, withWork := range []bool{false, true} {
+		t.Run(fmt.Sprintf("unpushed_work_%t", withWork), func(t *testing.T) {
+			t.Parallel()
+			source := initSourceRepo(t)
+			remote := initBareRemote(t)
+			runGit(t, source, "remote", "add", "origin", remote)
+			runGit(t, source, "push", "-u", "origin", "main")
+			oldHead := strings.TrimSpace(runGit(t, source, "rev-parse", "HEAD"))
+			runGit(t, source, "commit", "--allow-empty", "-m", "base advancement")
+			runGit(t, source, "push", "origin", "main")
+			backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+				Root: filepath.Join(t.TempDir(), "workspaces"), SourceRoot: source, AutoBranch: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			issue := Issue{Identifier: "base-comparison", BaseRef: oldHead, ProgressBaseRef: "main", PullRequestHeadSHA: oldHead}
+			info, err := backend.Create(t.Context(), issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if withWork {
+				runGit(t, info.Path, "commit", "--allow-empty", "-m", "issue work")
+			}
+			got, err := backend.(RecoveryStateProvider).RecoveryState(t.Context(), info, issue)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := 0
+			if withWork {
+				want = 1
+			}
+			if !got.PullRequestComparisonAvailable || len(got.CommitsNotInPullRequest) != want || got.UnpushedCommits != want {
+				t.Fatalf("RecoveryState = %+v, want %d work commits", got, want)
+			}
+			if withWork && !strings.Contains(got.CommitsNotInPullRequest[0], "issue work") {
+				t.Fatal(got.CommitsNotInPullRequest)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Closed and merged PRs no longer contribute stale head/base metadata to workspace comparisons. A clean workspace equal to the current base stays clean.
- Recovery evidence excludes base-reachable commits while retaining genuine unpushed issue commits. Reuses the existing base resolver; no brake, reason code, or recovery path is added. The existing cleanliness mechanism remains necessary to detect stranded work, so this fixes its evidence instead of removing it.

Fixes #2506

Invariants touched: none; preserves INV-3 by narrowing existing evidence collection without adding a mechanism or changing invariant enforcement.

## UI Surface Contract

- [x] N/A — no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — no visual changes.

## Test Plan

- [x] New table-driven regression tests failed before the fix and passed afterward: terminal PR comparison metadata, base-only commits, and real unpushed work.
- [x] Focused workspace recovery, runner conversion, and orchestrator completion-cleanliness tests.
- [x] `make check-fast` (worker gate, including invariants, build, lint, vet, and full tests).
- [x] Independent validator-agent review: pass, 9/10, no P1/P2 findings.
- Race, coverage, and nilaway remain merge-queue checks per worker protocol.
