### PR TITLE
docs(agents): default to Codex Sol at high effort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,25 +6,25 @@
 
 ## Issue effort selection
 
-Use Codex Astra (`gpt-6-astra`) at low effort by default for features, fixes,
-tests, reviews, and routine implementation, including cross-component work.
+The default is Codex Sol (`gpt-5.6-sol`) at `high` effort for all work: features,
+fixes, tests, reviews, and routine implementation, including cross-component work.
 
-Every issue must include an explicit override, with model unset:
+Every issue must include an explicit `detent-agent` block, with `model` unset:
 
 ```detent-agent
 schema: 1
-effort: low
+effort: high
 ```
 
-- `low` — the default for all work without a specific documented reason to escalate.
-- `medium` — an exception for a concrete reasoning difficulty or evidence that low was insufficient; explain the reason in the issue.
-- `high` — rare, significant research or architecture work with a written justification.
+- `high` — the default; use it unless the issue states a documented reason not to.
+- `low` — an exception that requires a written reason in the issue, and only for
+  trivial mechanical edits.
+- `medium` — an exception that requires a written reason in the issue.
 - `xhigh` and `max` — operator-designated only; never assign automatically.
 
-Concurrency, recovery, routing, multiple files, or a new endpoint alone do not
-justify higher effort. Preserve intentional operator exceptions. Configured
-complexity levels default to low; verify any approved exception against the
-runtime effort ceiling rather than raising broad defaults.
+Concurrency, recovery, routing, multiple files, or a new endpoint alone never
+justify changing the effort. Preserve intentional operator exceptions and leave
+`model` unset so the issue inherits the fleet-standard model.
 
 ## Mechanism moratorium
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,25 +26,25 @@
 
 ## Issue effort selection
 
-Use Codex Astra (`gpt-6-astra`) at low effort by default for features, fixes,
-tests, reviews, and routine implementation, including cross-component work.
+The default is Codex Sol (`gpt-5.6-sol`) at `high` effort for all work: features,
+fixes, tests, reviews, and routine implementation, including cross-component work.
 
-Every issue must include an explicit override, with model unset:
+Every issue must include an explicit `detent-agent` block, with `model` unset:
 
 ```detent-agent
 schema: 1
-effort: low
+effort: high
 ```
 
-- `low` — the default for all work without a specific documented reason to escalate.
-- `medium` — an exception for a concrete reasoning difficulty or evidence that low was insufficient; explain the reason in the issue.
-- `high` — rare, significant research or architecture work with a written justification.
+- `high` — the default; use it unless the issue states a documented reason not to.
+- `low` — an exception that requires a written reason in the issue, and only for
+  trivial mechanical edits.
+- `medium` — an exception that requires a written reason in the issue.
 - `xhigh` and `max` — operator-designated only; never assign automatically.
 
-Concurrency, recovery, routing, multiple files, or a new endpoint alone do not
-justify higher effort. Preserve intentional operator exceptions. Configured
-complexity levels default to low; verify any approved exception against the
-runtime effort ceiling rather than raising broad defaults.
+Concurrency, recovery, routing, multiple files, or a new endpoint alone never
+justify changing the effort. Preserve intentional operator exceptions and leave
+`model` unset so the issue inherits the fleet-standard model.
 
 ## Mechanism moratorium
 

--- a/tools/cifailure/main.go
+++ b/tools/cifailure/main.go
@@ -59,7 +59,7 @@ func report(ctx context.Context, input io.Reader, backend issueCreator, sha stri
 		if !integrationJob(j.Name) || (j.Conclusion != "failure" && j.Conclusion != "timed_out") {
 			continue
 		}
-		body := fmt.Sprintf("Post-merge integration job **%s** failed on main.\n\nJob: %s\nCommit: %s\n\nThis tracks CI instance health; it does not attribute a defect to the merged issue or change. Diagnose the linked logs before proposing a fix. Runner setup, backend startup, network/download, and protocol failures belong to the CI instance. Propose product changes only when the logs establish a product defect.\n\n```detent-agent\nschema: 1\neffort: low\n```", j.Name, j.URL, sha)
+		body := fmt.Sprintf("Post-merge integration job **%s** failed on main.\n\nJob: %s\nCommit: %s\n\nThis tracks CI instance health; it does not attribute a defect to the merged issue or change. Diagnose the linked logs before proposing a fix. Runner setup, backend startup, network/download, and protocol failures belong to the CI instance. Propose product changes only when the logs establish a product defect.\n\n```detent-agent\nschema: 1\neffort: high\n```", j.Name, j.URL, sha)
 		body = issueorigin.Stamp(body, issueorigin.Origin{
 			Kind: "doctor", Instance: "github-actions", Source: j.URL,
 			Fingerprint: issueorigin.Fingerprint("ci integration job " + j.Name),


### PR DESCRIPTION
## Summary

- Revert the 2026-09-08 Astra-low rollout in this repo's operator instructions.
- `AGENTS.md` and `CLAUDE.md` now state the fleet default as Codex Sol (`gpt-5.6-sol`) at `high` effort for all work.
- The `detent-agent` block stays required for this project (`backlog_admission.require_effort: true`) and the example is `effort: high`.
- `low` and `medium` become exceptions that need a written reason; `xhigh` and `max` stay operator-designated only.
- Concurrency, recovery, routing, multiple files, or a new endpoint alone never justify changing effort.

Operator-directed fleet policy change; no tracking issue.

Invariants touched: none.

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [ ] `make check` — not run locally; this change is Markdown-only with no Go, template, query, or CSS input touched. The merge queue runs the full gate.
