### PR TITLE
fix(workspace): retry loaded process inspection

### DIFF
--- a/internal/workspace/process_environment_darwin.go
+++ b/internal/workspace/process_environment_darwin.go
@@ -44,8 +44,8 @@ func scratchEnvironmentProcessIDs(ctx context.Context, root string) ([]int, erro
 }
 
 func readDarwinScratchEnvironment(ctx context.Context, read func() ([]byte, error), alive func() (bool, error)) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
+	// XNU can report EINVAL while exec or exit leaves a live process without a
+	// readable user stack. The reap operation's context owns the bounded wait.
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/internal/workspace/process_environment_darwin.go
+++ b/internal/workspace/process_environment_darwin.go
@@ -13,39 +13,62 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const darwinScratchEnvironmentRetryTimeout = time.Second
+
 func scratchEnvironmentProcessIDs(ctx context.Context, root string) ([]int, error) {
 	processes, err := unix.SysctlKinfoProcSlice("kern.proc.uid", os.Geteuid())
 	if err != nil {
 		return nil, err
 	}
+	return darwinScratchEnvironmentProcessIDs(ctx, root, processes, darwinScratchEnvironmentRetryTimeout,
+		func(pid int) ([]byte, error) {
+			return unix.SysctlRaw("kern.procargs2", pid)
+		}, func(pid int) (bool, error) {
+			current, err := unix.SysctlKinfoProcSlice("kern.proc.pid", pid)
+			return len(current) > 0 && current[0].Proc.P_stat != 5, err
+		})
+}
+
+func darwinScratchEnvironmentProcessIDs(
+	ctx context.Context,
+	root string,
+	processes []unix.KinfoProc,
+	retryTimeout time.Duration,
+	read func(int) ([]byte, error),
+	alive func(int) (bool, error),
+) ([]int, error) {
 	var owned []int
+	var result error
 	for _, process := range processes {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return owned, errors.Join(result, err)
 		}
 		pid := int(process.Proc.P_pid)
 		if pid <= 0 || pid == os.Getpid() || process.Proc.P_stat == 5 {
 			continue
 		}
-		data, err := readDarwinScratchEnvironment(ctx, func() ([]byte, error) {
-			return unix.SysctlRaw("kern.procargs2", pid)
+		data, err := readDarwinScratchEnvironment(ctx, retryTimeout, func() ([]byte, error) {
+			return read(pid)
 		}, func() (bool, error) {
-			current, err := unix.SysctlKinfoProcSlice("kern.proc.pid", pid)
-			return len(current) > 0 && current[0].Proc.P_stat != 5, err
+			return alive(pid)
 		})
 		if err != nil {
-			return nil, fmt.Errorf("inspect worker scratch ownership for process %d: %w", pid, err)
+			result = errors.Join(result, fmt.Errorf("inspect worker scratch ownership for process %d: %w", pid, err))
+			continue
 		}
 		if workerScratchEnvironmentMatches(root, darwinProcessEnvironment(data)) {
 			owned = append(owned, pid)
 		}
 	}
-	return owned, nil
+	return owned, result
 }
 
-func readDarwinScratchEnvironment(ctx context.Context, read func() ([]byte, error), alive func() (bool, error)) ([]byte, error) {
+func readDarwinScratchEnvironment(ctx context.Context, retryTimeout time.Duration, read func() ([]byte, error), alive func() (bool, error)) ([]byte, error) {
 	// XNU can report EINVAL while exec or exit leaves a live process without a
-	// readable user stack. The reap operation's context owns the bounded wait.
+	// readable user stack. Bound each process separately so a stalled transition
+	// cannot consume the reap operation's entire deadline before the scan advances.
+	ctx, cancel := context.WithTimeout(ctx, retryTimeout)
+	defer cancel()
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/internal/workspace/process_environment_darwin_test.go
+++ b/internal/workspace/process_environment_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -41,11 +42,13 @@ func TestReadDarwinScratchEnvironment(t *testing.T) {
 		alive      bool
 		inspectErr error
 		cancel     bool
+		firstDelay time.Duration
 		want       error
 		wantReads  int
 	}{
 		{name: "exec transition", first: unix.EIO, alive: true, wantReads: 2},
 		{name: "stack transition", first: unix.EINVAL, alive: true, wantReads: 2},
+		{name: "loaded stack transition", first: unix.EINVAL, alive: true, firstDelay: 150 * time.Millisecond, wantReads: 2},
 		{name: "exited", first: unix.EINVAL, wantReads: 1},
 		{name: "missing", first: unix.ESRCH, wantReads: 1},
 		{name: "permission denied", first: unix.EPERM, alive: true, want: unix.EPERM, wantReads: 1},
@@ -59,6 +62,17 @@ func TestReadDarwinScratchEnvironment(t *testing.T) {
 			data, err := readDarwinScratchEnvironment(ctx, func() ([]byte, error) {
 				reads++
 				if reads == 1 {
+					if tt.firstDelay > 0 {
+						// Model a loaded process whose user stack remains unavailable
+						// beyond the former private 100 ms inspection deadline.
+						timer := time.NewTimer(tt.firstDelay)
+						select {
+						case <-ctx.Done():
+							timer.Stop()
+							return nil, ctx.Err()
+						case <-timer.C:
+						}
+					}
 					if tt.cancel {
 						cancel()
 					}

--- a/internal/workspace/process_environment_darwin_test.go
+++ b/internal/workspace/process_environment_darwin_test.go
@@ -42,13 +42,16 @@ func TestReadDarwinScratchEnvironment(t *testing.T) {
 		alive      bool
 		inspectErr error
 		cancel     bool
+		always     bool
 		firstDelay time.Duration
+		retryFor   time.Duration
 		want       error
 		wantReads  int
 	}{
 		{name: "exec transition", first: unix.EIO, alive: true, wantReads: 2},
 		{name: "stack transition", first: unix.EINVAL, alive: true, wantReads: 2},
 		{name: "loaded stack transition", first: unix.EINVAL, alive: true, firstDelay: 150 * time.Millisecond, wantReads: 2},
+		{name: "stalled transition", first: unix.EINVAL, alive: true, always: true, retryFor: 10 * time.Millisecond, want: context.DeadlineExceeded},
 		{name: "exited", first: unix.EINVAL, wantReads: 1},
 		{name: "missing", first: unix.ESRCH, wantReads: 1},
 		{name: "permission denied", first: unix.EPERM, alive: true, want: unix.EPERM, wantReads: 1},
@@ -58,10 +61,14 @@ func TestReadDarwinScratchEnvironment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
+			retryFor := tt.retryFor
+			if retryFor == 0 {
+				retryFor = darwinScratchEnvironmentRetryTimeout
+			}
 			reads := 0
-			data, err := readDarwinScratchEnvironment(ctx, func() ([]byte, error) {
+			data, err := readDarwinScratchEnvironment(ctx, retryFor, func() ([]byte, error) {
 				reads++
-				if reads == 1 {
+				if reads == 1 || tt.always {
 					if tt.firstDelay > 0 {
 						// Model a loaded process whose user stack remains unavailable
 						// beyond the former private 100 ms inspection deadline.
@@ -80,12 +87,41 @@ func TestReadDarwinScratchEnvironment(t *testing.T) {
 				}
 				return []byte("environment"), nil
 			}, func() (bool, error) { return tt.alive, tt.inspectErr })
-			if !errors.Is(err, tt.want) || reads != tt.wantReads {
-				t.Fatalf("error = %v, reads = %d; want %v, %d", err, reads, tt.want, tt.wantReads)
+			if !errors.Is(err, tt.want) || tt.wantReads > 0 && reads != tt.wantReads {
+				t.Fatalf("error = %v, reads = %d; want error %v, reads %d", err, reads, tt.want, tt.wantReads)
 			}
 			if tt.wantReads == 2 && string(data) != "environment" {
 				t.Fatalf("environment = %q", data)
 			}
 		})
+	}
+}
+
+func TestDarwinScratchEnvironmentProcessIDsContinuesAfterInspectionFailure(t *testing.T) {
+	const (
+		unreadablePID = 2081001
+		ownedPID      = 2081002
+	)
+	root := t.TempDir()
+	processes := make([]unix.KinfoProc, 2)
+	processes[0].Proc.P_pid = unreadablePID
+	processes[1].Proc.P_pid = ownedPID
+
+	environment := binary.LittleEndian.AppendUint32(nil, 0)
+	environment = append(environment, "executable\x00DETENT_WORKER_SCRATCH="+root+"\x00"...)
+	pids, err := darwinScratchEnvironmentProcessIDs(t.Context(), root, processes, 10*time.Millisecond,
+		func(pid int) ([]byte, error) {
+			if pid == unreadablePID {
+				return nil, unix.EINVAL
+			}
+			return environment, nil
+		}, func(int) (bool, error) {
+			return true, nil
+		})
+	if !reflect.DeepEqual(pids, []int{ownedPID}) {
+		t.Fatalf("process IDs = %v, want [%d]", pids, ownedPID)
+	}
+	if !errors.Is(err, unix.EINVAL) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want EINVAL and deadline exceeded", err)
 	}
 }

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -78,7 +78,13 @@ func reapProcessesWithWait(
 ) (int, error) {
 	pids, err := scanOwnedWorkspaceProcessIDs(ctx, path, scan)
 	if err != nil {
-		return 0, fmt.Errorf("scan workspace processes: %w", err)
+		scanErr := fmt.Errorf("scan workspace processes: %w", err)
+		if len(pids) == 0 {
+			return 0, scanErr
+		}
+		reaped := make(map[int]struct{}, len(pids))
+		signalErr := signalWorkspaceProcesses(pids, syscall.SIGTERM, signal, reaped)
+		return len(reaped), errors.Join(scanErr, signalErr)
 	}
 	if len(pids) == 0 {
 		return 0, nil
@@ -168,17 +174,14 @@ func workspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
 		return nil, errors.New("workspace path must not resolve to a filesystem root")
 	}
 	path = canonical
-	owned, err := scratchEnvironmentProcessIDs(ctx, path)
-	if err != nil {
-		return nil, err
-	}
+	owned, scratchErr := scratchEnvironmentProcessIDs(ctx, path)
 	var cwd []int
 	if runtime.GOOS == "linux" {
 		cwd, err = linuxWorkspaceProcessIDs(path)
 	} else {
 		cwd, err = lsofWorkspaceProcessIDs(ctx, path)
 	}
-	return append(owned, cwd...), err
+	return append(owned, cwd...), errors.Join(scratchErr, err)
 }
 
 func linuxWorkspaceProcessIDs(path string) ([]int, error) {

--- a/internal/workspace/process_unix_test.go
+++ b/internal/workspace/process_unix_test.go
@@ -57,6 +57,14 @@ func TestReapProcesses(t *testing.T) {
 			wantReaped: 0,
 		},
 		{
+			name:        "initial scan signals known owners before failing",
+			initial:     []int{processID},
+			scanErr:     scanErr,
+			wantSignals: []syscall.Signal{syscall.SIGTERM},
+			wantErr:     scanErr,
+			wantReaped:  1,
+		},
+		{
 			name:        "wait fails",
 			initial:     []int{processID},
 			waitErr:     waitErr,

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -61,9 +61,6 @@ type workspaceProcessScanner func(context.Context, string) ([]int, error)
 
 func scanOwnedWorkspaceProcessIDs(ctx context.Context, path string, scan workspaceProcessScanner) ([]int, error) {
 	pids, err := scan(ctx, path)
-	if err != nil {
-		return nil, err
-	}
 	owned := make([]int, 0, len(pids))
 	seen := make(map[int]struct{}, len(pids))
 	for _, pid := range pids {
@@ -76,7 +73,7 @@ func scanOwnedWorkspaceProcessIDs(ctx context.Context, path string, scan workspa
 		seen[pid] = struct{}{}
 		owned = append(owned, pid)
 	}
-	return owned, nil
+	return owned, err
 }
 
 type Backend interface {


### PR DESCRIPTION
## Summary

- Retry transient macOS `kern.procargs2` ownership failures with a one-second per-PID budget bounded by the reap context.
- Continue scanning after a persistently unreadable PID, signal only positively owned descendants, and retain the scan error so cleanup remains fail-closed.
- Preserve the latest `EINVAL`/`EIO` across either retry deadline path so suite-load behavior and regression assertions are deterministic.

Fixes #2520

Invariants touched: none.

## UI Surface Contract

- [x] N/A; this change has no UI surface or layout impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR does not change primary operator screens.

## Test Plan

- [x] Validator reproduction: `go test ./internal/workspace -run 'Test(ReadDarwinScratchEnvironment|DarwinScratchEnvironmentProcessIDsContinuesAfterInspectionFailure|ReapProcesses)$' -count=10`
- [x] Suite-pressure stress: focused ownership tests at `-count=50` concurrently with the exact CLI acceptance test at `-count=3`
- [x] `env -u DETENT_API_TOKEN go test ./internal/cli -run '^TestRestartScratchCleanupWaitsForEscapedDescendant$' -count=3`
- [x] `make check-fast`
