### PR TITLE
test(hub): synchronize outbox shutdown checks

### DIFF
--- a/.detent/validation/2389/README.md
+++ b/.detent/validation/2389/README.md
@@ -1,0 +1,17 @@
+# Outbox shutdown investigation
+
+Original Windows job: https://github.com/digitaldrywood/detent/actions/runs/34314494525/job/102347759577
+
+The original job reports the combined Close timeout at 05:27:37.705Z and a 7.52-second test duration. It contains no stage diagnostics or goroutine dump, so it cannot identify the historical stalled stage. A later rerun of the same run is not the original evidence; retrieve the original job logs by job ID.
+
+The unchanged test passed 10 focused macOS race repetitions. A controlled reproduction reserved the sole database connection after the backend started and held it until the existing two-second Close guard fired. The captured stack in blocked-persistence.txt shows Close joining the worker in outboxWorker.stop, and the canceled worker waiting in database/sql.(*DB).conn through failOutbox. This establishes a post-cancellation persistence timeout failure mode, not the precise cause of the historical Windows delay.
+
+ProcessOutbox deliberately persists the canceled result with a fresh BusyTimeout context (five seconds by default). The old two-second guard could fail before that legitimate work completed. No production lifecycle defect was demonstrated.
+
+The revised test explicitly observes backend startup, cancellation, release, and return; exercises available and held database connections; and reopens SQLite after Close to verify the canceled item was persisted for retry. Thirty-second timers are OS integration deadlock guards, not behavioral timing assertions. Timeout failures identify the stage and include all goroutine stacks.
+
+Historical validation (September 9, before restoration): original focused race count=10 passed; controlled original-test reproduction failed at the expected guard; revised focused race count=20 passed. Full gate and current-head Windows CI are recorded in the issue Workpad.
+
+A temporary Go overlay removed outboxWorker.stop's WaitGroup join without changing the worktree. Both revised cases failed: the reopened outbox item remained processing instead of retrying. This confirms the persistence assertion detects a missing worker join.
+
+Restoration on September 11: focused non-race count=20 passed on current main plus this test patch. The worker protocol reserves new race/coverage runs for the merge queue and selects `make check-fast` as the local gate. Current-head local gate, validator review, and Windows CI results are recorded in the issue Workpad.

