### PR TITLE
fix(scheduler): refresh stale dependency blockers

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -84,6 +84,12 @@ signature permit (#2486). The vocabulary consolidates onto the existing
 `lifetime_limit_recovered` reason, emitted only when an override is present or
 the configured limits no longer apply. Elapsed time cannot release the park.
 
+Todo dispatch resolves non-terminal dependency refs through the existing dependency
+auto-unblock resolver and readiness predicate, sharing blocker reads within each
+dispatch refresh (#2509). Closed tracker state releases ordinary dependencies
+without requiring a terminal lane observation; human completion evidence remains
+required. This consolidates dependency readiness without adding a recovery loop.
+
 ## INV-4 — Native merge queue
 
 **Statement:** Merges go through the repository's merge queue when one exists.

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -969,6 +969,9 @@ func dependencyBlockerReady(blocker dependencyBlocker, cfg DependencyAutoUnblock
 		}
 		return false
 	}
+	if blocker.Ref.TrackerState == connector.BlockedRefTrackerStateClosed {
+		return true
+	}
 	if strings.TrimSpace(blocker.Ref.State) == "" {
 		return false
 	}

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -1700,12 +1700,13 @@ type dependencyAutoUnblockAudit struct {
 }
 
 type dependencyAutoUnblockConnector struct {
-	stateIssues     []connector.Issue
-	hydratedIssues  []connector.Issue
-	blockers        []connector.Issue
-	updates         []dependencyAutoUnblockUpdate
-	comments        []dependencyAutoUnblockAudit
-	identifierCalls []string
+	stateIssues       []connector.Issue
+	hydratedIssues    []connector.Issue
+	blockers          []connector.Issue
+	updates           []dependencyAutoUnblockUpdate
+	comments          []dependencyAutoUnblockAudit
+	identifierCalls   []string
+	identifierBatches int
 }
 
 type dependencyAutoUnblockRejectOnceConnector struct {
@@ -1738,6 +1739,7 @@ func (c *dependencyAutoUnblockConnector) FetchIssueStatesByIDs(context.Context, 
 }
 
 func (c *dependencyAutoUnblockConnector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
+	c.identifierBatches++
 	wanted := make(map[string]struct{}, len(identifiers))
 	for _, identifier := range identifiers {
 		normalized := strings.ToLower(strings.TrimSpace(identifier))

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -141,6 +141,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	o.enforceLifetimeLimits(ctx, state, issues, now)
 	o.observePullRequestHydrationRecovery(state, issues, now)
 	planner := o.dispatchPlanner()
+	blockerCache := make(map[string]dependencyBlocker)
 	o.logOwnershipEligibilityStartup(planner, issues)
 	var lastDispatchFailure string
 	decisions := make([]dispatchPlanDecision, 0, len(issues))
@@ -149,7 +150,14 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	planner.plan(state, issues, now, dispatchPlanHooks{
 		rankingIssues: rankingIssues,
 		hydrate: func(issue connector.Issue) (connector.Issue, bool) {
-			return o.hydrateDispatchIssue(ctx, state, issue, now)
+			hydrated, ok := o.hydrateDispatchIssue(ctx, state, issue, now)
+			if ok {
+				hydrated = o.hydrateDispatchDependencies(ctx, hydrated, blockerCache)
+				if blocked, exists := state.Blocked[hydrated.ID]; exists && blockedFromDependency(blocked) && !todoBlockedByNonTerminal(hydrated, o.cfg.TerminalStates) {
+					delete(state.Blocked, hydrated.ID)
+				}
+			}
+			return hydrated, ok
 		},
 		beforeDispatch: func(_ connector.Issue, continuationIndex int) bool {
 			if continuationIndex < 0 {
@@ -278,6 +286,34 @@ func (o *Orchestrator) preserveMissingDueRetry(state *State, retry Retry) bool {
 		return false
 	}
 	return !o.mergeWorkerLocalSlotsAvailable(state)
+}
+
+// hydrateDispatchDependencies shares blocker reads across candidates in one dispatch refresh.
+func (o *Orchestrator) hydrateDispatchDependencies(ctx context.Context, issue connector.Issue, cache map[string]dependencyBlocker) connector.Issue {
+	if !todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
+		return issue
+	}
+	issue = cloneIssue(issue)
+	for i, ref := range issue.BlockedBy {
+		if !todoBlockedByNonTerminal(connector.Issue{State: issue.State, BlockedBy: []connector.BlockedRef{ref}}, o.cfg.TerminalStates) {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(firstNonBlank(ref.Identifier, ref.ID)))
+		blocker, cached := cache[key]
+		if !cached {
+			blockers := o.resolveDependencyBlockers(ctx, connector.Issue{ID: issue.ID, Identifier: issue.Identifier, BlockedBy: []connector.BlockedRef{ref}})
+			if len(blockers) > 0 {
+				blocker = blockers[0]
+			}
+			cache[key] = blocker
+		}
+		if blocker.Resolved {
+			resolved := blocker.Ref
+			resolved.Source = ref.Source
+			issue.BlockedBy[i] = resolved
+		}
+	}
+	return issue
 }
 
 func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, state *State, issue connector.Issue, now time.Time) (connector.Issue, bool) {
@@ -1321,7 +1357,7 @@ func todoBlockedByNonTerminal(issue connector.Issue, terminalStates []string) bo
 		if strings.TrimSpace(blocker.State) == "" {
 			continue
 		}
-		if !stateIn(blocker.State, terminalStates) {
+		if !dependencyBlockerReady(dependencyBlocker{Ref: blocker}, DependencyAutoUnblockConfig{Readiness: DependencyReadinessTerminal}, terminalStates) {
 			return true
 		}
 	}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -294,20 +294,25 @@ func (o *Orchestrator) hydrateDispatchDependencies(ctx context.Context, issue co
 		return issue
 	}
 	issue = cloneIssue(issue)
-	for i, ref := range issue.BlockedBy {
+	pending := connector.Issue{ID: issue.ID, Identifier: issue.Identifier}
+	for _, ref := range issue.BlockedBy {
 		if !todoBlockedByNonTerminal(connector.Issue{State: issue.State, BlockedBy: []connector.BlockedRef{ref}}, o.cfg.TerminalStates) {
 			continue
 		}
 		key := strings.ToLower(strings.TrimSpace(firstNonBlank(ref.Identifier, ref.ID)))
-		blocker, cached := cache[key]
-		if !cached {
-			blockers := o.resolveDependencyBlockers(ctx, connector.Issue{ID: issue.ID, Identifier: issue.Identifier, BlockedBy: []connector.BlockedRef{ref}})
-			if len(blockers) > 0 {
-				blocker = blockers[0]
-			}
-			cache[key] = blocker
+		if _, cached := cache[key]; !cached {
+			pending.BlockedBy = append(pending.BlockedBy, ref)
+			cache[key] = dependencyBlocker{Ref: ref}
 		}
-		if blocker.Resolved {
+	}
+	if len(pending.BlockedBy) > 0 {
+		for _, blocker := range o.resolveDependencyBlockers(ctx, pending) {
+			cache[dependencyAutoUnblockBlockerKey(blocker)] = blocker
+		}
+	}
+	for i, ref := range issue.BlockedBy {
+		key := strings.ToLower(strings.TrimSpace(firstNonBlank(ref.Identifier, ref.ID)))
+		if blocker := cache[key]; blocker.Resolved {
 			resolved := blocker.Ref
 			resolved.Source = ref.Source
 			issue.BlockedBy[i] = resolved

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -148,6 +148,14 @@ func (p dispatchPlanner) plan(
 					continue
 				}
 			}
+			if hooks.hydrate != nil {
+				var hydrated bool
+				issue, hydrated = hooks.hydrate(issue)
+				if !hydrated {
+					logDecision(dispatchPlanDecision{Issue: issue, QueuePosition: queuePosition, Attempt: retry.Attempt, WorkerHost: retry.WorkerHost, Retry: true, SkipReason: dispatchSkipHydrationFailed})
+					continue
+				}
+			}
 			action, ok, reason := p.retryAction(state, issue, retry, now)
 			if !ok {
 				logDecision(dispatchPlanDecision{

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -4217,10 +4217,14 @@ func TestDispatchReadyIssuesRefreshesStaleBlocker(t *testing.T) {
 		closed      bool
 		missing     bool
 		human       bool
+		retry       bool
+		multiple    bool
 		wantRunning int
 	}{
 		{name: "closed Backlog blocker", closed: true, wantRunning: 2},
 		{name: "open Backlog blocker"},
+		{name: "closed blocker due retry", closed: true, retry: true, wantRunning: 2},
+		{name: "multiple closed blockers", closed: true, multiple: true, wantRunning: 2},
 		{name: "missing blocker", missing: true},
 		{name: "closed human blocker without evidence", closed: true, human: true},
 	} {
@@ -4240,16 +4244,36 @@ func TestDispatchReadyIssuesRefreshesStaleBlocker(t *testing.T) {
 			if tt.human {
 				tracker.blockers[0].Labels = []string{"human-owned"}
 			}
+			if tt.multiple {
+				second := blocker
+				second.ID, second.Identifier = "second", "owner/repo#11"
+				tracker.blockers = append(tracker.blockers, second)
+				for i := range candidates {
+					candidates[i].BlockedBy = append(candidates[i].BlockedBy, connector.BlockedRef{Identifier: second.Identifier, State: "Backlog"})
+				}
+			}
 			runner := newWorkerHostRunner()
 			orch := Orchestrator{cfg: cfg, connector: tracker, supervisor: newTestSupervisor(t, runner, cfg), runResults: make(chan runpkg.Completion)}
 			state := newState(cfg)
+			if tt.retry {
+				for _, candidate := range candidates {
+					state.Retry[candidate.ID] = Retry{Issue: candidate, Attempt: 3, DueAt: time.Now().Add(-time.Minute)}
+				}
+			}
 			orch.dispatchPlanner().trackBlockedCandidates(&state, candidates, time.Now())
 			orch.dispatchReadyIssues(t.Context(), &state, candidates, time.Now())
 			if len(state.Running) != tt.wantRunning {
 				t.Fatalf("running = %d, want %d", len(state.Running), tt.wantRunning)
 			}
-			if len(tracker.identifierCalls) != 1 {
-				t.Fatalf("blocker reads = %v, want one shared read", tracker.identifierCalls)
+			if tt.retry {
+				for _, running := range state.Running {
+					if running.Attempt != 3 {
+						t.Fatalf("retry attempt = %d, want 3", running.Attempt)
+					}
+				}
+			}
+			if tracker.identifierBatches != 1 {
+				t.Fatalf("blocker batches = %d, want one shared batch", tracker.identifierBatches)
 			}
 		})
 	}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -4209,3 +4209,48 @@ func TestSampledGateRefusalRemainsDurableAfterSelection(t *testing.T) {
 		})
 	}
 }
+
+func TestDispatchReadyIssuesRefreshesStaleBlocker(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name        string
+		closed      bool
+		missing     bool
+		human       bool
+		wantRunning int
+	}{
+		{name: "closed Backlog blocker", closed: true, wantRunning: 2},
+		{name: "open Backlog blocker"},
+		{name: "missing blocker", missing: true},
+		{name: "closed human blocker without evidence", closed: true, human: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := normalizeConfig(Config{MaxConcurrentAgents: 2, ActiveStates: []string{"Todo"}, TerminalStates: []string{"Done"}})
+			blocker := connector.Issue{ID: "blocker", Identifier: "owner/repo#10", State: "Backlog", Closed: tt.closed}
+			candidates := []connector.Issue{dispatchTestIssue("one", "Todo"), dispatchTestIssue("two", "Todo")}
+			for i := range candidates {
+				candidates[i].Fields = map[string]string{"Status": "Todo"}
+				candidates[i].BlockedBy = []connector.BlockedRef{{Identifier: blocker.Identifier, State: "Backlog"}}
+			}
+			tracker := &dependencyAutoUnblockConnector{hydratedIssues: candidates, blockers: []connector.Issue{blocker}}
+			if tt.missing {
+				tracker.blockers = nil
+			}
+			if tt.human {
+				tracker.blockers[0].Labels = []string{"human-owned"}
+			}
+			runner := newWorkerHostRunner()
+			orch := Orchestrator{cfg: cfg, connector: tracker, supervisor: newTestSupervisor(t, runner, cfg), runResults: make(chan runpkg.Completion)}
+			state := newState(cfg)
+			orch.dispatchPlanner().trackBlockedCandidates(&state, candidates, time.Now())
+			orch.dispatchReadyIssues(t.Context(), &state, candidates, time.Now())
+			if len(state.Running) != tt.wantRunning {
+				t.Fatalf("running = %d, want %d", len(state.Running), tt.wantRunning)
+			}
+			if len(tracker.identifierCalls) != 1 {
+				t.Fatalf("blocker reads = %v, want one shared read", tracker.identifierCalls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Todo issues waiting on blockers last observed in Backlog now refresh those blockers and dispatch when they are closed. Open, missing, and incomplete human prerequisites continue to wait. Blocker reads are shared across candidates within a dispatch refresh.

Consolidates dispatch readiness with the existing dependency auto-unblock resolver and readiness predicate, and clears stale dependency-only block entries after hydration. No new recovery mechanism is introduced.

Fixes #2509

Invariants touched: INV-3 — [same-PR documentation](docs/invariants.md#inv-3--mechanism-moratorium).

## UI Surface Contract

- [x] N/A: no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A: no visual changes to primary operator screens.

## Test Plan

- [x] Baseline regression reproduced closed Backlog dependencies preventing dispatch.
- [x] Table-driven dispatch tests cover closed, open, missing, and incomplete human blockers, shared reads, and existing tick dependency blocks.
- [x] Existing lightweight hydration and human-prerequisite tests pass.
- [x] `make check-fast` passed on the final diff (configured worker gate; includes invariants, build, lint, vet, and full Go suite).
- [x] Independent validator: approve, score 9/10, no P1/P2 findings after fixing the initial stale-block-entry finding.


Rework validation: due retries now hydrate before eligibility checks, preserving attempt 3 in the regression test. Multiple uncached blockers resolve in one batch shared across candidates. Both P2 threads addressed; fresh validator approved 9/10 with no P1/P2 findings, and `make check-fast` passed.
