### PR TITLE
test(installer): restore timeout process evidence

### DIFF
--- a/.detent/validation/2370/README.md
+++ b/.detent/validation/2370/README.md
@@ -1,0 +1,114 @@
+# Installer coverage timeout investigation
+
+## Restoration on September 11, 2026
+
+Operator authorization is recorded in #2408. The installer helper on current
+main (`9fa6fe3a`) is identical to the pre-patch helper. Restored only the installer
+test diagnostics from `f03d5962`; no production code or installer fixtures changed.
+The historical measurements below are preserved from that commit, not rerun
+or represented as validation of the restored head.
+
+Current validation:
+
+- Controlled cancellation/deadline assertions failed on current main (exit 1):
+  both errors lacked the expected process IDs and executable evidence.
+- `env -u DETENT_API_TOKEN go test . -run
+  '^(TestRunInstallerCommand|TestInstallerProcessGroup|TestInstallScript)' -count=1`
+  passed in 1.387s after restoration.
+- `env -u DETENT_API_TOKEN make check-fast` passed, including repository-wide
+  tests and the invariant gate. Independent validator: approve, score 9/10,
+  no P1/P2 findings. Race, coverage, and nilaway
+  are reserved for the merge queue by the worker protocol.
+
+## Finding
+
+The historical ten-second installer stalls did not recur in this investigation.
+Their nested command and host-level cause remain unestablished. Successful
+installation output alone does not establish that the shell has exited: service
+probes, PATH reporting, and EXIT cleanup follow installation. No deadline,
+fixture, installer behavior, or test scheduling changes are justified by the
+available evidence. For an invocation that already printed PATH guidance,
+service probing had returned and EXIT cleanup was the remaining script stage.
+That narrows where to sample, but does not establish that `rm` was blocked or
+identify a host-level cause.
+
+The existing failure report identifies shell startup, waiting, and output-pipe
+draining, but discards the live process group when cancellation kills it. A
+readiness-triggered cancellation regression reproduced this diagnostic gap for
+both cancellation and deadline causes. The old helper reported, for example:
+
+```text
+command "/bin/sh" args=["-c" "printf ready; read line <&3"] pid=90155 stage=wait start=1ms wait=2ms: signal: killed
+context deadline exceeded
+```
+
+It could not identify any live child at the time of cancellation.
+
+## Historical measurements (prior removed patch)
+
+Native macOS arm64, starting revision `3962d001`:
+
+- Unmodified `env -u DETENT_API_TOKEN go test -coverprofile=tmp/install-baseline.out ./...`
+  passed. Root package: 24.993 seconds, 75.0% coverage.
+- A second whole-repository coverage run traced installer external commands via
+  temporary PATH wrappers, preserving package and test parallelism and existing
+  subprocess deadlines. Root package: 19.937 seconds, 75.0% coverage; all traced
+  commands completed. Command arguments and environment values were not logged.
+- Traced commands included ten `launchctl`, thirteen `rm`, fifteen `curl`, twelve
+  `mktemp`, eleven `install`, and eighteen `mkdir` invocations. No unfinished
+  command established a culprit. Wrappers add process overhead, so this is not
+  a timing comparison against baseline.
+- That traced run failed three unrelated one-second PID-file readiness checks:
+  `TestRunTurnCancellationKillsChildProcessGroup`,
+  `TestLocalTransportCloseKillsChildProcessGroup`, and
+  `TestLocalTransportReapsChildAfterParentExits`. All passed 25 subsequent
+  unwrapped focused repetitions and five focused repetitions with the same
+  tracing environment. This does not establish whether the wrapper or concurrent
+  host pressure caused those failures. Follow-up: Backlog issue #2380.
+- With the final diagnostic code, an uncached whole-repository run
+  (`env -u DETENT_API_TOKEN go test -count=1 -coverprofile=tmp/install-instrumented.out ./...`)
+  passed without wrappers. Root package: 13.799 seconds, 75.0% coverage. This
+  reran every package rather than relying on results cached by earlier runs.
+- New cancellation/deadline evidence assertions failed against the old helper.
+  Five focused race repetitions passed after adding process evidence, including
+  installer success, target selection, authentication, redirect, fallback,
+  startup failure, exit failure, cancellation, and output-drain coverage.
+- An additional five race repetitions passed with a readiness-triggered nested
+  shell regression that checks the child's parent and process-group IDs before
+  cleanup. Existing inherited-descriptor checks still verify descendant exit.
+
+## Diagnostic change
+
+On cancellation, the test helper runs `ps -axo pid=,ppid=,pgid=,stat=,comm=`
+before killing its isolated process group. It retains only that group's process
+IDs, parent IDs, group IDs, states, and executable names. It does not collect
+command arguments or environment values from the process table. Failed waits
+also sample before remaining descendants are cleaned up.
+
+The diagnostic command has a separate one-second context and one-second output
+wait bound. Diagnostic failure is recorded as unavailable; it does not replace
+the original command error or cancellation cause. Sampling can add cleanup
+latency after failure. Successful commands do not launch a diagnostic process.
+The original installer deadline and process-group cleanup remain in place.
+If the snapshot observed a live, non-zombie group member and the shell exits
+successfully during sampling, preserve the original cancellation cause. If the
+group had already exited, consisted only of zombies, or could not be sampled,
+retain the original wait result: cancellation can legitimately lose the race
+with successful completion. Controlled regressions release the blocked shell
+either before or after taking a snapshot and wait for it to be reaped before
+returning the snapshot. The first regression catches false success after a live
+snapshot; the second catches false cancellation after an empty snapshot.
+Automated review of the initial PR identified the latter edge case, which the
+new regression reproduced before the correction.
+
+Table-driven tests cover group filtering, malformed/empty rows, spaced executable
+names, orphaned children, zombie-only groups, and live nested-command capture. This improves the next
+failure's evidence; it is not a demonstrated fix for the historical timeout.
+
+## Next failure
+
+Retain the complete `processes` field alongside stage, start/wait durations,
+stdout, and stderr. A live nested executable identifies where to investigate;
+its process state is a snapshot, not proof of a persistent host bottleneck.
+If sampling is unavailable or the group has already exited, do not infer a
+culprit. Preserve whole-repository scheduling while collecting further evidence.