--- a/.detent/validation/2389/blocked-persistence.txt
+++ b/.detent/validation/2389/blocked-persistence.txt
@@ -1,0 +1,74 @@
+--- FAIL: TestServiceCloseCancelsAndDrainsOutboxWorker (2.75s)
+    outbox_test.go:314: goroutines:
+        goroutine 65 [running]:
+        github.com/digitaldrywood/detent/internal/hubserver.TestServiceCloseCancelsAndDrainsOutboxWorker(0xc0001f8908)
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox_test.go:314 +0x8d8
+        testing.tRunner(0xc0001f8908, 0x1042ea0d0)
+            /usr/local/go/src/testing/testing.go:2193 +0x168
+        created by testing.(*T).Run in goroutine 1
+            /usr/local/go/src/testing/testing.go:2258 +0x7c0
+
+        goroutine 1 [chan receive]:
+        testing.tRunner.func1()
+            /usr/local/go/src/testing/testing.go:2142 +0x660
+        testing.tRunner(0xc0001f8248, 0xc00061fa28)
+            /usr/local/go/src/testing/testing.go:2199 +0x190
+        testing.runTests({0x10379350c, 0x20}, {0x1037ac860, 0x33}, 0xc00036eac8, {0x1043772d0, 0xda, 0xda}, {0x0?, 0xc000027428?, ...})
+            /usr/local/go/src/testing/testing.go:2740 +0x7a4
+        testing.(*M).Run(0xc00012a1e0)
+            /usr/local/go/src/testing/testing.go:2600 +0xb3c
+        main.main()
+            _testmain.go:480 +0x104
+
+        goroutine 66 [select]:
+        database/sql.(*DB).connectionOpener(0xc000756410, {0x1042e73c0, 0xc0001ce370})
+            /usr/local/go/src/database/sql/sql.go:1266 +0xbc
+        created by database/sql.OpenDB in goroutine 65
+            /usr/local/go/src/database/sql/sql.go:846 +0x250
+
+        goroutine 59 [select]:
+        database/sql.(*DB).conn(0xc000756410, {0x1042e73f8, 0xc00024a380}, 0x1)
+            /usr/local/go/src/database/sql/sql.go:1374 +0x4a4
+        database/sql.(*DB).exec(0xc000756410, {0x1042e73f8, 0xc00024a380}, {0x1037e5f8f, 0xb2}, {0xc0005c18d8, 0x7, 0x7}, 0x1)
+            /usr/local/go/src/database/sql/sql.go:1694 +0x5c
+        database/sql.(*DB).ExecContext.func1(0x1)
+            /usr/local/go/src/database/sql/sql.go:1677 +0x8c
+        database/sql.(*DB).retry(0x2005c1788?, 0xc0005c1780)
+            /usr/local/go/src/database/sql/sql.go:1581 +0x50
+        database/sql.(*DB).ExecContext(0xc000756410, {0x1042e73f8, 0xc00024a380}, {0x1037e5f8f, 0xb2}, {0xc0005c18d8, 0x7, 0x7})
+            /usr/local/go/src/database/sql/sql.go:1676 +0xfc
+        github.com/digitaldrywood/detent/internal/hubserver.(*Service).failOutbox(0xc0001f8d88, {0x1042e73f8, 0xc00024a380}, {{0xc00013a0a8, 0x11}, 0x1, {0xc000224a24, 0xc}, 0x1, {0xc000224a52, ...}, ...}, ...)
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox.go:669 +0x540
+        github.com/digitaldrywood/detent/internal/hubserver.(*Service).ProcessOutbox(0xc0001f8d88, {0x1042e73c0, 0xc0001ce0a0})
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox.go:549 +0x30c
+        github.com/digitaldrywood/detent/internal/hubserver.(*outboxWorker).run(0xc0006204e0, {0x1042e73c0, 0xc0001ce0a0})
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox.go:852 +0xd4
+        github.com/digitaldrywood/detent/internal/hubserver.(*outboxWorker).start.func1()
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox.go:843 +0x88
+        created by github.com/digitaldrywood/detent/internal/hubserver.(*outboxWorker).start in goroutine 65
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox.go:841 +0x12c
+
+        goroutine 437 [sync.WaitGroup.Wait]:
+        sync.runtime_SemacquireWaitGroup(0x1042e2c08?, 0x30?)
+            /usr/local/go/src/runtime/sema.go:114 +0x38
+        sync.(*WaitGroup).Wait(0xc0006204f8)
+            /usr/local/go/src/sync/waitgroup.go:206 +0xb8
+        github.com/digitaldrywood/detent/internal/hubserver.(*outboxWorker).stop(0xc0006204e0)
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox.go:880 +0x68
+        github.com/digitaldrywood/detent/internal/hubserver.(*Service).Close.func1()
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/service.go:280 +0x150
+        sync.(*Once).doSlow(0xc0001f8f7c, 0xc0005aaf78)
+            /usr/local/go/src/sync/once.go:78 +0x98
+        sync.(*Once).Do(0xc0001f8f7c, 0xc000344778)
+            /usr/local/go/src/sync/once.go:69 +0x38
+        github.com/digitaldrywood/detent/internal/hubserver.(*Service).Close(0xc0001f8d88)
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/service.go:270 +0x68
+        github.com/digitaldrywood/detent/internal/hubserver.TestServiceCloseCancelsAndDrainsOutboxWorker.func1()
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox_test.go:305 +0x34
+        created by github.com/digitaldrywood/detent/internal/hubserver.TestServiceCloseCancelsAndDrainsOutboxWorker in goroutine 65
+            /Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_2389-0c8cb45ea346/internal/hubserver/outbox_test.go:304 +0x7c0
+    outbox_test.go:315: database stats while Close is blocked: {MaxOpenConnections:1 OpenConnections:1 InUse:1 Idle:0 WaitCount:3 WaitDuration:4.393292ms MaxIdleClosed:0 MaxIdleTimeClosed:0 MaxLifetimeClosed:0}
+    outbox_test.go:316: Close() did not cancel and drain the outbox worker
+FAIL
+FAIL    github.com/digitaldrywood/detent/internal/hubserver 3.112s
+FAIL

