### PR TITLE
test(cli): isolate backend route test from host process scans

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -123,24 +123,45 @@ func buildRunner(
 	sessionStore runnerpkg.SessionStore,
 	logger *slog.Logger,
 ) (orchestrator.Runner, error) {
+	deps, err := buildRunnerDependencies(workflow, projectID, projectWorkdir, memory, sessionStore, logger)
+	if err != nil {
+		return nil, err
+	}
+	run, err := runnerpkg.NewRunner(deps)
+	if err != nil {
+		return nil, fmt.Errorf("create runner: %w", err)
+	}
+	return run, nil
+}
+
+// buildRunnerDependencies assembles production wiring independently of runner
+// construction so integration tests can substitute host process discovery.
+func buildRunnerDependencies(
+	workflow workflowconfig.Workflow,
+	projectID string,
+	projectWorkdir string,
+	memory globalconfig.Memory,
+	sessionStore runnerpkg.SessionStore,
+	logger *slog.Logger,
+) (runnerpkg.Dependencies, error) {
 	cfg := workflow.Config
 
 	backend, err := buildWorkspaceBackend(cfg, projectWorkdir, logger)
 	if err != nil {
-		return nil, err
+		return runnerpkg.Dependencies{}, err
 	}
 
 	pricing, err := budget.PricingForConfig(budget.Config{
 		PricingPath: cfg.Budget.PricingPath,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("load pricing: %w", err)
+		return runnerpkg.Dependencies{}, fmt.Errorf("load pricing: %w", err)
 	}
 	budgetGuardBuilder := func(cfg workflowconfig.Budget) (runnerpkg.BudgetChecker, runnerpkg.DispatchEstimator, error) {
 		return buildBudgetDispatchGuards(projectID, cfg, sessionStore, pricing)
 	}
 
-	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
+	return runnerpkg.Dependencies{
 		ProjectID:           projectID,
 		Workflow:            workflow,
 		Workspace:           backend,
@@ -151,11 +172,7 @@ func buildRunner(
 		MaxAgentRSSBytes:    uint64(memory.MaxAgentRSSBytes),
 		RSSPollInterval:     time.Duration(memory.PollIntervalMS) * time.Millisecond,
 		Logger:              logger,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create runner: %w", err)
-	}
-	return run, nil
+	}, nil
 }
 
 func buildBudgetDispatchGuards(

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -178,13 +178,7 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 }
 
 func TestBuildRunnerSupportsClaudeCodeBackendRoutes(t *testing.T) {
-	// The Claude stub leaves no orphan processes. Keep its route assertions
-	// independent of host-wide lsof scans, which can time out on busy macOS hosts.
-	scanDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(scanDir, "lsof"), []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
-		t.Fatalf("write empty workspace scan stub: %v", err)
-	}
-	t.Setenv("PATH", scanDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Parallel()
 
 	source := initRunnerSourceRepo(t)
 	claudeCommand, argsPath, stdinPath := writeRunnerClaudeStub(t)
@@ -239,9 +233,20 @@ Prompt {{ issue.identifier }}
 		t.Fatalf("Validate() error = %v", err)
 	}
 
-	run, err := buildRunner(workflow, "detent", source, globalconfig.Memory{}, sessionStore, nil)
+	deps, err := buildRunnerDependencies(workflow, "detent", source, globalconfig.Memory{}, sessionStore, nil)
 	if err != nil {
-		t.Fatalf("buildRunner() error = %v", err)
+		t.Fatalf("buildRunnerDependencies() error = %v", err)
+	}
+	// The Claude stub leaves no orphan processes. Substitute the existing
+	// reaper dependency rather than spawning a PATH stub under a real deadline.
+	var reapedPaths []string
+	deps.ReapWorkspaceProcesses = func(_ context.Context, path string, _ time.Duration) (int, error) {
+		reapedPaths = append(reapedPaths, path)
+		return 0, nil
+	}
+	run, err := runnerpkg.NewRunner(deps)
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
@@ -257,6 +262,15 @@ Prompt {{ issue.identifier }}
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(reapedPaths) == 0 {
+		t.Fatal("workspace reaper was not called")
+	}
+	for _, path := range reapedPaths {
+		if !filepath.IsAbs(path) || !strings.HasPrefix(path, workflow.Config.Workspace.Root+string(os.PathSeparator)) {
+			t.Errorf("reaped path = %q, want a workspace beneath %q", path, workflow.Config.Workspace.Root)
+		}
 	}
 
 	if result.FinalState != runnerpkg.FinalStateCompleted || result.Output != "claude streamed" {


### PR DESCRIPTION
## Summary

- Make Claude backend route validation use the runner's existing in-process workspace reaper dependency. The previous PATH shell stub still required subprocess startup within a five-second scan deadline and flaked during concurrent package validation.
- Extract dependency assembly while preserving production constructor wiring, process cleanup, deadlines, and errors. Keep route/usage/prompt assertions and verify cleanup receives workspace paths. No runtime mechanism is added or modified.

Fixes #2514

Invariants touched: none.

## UI Surface Contract

- [x] N/A — no UI changes.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — no visual changes.

## Test Plan

- [x] Baseline isolated route test passed; intermittent host timeout not reproduced locally.
- [x] `env -u DETENT_API_TOKEN go test ./internal/cli -run '^TestBuildRunner' -count=10`
- [x] `make check-fast` (worker gate; race, coverage, nilaway deferred to merge queue).
- [x] Validator review: approve, 10/10, no P1/P2 findings.
