### PR TITLE
fix(orchestrator): reset acknowledged loops

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -90,6 +90,13 @@ dispatch refresh (#2509). Closed tracker state releases ordinary dependencies
 without requiring a terminal lane observation; human completion evidence remains
 required. This consolidates dependency readiness without adding a recovery loop.
 
+An operator acknowledgement that moves an issue out of Blocked resets that issue's
+dispatch-loop history at the acknowledgement timestamp (#2517). Kanban moves and
+`detent issue --acknowledge-parks` share the existing recovery-park acknowledgement
+predicate and durable record; automatic unparks and unrelated issue history remain
+untouched. This consolidates operator retry intent with the existing acknowledgement
+path instead of adding another breaker or recovery loop.
+
 ## INV-4 — Native merge queue
 
 **Statement:** Merges go through the repository's merge queue when one exists.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -90,12 +90,12 @@ dispatch refresh (#2509). Closed tracker state releases ordinary dependencies
 without requiring a terminal lane observation; human completion evidence remains
 required. This consolidates dependency readiness without adding a recovery loop.
 
-An operator acknowledgement that moves an issue out of Blocked resets that issue's
-dispatch-loop history at the acknowledgement timestamp (#2517). Kanban moves and
-`detent issue --acknowledge-parks` share the existing recovery-park acknowledgement
-predicate and durable record; automatic unparks and unrelated issue history remain
-untouched. This consolidates operator retry intent with the existing acknowledgement
-path instead of adding another breaker or recovery loop.
+An explicit operator acknowledgement resets that issue's dispatch-loop history at
+the acknowledgement timestamp (#2517). Kanban moves out of Blocked and `detent issue
+--acknowledge-parks` share the existing recovery-park acknowledgement path, including
+when the CLI acknowledgement leaves the issue in Blocked; automatic unparks and
+unrelated issue history remain untouched. This consolidates operator retry intent
+instead of adding another breaker or recovery loop.
 
 ## INV-4 — Native merge queue
 

--- a/internal/orchestrator/cross_host_park.go
+++ b/internal/orchestrator/cross_host_park.go
@@ -192,13 +192,18 @@ func (o *Orchestrator) retainUnacknowledgedRecoveryParks(ctx context.Context, st
 				park = nil
 			}
 		}
-		acknowledged := park != nil && (o.recoveryParkSequenceAcknowledged(ctx, issue, parkedAt) || o.recoveryIntentAcknowledgesPark(ctx, issue, *park, parkedAt))
+		parkSequenceAcknowledgedAt, parkSequenceAcknowledged := o.recoveryParkSequenceAcknowledged(ctx, issue, parkedAt)
+		acknowledged := park != nil && (parkSequenceAcknowledged || o.recoveryIntentAcknowledgesPark(ctx, issue, *park, parkedAt))
 		if acknowledged {
+			if parkSequenceAcknowledged {
+				acknowledgedAt = laterDispatchLoopTime(acknowledgedAt, parkSequenceAcknowledgedAt)
+			}
 			if blocked, held := state.Blocked[issue.ID]; held && blocked.Source == BlockedSourceProjectStatus && blocked.Reason == park.Cause {
 				delete(state.Blocked, issue.ID)
 			}
 			park = nil
 		}
+		resetDispatchLoopState(state, issue, acknowledgedAt)
 		if park == nil {
 			if blocked, held := state.Blocked[issue.ID]; held && blocked.Source == BlockedSourceProjectStatus && acknowledgedPark != nil && blocked.Reason == acknowledgedPark.Cause && recoveryBlockPredatesAcknowledgement(blocked, acknowledgedAt) {
 				delete(state.Blocked, issue.ID)
@@ -225,13 +230,16 @@ func recoveryBlockPredatesAcknowledgement(blocked Blocked, acknowledgedAt time.T
 	return !parkedAt.After(acknowledgedAt)
 }
 
-func (o *Orchestrator) recoveryParkSequenceAcknowledged(ctx context.Context, issue connector.Issue, parkedAt time.Time) bool {
+func (o *Orchestrator) recoveryParkSequenceAcknowledged(ctx context.Context, issue connector.Issue, parkedAt time.Time) (time.Time, bool) {
 	reader, ok := o.workflowMetrics.(store.ParkSummaryStore)
 	if !ok || parkedAt.IsZero() {
-		return false
+		return time.Time{}, false
 	}
 	summary, err := reader.IssueParkSummary(ctx, store.IssueIdentity{ProjectID: o.workflowMetricsProjectID(), IssueID: issue.ID, Identifier: issue.Identifier, IssueURL: issue.URL})
-	return err == nil && summary.ParkCount > 0 && summary.AcknowledgedParkSequence >= summary.ParkCount && summary.AcknowledgedAt != nil && !summary.AcknowledgedAt.Before(parkedAt)
+	if err != nil || summary.ParkCount <= 0 || summary.AcknowledgedParkSequence < summary.ParkCount || summary.AcknowledgedAt == nil || summary.AcknowledgedAt.Before(parkedAt) {
+		return time.Time{}, false
+	}
+	return *summary.AcknowledgedAt, true
 }
 
 func recoveryParkEventMatchesIssue(event store.WorkflowPhaseEvent, issue connector.Issue) bool {
@@ -245,17 +253,10 @@ func recoveryParkEventMatchesIssue(event store.WorkflowPhaseEvent, issue connect
 }
 
 func recoveryParkAcknowledged(event store.WorkflowPhaseEvent, metadata workflowLaneMetadata, park workflowLaneBlockedRecoveryMetadata) bool {
-	if event.Reason == "operator_move" && metadata.Provenance.Origin == provenance.OriginHuman {
+	if operatorAcknowledgesRecoveryPark(event, metadata) {
 		return true
 	}
 	if event.Reason == "operator_configuration_recovery" && configurationRecoveryParkCause(park.Cause) && metadata.BlockedRecovery != nil && sameBlockedRecoveryPark(*metadata.BlockedRecovery, park) {
-		return true
-	}
-	if metadata.Provenance.Initiator == provenance.InitiatorHuman && metadata.Provenance.Basis == provenance.BasisAuthenticatedHuman {
-		return true
-	}
-	switch event.Reason {
-	case "kanban_move", "kanban_move_field":
 		return true
 	}
 	if metadata.Provenance.Initiator != provenance.InitiatorDetentInstance {

--- a/internal/orchestrator/cross_host_park.go
+++ b/internal/orchestrator/cross_host_park.go
@@ -150,7 +150,8 @@ func (o *Orchestrator) trackerRecoveryParkCommentsHold(issue connector.Issue, co
 
 func (o *Orchestrator) retainUnacknowledgedRecoveryParks(ctx context.Context, state *State, issues []connector.Issue) {
 	for _, issue := range issues {
-		if !stateIn(issue.State, o.cfg.ActiveStates) {
+		active := stateIn(issue.State, o.cfg.ActiveStates)
+		if !active && normalizeState(issue.State) != normalizeState(blockedStatusState) {
 			continue
 		}
 		if _, running := state.Running[issue.ID]; running {
@@ -161,6 +162,9 @@ func (o *Orchestrator) retainUnacknowledgedRecoveryParks(ctx context.Context, st
 		}
 		timeline, ok := o.issueWorkflowTimeline(ctx, issue)
 		if !ok {
+			if !active {
+				continue
+			}
 			if _, available := o.workflowMetrics.(WorkflowMetricsTimelineReader); available {
 				state.Blocked[issue.ID] = Blocked{Issue: cloneIssue(issue), Source: BlockedSourceProjectStatus, Reason: "recovery_park_history_unavailable"}
 			}
@@ -169,7 +173,8 @@ func (o *Orchestrator) retainUnacknowledgedRecoveryParks(ctx context.Context, st
 		var park *workflowLaneBlockedRecoveryMetadata
 		var parkedAt time.Time
 		var acknowledgedPark *workflowLaneBlockedRecoveryMetadata
-		var acknowledgedAt time.Time
+		var parkReleasedAt time.Time
+		var dispatchLoopResetAt time.Time
 		for _, event := range timeline.Events {
 			if event.PhaseType != store.WorkflowPhaseTypeLane || event.Status != "entered" || !recoveryParkEventMatchesIssue(event, issue) {
 				continue
@@ -188,7 +193,10 @@ func (o *Orchestrator) retainUnacknowledgedRecoveryParks(ctx context.Context, st
 			}
 			if park != nil && recoveryParkAcknowledged(event, metadata, *park) {
 				acknowledgedPark = park
-				acknowledgedAt = workflowLaneTransitionAt(event)
+				parkReleasedAt = workflowLaneTransitionAt(event)
+				if operatorAcknowledgesRecoveryPark(event, metadata) {
+					dispatchLoopResetAt = laterDispatchLoopTime(dispatchLoopResetAt, parkReleasedAt)
+				}
 				park = nil
 			}
 		}
@@ -196,16 +204,19 @@ func (o *Orchestrator) retainUnacknowledgedRecoveryParks(ctx context.Context, st
 		acknowledged := park != nil && (parkSequenceAcknowledged || o.recoveryIntentAcknowledgesPark(ctx, issue, *park, parkedAt))
 		if acknowledged {
 			if parkSequenceAcknowledged {
-				acknowledgedAt = laterDispatchLoopTime(acknowledgedAt, parkSequenceAcknowledgedAt)
+				dispatchLoopResetAt = laterDispatchLoopTime(dispatchLoopResetAt, parkSequenceAcknowledgedAt)
 			}
-			if blocked, held := state.Blocked[issue.ID]; held && blocked.Source == BlockedSourceProjectStatus && blocked.Reason == park.Cause {
+			if blocked, held := state.Blocked[issue.ID]; active && held && blocked.Source == BlockedSourceProjectStatus && blocked.Reason == park.Cause {
 				delete(state.Blocked, issue.ID)
 			}
 			park = nil
 		}
-		resetDispatchLoopState(state, issue, acknowledgedAt)
+		resetDispatchLoopState(state, issue, dispatchLoopResetAt)
+		if !active {
+			continue
+		}
 		if park == nil {
-			if blocked, held := state.Blocked[issue.ID]; held && blocked.Source == BlockedSourceProjectStatus && acknowledgedPark != nil && blocked.Reason == acknowledgedPark.Cause && recoveryBlockPredatesAcknowledgement(blocked, acknowledgedAt) {
+			if blocked, held := state.Blocked[issue.ID]; held && blocked.Source == BlockedSourceProjectStatus && acknowledgedPark != nil && blocked.Reason == acknowledgedPark.Cause && recoveryBlockPredatesAcknowledgement(blocked, parkReleasedAt) {
 				delete(state.Blocked, issue.ID)
 			}
 			if blocked, ok := state.Blocked[issue.ID]; ok && (blocked.RecoveryReason == "park_acknowledgement_required" || blocked.Reason == "recovery_park_history_unavailable") {

--- a/internal/orchestrator/cross_host_park_test.go
+++ b/internal/orchestrator/cross_host_park_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/provenance"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestCrossHostParkRecovery(t *testing.T) {
@@ -362,6 +363,12 @@ func TestRecoveryParkSummaryAcknowledgementConverges(t *testing.T) {
 			}
 			for range 2 {
 				state := newState(host.cfg)
+				state.BoardIssues = []connector.Issue{issue}
+				attempt := dispatchLoopHistoryAttempt(4, store.WorkAttemptTerminalNoProgress, autoPromoteReworkSignature{}, implementProgressDiffStats{Status: "clean"}, nil, 4)
+				attempt.IssueID = issue.ID
+				attempt.Identifier = issue.Identifier
+				attempt.CompletedAt = now.Add(-time.Minute)
+				state.WorkAttempts = []telemetry.WorkAttempt{telemetryWorkAttempt(attempt, now)}
 				state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceProjectStatus, Reason: dispatchLoopDetectedReason, Recovery: park.BlockedRecovery}
 				if independent {
 					state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceDependency, Reason: "dependency remains open"}
@@ -370,6 +377,16 @@ func TestRecoveryParkSummaryAcknowledgementConverges(t *testing.T) {
 				blocked, held := state.Blocked[issue.ID]
 				if held != independent || independent && blocked.Source != BlockedSourceDependency {
 					t.Fatalf("acknowledged park reconciliation = %#v, held %v", blocked, held)
+				}
+				if got := len(state.WorkAttempts); got != 1 {
+					t.Fatalf("retained work attempts = %d, want complete history", got)
+				}
+				wantLoops := 0
+				if independent {
+					wantLoops = 1
+				}
+				if got := len(state.Snapshot(now).DispatchLoops); got != wantLoops {
+					t.Fatalf("dispatch-loop snapshots = %d, want %d", got, wantLoops)
 				}
 			}
 			if !independent {

--- a/internal/orchestrator/cross_host_park_test.go
+++ b/internal/orchestrator/cross_host_park_test.go
@@ -401,6 +401,44 @@ func TestRecoveryParkSummaryAcknowledgementConverges(t *testing.T) {
 	}
 }
 
+func TestBlockedRecoveryParkSummaryAcknowledgementResetsDispatchLoop(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 11, 16, 30, 0, 0, time.UTC)
+	parkedAt := now.Add(-time.Hour)
+	issue := recoveryTestIssue()
+	db := openWorkAttemptRecoveryStore(t, t.Context())
+	host := newWorkAttemptRecoveryOrchestrator(t, db, nil)
+	park := workflowLaneMetadata{BlockedRecovery: &workflowLaneBlockedRecoveryMetadata{Owner: blockedRecoveryOwnerHuman, Cause: dispatchLoopDetectedReason, CauseFingerprint: "park-4"}}
+	host.recordLaneTransition(t.Context(), issue, blockedStatusState, parkedAt, dispatchLoopDetectedReason, park)
+	identity := store.IssueIdentity{ProjectID: "detent", IssueID: issue.ID}
+	summary, err := db.(store.ParkSummaryStore).IssueParkSummary(t.Context(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.(store.ParkSummaryStore).AcknowledgeIssueParks(t.Context(), identity, summary.ParkCount, now); err != nil {
+		t.Fatal(err)
+	}
+	issue.State = blockedStatusState
+	issue.StageUpdatedAt = &parkedAt
+	attempt := dispatchLoopHistoryAttempt(4, store.WorkAttemptTerminalNoProgress, autoPromoteReworkSignature{}, implementProgressDiffStats{Status: "clean"}, nil, 4)
+	attempt.IssueID = issue.ID
+	attempt.Identifier = issue.Identifier
+	attempt.CompletedAt = now.Add(-time.Minute)
+	state := newState(host.cfg)
+	state.BoardIssues = []connector.Issue{issue}
+	state.WorkAttempts = []telemetry.WorkAttempt{telemetryWorkAttempt(attempt, now)}
+	state.Blocked[issue.ID] = Blocked{Issue: issue, Source: BlockedSourceProjectStatus, Reason: dispatchLoopDetectedReason, Recovery: park.BlockedRecovery}
+
+	host.retainUnacknowledgedRecoveryParks(t.Context(), &state, []connector.Issue{issue})
+
+	if _, held := state.Blocked[issue.ID]; !held {
+		t.Fatal("CLI acknowledgement removed the tracker Blocked lane projection")
+	}
+	if got := len(state.Snapshot(now).DispatchLoops); got != 0 {
+		t.Fatalf("dispatch-loop snapshots = %d, want acknowledged loop reset while issue remains Blocked", got)
+	}
+}
+
 func TestAcknowledgedParkClearsDelayedTrackerObservation(t *testing.T) {
 	t.Parallel()
 	db := openWorkAttemptRecoveryStore(t, t.Context())
@@ -435,6 +473,12 @@ func TestCrossHostParkPreservesConfiguredCooldownRecovery(t *testing.T) {
 			host.workflowMetrics = openValidatorMemoStore(t)
 			host.recoveryInspector = staticBlockedRecoveryInspector{snapshot: runpkg.BlockedRecoverySnapshot{ConfigFingerprint: "unchanged", Health: "ready"}}
 			state := newState(host.cfg)
+			state.BoardIssues = []connector.Issue{issue}
+			attempt := dispatchLoopHistoryAttempt(4, store.WorkAttemptTerminalNoProgress, autoPromoteReworkSignature{}, implementProgressDiffStats{Status: "clean"}, nil, 4)
+			attempt.IssueID = issue.ID
+			attempt.Identifier = issue.Identifier
+			attempt.CompletedAt = now.Add(-time.Minute)
+			state.WorkAttempts = []telemetry.WorkAttempt{telemetryWorkAttempt(attempt, now)}
 			metadata := host.newBlockedRecoveryMetadata(t.Context(), issue, RunModeImplement, cause, blockedRecoveryPredicateFingerprintChange, "Todo", DiffStats{})
 			if err := host.updateIssueStateByIDStrictWithMetadata(t.Context(), &state, issue.ID, issue, "Blocked", now, cause, metadata); err != nil {
 				t.Fatal(err)
@@ -446,6 +490,9 @@ func TestCrossHostParkPreservesConfiguredCooldownRecovery(t *testing.T) {
 			host.retainUnacknowledgedRecoveryParks(t.Context(), &state, tracker.stateIssues)
 			if _, held := state.Blocked[issue.ID]; held {
 				t.Fatal("dispatch guard rejected configured cooldown recovery")
+			}
+			if got := len(state.Snapshot(tracker.now).DispatchLoops); got != 1 {
+				t.Fatalf("dispatch-loop snapshots = %d, want automatic recovery to preserve history", got)
 			}
 		})
 	}

--- a/internal/orchestrator/dispatch_loop.go
+++ b/internal/orchestrator/dispatch_loop.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/provenance"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
@@ -79,6 +82,7 @@ func (o *Orchestrator) evaluateDispatchLoopProgress(
 		}
 		return decision
 	}
+	attempts = dispatchLoopAttemptsAfter(attempts, o.dispatchLoopAcknowledgedAt(ctx, decision.Issue))
 
 	current := dispatchLoopFingerprintFromDecision(decision, currentLane)
 	withinAttemptAdvanced, withinAttemptComplete := dispatchLoopWithinAttemptProgress(
@@ -109,6 +113,102 @@ func (o *Orchestrator) evaluateDispatchLoopProgress(
 	decision.Block = true
 	decision.DependencyDeferral = false
 	return decision
+}
+
+func (o *Orchestrator) dispatchLoopAcknowledgedAt(ctx context.Context, issue connector.Issue) time.Time {
+	var acknowledgedAt time.Time
+	if timeline, ok := o.issueWorkflowTimeline(ctx, issue); ok {
+		for _, event := range timeline.Events {
+			if event.PhaseType != store.WorkflowPhaseTypeLane || !strings.EqualFold(strings.TrimSpace(event.Status), "entered") ||
+				normalizeState(event.PreviousPhaseName) != normalizeState(blockedStatusState) || !recoveryParkEventMatchesIssue(event, issue) {
+				continue
+			}
+			metadata, _ := workflowLaneMetadataFromJSON(event.MetadataJSON)
+			if operatorAcknowledgesRecoveryPark(event, metadata) {
+				acknowledgedAt = laterDispatchLoopTime(acknowledgedAt, workflowLaneTransitionAt(event))
+			}
+		}
+	}
+	if reader, ok := o.workflowMetrics.(store.ParkSummaryStore); ok {
+		summary, err := reader.IssueParkSummary(ctx, store.IssueIdentity{
+			ProjectID:  o.workflowMetricsProjectID(),
+			IssueID:    issue.ID,
+			Identifier: issue.Identifier,
+			IssueURL:   issue.URL,
+		})
+		if err == nil && summary.ParkCount > 0 && summary.AcknowledgedParkSequence >= summary.ParkCount && summary.AcknowledgedAt != nil {
+			acknowledgedAt = laterDispatchLoopTime(acknowledgedAt, *summary.AcknowledgedAt)
+		}
+	}
+	return acknowledgedAt
+}
+
+func operatorAcknowledgesRecoveryPark(event store.WorkflowPhaseEvent, metadata workflowLaneMetadata) bool {
+	if event.Reason == "operator_move" && metadata.Provenance.Origin == provenance.OriginHuman {
+		return true
+	}
+	if metadata.Provenance.Initiator == provenance.InitiatorHuman && metadata.Provenance.Basis == provenance.BasisAuthenticatedHuman {
+		return true
+	}
+	switch event.Reason {
+	case "kanban_move", "kanban_move_field":
+		return true
+	default:
+		return false
+	}
+}
+
+func dispatchLoopAttemptsAfter(attempts []store.WorkAttempt, acknowledgedAt time.Time) []store.WorkAttempt {
+	if acknowledgedAt.IsZero() {
+		return attempts
+	}
+	kept := make([]store.WorkAttempt, 0, len(attempts))
+	for _, attempt := range attempts {
+		if attempt.CompletedAt.IsZero() || attempt.CompletedAt.After(acknowledgedAt) {
+			kept = append(kept, attempt)
+		}
+	}
+	return kept
+}
+
+func resetDispatchLoopState(state *State, issue connector.Issue, acknowledgedAt time.Time) bool {
+	if state == nil || acknowledgedAt.IsZero() {
+		return false
+	}
+	key := workflowIssueIdentityKey(issue)
+	if key == "" {
+		return false
+	}
+	if state.dispatchLoopResets == nil {
+		state.dispatchLoopResets = map[string]time.Time{}
+	}
+	state.dispatchLoopResets[key] = laterDispatchLoopTime(state.dispatchLoopResets[key], acknowledgedAt)
+	cleared := false
+	for _, attempt := range state.WorkAttempts {
+		matches := snapshotIssueMatches(telemetryIssue(issue, 0, 0, acknowledgedAt, nil), attempt.IssueID, attempt.Identifier, attempt.IssueURL)
+		if matches && strings.EqualFold(strings.TrimSpace(attempt.Status), string(store.WorkAttemptStatusTerminal)) &&
+			attempt.CompletedAt != nil && !attempt.CompletedAt.After(acknowledgedAt) {
+			record, ok := implementProgressRecordFromAnyAttempt(store.WorkAttempt{
+				TerminalState:      store.WorkAttemptTerminalState(attempt.TerminalState),
+				WorkerMetadataJSON: attempt.WorkerMetadataJSON,
+			})
+			cleared = cleared || ok && record.ConsecutiveNoProgress > 0
+		}
+	}
+	return cleared
+}
+
+func dispatchLoopSnapshotAttemptVisible(issue telemetry.Issue, attempt telemetry.WorkAttempt, resets map[string]time.Time) bool {
+	key := workflowIssueIdentityKey(connector.Issue{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL})
+	resetAt := resets[key]
+	return resetAt.IsZero() || attempt.CompletedAt == nil || attempt.CompletedAt.After(resetAt)
+}
+
+func laterDispatchLoopTime(current, candidate time.Time) time.Time {
+	if candidate.After(current) {
+		return candidate
+	}
+	return current
 }
 
 func dispatchLoopPreservesSpecificDecision(decision implementCompletionProgressDecision) bool {

--- a/internal/orchestrator/dispatch_loop_test.go
+++ b/internal/orchestrator/dispatch_loop_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -186,6 +187,104 @@ func TestEvaluateDispatchLoopProgress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEvaluateDispatchLoopProgressStartsAtOneAfterOperatorMove(t *testing.T) {
+	t.Parallel()
+
+	movedAt := time.Date(2026, 8, 18, 14, 30, 0, 0, time.UTC)
+	operatorMove := store.WorkflowPhaseEvent{
+		ID:                2,
+		IssueID:           "issue-loop",
+		PhaseType:         store.WorkflowPhaseTypeLane,
+		PhaseName:         "Rework",
+		PreviousPhaseName: "Blocked",
+		Reason:            "kanban_move",
+		Status:            "entered",
+		StartedAt:         movedAt,
+	}
+	automaticMove := operatorMove
+	automaticMove.Reason = workflowActionBlockedReadyPRReconciliation
+	tests := []struct {
+		name      string
+		metrics   *dispatchLoopTimelineRecorder
+		wantCount int
+		wantBlock bool
+	}{
+		{
+			name:      "kanban move",
+			metrics:   &dispatchLoopTimelineRecorder{timeline: store.WorkflowTimeline{Events: []store.WorkflowPhaseEvent{operatorMove}}},
+			wantCount: 1,
+		},
+		{
+			name: "park acknowledgement CLI",
+			metrics: &dispatchLoopTimelineRecorder{summary: &store.ParkSummary{
+				ProjectID: "detent", IssueID: "issue-loop", ParkCount: 1, AcknowledgedParkSequence: 1, AcknowledgedAt: &movedAt,
+			}},
+			wantCount: 1,
+		},
+		{
+			name:      "automatic unpark retains history",
+			metrics:   &dispatchLoopTimelineRecorder{timeline: store.WorkflowTimeline{Events: []store.WorkflowPhaseEvent{automaticMove}}},
+			wantCount: 3,
+			wantBlock: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			history := []store.WorkAttempt{
+				dispatchLoopHistoryAttempt(2, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, implementProgressDiffStats{Status: "clean"}, nil, 2),
+				dispatchLoopHistoryAttempt(1, store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, implementProgressDiffStats{Status: "clean"}, nil, 1),
+			}
+			orch := &Orchestrator{
+				cfg:             Config{Project: scheduler.ProjectCandidate{ID: "detent"}},
+				workAttempts:    &implementProgressAttemptStore{history: history},
+				workflowMetrics: tt.metrics,
+			}
+			running := dispatchLoopRunning("Rework", DiffStats{Status: "clean"})
+			running.DispatchLoopStart = dispatchLoopTestStart("Rework", autoPromoteReworkSignature{}, implementProgressDiffStats{HeadSHA: "same-workspace-head", Status: "clean"})
+			decision := dispatchLoopDecision("Rework", store.WorkAttemptTerminalSuccess, autoPromoteReworkSignature{}, DiffStats{Status: "clean"})
+
+			got := orch.evaluateDispatchLoopProgress(t.Context(), running, decision)
+
+			if got.ConsecutiveNoProgress != tt.wantCount || got.Block != tt.wantBlock {
+				t.Fatalf("evaluateDispatchLoopProgress() = count %d block %v reason %q, want count %d block %v", got.ConsecutiveNoProgress, got.Block, got.Reason, tt.wantCount, tt.wantBlock)
+			}
+		})
+	}
+}
+
+type dispatchLoopTimelineRecorder struct {
+	timeline store.WorkflowTimeline
+	summary  *store.ParkSummary
+}
+
+func (r *dispatchLoopTimelineRecorder) RecordWorkflowPhaseEvent(context.Context, store.WorkflowPhaseEvent) (int64, error) {
+	return 0, nil
+}
+
+func (r *dispatchLoopTimelineRecorder) IssueWorkflowTimeline(context.Context, store.IssueIdentity) (store.WorkflowTimeline, error) {
+	return r.timeline, nil
+}
+
+func (r *dispatchLoopTimelineRecorder) IssueParkSummary(context.Context, store.IssueIdentity) (store.ParkSummary, error) {
+	if r.summary == nil {
+		return store.ParkSummary{}, store.ErrNotFound
+	}
+	return *r.summary, nil
+}
+
+func (r *dispatchLoopTimelineRecorder) IssueParkSummaries(context.Context, []store.IssueIdentity) (map[store.IssueIdentity]store.ParkSummary, error) {
+	return map[store.IssueIdentity]store.ParkSummary{}, nil
+}
+
+func (r *dispatchLoopTimelineRecorder) ListIssueParkSummaries(context.Context, string) ([]store.ParkSummary, error) {
+	return []store.ParkSummary{}, nil
+}
+
+func (r *dispatchLoopTimelineRecorder) AcknowledgeIssueParks(context.Context, store.IssueIdentity, int64, time.Time) error {
+	return nil
 }
 
 func TestEvaluateDispatchLoopProgressCreditsWithinAttemptProgress(t *testing.T) {

--- a/internal/orchestrator/operator_move.go
+++ b/internal/orchestrator/operator_move.go
@@ -34,6 +34,7 @@ type OperatorMoveResult struct {
 	ClaimCleared         bool
 	RetryCleared         bool
 	FailureMemoryCleared bool
+	DispatchLoopCleared  bool
 }
 
 type operatorMoveRequest struct {
@@ -135,6 +136,7 @@ func (o *Orchestrator) handleOperatorMove(state *State, request OperatorMoveRequ
 	delete(state.AutoPromoteDecisions, issueID)
 
 	result := OperatorMoveResult{Reconciled: true}
+	result.DispatchLoopCleared = resetDispatchLoopState(state, issue, at)
 	if blocked, ok := state.Blocked[issueID]; ok && blocked.Source == BlockedSourceProjectStatus {
 		delete(state.Blocked, issueID)
 		result.BlockedCleared = true
@@ -184,6 +186,7 @@ func (o *Orchestrator) handleOperatorMove(state *State, request OperatorMoveRequ
 			"claim_cleared", result.ClaimCleared,
 			"retry_cleared", result.RetryCleared,
 			"failure_memory_cleared", result.FailureMemoryCleared,
+			"dispatch_loop_cleared", result.DispatchLoopCleared,
 		)
 	}
 	return result
@@ -251,6 +254,9 @@ func operatorMoveEventMessage(issue connector.Issue, fromState string, toState s
 	message := "reconciled " + issueLabel(issue) + " after operator Kanban move from " + fromState + " to " + toState
 	if result.BlockedCleared {
 		message += "; cleared stale project-status runtime block"
+	}
+	if result.DispatchLoopCleared {
+		message += "; cleared acknowledged dispatch-loop history"
 	}
 	return message
 }

--- a/internal/orchestrator/operator_move_test.go
+++ b/internal/orchestrator/operator_move_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestHandleOperatorMoveClearsOnlyMovedIssueRuntimeMemory(t *testing.T) {
@@ -34,6 +36,24 @@ func TestHandleOperatorMoveClearsOnlyMovedIssueRuntimeMemory(t *testing.T) {
 	state.InstantFailures[unrelated.ID] = InstantFailure{Issue: unrelated, Count: 1}
 	state.RepeatedFailures[moved.ID] = RepeatedFailure{Issue: moved, Count: 2}
 	state.RepeatedFailures[unrelated.ID] = RepeatedFailure{Issue: unrelated, Count: 1}
+	state.WorkAttempts = []telemetry.WorkAttempt{
+		{
+			AttemptID:          4,
+			IssueID:            moved.ID,
+			Identifier:         moved.Identifier,
+			Status:             string(store.WorkAttemptStatusTerminal),
+			CompletedAt:        timePointer(at.Add(-time.Minute)),
+			WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: "no_progress", Reason: dispatchLoopDetectedReason, TrackerState: "Rework", ConsecutiveNoProgress: 4, NoProgressLimit: 3}}),
+		},
+		{
+			AttemptID:          2,
+			IssueID:            unrelated.ID,
+			Identifier:         unrelated.Identifier,
+			Status:             string(store.WorkAttemptStatusTerminal),
+			CompletedAt:        timePointer(at.Add(-2 * time.Minute)),
+			WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: "no_progress", Reason: dispatchLoopDetectedReason, TrackerState: "Blocked", ConsecutiveNoProgress: 2, NoProgressLimit: 3}}),
+		},
+	}
 	state.FailureBreaker.Failures[class] = []ProjectFailure{
 		{IssueID: unrelated.ID, At: at.Add(-time.Minute)},
 		{IssueID: moved.ID, At: at},
@@ -59,6 +79,7 @@ func TestHandleOperatorMoveClearsOnlyMovedIssueRuntimeMemory(t *testing.T) {
 		ClaimCleared:         true,
 		RetryCleared:         true,
 		FailureMemoryCleared: true,
+		DispatchLoopCleared:  true,
 	}) {
 		t.Fatalf("handleOperatorMove() = %#v", result)
 	}
@@ -108,6 +129,16 @@ func TestHandleOperatorMoveClearsOnlyMovedIssueRuntimeMemory(t *testing.T) {
 	}
 	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "operator_kanban_move_reconciled" {
 		t.Fatalf("RecentEvents = %#v, want operator move audit event", state.RecentEvents)
+	}
+	if loops := snapshot.DispatchLoops; len(loops) != 1 || loops[0].IssueID != unrelated.ID {
+		t.Fatalf("DispatchLoops = %#v, want only unrelated issue", loops)
+	}
+	progress := snapshot.BoardIssues[0].CompletionProgress
+	if progress.Outcome != "no_progress" || progress.Reason != dispatchLoopDetectedReason || progress.ConsecutiveNoProgress != 0 || progress.NoProgressLimit != 3 {
+		t.Fatalf("moved issue CompletionProgress = %#v, want preserved result with reset counter", progress)
+	}
+	if got := len(snapshot.WorkAttempts); got != 2 {
+		t.Fatalf("WorkAttempts len = %d, want complete history", got)
 	}
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -90,15 +90,15 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	statusDrift := authorizedStatusDrift(s.StatusDrift, s.Authorization, s.SelectorContext)
 	boardIssueSnapshots := issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now, s.laneEntries)
 	applyIssueRuntimeIdentities(boardIssueSnapshots, s.Running, s.WorkAttempts)
-	applyIssueCompletionProgress(boardIssueSnapshots, s.WorkAttempts)
-	dispatchLoops := dispatchLoopSnapshots(boardIssueSnapshots, s.WorkAttempts)
+	applyIssueCompletionProgress(boardIssueSnapshots, s.WorkAttempts, s.dispatchLoopResets)
+	dispatchLoops := dispatchLoopSnapshots(boardIssueSnapshots, s.WorkAttempts, s.dispatchLoopResets)
 	s.applyGatePendingSnapshots(boardIssueSnapshots, boardIssues)
 	s.applyAutoPromoteDecisionSnapshots(boardIssueSnapshots, boardIssues, now)
 	s.applyArtifactGateWaitDispatchSnapshots(boardIssueSnapshots, boardIssues)
 	strandedActiveIssues := strandedActiveIssueSnapshots(s, boardIssueSnapshots, now)
 	pipelineIssueSnapshots := pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now, s.laneEntries)
 	applyIssueRuntimeIdentities(pipelineIssueSnapshots, s.Running, s.WorkAttempts)
-	applyIssueCompletionProgress(pipelineIssueSnapshots, s.WorkAttempts)
+	applyIssueCompletionProgress(pipelineIssueSnapshots, s.WorkAttempts, s.dispatchLoopResets)
 	s.applyAutoPromoteDecisionSnapshots(pipelineIssueSnapshots, pipeline, now)
 	s.applyArtifactGateWaitDispatchSnapshots(pipelineIssueSnapshots, pipeline)
 	snapshot := telemetry.Snapshot{
@@ -987,7 +987,7 @@ func applyIssueRuntimeIdentities(issues []telemetry.Issue, running map[string]Ru
 	}
 }
 
-func applyIssueCompletionProgress(issues []telemetry.Issue, attempts []telemetry.WorkAttempt) {
+func applyIssueCompletionProgress(issues []telemetry.Issue, attempts []telemetry.WorkAttempt, dispatchLoopResets map[string]time.Time) {
 	for index := range issues {
 		var latest *telemetry.WorkAttempt
 		for attemptIndex := range attempts {
@@ -1010,18 +1010,22 @@ func applyIssueCompletionProgress(issues []telemetry.Issue, attempts []telemetry
 		if !ok {
 			continue
 		}
+		consecutiveNoProgress := record.ConsecutiveNoProgress
+		if !dispatchLoopSnapshotAttemptVisible(issues[index], *latest, dispatchLoopResets) {
+			consecutiveNoProgress = 0
+		}
 		issues[index].CompletionProgress = telemetry.CompletionProgress{
 			Outcome:               strings.TrimSpace(record.Outcome),
 			Reason:                strings.TrimSpace(record.Reason),
 			Kinds:                 append([]string(nil), record.ProgressKinds...),
 			CompletionKind:        strings.TrimSpace(record.CompletionKind),
-			ConsecutiveNoProgress: record.ConsecutiveNoProgress,
+			ConsecutiveNoProgress: consecutiveNoProgress,
 			NoProgressLimit:       record.NoProgressLimit,
 		}
 	}
 }
 
-func dispatchLoopSnapshots(issues []telemetry.Issue, attempts []telemetry.WorkAttempt) []telemetry.DispatchLoop {
+func dispatchLoopSnapshots(issues []telemetry.Issue, attempts []telemetry.WorkAttempt, dispatchLoopResets map[string]time.Time) []telemetry.DispatchLoop {
 	var loops []telemetry.DispatchLoop
 	for _, issue := range issues {
 		progress := issue.CompletionProgress
@@ -1032,7 +1036,8 @@ func dispatchLoopSnapshots(issues []telemetry.Issue, attempts []telemetry.WorkAt
 		for attemptIndex := range attempts {
 			attempt := &attempts[attemptIndex]
 			if !strings.EqualFold(strings.TrimSpace(attempt.Status), string(store.WorkAttemptStatusTerminal)) ||
-				!snapshotIssueMatches(issue, attempt.IssueID, attempt.Identifier, attempt.IssueURL) {
+				!snapshotIssueMatches(issue, attempt.IssueID, attempt.Identifier, attempt.IssueURL) ||
+				!dispatchLoopSnapshotAttemptVisible(issue, *attempt, dispatchLoopResets) {
 				continue
 			}
 			if latest == nil || workAttemptCompletedAfter(*attempt, *latest) {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -121,6 +121,7 @@ type State struct {
 	graphQLUsageSamples      []graphQLUsageSample
 	laneEntries              map[string]time.Time
 	laneProvenance           map[string]provenance.Attribution
+	dispatchLoopResets       map[string]time.Time
 	planRework               map[string]struct{}
 	epicTransitionWatch      []connector.Issue
 	pendingEpicParentLookups map[string]connector.Issue
@@ -434,6 +435,7 @@ func newState(cfg Config) State {
 		CleanupFailures:          map[string]string{},
 		laneEntries:              map[string]time.Time{},
 		laneProvenance:           map[string]provenance.Attribution{},
+		dispatchLoopResets:       map[string]time.Time{},
 		planRework:               map[string]struct{}{},
 		pendingEpicParentLookups: map[string]connector.Issue{},
 	}
@@ -535,6 +537,7 @@ func (s State) clone() State {
 		graphQLUsageSamples:      append([]graphQLUsageSample(nil), s.graphQLUsageSamples...),
 		laneEntries:              maps.Clone(s.laneEntries),
 		laneProvenance:           maps.Clone(s.laneProvenance),
+		dispatchLoopResets:       maps.Clone(s.dispatchLoopResets),
 		planRework:               make(map[string]struct{}, len(s.planRework)),
 		epicTransitionWatch:      cloneIssues(s.epicTransitionWatch),
 		pendingEpicParentLookups: cloneIssueMap(s.pendingEpicParentLookups),


### PR DESCRIPTION
## Summary

- Reset an issue’s dispatch-loop history when an operator moves it out of Blocked or acknowledges its current park sequence.
- Preserve automatic-unpark history, unrelated issue state, general completion telemetry, and the complete work-attempt history.
- Consolidate the reset boundary with the existing recovery-park acknowledgement path and expose the reset in operator-move telemetry.

Fixes #2517

Invariants touched: INV-3 ([same-PR invariant edit](https://github.com/digitaldrywood/detent/blob/113d142e/docs/invariants.md#inv-3--mechanism-moratorium)).

## UI Surface Contract

- [x] N/A — this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A — this PR has no visual changes.

## Test Plan

- [x] Focused operator-move, dispatch-loop, and cross-host acknowledgement regression tests.
- [x] `make check-fast` after rebasing onto current `origin/main`.
- [x] Validator review: PASS, 9/10, no P1/P2 findings.
- [x] Race, coverage, and nilaway are reserved for the merge queue by project policy.