--- a/internal/hubserver/outbox_test.go
+++ b/internal/hubserver/outbox_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -275,36 +276,94 @@ func TestOutboxReclaimsInterruptedProcessingAfterTimeout(t *testing.T) {
 func TestServiceCloseCancelsAndDrainsOutboxWorker(t *testing.T) {
 	t.Parallel()
 
-	backend := &blockingOutboxBackend{started: make(chan struct{})}
-	service, err := Open(t.Context(), Config{
-		DatabasePath:       filepath.Join(t.TempDir(), "hub.db"),
-		Logger:             discardLogger(),
-		OutboxBackend:      backend,
-		OutboxPollInterval: time.Hour,
-	})
-	if err != nil {
-		t.Fatalf("Open() error = %v", err)
-	}
-	repositoryID, issueID := seedProjection(t, service.database.db)
-	appendTestWorkpadEvent(t, service, repositoryID, issueID, "blocking-key", "coding")
-	select {
-	case <-backend.started:
-	case <-time.After(2 * time.Second):
-		service.Close()
-		t.Fatal("outbox worker did not start delivery")
-	}
-
-	closed := make(chan error, 1)
-	go func() {
-		closed <- service.Close()
-	}()
-	select {
-	case err := <-closed:
-		if err != nil {
-			t.Fatalf("Close() error = %v", err)
+	for _, holdConnection := range []bool{false, true} {
+		name := "available database"
+		if holdConnection {
+			name = "held database connection"
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Close() did not cancel and drain the outbox worker")
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := &blockingOutboxBackend{
+				started: make(chan struct{}), canceled: make(chan struct{}),
+				release: make(chan struct{}), returned: make(chan struct{}),
+			}
+			release := sync.OnceFunc(func() { close(backend.release) })
+			path := filepath.Join(t.TempDir(), "hub.db")
+			service, err := Open(t.Context(), Config{
+				DatabasePath: path, Logger: discardLogger(),
+				OutboxBackend: backend, OutboxPollInterval: time.Hour,
+			})
+			if err != nil {
+				t.Fatalf("Open() error = %v", err)
+			}
+			closed := make(chan struct{})
+			var closeErr error
+			startClose := sync.OnceFunc(func() {
+				go func() {
+					closeErr = service.Close()
+					close(closed)
+				}()
+			})
+			t.Cleanup(func() {
+				release()
+				startClose()
+				waitForOutboxShutdownStage(t, closed, "cleanup Close")
+			})
+			repositoryID, issueID := seedProjection(t, service.database.db)
+			appendTestWorkpadEvent(t, service, repositoryID, issueID, "blocking-key", "coding")
+			waitForOutboxShutdownStage(t, backend.started, "delivery start")
+
+			var releaseConnection func()
+			if holdConnection {
+				conn, err := service.database.db.Conn(t.Context())
+				if err != nil {
+					t.Fatalf("hold database connection: %v", err)
+				}
+				releaseConnection = sync.OnceFunc(func() {
+					if err := conn.Close(); err != nil {
+						t.Errorf("release database connection: %v", err)
+					}
+				})
+				t.Cleanup(releaseConnection)
+			}
+			startClose()
+			waitForOutboxShutdownStage(t, backend.canceled, "delivery cancellation")
+			select {
+			case <-closed:
+				t.Fatal("Close returned before the active backend was released")
+			default:
+			}
+			release()
+			waitForOutboxShutdownStage(t, backend.returned, "backend return")
+			if releaseConnection != nil {
+				select {
+				case <-closed:
+					t.Fatal("Close returned before canceled delivery could be persisted")
+				default:
+				}
+				releaseConnection()
+			}
+			waitForOutboxShutdownStage(t, closed, "worker drain and database close")
+			if closeErr != nil {
+				t.Fatalf("Close() error = %v", closeErr)
+			}
+			reopened := openTestService(t, Config{DatabasePath: path})
+			assertOutboxStatus(t, reopened.database.db, "blocking-key", outboxRetrying, 1)
+		})
+	}
+}
+
+func waitForOutboxShutdownStage(t *testing.T, done <-chan struct{}, stage string) {
+	t.Helper()
+	// SQLite shutdown involves OS I/O; this bounds deadlocks, not expected latency.
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		stacks := make([]byte, 1<<20)
+		t.Fatalf("outbox shutdown stalled at %s:\n%s", stage, stacks[:runtime.Stack(stacks, true)])
 	}
 }
 
@@ -359,13 +418,19 @@ func (b *recordingOutboxBackend) keys() []string {
 }
 
 type blockingOutboxBackend struct {
-	started chan struct{}
-	once    sync.Once
+	started  chan struct{}
+	canceled chan struct{}
+	release  chan struct{}
+	returned chan struct{}
+	once     sync.Once
 }
 
 func (b *blockingOutboxBackend) Execute(ctx context.Context, _ OutboxItem) error {
 	b.once.Do(func() { close(b.started) })
 	<-ctx.Done()
+	close(b.canceled)
+	<-b.release
+	defer close(b.returned)
 	return ctx.Err()
 }
 


### PR DESCRIPTION
## Summary

The outbox shutdown test could time out after two seconds while a canceled delivery was still persisting its retry state. Restore explicit startup, cancellation, backend release, and drain synchronization, exercise available and held database connections, and verify retry persistence after reopening SQLite. A 30-second OS integration guard reports the stalled stage and goroutine stacks.

Recorded deterministic evidence identifies post-cancellation persistence as a failure mode; the original Windows stalled stage remains unknown. Production shutdown is unchanged. Restoration was authorized in #2414; this fresh PR replaces closed #2396.

Fixes #2389

Invariants touched: none.

## UI Surface Contract

- [x] N/A: test and investigation evidence only.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes.

## Test Plan

- [x] Focused shutdown test, count=20.
- [x] `make check-fast` (configured worker gate; race, coverage, nilaway reserved for merge queue).
- [x] Independent validator: approve, score 94, no P1/P2 findings.
- [x] Preserved historical focused race count=20 and join-removal mutation evidence, explicitly identified as historical.
- [x] Current-head Windows portability passed (32m42s); all executed CI jobs passed, including four race shards, coverage, invariants, Browser Visual, and macOS portability: https://github.com/digitaldrywood/detent/actions/runs/34648147613