--- a/install_test.go
+++ b/install_test.go
@@ -663,16 +663,19 @@ func TestRunInstallerCommand(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		script     string
-		missing    bool
-		cancelWith error
-		expired    bool
-		wantStage  string
-		wantError  error
-		wantExit   int
-		wantStdout string
-		wantStderr string
+		name               string
+		script             string
+		missing            bool
+		cancelWith         error
+		expired            bool
+		wantStage          string
+		wantError          error
+		wantExit           int
+		wantStdout         string
+		wantStderr         string
+		wantChild          bool
+		exitDuringSnapshot bool
+		snapshotAfterExit  bool
 	}{
 		{name: "success", script: "printf stdout; printf stderr >&2", wantStdout: "stdout", wantStderr: "stderr"},
 		{name: "expired before start", expired: true, wantStage: "start", wantError: context.DeadlineExceeded},
@@ -680,6 +683,9 @@ func TestRunInstallerCommand(t *testing.T) {
 		{name: "exit failure", script: "printf stdout; printf stderr >&2; exit 23", wantStage: "wait", wantExit: 23, wantStdout: "stdout", wantStderr: "stderr"},
 		{name: "canceled running command", script: "printf ready; read line <&3", cancelWith: context.Canceled, wantStage: "wait", wantError: context.Canceled, wantStdout: "ready"},
 		{name: "deadline during wait", script: "printf ready; read line <&3", cancelWith: context.DeadlineExceeded, wantStage: "wait", wantError: context.DeadlineExceeded, wantStdout: "ready"},
+		{name: "deadline in nested command", script: "sh -c 'printf ready; read line <&3' & wait", cancelWith: context.DeadlineExceeded, wantStage: "wait", wantError: context.DeadlineExceeded, wantStdout: "ready", wantChild: true},
+		{name: "exit during deadline snapshot", script: "printf ready; read line <&3; exit 0", cancelWith: context.DeadlineExceeded, wantStage: "wait", wantError: context.DeadlineExceeded, wantStdout: "ready", exitDuringSnapshot: true},
+		{name: "completed before snapshot", script: "printf ready; read line <&3; exit 0", cancelWith: context.DeadlineExceeded, wantStdout: "ready", exitDuringSnapshot: true, snapshotAfterExit: true},
 		{name: "descendant holds stdout", script: "(read line <&3) 2>/dev/null & printf stdout; exit 0", wantStage: "output drain", wantError: exec.ErrWaitDelay, wantStdout: "stdout"},
 		{name: "descendant holds stderr", script: "(read line <&3) >/dev/null & printf stderr >&2; exit 0", wantStage: "output drain", wantError: exec.ErrWaitDelay, wantStderr: "stderr"},
 	}
@@ -719,8 +725,37 @@ func TestRunInstallerCommand(t *testing.T) {
 				cmd.Stdout = installerReadyWriter{output: &stdout, cancel: func() { cancel(tt.cancelWith) }}
 			}
 
+			snapshot := installerProcessEvidence
+			observedExit := false
+			if tt.exitDuringSnapshot {
+				snapshot = func(group int) installerProcessSnapshot {
+					var evidence installerProcessSnapshot
+					if !tt.snapshotAfterExit {
+						evidence = installerProcessEvidence(group)
+					}
+					_ = release.Close()
+					deadline := time.NewTimer(10 * time.Second)
+					defer deadline.Stop()
+					tick := time.NewTicker(time.Millisecond)
+					defer tick.Stop()
+					for {
+						if errors.Is(cmd.Process.Signal(syscall.Signal(0)), os.ErrProcessDone) {
+							observedExit = true
+							if tt.snapshotAfterExit {
+								return installerProcessEvidence(group)
+							}
+							return evidence
+						}
+						select {
+						case <-deadline.C:
+							return evidence
+						case <-tick.C:
+						}
+					}
+				}
+			}
 			done := make(chan error, 1)
-			go func() { done <- runInstallerCommand(ctx, cmd) }()
+			go func() { done <- runInstallerCommandWithEvidence(ctx, cmd, snapshot) }()
 			select {
 			case err = <-done:
 			case <-time.After(30 * time.Second):
@@ -734,6 +769,9 @@ func TestRunInstallerCommand(t *testing.T) {
 				t.Fatal("installer command did not finish; output pipe remained open")
 			}
 			_ = inherited.Close()
+			if tt.exitDuringSnapshot && !observedExit {
+				t.Fatal("command did not exit while collecting process evidence")
+			}
 			if deadlineErr := exited.SetReadDeadline(time.Now().Add(10 * time.Second)); deadlineErr != nil {
 				t.Fatal(deadlineErr)
 			}
@@ -749,6 +787,15 @@ func TestRunInstallerCommand(t *testing.T) {
 			}
 			if tt.wantError != nil && !errors.Is(err, tt.wantError) {
 				t.Fatalf("runInstallerCommand() error = %v, want %v", err, tt.wantError)
+			}
+			if tt.cancelWith != nil && tt.wantError != nil {
+				want := fmt.Sprintf("pid=%d ppid=", cmd.Process.Pid)
+				if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), "executable=") {
+					t.Fatalf("runInstallerCommand() error = %v, want process evidence containing %q and executable", err, want)
+				}
+			}
+			if tt.wantChild && !strings.Contains(err.Error(), fmt.Sprintf("ppid=%d pgid=%d", cmd.Process.Pid, cmd.Process.Pid)) {
+				t.Fatalf("runInstallerCommand() error = %v, want nested command captured before cleanup", err)
 			}
 			if tt.wantExit != 0 {
 				var exitErr *exec.ExitError
@@ -775,9 +822,15 @@ func (w installerReadyWriter) Write(p []byte) (int, error) {
 }
 
 func runInstallerCommand(ctx context.Context, cmd *exec.Cmd) error {
+	return runInstallerCommandWithEvidence(ctx, cmd, installerProcessEvidence)
+}
+
+func runInstallerCommandWithEvidence(ctx context.Context, cmd *exec.Cmd, snapshot func(int) installerProcessSnapshot) error {
 	cmd.WaitDelay = time.Second
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var processEvidence installerProcessSnapshot
 	cmd.Cancel = func() error {
+		processEvidence = snapshot(cmd.Process.Pid)
 		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		if errors.Is(err, syscall.ESRCH) {
 			return os.ErrProcessDone
@@ -792,10 +845,16 @@ func runInstallerCommand(ctx context.Context, cmd *exec.Cmd) error {
 	startDuration := time.Since(started)
 	waiting := time.Now()
 	err := cmd.Wait()
+	if err == nil && processEvidence.live {
+		err = context.Cause(ctx)
+	}
 	if err == nil {
 		return nil
 	}
 	waitDuration := time.Since(waiting)
+	if processEvidence.description == "" {
+		processEvidence = snapshot(cmd.Process.Pid)
+	}
 	if killErr := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); killErr != nil && !errors.Is(killErr, syscall.ESRCH) {
 		err = errors.Join(err, fmt.Errorf("clean up command process group: %w", killErr))
 	}
@@ -803,8 +862,76 @@ func runInstallerCommand(ctx context.Context, cmd *exec.Cmd) error {
 	if errors.Is(err, exec.ErrWaitDelay) {
 		stage = "output drain"
 	}
-	return fmt.Errorf("command %q args=%q pid=%d stage=%s start=%s wait=%s: %w", cmd.Path, cmd.Args[1:], cmd.Process.Pid, stage,
-		startDuration.Round(time.Millisecond), waitDuration.Round(time.Millisecond), errors.Join(err, context.Cause(ctx)))
+	return fmt.Errorf("command %q args=%q pid=%d stage=%s start=%s wait=%s processes=%q: %w", cmd.Path, cmd.Args[1:], cmd.Process.Pid, stage,
+		startDuration.Round(time.Millisecond), waitDuration.Round(time.Millisecond), processEvidence.description, errors.Join(err, context.Cause(ctx)))
+}
+
+type installerProcessSnapshot struct {
+	description string
+	live        bool
+}
+
+func installerProcessEvidence(group int) installerProcessSnapshot {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ps", "-axo", "pid=,ppid=,pgid=,stat=,comm=")
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	cmd.WaitDelay = time.Second
+	output, err := cmd.Output()
+	if err != nil {
+		return installerProcessSnapshot{description: fmt.Sprintf("snapshot unavailable: %v", errors.Join(err, context.Cause(ctx)))}
+	}
+	return installerProcessGroup(string(output), group)
+}
+
+func installerProcessGroup(output string, group int) installerProcessSnapshot {
+	var processes []string
+	var snapshot installerProcessSnapshot
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 5 || fields[2] != strconv.Itoa(group) {
+			continue
+		}
+		processes = append(processes, fmt.Sprintf("pid=%s ppid=%s pgid=%s state=%s executable=%s", fields[0], fields[1], fields[2], fields[3], strings.Join(fields[4:], " ")))
+		if !strings.HasPrefix(fields[3], "Z") {
+			snapshot.live = true
+		}
+	}
+	if len(processes) == 0 {
+		return installerProcessSnapshot{description: "no process group members observed"}
+	}
+	snapshot.description = strings.Join(processes, "; ")
+	return snapshot
+}
+
+func TestInstallerProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		output   string
+		want     string
+		wantLive bool
+	}{
+		{name: "empty", want: "no process group members observed"},
+		{name: "unrelated groups", output: "123 1 123 S unrelated\n456 1 456 R other", want: "no process group members observed"},
+		{name: "malformed rows", output: "\n100 1 100\n100 1 invalid S sh", want: "no process group members observed"},
+		{name: "shell and child", output: " 100 1 100 S /bin/sh\n101 100 100 R /bin/rm\n102 1 102 S unrelated", want: "pid=100 ppid=1 pgid=100 state=S executable=/bin/sh; pid=101 ppid=100 pgid=100 state=R executable=/bin/rm", wantLive: true},
+		{name: "executable contains spaces", output: "101 100 100 S /path with spaces/tool", want: "pid=101 ppid=100 pgid=100 state=S executable=/path with spaces/tool", wantLive: true},
+		{name: "child after shell exit", output: "101 1 100 S rm", want: "pid=101 ppid=1 pgid=100 state=S executable=rm", wantLive: true},
+		{name: "zombie only", output: "100 1 100 Z sh", want: "pid=100 ppid=1 pgid=100 state=Z executable=sh"},
+		{name: "zombie parent with live child", output: "100 1 100 Z sh\n101 100 100 S rm", want: "pid=100 ppid=1 pgid=100 state=Z executable=sh; pid=101 ppid=100 pgid=100 state=S executable=rm", wantLive: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := installerProcessGroup(tt.output, 100)
+			if got.description != tt.want || got.live != tt.wantLive {
+				t.Fatalf("installerProcessGroup() = %+v, want description %q and live=%t", got, tt.want, tt.wantLive)
+			}
+		})
+	}
 }
 
 func reservePort(t *testing.T) int {


### PR DESCRIPTION
## Summary

Installer subprocess failures now capture the isolated process group's IDs, states, and executable names before cleanup destroys that evidence. Sampling is bounded and preserves cancellation/completion outcomes, with table-driven regressions for nested commands and both race orders.

A rework review found that Darwin returns `EPERM` when signaling a zombie-only process group. Successful snapshots now distinguish confirmed empty/zombie-only groups from unavailable or live observations, so a successful cancellation race is preserved without weakening cleanup.

This restores the diagnostic work authorized in #2408. The historical ten-second timeout cause remains unestablished; deadlines, fixtures, installer behavior, and parallel scheduling are unchanged. The investigation report distinguishes historical coverage runs from current validation.

Fixes #2370

Invariants touched: none.

## UI Surface Contract

- [x] N/A: installer test diagnostics only.
- [x] No persistent top-of-screen messaging is added.
- [x] No visual changes; browser verification is not applicable.

## Test Plan

- [x] Controlled cancellation/deadline evidence assertions fail against the original helper.
- [x] Focused installer and helper tests pass, including cancellation/completion races, zombie-only signal decisions, and inherited-descriptor cleanup.
- [x] `make check-fast` (configured worker gate; full race/coverage/nilaway run in the merge queue).
- [x] Independent validator review: approve, score 0.97, no P1/P2 findings.
